### PR TITLE
chore: sort all HelmRelease YAML files alphabetically

### DIFF
--- a/kubernetes/apps/ai/comfyui/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/comfyui/app/helmrelease.yaml
@@ -13,10 +13,6 @@ spec:
     controllers:
       comfyui:
         pod:
-          runtimeClassName: nvidia
-
-          priorityClassName: ai-gpu-critical
-
           affinity:
             nodeAffinity:
               requiredDuringSchedulingIgnoredDuringExecution:
@@ -29,6 +25,10 @@ spec:
 
           nodeSelector:
             nvidia.com/gpu.present: "true"
+
+          priorityClassName: ai-gpu-critical
+
+          runtimeClassName: nvidia
 
         annotations:
           reloader.stakater.com/auto: "true"
@@ -51,9 +51,6 @@ spec:
               WEB_ENABLE_AUTH: "false"
               WORKSPACE: "/workspace"
 
-            securityContext:
-              privileged: true
-
             resources:
               requests:
                 nvidia.com/gpu: 1 # requesting 1 GPU
@@ -62,6 +59,9 @@ spec:
               limits:
                 memory: 32Gi
                 nvidia.com/gpu: 1 # requesting 1 GPU
+
+            securityContext:
+              privileged: true
 
     service:
       app:
@@ -89,18 +89,6 @@ spec:
                 port: *httpPort
 
     persistence:
-      workspace:
-        enabled: true
-        existingClaim: comfyui-workspace-pvc
-        globalMounts:
-          - path: /workspace
-
-      output:
-        enabled: true
-        existingClaim: comfyui-output-pvc
-        globalMounts:
-          - path: /workspace/ComfyUI/output
-
       config:
         type: configMap
         name: comfyui-configmap
@@ -110,3 +98,15 @@ spec:
               - path: /workspace/ComfyUI/custom_nodes/ComfyUI-Manager/config.ini
                 subPath: config.ini
                 readOnly: true
+      output:
+        enabled: true
+        existingClaim: comfyui-output-pvc
+        globalMounts:
+          - path: /workspace/ComfyUI/output
+
+      workspace:
+        enabled: true
+        existingClaim: comfyui-workspace-pvc
+        globalMounts:
+          - path: /workspace
+

--- a/kubernetes/apps/ai/ollama/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/ollama/app/helmrelease.yaml
@@ -13,10 +13,6 @@ spec:
     controllers:
       backend:
         pod:
-          runtimeClassName: nvidia
-
-          priorityClassName: ai-gpu-critical
-
           affinity:
             nodeAffinity:
               requiredDuringSchedulingIgnoredDuringExecution:
@@ -29,6 +25,10 @@ spec:
 
           nodeSelector:
             nvidia.com/gpu.present: "true"
+
+          priorityClassName: ai-gpu-critical
+
+          runtimeClassName: nvidia
 
         annotations:
           reloader.stakater.com/auto: "true"
@@ -54,9 +54,6 @@ spec:
               OLLAMA_CONTEXT_LENGTH: 8192
               OLLAMA_NUM_PARALLEL: 4
 
-            securityContext:
-              privileged: true
-
             resources:
               requests:
                 memory: 6G
@@ -65,6 +62,9 @@ spec:
               limits:
                 memory: 6G
                 nvidia.com/gpu: 1
+
+            securityContext:
+              privileged: true
 
     service:
       backend:
@@ -106,8 +106,8 @@ spec:
               - path: *pvc
 
       tmp:
-        type: emptyDir
         enabled: true
+        type: emptyDir
         medium: Memory
         globalMounts:
           - path: /tmp

--- a/kubernetes/apps/auth/kanidm/app/helmrelease.yaml
+++ b/kubernetes/apps/auth/kanidm/app/helmrelease.yaml
@@ -48,30 +48,6 @@ spec:
               capabilities:
                 drop:
                   - ALL
-    persistence:
-      data:
-        existingClaim: kanidm-data-pvc
-        globalMounts:
-          - path: /data
-            subPath: data
-      certs:
-        type: secret
-        name: idm-lovenet-tls
-        defaultMode: 0400
-        globalMounts:
-          - path: /certs
-      tmpfs:
-        type: emptyDir
-        globalMounts:
-          - path: /var/run
-            subPath: var-run
-    route:
-      app:
-        hostnames:
-          - idm.${SECRET_DOMAIN}
-        parentRefs:
-          - name: external
-            namespace: network
     service:
       app:
         ports:
@@ -79,3 +55,27 @@ spec:
             port: 8443
           ldap:
             port: 3636
+    route:
+      app:
+        hostnames:
+          - idm.${SECRET_DOMAIN}
+        parentRefs:
+          - name: external
+            namespace: network
+    persistence:
+      certs:
+        type: secret
+        defaultMode: 0400
+        name: idm-lovenet-tls
+        globalMounts:
+          - path: /certs
+      data:
+        existingClaim: kanidm-data-pvc
+        globalMounts:
+          - path: /data
+            subPath: data
+      tmpfs:
+        type: emptyDir
+        globalMounts:
+          - path: /var/run
+            subPath: var-run

--- a/kubernetes/apps/auth/pocket-id/app/helmrelease.yaml
+++ b/kubernetes/apps/auth/pocket-id/app/helmrelease.yaml
@@ -12,11 +12,11 @@ spec:
   values:
     defaultPodOptions:
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 1000
         fsGroup: 1000
         fsGroupChangePolicy: Always
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
     controllers:
       pocket-id:
         annotations:
@@ -89,18 +89,11 @@ spec:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
               capabilities: {drop: ["ALL"]}
-    persistence:
-      data:
-        existingClaim: pocket-id-data-pvc
-        globalMounts:
-          - path: /app/data
-      tmpfs:
-        type: emptyDir
-        advancedMounts:
-          pocket-id:
-            app:
-              - path: /tmp
-                subPath: tmp
+    service:
+      app:
+        ports:
+          http:
+            port: *httpPort
     route:
       main:
         hostnames:
@@ -113,8 +106,15 @@ spec:
           - backendRefs:
               - identifier: app
                 port: *httpPort
-    service:
-      app:
-        ports:
-          http:
-            port: *httpPort
+    persistence:
+      data:
+        existingClaim: pocket-id-data-pvc
+        globalMounts:
+          - path: /app/data
+      tmpfs:
+        type: emptyDir
+        advancedMounts:
+          pocket-id:
+            app:
+              - path: /tmp
+                subPath: tmp

--- a/kubernetes/apps/collab/atuin/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/atuin/app/helmrelease.yaml
@@ -14,12 +14,12 @@ spec:
       main:
         pod:
           securityContext:
-            runAsUser: 568
-            runAsGroup: 568
-            runAsNonRoot: true
             fsGroup: 568
             fsGroupChangePolicy: OnRootMismatch
 
+            runAsGroup: 568
+            runAsNonRoot: true
+            runAsUser: 568
           topologySpreadConstraints:
             - maxSkew: 1
               topologyKey: kubernetes.io/hostname
@@ -78,11 +78,14 @@ spec:
                 drop:
                   - ALL
 
-    persistence:
-      config:
-        enabled: true
-        type: emptyDir
-
+    service:
+      main:
+        controller: main
+        ports:
+          http:
+            port: *httpPort
+          metrics:
+            port: *metricsPort
     route:
       main:
         hostnames:
@@ -96,14 +99,11 @@ spec:
               - identifier: main
                 port: *httpPort
 
-    service:
-      main:
-        controller: main
-        ports:
-          http:
-            port: *httpPort
-          metrics:
-            port: *metricsPort
+    persistence:
+      config:
+        enabled: true
+        type: emptyDir
+
 
     serviceMonitor:
       main:

--- a/kubernetes/apps/collab/exercisediary/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/exercisediary/app/helmrelease.yaml
@@ -5,18 +5,18 @@ kind: HelmRelease
 metadata:
   name: &app exercisediary
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: app-template
 
+  interval: 30m
   values:
     controllers:
       main:
-        type: statefulset
         annotations:
           reloader.stakater.com/auto: "true"
 
+        type: statefulset
         containers:
           main:
             image:
@@ -45,6 +45,12 @@ spec:
 
     route:
       main:
+        annotations:
+          glance/name: "Exercise Diary"
+          glance/show: "true"
+          #glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/paperless-ngx.png"
+          glance/id: "Collaboration"
+
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
         parentRefs:
@@ -55,12 +61,6 @@ spec:
           - backendRefs:
               - identifier: main
                 port: *httpPort
-        annotations:
-          glance/name: "Exercise Diary"
-          glance/show: "true"
-          #glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/paperless-ngx.png"
-          glance/id: "Collaboration"
-
     persistence:
       config:
         existingClaim: exercisediary-data-pvc

--- a/kubernetes/apps/collab/glance/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/glance/app/helmrelease.yaml
@@ -5,10 +5,10 @@ kind: HelmRelease
 metadata:
   name: &app glance
 spec:
-  interval: 1h
   chartRef:
     kind: OCIRepository
     name: app-template
+  interval: 1h
   install:
     remediation:
       retries: 3
@@ -20,33 +20,37 @@ spec:
   values:
     controllers:
       glance:
-        type: statefulset
+        pod:
+          securityContext:
+            fsGroup: 1000
+            fsGroupChangePolicy: OnRootMismatch
+            runAsGroup: 1000
+            runAsNonRoot: true
+            runAsUser: 1000
         annotations:
           reloader.stakater.com/auto: "true"
+        serviceAccount:
+          identifier: *app
+        type: statefulset
         containers:
           glance:
             image:
               repository: docker.io/glanceapp/glance
               tag: v0.8.4@sha256:6df86a7e8868d1eda21f35205134b1962c422957e42a0c44d4717c8e8f741b1a
-            securityContext:
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: true
-              capabilities: {drop: ["ALL"]}
             resources:
               requests:
                 cpu: 100m
                 memory: 64Mi
               limits:
                 memory: 96Mi
-          k8s-extension:
-            image:
-              repository: ghcr.io/lukasdietrich/glance-k8s/glance-k8s
-              tag: v0.4.7@sha256:4ff785aa8d33d9bd065f1f66cb1c9d4eedd7c0793af07f2bebfb22889f0b07ee
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
               capabilities: {drop: ["ALL"]}
-            resources: {}
+          k8s-extension:
+            image:
+              repository: ghcr.io/lukasdietrich/glance-k8s/glance-k8s
+              tag: v0.4.7@sha256:4ff785aa8d33d9bd065f1f66cb1c9d4eedd7c0793af07f2bebfb22889f0b07ee
             probes:
               liveness:
                 enabled: true
@@ -62,15 +66,11 @@ spec:
                   httpGet:
                     path: /healthz
                     port: 8080
-        serviceAccount:
-          identifier: *app
-        pod:
-          securityContext:
-            runAsUser: 1000
-            runAsGroup: 1000
-            runAsNonRoot: true
-            fsGroup: 1000
-            fsGroupChangePolicy: OnRootMismatch
+            resources: {}
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: {drop: ["ALL"]}
     service:
       glance:
         controller: glance
@@ -102,10 +102,18 @@ spec:
           - path: /app/config/glance.yml
             subPath: glance.yml
             readOnly: true
-    serviceAccount:
-      glance:
-        enabled: true
     rbac:
+      bindings:
+        list:
+          type: ClusterRoleBinding
+          forceRename: *app
+          roleRef:
+            kind: ClusterRole
+            name: *app
+          subjects:
+            - kind: ServiceAccount
+              name: *app
+              namespace: "{{ .Release.Namespace }}"
       roles:
         list:
           type: ClusterRole
@@ -126,14 +134,6 @@ spec:
             - apiGroups: ["apps"]
               resources: ["deployments", "statefulsets", "daemonsets"]
               verbs: ["list"]
-      bindings:
-        list:
-          type: ClusterRoleBinding
-          forceRename: *app
-          roleRef:
-            kind: ClusterRole
-            name: *app
-          subjects:
-            - kind: ServiceAccount
-              name: *app
-              namespace: "{{ .Release.Namespace }}"
+    serviceAccount:
+      glance:
+        enabled: true

--- a/kubernetes/apps/collab/it-tools/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/it-tools/app/helmrelease.yaml
@@ -5,17 +5,17 @@ kind: HelmRelease
 metadata:
   name: &app it-tools
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: app-template
 
+  interval: 30m
   values:
     controllers:
       it-tools:
-        type: statefulset
         annotations:
           reloader.stakater.com/auto: "true"
+        type: statefulset
         containers:
           app:
             image:
@@ -42,6 +42,11 @@ spec:
 
     route:
       app:
+        annotations:
+          glance/name: "IT Tools"
+          glance/show: "true"
+          glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/it-tools-light.png"
+          glance/id: "Collaboration"
         hostnames:
           - it-tools.${SECRET_DOMAIN}
         parentRefs:
@@ -52,8 +57,3 @@ spec:
           - backendRefs:
               - identifier: app
                 port: *port
-        annotations:
-          glance/name: "IT Tools"
-          glance/show: "true"
-          glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/it-tools-light.png"
-          glance/id: "Collaboration"

--- a/kubernetes/apps/collab/mealie/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/mealie/app/helmrelease.yaml
@@ -5,11 +5,11 @@ kind: HelmRelease
 metadata:
   name: &app mealie
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: app-template
 
+  interval: 30m
   values:
     controllers:
       main:
@@ -52,6 +52,12 @@ spec:
 
     route:
       main:
+        annotations:
+          glance/name: "Mealie"
+          glance/show: "true"
+          glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/mealie.png"
+          glance/id: "Collaboration"
+
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
         parentRefs:
@@ -62,12 +68,6 @@ spec:
           - backendRefs:
               - identifier: main
                 port: *httpPort
-        annotations:
-          glance/name: "Mealie"
-          glance/show: "true"
-          glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/mealie.png"
-          glance/id: "Collaboration"
-
     persistence:
       config:
         existingClaim: mealie-config-pvc

--- a/kubernetes/apps/collab/medikeep/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/medikeep/app/helmrelease.yaml
@@ -5,18 +5,26 @@ kind: HelmRelease
 metadata:
   name: &app medikeep
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: app-template
 
+  interval: 30m
   values:
     controllers:
       main:
-        type: statefulset
+        pod:
+          securityContext:
+            fsGroup: 999
+            fsGroupChangePolicy: OnRootMismatch
 
+            runAsGroup: 999
+            runAsNonRoot: true
+            runAsUser: 999
         annotations:
           reloader.stakater.com/auto: "true"
+
+        type: statefulset
 
         initContainers:
           init-db:
@@ -42,6 +50,10 @@ spec:
               MPLCONFIGDIR: /app/matplotlib
 
             envFrom: *envFrom
+            probes:
+              startup:
+                enabled: false
+
 
             resources:
               requests:
@@ -57,18 +69,6 @@ spec:
                 drop:
                   - ALL
 
-            probes:
-              startup:
-                enabled: false
-
-        pod:
-          securityContext:
-            runAsUser: 999
-            runAsGroup: 999
-            runAsNonRoot: true
-            fsGroup: 999
-            fsGroupChangePolicy: OnRootMismatch
-
     service:
       main:
         controller: main
@@ -80,6 +80,12 @@ spec:
 
     route:
       main:
+        annotations:
+          glance/name: "MediKeep"
+          glance/show: "true"
+          #glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/paperless-ngx.png"
+          glance/id: "Collaboration"
+
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
         parentRefs:
@@ -90,12 +96,23 @@ spec:
           - backendRefs:
               - identifier: main
                 port: *reactPort
-        annotations:
-          glance/name: "MediKeep"
-          glance/show: "true"
-          #glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/paperless-ngx.png"
-          glance/id: "Collaboration"
-
+    persistence:
+      backups:
+        type: emptyDir
+        globalMounts:
+          - path: /app/backups
+      logs:
+        type: emptyDir
+        globalMounts:
+          - path: /app/logs
+      matplotlib:
+        type: emptyDir
+        globalMounts:
+          - path: /app/matplotlib
+      uploads:
+        type: emptyDir
+        globalMounts:
+          - path: /app/uploads
     serviceMonitor:
       main:
         serviceName: *app
@@ -106,20 +123,3 @@ spec:
             interval: 1m
             scrapeTimeout: 10s
 
-    persistence:
-      logs:
-        type: emptyDir
-        globalMounts:
-          - path: /app/logs
-      uploads:
-        type: emptyDir
-        globalMounts:
-          - path: /app/uploads
-      backups:
-        type: emptyDir
-        globalMounts:
-          - path: /app/backups
-      matplotlib:
-        type: emptyDir
-        globalMounts:
-          - path: /app/matplotlib

--- a/kubernetes/apps/collab/nametag/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/nametag/app/helmrelease.yaml
@@ -5,18 +5,18 @@ kind: HelmRelease
 metadata:
   name: nametag
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: app-template
 
+  interval: 30m
   values:
     controllers:
       main:
-        type: statefulset
-
         annotations:
           reloader.stakater.com/auto: "true"
+
+        type: statefulset
 
         initContainers:
           init-db:
@@ -56,6 +56,11 @@ spec:
 
     route:
       main:
+        annotations:
+          glance/name: "Nametag"
+          glance/show: "true"
+          #glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/paperless-ngx.png"
+          glance/id: "Collaboration"
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
         parentRefs:
@@ -66,8 +71,3 @@ spec:
           - backendRefs:
               - identifier: main
                 port: *httpPort
-        annotations:
-          glance/name: "Nametag"
-          glance/show: "true"
-          #glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/paperless-ngx.png"
-          glance/id: "Collaboration"

--- a/kubernetes/apps/collab/nextcloud/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/nextcloud/app/helmrelease.yaml
@@ -5,82 +5,29 @@ kind: HelmRelease
 metadata:
   name: nextcloud
 spec:
-  timeout: 15m
-  interval: 1h
   chartRef:
     kind: OCIRepository
     name: nextcloud
+  interval: 1h
+  timeout: 15m
   values:
-    nginx:
+    externalDatabase:
+      database: nextcloud
       enabled: true
-    nextcloud:
-      extraInitContainers:
-        - name: init-db
-          image: ghcr.io/home-operations/postgres-init:18.3.0@sha256:6fa1f331cddd2eb0b6afa7b8d3685c864127a81ab01c3d9400bc3ff5263a51cf
-          envFrom:
-            - secretRef:
-                name: nextcloud-secret
-        - name: create-redis-session-ini
-          image: busybox:1.37-uclibc
-          command:
-            - sh
-            - -c
-            - touch /usr/local/etc/php/conf.d/redis-session.ini
-          volumeMounts:
-            - name: php-confd
-              mountPath: "/usr/local/etc/php/conf.d/"
-      extraVolumeMounts:
-        - name: php-confd
-          mountPath: "/usr/local/etc/php/conf.d/redis-session.ini"
-          subPath: redis-session.ini
-        - name: tmpfs
-          mountPath: "/tmp"
-      extraVolumes:
-        - name: php-confd
-          emptyDir: {}
-        - name: tmpfs
-          emptyDir: {}
-      datadir: /var/www/data
-      extraEnv:
-        - name: REDIS_HOST
-          value: dragonfly.databases.svc.cluster.local.
-        - name: REDIS_HOST_PORT
-          value: "6379"
       existingSecret:
         enabled: true
+        passwordKey: INIT_POSTGRES_PASS
         secretName: nextcloud-secret
-      host: &host cloud.${SECRET_DOMAIN}
-      mail:
-        enabled: true
-        fromAddress: admin
-        domain: ${SECRET_DOMAIN}
-        smtp:
-          host: smtp-relay.${SECRET_DOMAIN}
-          port: 25
-          authtype: NONE
-          name: ""
-          password: ""
-      securityContext:
-        runAsUser: 1022
-        runAsGroup: 1022
-        fsGroup: 1022
-        fsGroupChangePolicy: "OnRootMismatch"
-        runAsNonRoot: true
+        usernameKey: INIT_POSTGRES_USER
+      host: postgres-nextcloud-rw.databases.svc.cluster.local.
+      type: postgresql
+    ingress:
+      enabled: false
+    internalDatabase:
+      enabled: false
+    nextcloud:
       configs:
         # log levels: 0=debug, 1=info, 2=warn, 3=error, 4=fatal
-        logging.config.php: |-
-          <?php
-          $CONFIG = array (
-            'log_type' => 'file',
-            'logfile' => 'nextcloud.log',
-            'loglevel' => 0,
-            'logdateformat' => 'F d, Y H:i:s'
-            );
-        timezone.config.php: |-
-          <?php
-          $CONFIG = array (
-            'default_timezone' => 'America/Los_Angeles',
-          );
         local.config.php: |-
           <?php
           $CONFIG = array (
@@ -102,32 +49,85 @@ spec:
             'check_data_directory_permissions' => false,
             'overwrite.cli.url' => 'https://cloud.thesteamedcrab.com',
           );
-    internalDatabase:
-      enabled: false
-    externalDatabase:
-      enabled: true
-      type: postgresql
-      host: postgres-nextcloud-rw.databases.svc.cluster.local.
-      database: nextcloud
+        logging.config.php: |-
+          <?php
+          $CONFIG = array (
+            'log_type' => 'file',
+            'logfile' => 'nextcloud.log',
+            'loglevel' => 0,
+            'logdateformat' => 'F d, Y H:i:s'
+            );
+        timezone.config.php: |-
+          <?php
+          $CONFIG = array (
+            'default_timezone' => 'America/Los_Angeles',
+          );
+      datadir: /var/www/data
       existingSecret:
         enabled: true
         secretName: nextcloud-secret
-        usernameKey: INIT_POSTGRES_USER
-        passwordKey: INIT_POSTGRES_PASS
-    ingress:
-      enabled: false
+      extraEnv:
+        - name: REDIS_HOST
+          value: dragonfly.databases.svc.cluster.local.
+        - name: REDIS_HOST_PORT
+          value: "6379"
+      extraInitContainers:
+        - envFrom:
+            - secretRef:
+                name: nextcloud-secret
+          image: ghcr.io/home-operations/postgres-init:18.3.0@sha256:6fa1f331cddd2eb0b6afa7b8d3685c864127a81ab01c3d9400bc3ff5263a51cf
+          name: init-db
+        - command:
+            - sh
+            - -c
+            - touch /usr/local/etc/php/conf.d/redis-session.ini
+          image: busybox:1.37-uclibc
+          name: create-redis-session-ini
+          volumeMounts:
+            - mountPath: "/usr/local/etc/php/conf.d/"
+              name: php-confd
+      extraVolumeMounts:
+        - mountPath: "/usr/local/etc/php/conf.d/redis-session.ini"
+          name: php-confd
+          subPath: redis-session.ini
+        - mountPath: "/tmp"
+          name: tmpfs
+      extraVolumes:
+        - emptyDir: {}
+          name: php-confd
+        - emptyDir: {}
+          name: tmpfs
+      host: &host cloud.${SECRET_DOMAIN}
+      mail:
+        domain: ${SECRET_DOMAIN}
+        enabled: true
+        fromAddress: admin
+        smtp:
+          authtype: NONE
+          host: smtp-relay.${SECRET_DOMAIN}
+          name: ""
+          password: ""
+          port: 25
+      securityContext:
+        fsGroup: 1022
+        fsGroupChangePolicy: "OnRootMismatch"
+        runAsGroup: 1022
+        runAsNonRoot: true
+        runAsUser: 1022
+    nginx:
+      enabled: true
     persistence:
       enabled: true
       existingClaim: nextcloud-config-pvc
       nextcloudData:
-        enabled: true
-        existingClaim: nextcloud-data-pvc
         accessMode: ReadWriteMany
     # this seems to be required for nextcloud initialization which takes a long time
+        enabled: true
+        existingClaim: nextcloud-data-pvc
     startupProbe:
       enabled: true
+      failureThreshold: 30
       initialDelaySeconds: 10
       periodSeconds: 20
-      timeoutSeconds: 5
-      failureThreshold: 30
       successThreshold: 1
+      timeoutSeconds: 5

--- a/kubernetes/apps/collab/obsidian-couchdb/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/obsidian-couchdb/app/helmrelease.yaml
@@ -5,25 +5,25 @@ kind: HelmRelease
 metadata:
   name: obsidian-couchdb
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: app-template
 
+  interval: 30m
   values:
     controllers:
       main:
-        type: statefulset
+        pod:
+          securityContext:
+            fsGroup: ${APP_GID}
+            fsGroupChangePolicy: "OnRootMismatch"
 
+            runAsGroup: ${APP_GID}
+            runAsUser: ${APP_UID}
         annotations:
           reloader.stakater.com/auto: "true"
 
-        pod:
-          securityContext:
-            runAsUser: ${APP_UID}
-            runAsGroup: ${APP_GID}
-            fsGroup: ${APP_GID}
-            fsGroupChangePolicy: "OnRootMismatch"
+        type: statefulset
 
         initContainers:
           init-config:
@@ -88,6 +88,10 @@ spec:
             init-config:
               - path: /tmp/config
 
+      config-storage:
+        type: emptyDir
+        globalMounts:
+          - path: /opt/couchdb/etc/default.d
       data:
         existingClaim: obsidian-data-pvc
         advancedMounts:
@@ -95,7 +99,3 @@ spec:
             main:
               - path: /opt/couchdb/data
 
-      config-storage:
-        type: emptyDir
-        globalMounts:
-          - path: /opt/couchdb/etc/default.d

--- a/kubernetes/apps/collab/open-webui/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/open-webui/app/helmrelease.yaml
@@ -5,10 +5,10 @@ kind: HelmRelease
 metadata:
   name: &app open-webui
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: app-template
+  interval: 30m
   install:
     remediation:
       retries: 3
@@ -20,10 +20,10 @@ spec:
   values:
     controllers:
       open-webui:
-        type: statefulset
-
         annotations:
           reloader.stakater.com/auto: "true"
+
+        type: statefulset
 
         containers:
           app:
@@ -55,6 +55,12 @@ spec:
 
     route:
       main:
+        annotations:
+          glance/name: "Open Web UI"
+          glance/show: "true"
+          glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/open-webui.png"
+          glance/id: "Collaboration"
+
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
         parentRefs:
@@ -65,12 +71,6 @@ spec:
           - backendRefs:
               - identifier: app
                 port: *httpPort
-        annotations:
-          glance/name: "Open Web UI"
-          glance/show: "true"
-          glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/open-webui.png"
-          glance/id: "Collaboration"
-
     persistence:
       config:
         existingClaim: open-webui-data-pvc

--- a/kubernetes/apps/collab/paperless/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/paperless/app/helmrelease.yaml
@@ -5,18 +5,18 @@ kind: HelmRelease
 metadata:
   name: paperless
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: app-template
 
+  interval: 30m
   values:
     controllers:
       main:
-        type: statefulset
-
         annotations:
           reloader.stakater.com/auto: "true"
+
+        type: statefulset
 
         initContainers:
           init-db:
@@ -71,6 +71,12 @@ spec:
 
     route:
       main:
+        annotations:
+          glance/name: "Paperless"
+          glance/show: "true"
+          glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/paperless-ngx.png"
+          glance/id: "Collaboration"
+
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
         parentRefs:
@@ -81,12 +87,6 @@ spec:
           - backendRefs:
               - identifier: main
                 port: *httpPort
-        annotations:
-          glance/name: "Paperless"
-          glance/show: "true"
-          glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/paperless-ngx.png"
-          glance/id: "Collaboration"
-
     persistence:
       library:
         existingClaim: paperless-library-pvc

--- a/kubernetes/apps/collab/searxng/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/searxng/app/helmrelease.yaml
@@ -5,28 +5,28 @@ kind: HelmRelease
 metadata:
   name: searxng
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: app-template
+  interval: 30m
   values:
     controllers:
       searxng:
-        type: statefulset
         annotations:
           reloader.stakater.com/auto: "true"
+        type: statefulset
         containers:
           app:
             image:
               repository: ghcr.io/searxng/searxng
               tag: 2025.8.19-25647c2@sha256:81084f251c63f62b79ca15c25d29f7159812cfd06b6dc8ef720e007e6d4f8ad8
-            envFrom:
-              - secretRef:
-                  name: searxng-secret
             env:
               SEARXNG_BASE_URL: https://search.${SECRET_DOMAIN}
               SEARXNG_URL: https://search.${SECRET_DOMAIN}
               SEARXNG_PORT: &httpPort 8080
+            envFrom:
+              - secretRef:
+                  name: searxng-secret
             probes:
               liveness: &probes
                 enabled: true
@@ -42,6 +42,12 @@ spec:
               readiness: *probes
               startup:
                 enabled: false
+            resources:
+              requests:
+                cpu: 15m
+                memory: 1Gi
+              limits:
+                memory: 1Gi
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
@@ -53,12 +59,6 @@ spec:
                   - SETGID
                   - SETUID
                   - DAC_OVERRIDE
-            resources:
-              requests:
-                cpu: 15m
-                memory: 1Gi
-              limits:
-                memory: 1Gi
     service:
       app:
         controller: searxng
@@ -67,6 +67,12 @@ spec:
             port: *httpPort
     route:
       app:
+        annotations:
+          glance/name: "Searxng"
+          glance/show: "true"
+          glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/searxng.png"
+          glance/id: "Collaboration"
+
         hostnames:
           - "search.${SECRET_DOMAIN}"
         parentRefs:
@@ -77,12 +83,6 @@ spec:
           - backendRefs:
               - identifier: app
                 port: *httpPort
-        annotations:
-          glance/name: "Searxng"
-          glance/show: "true"
-          glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/searxng.png"
-          glance/id: "Collaboration"
-
     persistence:
       config:
         type: configMap

--- a/kubernetes/apps/collab/sparkyfitness/app/frontend/helmrelease.yaml
+++ b/kubernetes/apps/collab/sparkyfitness/app/frontend/helmrelease.yaml
@@ -5,18 +5,18 @@ kind: HelmRelease
 metadata:
   name: &app sparkyfitness-frontend
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: app-template
 
+  interval: 30m
   values:
     controllers:
       main:
-        type: statefulset
         annotations:
           reloader.stakater.com/auto: "true"
 
+        type: statefulset
         containers:
           main:
             image:
@@ -45,6 +45,11 @@ spec:
 
     route:
       main:
+        annotations:
+          glance/name: "Sparky Fitness"
+          glance/show: "true"
+          glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/sparky-fitness.png"
+          glance/id: "Fitness"
         hostnames:
           - "fitness.${SECRET_DOMAIN}"
         parentRefs:
@@ -55,8 +60,3 @@ spec:
           - backendRefs:
               - identifier: main
                 port: *httpPort
-        annotations:
-          glance/name: "Sparky Fitness"
-          glance/show: "true"
-          glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/sparky-fitness.png"
-          glance/id: "Fitness"

--- a/kubernetes/apps/collab/sparkyfitness/app/server/helmrelease.yaml
+++ b/kubernetes/apps/collab/sparkyfitness/app/server/helmrelease.yaml
@@ -5,17 +5,17 @@ kind: HelmRelease
 metadata:
   name: &app sparkyfitness-server
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: app-template
+  interval: 30m
 
   values:
     controllers:
       main:
-        type: statefulset
         annotations:
           reloader.stakater.com/auto: "true"
+        type: statefulset
 
         initContainers:
           01-init-db:
@@ -47,7 +47,7 @@ spec:
               SPARKY_FITNESS_DISABLE_SIGNUP: false
               ALLOW_PRIVATE_NETWORK_CORS: false
               SPARKY_FITNESS_EXTRA_TRUSTED_ORIGINS: ""
-              
+
               # SPARKY_FITNESS_ADMIN_EMAIL: ${SPARKY_FITNESS_ADMIN_EMAIL}  #User with this email can access the admin panel
               # GARMIN_MICROSERVICE_URL: http://sparkyfitness-garmin:8000 # Add Garmin microservice URL
 

--- a/kubernetes/apps/collab/startpunkt-user/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/startpunkt-user/app/helmrelease.yaml
@@ -5,18 +5,18 @@ kind: HelmRelease
 metadata:
   name: &app startpunkt-user
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: app-template
 
+  interval: 30m
   values:
     controllers:
       main:
-        type: statefulset
         annotations:
           reloader.stakater.com/auto: "true"
 
+        type: statefulset
         containers:
           main:
             image:
@@ -61,10 +61,15 @@ spec:
                 subPath: application.yaml
                 readOnly: true
 
-    serviceAccount:
-      startpunkt-user: {}
 
     rbac:
+      bindings:
+        startpunkt:
+          type: ClusterRoleBinding
+          roleRef:
+            identifier: startpunkt
+          subjects:
+            - identifier: startpunkt-user
       roles:
         startpunkt:
           type: ClusterRole
@@ -78,10 +83,5 @@ spec:
             - apiGroups: ["gateway.networking.k8s.io"]
               verbs: ["get", "list", "watch"]
               resources: ["httproutes"]
-      bindings:
-        startpunkt:
-          type: ClusterRoleBinding
-          roleRef:
-            identifier: startpunkt
-          subjects:
-            - identifier: startpunkt-user
+    serviceAccount:
+      startpunkt-user: {}

--- a/kubernetes/apps/collab/swiparr/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/swiparr/app/helmrelease.yaml
@@ -5,18 +5,18 @@ kind: HelmRelease
 metadata:
   name: swiparr
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: app-template
 
+  interval: 30m
   values:
     controllers:
       main:
-        type: statefulset
-
         annotations:
           reloader.stakater.com/auto: "true"
+
+        type: statefulset
 
         containers:
           main:
@@ -27,13 +27,6 @@ spec:
               JELLYFIN_URL: "http://jellyfin.media:8096"
               JELLYFIN_USE_WATCHLIST: false
               USE_SECURE_COOKIES: true
-
-            resources:
-              requests:
-                cpu: 15m
-                memory: 300Mi
-              limits:
-                memory: 300Mi
 
             probes:
               liveness: &probes
@@ -49,6 +42,13 @@ spec:
                   failureThreshold: 3
               readiness: *probes
               startup: *probes
+            resources:
+              requests:
+                cpu: 15m
+                memory: 300Mi
+              limits:
+                memory: 300Mi
+
 
     service:
       main:
@@ -59,6 +59,12 @@ spec:
 
     route:
       main:
+        annotations:
+          glance/name: "Swiparr"
+          glance/show: "true"
+          glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/swiparr.png"
+          glance/id: "Collaboration"
+
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
         parentRefs:
@@ -69,12 +75,6 @@ spec:
           - backendRefs:
               - identifier: main
                 port: *httpPort
-        annotations:
-          glance/name: "Swiparr"
-          glance/show: "true"
-          glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/swiparr.png"
-          glance/id: "Collaboration"
-
     persistence:
       data:
         existingClaim: swiparr-data-pvc

--- a/kubernetes/apps/databases/cloudnative-pg/app/helmrelease.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/app/helmrelease.yaml
@@ -5,7 +5,6 @@ kind: HelmRelease
 metadata:
   name: cloudnative-pg
 spec:
-  interval: 30m
   chart:
     spec:
       chart: cloudnative-pg
@@ -14,6 +13,7 @@ spec:
         name: cloudnative-pg
       version: 0.28.0
 
+  interval: 30m
   values:
     crds:
       create: true

--- a/kubernetes/apps/downloads/jdownloader2/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/jdownloader2/app/helmrelease.yaml
@@ -36,17 +36,6 @@ spec:
               limits:
                 memory: 1G
 
-    persistence:
-      config:
-        existingClaim: jdownloader-config-pvc
-        globalMounts:
-          - path: /config
-
-      downloads:
-        existingClaim: jdownloader-downloads-pvc
-        globalMounts:
-          - path: /output
-
     service:
       main:
         controller: main
@@ -71,3 +60,14 @@ spec:
           - backendRefs:
               - identifier: main
                 port: *httpPort
+    persistence:
+      config:
+        existingClaim: jdownloader-config-pvc
+        globalMounts:
+          - path: /config
+
+      downloads:
+        existingClaim: jdownloader-downloads-pvc
+        globalMounts:
+          - path: /output
+

--- a/kubernetes/apps/downloads/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/prowlarr/app/helmrelease.yaml
@@ -15,11 +15,11 @@ spec:
       main:
         pod:
           securityContext:
-            runAsUser: 568
-            runAsGroup: 568
             fsGroup: 568
             fsGroupChangePolicy: "OnRootMismatch"
 
+            runAsGroup: 568
+            runAsUser: 568
         annotations:
           reloader.stakater.com/auto: "true"
         type: statefulset
@@ -52,10 +52,11 @@ spec:
                   - NET_ADMIN
                   - NET_RAW
 
-    persistence:
-      config:
-        existingClaim: prowlarr-config-pvc
-
+    service:
+      main:
+        ports:
+          http:
+            port: *httpPort
     route:
       main:
         annotations:
@@ -74,8 +75,7 @@ spec:
               - identifier: main
                 port: *httpPort
 
-    service:
-      main:
-        ports:
-          http:
-            port: *httpPort
+    persistence:
+      config:
+        existingClaim: prowlarr-config-pvc
+

--- a/kubernetes/apps/downloads/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/qbittorrent/app/helmrelease.yaml
@@ -13,14 +13,6 @@ spec:
     controllers:
       main:
         pod:
-          securityContext:
-            fsGroup: 1001
-            fsGroupChangePolicy: OnRootMismatch
-            runAsGroup: 1001
-            runAsUser: 1000
-            supplementalGroups:
-              - 100
-
           affinity:
             podAntiAffinity:
               requiredDuringSchedulingIgnoredDuringExecution:
@@ -30,6 +22,14 @@ spec:
                         operator: In
                         values: ["sabnzbd"]
                   topologyKey: kubernetes.io/hostname
+
+          securityContext:
+            fsGroup: 1001
+            fsGroupChangePolicy: OnRootMismatch
+            runAsGroup: 1001
+            runAsUser: 1000
+            supplementalGroups:
+              - 100
 
         annotations:
           reloader.stakater.com/auto: "true"
@@ -76,19 +76,23 @@ spec:
               capabilities: {drop: ["ALL"]}
               readOnlyRootFilesystem: true
 
-    persistence:
-      config:
-        existingClaim: qbittorrent-config-pvc
+    service:
+      app:
+        forceRename: "{{ .Release.Name }}"
+        ports:
+          http:
+            port: *httpPort
+        primary: true
 
-      downloads:
-        existingClaim: qbittorrent-downloads
-
-      incomplete:
-        existingClaim: qbittorrent-incomplete
-
-      media:
-        existingClaim: qbittorrent-media
-
+      bittorrent:
+        type: LoadBalancer
+        annotations:
+          lbipam.cilium.io/ips: 10.45.0.14 #SVC_QBITTORRENT_ADDR
+        externalTrafficPolicy: Local
+        ports:
+          bittorrent:
+            port: *port-bt
+            protocol: TCP
     route:
       app:
         annotations:
@@ -107,20 +111,16 @@ spec:
               - identifier: app
                 port: *httpPort
 
-    service:
-      app:
-        forceRename: "{{ .Release.Name }}"
-        ports:
-          http:
-            port: *httpPort
-        primary: true
+    persistence:
+      config:
+        existingClaim: qbittorrent-config-pvc
 
-      bittorrent:
-        type: LoadBalancer
-        annotations:
-          lbipam.cilium.io/ips: 10.45.0.14 #SVC_QBITTORRENT_ADDR
-        externalTrafficPolicy: Local
-        ports:
-          bittorrent:
-            port: *port-bt
-            protocol: TCP
+      downloads:
+        existingClaim: qbittorrent-downloads
+
+      incomplete:
+        existingClaim: qbittorrent-incomplete
+
+      media:
+        existingClaim: qbittorrent-media
+

--- a/kubernetes/apps/downloads/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/sabnzbd/app/helmrelease.yaml
@@ -76,19 +76,11 @@ spec:
               #readOnlyRootFilesystem: true
               #capabilities: {drop: ["ALL"]}
 
-    persistence:
-      complete:
-        existingClaim: sabnzbd-complete-pvc
-
-      config:
-        existingClaim: sabnzbd-config-pvc
-
-      downloads:
-        existingClaim: sabnzbd-downloads-pvc
-
-      incomplete:
-        existingClaim: sabnzbd-incomplete-pvc
-
+    service:
+      main:
+        ports:
+          http:
+            port: *httpPort
     route:
       main:
         annotations:
@@ -107,8 +99,16 @@ spec:
               - identifier: main
                 port: *httpPort
 
-    service:
-      main:
-        ports:
-          http:
-            port: *httpPort
+    persistence:
+      complete:
+        existingClaim: sabnzbd-complete-pvc
+
+      config:
+        existingClaim: sabnzbd-config-pvc
+
+      downloads:
+        existingClaim: sabnzbd-downloads-pvc
+
+      incomplete:
+        existingClaim: sabnzbd-incomplete-pvc
+

--- a/kubernetes/apps/downloads/slskd/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/slskd/app/helmrelease.yaml
@@ -70,24 +70,11 @@ spec:
               capabilities: {drop: ["ALL"]}
               readOnlyRootFilesystem: true
 
-    persistence:
-      config:
-        existingClaim: slskd-config-pvc
-
-      config-file:
-        type: configMap
-        name: slskd-configmap
-        globalMounts:
-          - path: /config/slskd.yml
-            subPath: slskd.yml
-            readOnly: true
-
-      media:
-        existingClaim: slskd-downloads-pvc
-
-      tmp:
-        type: emptyDir
-
+    service:
+      app:
+        ports:
+          http:
+            port: *httpPort
     route:
       main:
         annotations:
@@ -106,11 +93,24 @@ spec:
               - identifier: app
                 port: *httpPort
 
-    service:
-      app:
-        ports:
-          http:
-            port: *httpPort
+    persistence:
+      config:
+        existingClaim: slskd-config-pvc
+
+      config-file:
+        type: configMap
+        name: slskd-configmap
+        globalMounts:
+          - path: /config/slskd.yml
+            subPath: slskd.yml
+            readOnly: true
+
+      media:
+        existingClaim: slskd-downloads-pvc
+
+      tmp:
+        type: emptyDir
+
 
     serviceMonitor:
       app:

--- a/kubernetes/apps/external-secrets/external-secrets/app/helmrelease.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/app/helmrelease.yaml
@@ -19,13 +19,13 @@ kind: HelmRelease
 metadata:
   name: external-secrets
 spec:
-  interval: 1h
   chartRef:
     kind: OCIRepository
     name: external-secrets
   install:
     remediation:
       retries: -1
+  interval: 1h
   upgrade:
     cleanupOnFail: true
     remediation:

--- a/kubernetes/apps/external-secrets/onepassword-connect/app/helmrelease.yaml
+++ b/kubernetes/apps/external-secrets/onepassword-connect/app/helmrelease.yaml
@@ -5,10 +5,10 @@ kind: HelmRelease
 metadata:
   name: onepassword-connect
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: onepassword-connect
+  interval: 30m
   valuesFrom:
     - kind: ConfigMap
       name: onepassword-connect-values

--- a/kubernetes/apps/flux-system/flux-instance/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/helmrelease.yaml
@@ -19,13 +19,13 @@ kind: HelmRelease
 metadata:
   name: flux-instance
 spec:
-  interval: 1h
   chartRef:
     kind: OCIRepository
     name: flux-instance
   install:
     remediation:
       retries: -1
+  interval: 1h
   upgrade:
     cleanupOnFail: true
     remediation:

--- a/kubernetes/apps/flux-system/flux-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/flux-operator/app/helmrelease.yaml
@@ -12,7 +12,6 @@ spec:
   ref:
     tag: 0.47.0
   url: oci://ghcr.io/controlplaneio-fluxcd/charts/flux-operator
-
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
@@ -20,13 +19,13 @@ kind: HelmRelease
 metadata:
   name: flux-operator
 spec:
-  interval: 1h
   chartRef:
     kind: OCIRepository
     name: flux-operator
   install:
     remediation:
       retries: -1
+  interval: 1h
   upgrade:
     cleanupOnFail: true
     remediation:

--- a/kubernetes/apps/flux-system/kustomize-mutating-webhook/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/kustomize-mutating-webhook/app/helmrelease.yaml
@@ -5,41 +5,41 @@ kind: HelmRelease
 metadata:
   name: &app kustomize-mutating-webhook
 spec:
-  interval: 5m
   chart:
     spec:
-      version: 0.11.0
       chart: kustomize-mutating-webhook
+      interval: 5m
       sourceRef:
         kind: HelmRepository
         name: fluxcd-kustomize-mutating-webhook
-      interval: 5m
+      version: 0.11.0
+  driftDetection:
+    mode: enabled
   install:
-    timeout: 10m
-    replace: true
     crds: CreateReplace
     createNamespace: true
+    replace: true
     strategy:
       name: RetryOnFailure
       retryInterval: 5m
+    timeout: 10m
+  interval: 5m
+  maxHistory: 3
+  rollback:
+    cleanupOnFail: true
+    force: true
+    recreate: true
+  test:
+    enable: true
+  uninstall:
+    keepHistory: false
   upgrade:
+    cleanupOnFail: true
+    crds: CreateReplace
     remediation:
       remediateLastFailure: true
       retries: 3
       strategy: rollback
-    cleanupOnFail: true
-    crds: CreateReplace
-  test:
-    enable: true
-  rollback:
-    recreate: true
-    force: true
-    cleanupOnFail: true
-  uninstall:
-    keepHistory: false
-  driftDetection:
-    mode: enabled
-  maxHistory: 3
   valuesFrom:
     - kind: ConfigMap
       name: kustomization-mutating-webhook-values

--- a/kubernetes/apps/home/birdcam-youtube/app/helmrelease.yaml
+++ b/kubernetes/apps/home/birdcam-youtube/app/helmrelease.yaml
@@ -5,51 +5,32 @@ kind: HelmRelease
 metadata:
   name: &app birdcam-youtube
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: app-template
     namespace: flux-system
+  interval: 30m
   dependsOn:
     - name: frigate
       namespace: home
   values:
     controllers:
       main:
-        type: statefulset
-        replicas: 1
-
+        pod:
+          nodeSelector:
+            intel.feature.node.kubernetes.io/gpu: "true"
         annotations:
           reloader.stakater.com/auto: "true"
 
+        replicas: 1
+
+        type: statefulset
         containers:
           main:
             image:
               repository: ghcr.io/jrottenberg/ffmpeg
               tag: 8.1-vaapi@sha256:a697f6d7dcb3157cbe7e01a8bb6aeeaf9d7c1914adc19304c503c63769c11091
 
-            envFrom:
-              - secretRef:
-                  name: *app
-
-            env:
-              LIBVA_DRIVER_NAME: iHD
-
-            probes:
-              liveness: &probes
-                enabled: false
-                custom: true
-                spec:
-                  httpGet:
-                    host: frigate.home
-                    path: /api/version
-                    port: &unsecurePort 5000
-                  initialDelaySeconds: 0
-                  periodSeconds: 10
-                  timeoutSeconds: 7
-                  failureThreshold: 30
-              readiness: *probes
-              startup: *probes
 
             args:
               - "-re"         # Read input at native frame rate. This is equivalent to setting
@@ -67,6 +48,28 @@ spec:
               - "-v"
               - "verbose"
 
+            env:
+              LIBVA_DRIVER_NAME: iHD
+
+            envFrom:
+              - secretRef:
+                  name: *app
+
+            probes:
+              liveness: &probes
+                enabled: false
+                custom: true
+                spec:
+                  httpGet:
+                    host: frigate.home
+                    path: /api/version
+                    port: &unsecurePort 5000
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 7
+                  failureThreshold: 30
+              readiness: *probes
+              startup: *probes
             resources:
               requests:
                 gpu.intel.com/i915: "1"
@@ -79,6 +82,3 @@ spec:
             securityContext:
               privileged: true
 
-        pod:
-          nodeSelector:
-            intel.feature.node.kubernetes.io/gpu: "true"

--- a/kubernetes/apps/home/emqx/app/helmrelease.yaml
+++ b/kubernetes/apps/home/emqx/app/helmrelease.yaml
@@ -5,71 +5,21 @@ kind: HelmRelease
 metadata:
   name: emqx
 spec:
-  interval: 30m
   chart:
     spec:
       chart: emqx
       # renovate: registryUrl=https://repos.emqx.io/charts
-      version: 5.8.9
       sourceRef:
         kind: HelmRepository
         name: emqx-charts
 
+      version: 5.8.9
+  interval: 30m
   values:
-    priorityClassName: home-cluster-critical
-
-    image:
-      repository: public.ecr.aws/emqx/emqx
-
-    replicaCount: 3
-    recreatePods: true
-
-    emqxConfig:
-      EMQX_ALLOW_ANONYMOUS: "false"
-      EMQX_AUTH__MNESIA__PASSWORD_HASH: plain
-      EMQX_DASHBOARD__DEFAULT_USERNAME: admin
-
-    service:
-      type: LoadBalancer
-      annotations:
-        lbipam.cilium.io/ips: ${SVC_EMQX_ADDR}
-      externalTrafficPolicy: Cluster
-
-    metrics:
-      enabled: false
-
-    securityContext:
-      privileged: true
-      capabilities:
-        add:
-          - NET_ADMIN
-          - NET_RAW
-
-    probles:
-      startup:
-        enabled: false
-      readiness:
-        enabled: false
-      liveness:
-        enabled: false
-
-    persistence:
-      enabled: true
-      storageClassName: ceph-block
-      size: 1Gi
-
-    resources:
-      requests:
-        cpu: 30m
-        memory: 700M
-      limits:
-        memory: 700M
-
     affinity:
       podAntiAffinity:
         preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
+          - podAffinityTerm:
               labelSelector:
                 matchExpressions:
                   - key: app.kubernetes.io/name
@@ -77,16 +27,66 @@ spec:
                     values: ["emqx"]
               topologyKey: kubernetes.io/hostname
 
+            weight: 100
+    emqxConfig:
+      EMQX_ALLOW_ANONYMOUS: "false"
+      EMQX_AUTH__MNESIA__PASSWORD_HASH: plain
+      EMQX_DASHBOARD__DEFAULT_USERNAME: admin
+
+    image:
+      repository: public.ecr.aws/emqx/emqx
+
+    metrics:
+      enabled: false
+
+    persistence:
+      enabled: true
+      size: 1Gi
+
+      storageClassName: ceph-block
+    priorityClassName: home-cluster-critical
+
+    probles:
+      liveness:
+        enabled: false
+
+      readiness:
+        enabled: false
+      startup:
+        enabled: false
+    recreatePods: true
+
+    replicaCount: 3
+    resources:
+      limits:
+        memory: 700M
+
+      requests:
+        cpu: 30m
+        memory: 700M
+    securityContext:
+      capabilities:
+        add:
+          - NET_ADMIN
+          - NET_RAW
+
+      privileged: true
+    service:
+      annotations:
+        lbipam.cilium.io/ips: ${SVC_EMQX_ADDR}
+      externalTrafficPolicy: Cluster
+
+      type: LoadBalancer
   valuesFrom:
-    - targetPath: emqxConfig.EMQX_DASHBOARD__DEFAULT_PASSWORD
-      kind: Secret
+    - kind: Secret
       name: emqx
+      targetPath: emqxConfig.EMQX_DASHBOARD__DEFAULT_PASSWORD
       valuesKey: admin_password
-    - targetPath: emqxConfig.EMQX_AUTH__USER__1__USERNAME
-      kind: Secret
+    - kind: Secret
       name: emqx
+      targetPath: emqxConfig.EMQX_AUTH__USER__1__USERNAME
       valuesKey: user_1_username
-    - targetPath: emqxConfig.EMQX_AUTH__USER__1__PASSWORD
-      kind: Secret
+    - kind: Secret
       name: emqx
+      targetPath: emqxConfig.EMQX_AUTH__USER__1__PASSWORD
       valuesKey: user_1_password

--- a/kubernetes/apps/home/esphome/app/helmrelease.yaml
+++ b/kubernetes/apps/home/esphome/app/helmrelease.yaml
@@ -5,11 +5,11 @@ kind: HelmRelease
 metadata:
   name: esphome
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: app-template
 
+  interval: 30m
   values:
     defaultPodOptions:
       securityContext:
@@ -20,18 +20,7 @@ spec:
 
     controllers:
       main:
-        type: statefulset
-
-        annotations:
-          reloader.stakater.com/auto: "true"
-
         pod:
-          priorityClassName: home-cluster-critical
-
-          annotations:
-            k8s.v1.cni.cncf.io/networks: esphome-iot-static
-
-          # IOT VLAN (20)
           affinity:
             nodeAffinity:
               requiredDuringSchedulingIgnoredDuringExecution:
@@ -42,11 +31,30 @@ spec:
                         values:
                           - "true"
 
+          annotations:
+            k8s.v1.cni.cncf.io/networks: esphome-iot-static
+
+          # IOT VLAN (20)
+          priorityClassName: home-cluster-critical
+
+        annotations:
+          reloader.stakater.com/auto: "true"
+
+        type: statefulset
+
         containers:
           main:
             image:
               repository: ghcr.io/home-operations/esphome
               tag: 2026.4.0@sha256:f2903ef91562cd00ff7707cfff417565879ad4a147a27343bc9f4be1bfe849cd
+
+
+            env:
+              ESPHOME_DASHBOARD_USE_PING: true
+              ESPHOME__INSTANCE_NAME: ESPHome
+              ESPHOME__PORT: &httpPort 6052
+              ESPHOME__APPLICATION_URL: &host "{{ .Release.Name }}.${SECRET_DOMAIN}"
+              ESPHOME__LOG_LEVEL: info
 
             probes:
               liveness:
@@ -67,20 +75,12 @@ spec:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
               capabilities: {drop: ["ALL"], add: ["NET_RAW"]}
-
-            env:
-              ESPHOME_DASHBOARD_USE_PING: true
-              ESPHOME__INSTANCE_NAME: ESPHome
-              ESPHOME__PORT: &httpPort 6052
-              ESPHOME__APPLICATION_URL: &host "{{ .Release.Name }}.${SECRET_DOMAIN}"
-              ESPHOME__LOG_LEVEL: info
-
     service:
       main:
-        controller: main
         type: LoadBalancer
         annotations:
           lbipam.cilium.io/ips: ${SVC_ESPHOME_ADDR}
+        controller: main
         externalTrafficPolicy: Cluster
         ports:
           http:
@@ -88,6 +88,12 @@ spec:
 
     route:
       main:
+        annotations:
+          glance/name: "ESPHome"
+          glance/show: "true"
+          glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/esphome.png"
+          glance/id: "Home Automation"
+
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
         parentRefs:
@@ -98,25 +104,19 @@ spec:
           - backendRefs:
               - identifier: main
                 port: *httpPort
-        annotations:
-          glance/name: "ESPHome"
-          glance/show: "true"
-          glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/esphome.png"
-          glance/id: "Home Automation"
-
     persistence:
-      config:
-        existingClaim: esphome-config
-        globalMounts:
-          - path: /config
       buildcache:
-        suffix: buildcache
-        size: 50Gi
         accessMode: ReadWriteOnce
+        size: 50Gi
+        suffix: buildcache
         advancedMounts:
           main:
             main:
               - path: /cache
+      config:
+        existingClaim: esphome-config
+        globalMounts:
+          - path: /config
       tmpfs:
         type: emptyDir
         advancedMounts:

--- a/kubernetes/apps/home/esphome/code/helmrelease.yaml
+++ b/kubernetes/apps/home/esphome/code/helmrelease.yaml
@@ -5,11 +5,11 @@ kind: HelmRelease
 metadata:
   name: esphome-code
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: app-template
 
+  interval: 30m
   dependsOn:
     - name: esphome
       namespace: home
@@ -17,10 +17,17 @@ spec:
   values:
     controllers:
       main:
-        type: statefulset
+        pod:
+          securityContext:
+            fsGroup: 0
+            fsGroupChangePolicy: OnRootMismatch
 
+            runAsGroup: 0
+            runAsUser: 0
         annotations:
           reloader.stakater.com/auto: "true"
+
+        type: statefulset
 
         containers:
           main:
@@ -46,13 +53,6 @@ spec:
               limits:
                 memory: 120M
 
-        pod:
-          securityContext:
-            runAsUser: 0
-            runAsGroup: 0
-            fsGroup: 0
-            fsGroupChangePolicy: OnRootMismatch
-
     service:
       main:
         controller: main
@@ -62,6 +62,12 @@ spec:
 
     route:
       main:
+        annotations:
+          glance/name: "ESPHome Code"
+          glance/show: "true"
+          glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/vscode.png"
+          glance/id: "Home Automation"
+
         hostnames:
           - "esphome-code.${SECRET_DOMAIN}"
         parentRefs:
@@ -72,12 +78,6 @@ spec:
           - backendRefs:
               - identifier: main
                 port: *httpPort
-        annotations:
-          glance/name: "ESPHome Code"
-          glance/show: "true"
-          glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/vscode.png"
-          glance/id: "Home Automation"
-
     persistence:
       config:
         existingClaim: esphome-config

--- a/kubernetes/apps/home/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/home/frigate/app/helmrelease.yaml
@@ -5,22 +5,15 @@ kind: HelmRelease
 metadata:
   name: frigate
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: app-template
 
+  interval: 30m
   values:
     controllers:
       main:
-        type: statefulset
-
-        annotations:
-          reloader.stakater.com/auto: "true"
-
         pod:
-          priorityClassName: home-cluster-critical
-
           annotations:
             k8s.v1.cni.cncf.io/networks: frigate-security-static
 
@@ -28,6 +21,13 @@ spec:
             google.feature.node.kubernetes.io/coral-usb: "true"
             intel.feature.node.kubernetes.io/gpu: "true"
             node.network/vlan-security: "true"
+
+          priorityClassName: home-cluster-critical
+
+        annotations:
+          reloader.stakater.com/auto: "true"
+
+        type: statefulset
 
         containers:
           main:
@@ -69,13 +69,6 @@ spec:
                   timeoutSeconds: 1
                   failureThreshold: 30
 
-            securityContext:
-              privileged: true
-              capabilities:
-                add:
-                  - NET_ADMIN
-                  - NET_RAW
-
             resources:
               requests:
                 gpu.intel.com/i915: "1"
@@ -84,6 +77,13 @@ spec:
               limits:
                 gpu.intel.com/i915: "1"
                 memory: 12Gi
+
+            securityContext:
+              privileged: true
+              capabilities:
+                add:
+                  - NET_ADMIN
+                  - NET_RAW
 
     service:
       main:
@@ -111,16 +111,6 @@ spec:
 
     route:
       main:
-        hostnames:
-          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-        parentRefs:
-          - name: internal
-            namespace: network
-            sectionName: https
-        rules:
-          - backendRefs:
-              - identifier: main
-                port: *securePort
         annotations:
           startpunkt.ullberg.us/enable: "true"
           startpunkt.ullberg.us/name: "Security Cameras"
@@ -131,34 +121,44 @@ spec:
           glance/show: "true"
           glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/frigate.png"
           glance/id: "Security"
+        hostnames:
+          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: main
+                port: *securePort
     persistence:
-      config:
-        enabled: true
-        existingClaim: frigate-config-pvc
-        globalMounts:
-          - path: /config
-
-      clips:
-        existingClaim: frigate-clips-pvc
-        globalMounts:
-          - path: /media/frigate/clips
-
-      recordings:
-        existingClaim: frigate-recordings-pvc
-        globalMounts:
-          - path: /media/frigate/recordings
-
-      exports:
-        existingClaim: frigate-exports-pvc
-        globalMounts:
-          - path: /media/frigate/exports
-
       cache:
         type: emptyDir
         medium: Memory
         sizeLimit: 2Gi
         globalMounts:
           - path: /dev/shm
+
+      clips:
+        existingClaim: frigate-clips-pvc
+        globalMounts:
+          - path: /media/frigate/clips
+
+      config:
+        enabled: true
+        existingClaim: frigate-config-pvc
+        globalMounts:
+          - path: /config
+
+      exports:
+        existingClaim: frigate-exports-pvc
+        globalMounts:
+          - path: /media/frigate/exports
+
+      recordings:
+        existingClaim: frigate-recordings-pvc
+        globalMounts:
+          - path: /media/frigate/recordings
 
       usb:
         type: hostPath

--- a/kubernetes/apps/home/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/home/home-assistant/app/helmrelease.yaml
@@ -5,18 +5,48 @@ kind: HelmRelease
 metadata:
   name: &app home-assistant
 spec:
-  interval: 1h
   chartRef:
     kind: OCIRepository
     name: app-template
 
+  interval: 1h
   values:
     controllers:
       main:
-        type: statefulset
+        pod:
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: node.network/vlan-iot
+                        operator: In
+                        values:
+                          - "true"
+                      - key: node.network/vlan-security
+                        operator: In
+                        values:
+                          - "true"
+
+          annotations:
+            k8s.v1.cni.cncf.io/networks: hass-iot-static, hass-security-static
+
+          # IOT VLAN (20), SECURITY VLAN (40)
+          priorityClassName: home-cluster-critical
+
+          securityContext:
+            fsGroup: 568
+            fsGroupChangePolicy: OnRootMismatch
+            runAsGroup: 568
+            runAsUser: 568
+            supplementalGroups:
+              - 100
+              - 1010
 
         annotations:
           reloader.stakater.com/auto: "true"
+
+        type: statefulset
 
         initContainers:
           init-db:
@@ -54,42 +84,12 @@ spec:
                 memory: 1.4G
               limits:
                 memory: 1.4G
-        pod:
-          priorityClassName: home-cluster-critical
-
-          securityContext:
-            runAsUser: 568
-            runAsGroup: 568
-            fsGroup: 568
-            fsGroupChangePolicy: OnRootMismatch
-            supplementalGroups:
-              - 100
-              - 1010
-
-          annotations:
-            k8s.v1.cni.cncf.io/networks: hass-iot-static, hass-security-static
-
-          # IOT VLAN (20), SECURITY VLAN (40)
-          affinity:
-            nodeAffinity:
-              requiredDuringSchedulingIgnoredDuringExecution:
-                nodeSelectorTerms:
-                  - matchExpressions:
-                      - key: node.network/vlan-iot
-                        operator: In
-                        values:
-                          - "true"
-                      - key: node.network/vlan-security
-                        operator: In
-                        values:
-                          - "true"
-
     service:
       main:
-        controller: main
         type: LoadBalancer
         annotations:
           lbipam.cilium.io/ips: ${SVC_HOME_ASSISTANT_ADDR}
+        controller: main
         externalTrafficPolicy: Cluster
         ports:
           http:
@@ -97,16 +97,6 @@ spec:
 
     route:
       main:
-        hostnames:
-          - "hass.${SECRET_DOMAIN}"
-        parentRefs:
-          - name: external
-            namespace: network
-            sectionName: https
-        rules:
-          - backendRefs:
-              - identifier: main
-                port: *httpPort
         annotations:
           glance/name: "Home Assistant"
           glance/show: "true"
@@ -118,16 +108,21 @@ spec:
           startpunkt.ullberg.us/name: "Home Assistant"
           startpunkt.ullberg.us/instance: "user"
 
+        hostnames:
+          - "hass.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: external
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: main
+                port: *httpPort
     persistence:
       config:
         existingClaim: home-assistant-config-pvc
         globalMounts:
           - path: /config
-
-      media:
-        existingClaim: home-assistant-media-pvc
-        globalMounts:
-          - path: /media
 
       config-cache:
         accessMode: ReadWriteOnce
@@ -137,6 +132,11 @@ spec:
           main:
             main:
               - path: /config/.venv
+
+      media:
+        existingClaim: home-assistant-media-pvc
+        globalMounts:
+          - path: /media
 
       tmp:
         type: emptyDir

--- a/kubernetes/apps/home/home-assistant/code/helmrelease.yaml
+++ b/kubernetes/apps/home/home-assistant/code/helmrelease.yaml
@@ -5,11 +5,11 @@ kind: HelmRelease
 metadata:
   name: home-assistant-code
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: app-template
 
+  interval: 30m
   dependsOn:
     - name: home-assistant
       namespace: home
@@ -17,10 +17,17 @@ spec:
   values:
     controllers:
       main:
-        type: statefulset
+        pod:
+          securityContext:
+            fsGroup: 0
+            fsGroupChangePolicy: OnRootMismatch
 
+            runAsGroup: 0
+            runAsUser: 0
         annotations:
           reloader.stakater.com/auto: "true"
+
+        type: statefulset
 
         containers:
           main:
@@ -46,13 +53,6 @@ spec:
               limits:
                 memory: 640M
 
-        pod:
-          securityContext:
-            runAsUser: 0
-            runAsGroup: 0
-            fsGroup: 0
-            fsGroupChangePolicy: OnRootMismatch
-
     service:
       main:
         controller: main
@@ -62,6 +62,12 @@ spec:
 
     route:
       main:
+        annotations:
+          glance/name: "Home Assistant Code"
+          glance/show: "true"
+          glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/vscode.png"
+          glance/id: "Home Automation"
+
         hostnames:
           - "hass-code.${SECRET_DOMAIN}"
         parentRefs:
@@ -72,12 +78,6 @@ spec:
           - backendRefs:
               - identifier: main
                 port: *httpPort
-        annotations:
-          glance/name: "Home Assistant Code"
-          glance/show: "true"
-          glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/vscode.png"
-          glance/id: "Home Automation"
-
     persistence:
       config:
         existingClaim: home-assistant-config-pvc

--- a/kubernetes/apps/home/matter-server/app/helmrelease.yaml
+++ b/kubernetes/apps/home/matter-server/app/helmrelease.yaml
@@ -5,12 +5,12 @@ kind: HelmRelease
 metadata:
   name: &app matter-server
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: app-template
     namespace: flux-system
 
+  interval: 30m
   dependsOn: []
 
   install:
@@ -25,16 +25,7 @@ spec:
   values:
     controllers:
       *app :
-        annotations:
-          reloader.stakater.com/auto: "true"
-
         pod:
-          priorityClassName: home-cluster-critical
-
-          annotations:
-            k8s.v1.cni.cncf.io/networks: matter-server-iot-static
-
-          # IOT VLAN (20)
           affinity:
             nodeAffinity:
               requiredDuringSchedulingIgnoredDuringExecution:
@@ -45,14 +36,23 @@ spec:
                         values:
                           - "true"
 
+          annotations:
+            k8s.v1.cni.cncf.io/networks: matter-server-iot-static
+
+          # IOT VLAN (20)
+          priorityClassName: home-cluster-critical
+
           securityContext:
-            runAsUser: 0                      # Must be run as root user
-            runAsGroup: 0
-            runAsNonRoot: false               # Must be run as root user
             fsGroup: 0
             fsGroupChangePolicy: "OnRootMismatch"
+            runAsGroup: 0
+            runAsNonRoot: false               # Must be run as root user
+            runAsUser: 0                      # Must be run as root user
             supplementalGroups:
               - 34
+
+        annotations:
+          reloader.stakater.com/auto: "true"
 
         containers:
           *app :
@@ -61,17 +61,17 @@ spec:
               tag: 8.1.0@sha256:170aa093ce91c76cde4cc390918307590f0f5558fcec93f913af3cb019e6562a
               pullPolicy: IfNotPresent
 
-            env:
-              MATTER_SERVER__INSTANCE_NAME: *app
-              MATTER_SERVER__PORT: &httpPort 5580
-              MATTER_SERVER__APPLICATION_URL: &host "{{ .Release.Name }}.${SECRET_DOMAIN}"
-              MATTER_SERVER__LOG_LEVEL: info
-    
             args:
               - --storage-path=/data
               - --primary-interface=net1
               - --log-level=debug
               - --log-level-sdk=info
+
+            env:
+              MATTER_SERVER__INSTANCE_NAME: *app
+              MATTER_SERVER__PORT: &httpPort 5580
+              MATTER_SERVER__APPLICATION_URL: &host "{{ .Release.Name }}.${SECRET_DOMAIN}"
+              MATTER_SERVER__LOG_LEVEL: info
 
             resources:
               requests:
@@ -82,10 +82,10 @@ spec:
 
     service:
       *app :
-        controller: *app
+        type: LoadBalancer
         annotations:
           lbipam.cilium.io/ips: ${SVC_MATTER_ADDR}
-        type: LoadBalancer
+        controller: *app
         externalTrafficPolicy: Local
         ports:
           http:
@@ -93,6 +93,12 @@ spec:
 
     route:
       main:
+        annotations:
+          glance/name: "Matter Server"
+          glance/show: "true"
+          glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/matter.png"
+          glance/id: "Home Automation"
+
         hostnames:
           - "matter.${SECRET_DOMAIN}"
         parentRefs:
@@ -103,12 +109,6 @@ spec:
           - backendRefs:
               - identifier: *app
                 port: *httpPort
-        annotations:
-          glance/name: "Matter Server"
-          glance/show: "true"
-          glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/matter.png"
-          glance/id: "Home Automation"
-
     persistence:
       data:
         existingClaim: matter-server-data-pvc

--- a/kubernetes/apps/home/netbox/app/helmrelease.yaml
+++ b/kubernetes/apps/home/netbox/app/helmrelease.yaml
@@ -4,79 +4,44 @@ kind: HelmRelease
 metadata:
   name: &app netbox
 spec:
-  interval: 1h
   chartRef:
     kind: OCIRepository
     name: netbox
+  interval: 1h
   values:
-    commonLabels:
-      postgres: "true"
-      teleport: enabled
-    commonAnnotations:
-      reloader.stakater.com/auto: "true"
-    initContainers:
-      - name: init-db
-        image: ghcr.io/home-operations/postgres-init:18
-        envFrom:
-          - secretRef:
-              name: &secret netbox-secret
-    superuser:
-      existingSecret: *secret
     admins:
       - ["rwlove", "server.netbox@${SECRET_DOMAIN}"]
-    loginRequired: false
-    timeZone: ${TIMEZONE}
-    dateFormat: "j. F, Y"
-    shortDateFormat: "j.m.Y"
-    timeFormat: "G:i"
-    shortTimeFormat: "H:i:s"
-    dateTimeFormat: "j. F, Y g:i a"
-    shortDateTimeFormat: "j.m.Y H:i"
-    storages:
-      default:
-        BACKEND: "storages.backends.s3.S3Storage"
-        OPTIONS:
-          bucket_name: "netbox"
-          endpoint_url: "http://garage.storage.svc.cluster.local:3900"
-          region_name: "us-east-1"
-    existingSecret: *secret
-    metricsEnabled: true
-    postgresql:
-      enabled: false
-    valkey:
-      enabled: false
-    tasksDatabase:
-      host: dragonfly.databases.svc.cluster.local
-      database: 3
-      #existingSecretName: "netbox-secret"
-      #existingSecretKey: "REDIS_PASSWORD"
     cachingDatabase:
-      host: dragonfly.databases.svc.cluster.local
       database: 4
       #existingSecretName: "netbox-secret"
       #existingSecretKey: "REDIS_PASSWORD"
-    externalDatabase:
-      host: postgres-netbox-rw.databases.svc.cluster.local
-      port: 5432
-      database: netbox
-      username: netbox
-      existingSecretName: "netbox-secret"
-      existingSecretKey: "NETBOX_PG_PASS"
-    email:
-      server: smtp-relay.home.svc.cluster.local
-      port: 2525
-      from: netbox@${SECRET_DOMAIN}
+      host: dragonfly.databases.svc.cluster.local
+    commonAnnotations:
+      reloader.stakater.com/auto: "true"
+    commonLabels:
+      postgres: "true"
+      teleport: enabled
     csrf:
       trustedOrigins: ["https://netbox.${SECRET_DOMAIN}"]
-    persistence:
+    dateFormat: "j. F, Y"
+    dateTimeFormat: "j. F, Y g:i a"
+    email:
+      from: netbox@${SECRET_DOMAIN}
+      port: 2525
+      server: smtp-relay.home.svc.cluster.local
+    existingSecret: &secret netbox-secret
+    externalDatabase:
+      database: netbox
+      existingSecretKey: "NETBOX_PG_PASS"
+      existingSecretName: "netbox-secret"
+      host: postgres-netbox-rw.databases.svc.cluster.local
+      port: 5432
+      username: netbox
+    extraConfig:
+      - secret:
+          secretName: *secret
+    housekeeping:
       enabled: false
-    readinessProbe:
-      enabled: false
-    livenessProbe:
-      enabled: false
-    service:
-      annotations:
-        teleport.dev/name: *app
     httpRoute:
       enabled: true
       hostnames:
@@ -84,19 +49,54 @@ spec:
       parentRefs:
         - name: internal
           namespace: network
-    extraConfig:
-      - secret:
-          secretName: *secret
-    housekeeping:
+    initContainers:
+      - envFrom:
+          - secretRef:
+              name: *secret
+        image: ghcr.io/home-operations/postgres-init:18
+        name: init-db
+    livenessProbe:
+      enabled: false
+    loginRequired: false
+    metricsEnabled: true
+    persistence:
+      enabled: false
+    postgresql:
+      enabled: false
+    readinessProbe:
+      enabled: false
+    service:
+      annotations:
+        teleport.dev/name: *app
+    shortDateFormat: "j.m.Y"
+    shortDateTimeFormat: "j.m.Y H:i"
+    shortTimeFormat: "H:i:s"
+    storages:
+      default:
+        BACKEND: "storages.backends.s3.S3Storage"
+        OPTIONS:
+          bucket_name: "netbox"
+          endpoint_url: "http://garage.storage.svc.cluster.local:3900"
+          region_name: "us-east-1"
+    superuser:
+      existingSecret: *secret
+    tasksDatabase:
+      database: 3
+      #existingSecretName: "netbox-secret"
+      #existingSecretKey: "REDIS_PASSWORD"
+      host: dragonfly.databases.svc.cluster.local
+    timeFormat: "G:i"
+    timeZone: ${TIMEZONE}
+    valkey:
       enabled: false
     worker:
       enabled: false
   valuesFrom:
-    - targetPath: storages.default.OPTIONS.access_key
-      kind: Secret
+    - kind: Secret
       name: *secret
+      targetPath: storages.default.OPTIONS.access_key
       valuesKey: AWS_ACCESS_KEY_ID
-    - targetPath: storages.default.OPTIONS.secret_key
-      kind: Secret
+    - kind: Secret
       name: *secret
+      targetPath: storages.default.OPTIONS.secret_key
       valuesKey: AWS_SECRET_ACCESS_KEY

--- a/kubernetes/apps/home/node-red/app/helmrelease.yaml
+++ b/kubernetes/apps/home/node-red/app/helmrelease.yaml
@@ -5,29 +5,15 @@ kind: HelmRelease
 metadata:
   name: &app node-red
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: app-template
 
+  interval: 30m
   values:
     controllers:
       main:
-        type: statefulset
-        annotations:
-          reloader.stakater.com/auto: "true"
-
         pod:
-          securityContext:
-            runAsUser: 568
-            runAsGroup: 568
-            fsGroup: 568
-            fsGroupChangePolicy: "OnRootMismatch"
-
-          annotations:
-            k8s.v1.cni.cncf.io/networks: node-red-iot-static
-
-          # IOT VLAN (20)
           affinity:
             nodeAffinity:
               requiredDuringSchedulingIgnoredDuringExecution:
@@ -38,6 +24,20 @@ spec:
                         values:
                           - "true"
 
+          annotations:
+            k8s.v1.cni.cncf.io/networks: node-red-iot-static
+
+          # IOT VLAN (20)
+          securityContext:
+            fsGroup: 568
+            fsGroupChangePolicy: "OnRootMismatch"
+
+            runAsGroup: 568
+            runAsUser: 568
+        annotations:
+          reloader.stakater.com/auto: "true"
+
+        type: statefulset
         containers:
           main:
             image:
@@ -52,19 +52,19 @@ spec:
               NODE_RED__APPLICATION_URL: &host "{{ .Release.Name }}.${SECRET_DOMAIN}"
               NODE_RED__LOG_LEVEL: info
 
-            securityContext:
-              privileged: true
-              capabilities:
-                add:
-                  - NET_ADMIN
-                  - NET_RAW
-
             resources:
               requests:
                 cpu: 35m
                 memory: 200M
               limits:
                 memory: 200M
+
+            securityContext:
+              privileged: true
+              capabilities:
+                add:
+                  - NET_ADMIN
+                  - NET_RAW
 
     service:
       main:
@@ -75,6 +75,11 @@ spec:
 
     route:
       main:
+        annotations:
+          glance/name: "Node Red"
+          glance/show: "true"
+          glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/node-red.png"
+          glance/id: "Home Automation"
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
         parentRefs:
@@ -85,12 +90,6 @@ spec:
           - backendRefs:
               - identifier: main
                 port: *httpPort
-        annotations:
-          glance/name: "Node Red"
-          glance/show: "true"
-          glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/node-red.png"
-          glance/id: "Home Automation"
-          
     persistence:
       data:
         existingClaim: node-red-data-pvc

--- a/kubernetes/apps/home/smtp-relay/app/helmrelease.yaml
+++ b/kubernetes/apps/home/smtp-relay/app/helmrelease.yaml
@@ -5,20 +5,36 @@ kind: HelmRelease
 metadata:
   name: &app smtp-relay
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: app-template
 
+  interval: 30m
   values:
     controllers:
       main:
-        type: statefulset
-        replicas: 1
+
+        pod:
+          securityContext:
+            fsGroup: 568
+            fsGroupChangePolicy: OnRootMismatch
+
+            runAsGroup: 568
+            runAsUser: 568
+          topologySpreadConstraints:
+            - maxSkew: 1
+              topologyKey: kubernetes.io/hostname
+              whenUnsatisfiable: DoNotSchedule
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: *app
 
         annotations:
           reloader.stakater.com/auto: "true"
 
+        replicas: 1
+
+        type: statefulset
         containers:
           main:
             image:
@@ -49,22 +65,6 @@ spec:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
               capabilities: {drop: ["ALL"]}
-
-        pod:
-          securityContext:
-            runAsUser: 568
-            runAsGroup: 568
-            fsGroup: 568
-            fsGroupChangePolicy: OnRootMismatch
-
-          topologySpreadConstraints:
-            - maxSkew: 1
-              topologyKey: kubernetes.io/hostname
-              whenUnsatisfiable: DoNotSchedule
-              labelSelector:
-                matchLabels:
-                  app.kubernetes.io/name: *app
-
     service:
       main:
         type: LoadBalancer
@@ -76,14 +76,10 @@ spec:
             port: *metricsPort
           smtp:
             port: *port
-
-    serviceMonitor:
-      main:
-        serviceName: *app
-        endpoints:
-          - port: metrics
-
     persistence:
+      cache:
+        type: emptyDir
+        medium: Memory
       config:
         type: configMap
         name: *app
@@ -92,6 +88,10 @@ spec:
             subPath: maddy.conf
             readOnly: true
 
-      cache:
-        type: emptyDir
-        medium: Memory
+
+    serviceMonitor:
+      main:
+        serviceName: *app
+        endpoints:
+          - port: metrics
+

--- a/kubernetes/apps/home/wyoming-services/app/helmrelease.yaml
+++ b/kubernetes/apps/home/wyoming-services/app/helmrelease.yaml
@@ -5,15 +5,33 @@ kind: HelmRelease
 metadata:
   name: wyoming-services
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: app-template
 
+  interval: 30m
   values:
     controllers:
-      piper:
+      openwakeword:
+        annotations:
+          reloader.stakater.com/auto: "true"
+
         type: statefulset
+
+        containers:
+          main:
+            image:
+              repository: docker.io/rhasspy/wyoming-openwakeword
+              tag: 2.1.0
+            args:
+              - --preload-model
+              - "ok_nabu"
+              - --custom-model-dir
+              - /custom
+
+      piper:
+        annotations:
+          reloader.stakater.com/auto: "true"
 
         statefulset:
           volumeClaimTemplates:
@@ -24,8 +42,7 @@ spec:
               globalMounts:
                 - path: /data
 
-        annotations:
-          reloader.stakater.com/auto: "true"
+        type: statefulset
 
         containers:
           main:
@@ -44,7 +61,8 @@ spec:
                 memory: 600Mi
 
       whisper:
-        type: statefulset
+        annotations:
+          reloader.stakater.com/auto: "true"
 
         statefulset:
           volumeClaimTemplates:
@@ -55,8 +73,7 @@ spec:
               globalMounts:
                 - path: /data
 
-        annotations:
-          reloader.stakater.com/auto: "true"
+        type: statefulset
 
         containers:
           main:
@@ -75,24 +92,16 @@ spec:
               limits:
                 memory: 2G
 
-      openwakeword:
-        type: statefulset
-
-        annotations:
-          reloader.stakater.com/auto: "true"
-
-        containers:
-          main:
-            image:
-              repository: docker.io/rhasspy/wyoming-openwakeword
-              tag: 2.1.0
-            args:
-              - --preload-model
-              - "ok_nabu"
-              - --custom-model-dir
-              - /custom
-
     service:
+      openwakeword:
+        type: LoadBalancer
+        annotations:
+          lbipam.cilium.io/ips: ${SVC_WYOMING_WAKEWORD_ADDR}
+        controller: openwakeword
+        ports:
+          http:
+            port: 10400
+
       piper:
         type: LoadBalancer
         annotations:
@@ -104,22 +113,13 @@ spec:
 
       whisper:
         type: LoadBalancer
-        controller: whisper
         annotations:
           lbipam.cilium.io/ips: ${SVC_WYOMING_WHISPER_ADDR}
+        controller: whisper
         ports:
           http:
             port: 10300
             protocol: TCP
-
-      openwakeword:
-        type: LoadBalancer
-        controller: openwakeword
-        annotations:
-          lbipam.cilium.io/ips: ${SVC_WYOMING_WAKEWORD_ADDR}
-        ports:
-          http:
-            port: 10400
 
     persistence:
       openwakeword-config:

--- a/kubernetes/apps/home/zigbee2mqtt/app/helmrelease.yaml
+++ b/kubernetes/apps/home/zigbee2mqtt/app/helmrelease.yaml
@@ -5,22 +5,15 @@ kind: HelmRelease
 metadata:
   name: zigbee2mqtt
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: app-template
 
+  interval: 30m
   values:
     controllers:
       main:
-        type: statefulset
-
-        annotations:
-          reloader.stakater.com/auto: "true"
-
         pod:
-          priorityClassName: home-cluster-critical
-
           affinity:
             nodeAffinity:
               requiredDuringSchedulingIgnoredDuringExecution:
@@ -33,6 +26,13 @@ spec:
 
           nodeSelector:
             zigbee.feature.node.kubernetes.io/sonoff: "true"
+
+          priorityClassName: home-cluster-critical
+
+        annotations:
+          reloader.stakater.com/auto: "true"
+
+        type: statefulset
 
         containers:
           main:
@@ -80,15 +80,15 @@ spec:
                   failureThreshold: 30
                   periodSeconds: 10
 
-            securityContext:
-              privileged: true
-
             resources:
               requests:
                 cpu: 23m
                 memory: 300M
               limits:
                 memory: 300M
+
+            securityContext:
+              privileged: true
 
     service:
       main:
@@ -101,19 +101,14 @@ spec:
             enabled: true
             port: 9000
 
-    serviceMonitor:
-      main:
-        serviceName: &app zigbee
-        enabled: true
-        endpoints:
-          - port: metrics
-            scheme: http
-            path: /metrics
-            interval: 1m
-            scrapeTimeout: 10s
-
     route:
       main:
+        annotations:
+          glance/name: "Zigbee 2 MQTT"
+          glance/show: "true"
+          glance/id: "Home Automation"
+          glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/zigbee2mqtt-light.png"
+
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
         parentRefs:
@@ -124,12 +119,6 @@ spec:
           - backendRefs:
               - identifier: main
                 port: *httpPort
-        annotations:
-          glance/name: "Zigbee 2 MQTT"
-          glance/show: "true"
-          glance/id: "Home Automation"
-          glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/zigbee2mqtt-light.png"
-
     persistence:
       config:
         existingClaim: zigbee2mqtt-config-pvc
@@ -142,3 +131,14 @@ spec:
         hostPathType: CharDevice
         globalMounts:
           - path: *serialdevice
+    serviceMonitor:
+      main:
+        enabled: true
+        serviceName: &app zigbee
+        endpoints:
+          - port: metrics
+            scheme: http
+            path: /metrics
+            interval: 1m
+            scrapeTimeout: 10s
+

--- a/kubernetes/apps/home/zwave-js-ui/app/helmrelease.yaml
+++ b/kubernetes/apps/home/zwave-js-ui/app/helmrelease.yaml
@@ -5,18 +5,34 @@ kind: HelmRelease
 metadata:
   name: &app zwave-js-ui
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: app-template
 
+  interval: 30m
   values:
     controllers:
       main:
-        type: statefulset
+        pod:
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: nabu.feature.node.kubernetes.io/zwa2
+                        operator: In
+                        values:
+                          - "true"
+
+          nodeSelector:
+            nabu.feature.node.kubernetes.io/zwa2: "true"
+
+          priorityClassName: home-cluster-critical
+
         annotations:
           reloader.stakater.com/auto: "true"
 
+        type: statefulset
         containers:
           main:
             image:
@@ -39,9 +55,6 @@ spec:
               startup:
                 enabled: false
 
-            securityContext:
-              privileged: true
-
             resources:
               requests:
                 cpu: 50m
@@ -49,21 +62,8 @@ spec:
               limits:
                 memory: 746M
 
-        pod:
-          priorityClassName: home-cluster-critical
-
-          affinity:
-            nodeAffinity:
-              requiredDuringSchedulingIgnoredDuringExecution:
-                nodeSelectorTerms:
-                  - matchExpressions:
-                      - key: nabu.feature.node.kubernetes.io/zwa2
-                        operator: In
-                        values:
-                          - "true"
-
-          nodeSelector:
-            nabu.feature.node.kubernetes.io/zwa2: "true"
+            securityContext:
+              privileged: true
 
     service:
       main:
@@ -76,6 +76,12 @@ spec:
 
     route:
       main:
+        annotations:
+          glance/name: "ZWave JS UI"
+          glance/show: "true"
+          glance/id: "Home Automation"
+          glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/z-wave-js-ui.png"
+
         hostnames:
           - "zwave.${SECRET_DOMAIN}"
         parentRefs:
@@ -86,12 +92,6 @@ spec:
           - backendRefs:
               - identifier: main
                 port: *httpPort
-        annotations:
-          glance/name: "ZWave JS UI"
-          glance/show: "true"
-          glance/id: "Home Automation"
-          glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/z-wave-js-ui.png"
-
     persistence:
       config:
         existingClaim: zwavejs2mqtt-config-pvc

--- a/kubernetes/apps/istio-system/istio/app/base/helmrelease.yaml
+++ b/kubernetes/apps/istio-system/istio/app/base/helmrelease.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
@@ -6,10 +7,10 @@ spec:
   chart:
     spec:
       chart: base
-      version: 1.29.1
       sourceRef:
         kind: HelmRepository
         name: istio
+      version: 1.29.1
   interval: 5m
   values:
   # https://artifacthub.io/packages/helm/istio-official/base

--- a/kubernetes/apps/istio-system/istio/app/istiod/helmrelease.yaml
+++ b/kubernetes/apps/istio-system/istio/app/istiod/helmrelease.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
@@ -6,13 +7,13 @@ spec:
   chart:
     spec:
       chart: istiod
-      version: 1.24.2
       sourceRef:
         kind: HelmRepository
         name: istio
+      version: 1.24.2
   dependsOn:
-  - name: istio-base
-    namespace: istio-system
+    - name: istio-base
+      namespace: istio-system
   interval: 5m
   values:
   # https://artifacthub.io/packages/helm/istio-official/istiod

--- a/kubernetes/apps/istio-system/kiali/app/helmrelease.yaml
+++ b/kubernetes/apps/istio-system/kiali/app/helmrelease.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
@@ -6,10 +7,10 @@ spec:
   chart:
     spec:
       chart: kiali-operator
-      version: 2.24.0
       sourceRef:
         kind: HelmRepository
         name: kiali
+      version: 2.24.0
   interval: 5m
   values:
   # https://artifacthub.io/packages/olm/community-operators/kiali

--- a/kubernetes/apps/kuadrant/kuadrant-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/kuadrant/kuadrant-operator/app/helmrelease.yaml
@@ -8,10 +8,10 @@ spec:
   chart:
     spec:
       chart: kuadrant-operator
-      version: 1.1.0
       sourceRef:
         kind: HelmRepository
         name: kuadrant
+      version: 1.1.0
   interval: 30m
   values:
   # https://artifacthub.io/packages/helm/kuadrant/kuadrant-operator

--- a/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
@@ -24,38 +24,38 @@ spec:
     priorityClassName: system-cluster-critical
     replicaCount: 3
     servers:
-      - zones:
-          - zone: .
-            scheme: dns://
-            use_tcp: true
-        port: 53
-        plugins:
+      - plugins:
           - name: errors
-          - name: health
-            configBlock: |-
+          - configBlock: |-
               lameduck 5s
+            name: health
           - name: ready
-          - name: kubernetes
-            parameters: cluster.local in-addr.arpa ip6.arpa
-            configBlock: |-
+          - configBlock: |-
               pods verified
               fallthrough in-addr.arpa ip6.arpa
+            name: kubernetes
+            parameters: cluster.local in-addr.arpa ip6.arpa
           - name: autopath
             parameters: "@kubernetes"
           - name: forward
             parameters: . /etc/resolv.conf
-          - name: cache
-            configBlock: |-
+          - configBlock: |-
               prefetch 20
               serve_stale
+            name: cache
           - name: loop
           - name: reload
           - name: loadbalance
           - name: prometheus
             parameters: 0.0.0.0:9153
-          - name: log
-            configBlock: |-
+          - configBlock: |-
               class error
+            name: log
+        port: 53
+        zones:
+          - scheme: dns://
+            use_tcp: true
+            zone: .
     service:
       clusterIP: 10.43.0.10
       name: kube-dns

--- a/kubernetes/apps/kube-system/descheduler/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/descheduler/app/helmrelease.yaml
@@ -25,14 +25,14 @@ spec:
             - args:
                 metricsUtilization:
                   source: KubernetesMetrics
-                thresholds:
-                  cpu: 20
-                  memory: 20
-                  pods: 20
                 targetThresholds:
                   cpu: 50
                   memory: 50
                   pods: 50
+                thresholds:
+                  cpu: 20
+                  memory: 20
+                  pods: 20
               name: LowNodeUtilization
             - args:
                 excludeOwnerKinds:

--- a/kubernetes/apps/kube-system/k8tz/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/k8tz/app/helmrelease.yaml
@@ -18,15 +18,15 @@ spec:
   postRenderers:
     - kustomize:
         patches:
-          - target:
-              kind: Namespace
-              version: v1
-            patch: |-
+          - patch: |-
               $patch: delete
               apiVersion: v1
               kind: Namespace
               metadata:
                 name: not-used
+            target:
+              kind: Namespace
+              version: v1
   values:
     affinity:
       podAntiAffinity:

--- a/kubernetes/apps/kube-system/kubelet-csr-approver/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/kubelet-csr-approver/app/helmrelease.yaml
@@ -8,10 +8,10 @@ spec:
   chart:
     spec:
       chart: kubelet-csr-approver
-      version: 1.2.14
       sourceRef:
         kind: HelmRepository
         name: postfinance
+      version: 1.2.14
   interval: 30m
   values:
     priorityClassName: system-cluster-critical

--- a/kubernetes/apps/kube-system/metrics-server/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/metrics-server/app/helmrelease.yaml
@@ -21,12 +21,12 @@ spec:
       enabled: true
 
     resources:
-      requests:
-        cpu: 30m
-        memory: 140M
       limits:
         memory: 140M
 
+      requests:
+        cpu: 30m
+        memory: 140M
     securityContext:
       allowPrivilegeEscalation: true
       capabilities:

--- a/kubernetes/apps/kube-system/node-feature-discovery/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/node-feature-discovery/app/helmrelease.yaml
@@ -14,7 +14,6 @@ spec:
   url: oci://ghcr.io/home-operations/charts-mirror/node-feature-discovery
   verify:
     provider: cosign
-
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
@@ -35,12 +34,12 @@ spec:
   values:
     gc:
       resources:
-        requests:
-          cpu: 10m
-          memory: 128Mi
         limits:
           memory: 128Mi
 
+        requests:
+          cpu: 10m
+          memory: 128Mi
     prometheus:
       enable: true
 
@@ -53,8 +52,8 @@ spec:
             - usb
 
       resources:
+        limits:
+          memory: 86M
         requests:
           cpu: 20m
-          memory: 86M
-        limits:
           memory: 86M

--- a/kubernetes/apps/kube-system/node-problem-detector/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/node-problem-detector/app/helmrelease.yaml
@@ -5,16 +5,16 @@ kind: HelmRelease
 metadata:
   name: node-problem-detector
 spec:
-  interval: 30m
   chart:
     spec:
       # renovate: registryUrl=https://charts.deliveryhero.io/
       chart: node-problem-detector
-      version: 2.3.14
       sourceRef:
         kind: HelmRepository
         name: deliveryhero-charts
 
+      version: 2.3.14
+  interval: 30m
   values:
     image:
       repository: registry.k8s.io/node-problem-detector/node-problem-detector

--- a/kubernetes/apps/kube-system/nvidia-device-plugin/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/nvidia-device-plugin/app/helmrelease.yaml
@@ -5,21 +5,16 @@ kind: HelmRelease
 metadata:
   name: nvidia-device-plugin
 spec:
-  interval: 30m
   chart:
     spec:
       chart: nvidia-device-plugin
-      version: 0.19.0
       sourceRef:
         kind: HelmRepository
         name: nvidia
 
+      version: 0.19.0
+  interval: 30m
   values:
-    runtimeClassName: nvidia
-    nodeSelector:
-      nvidia.com/gpu.present: "true"
-    securityContext:
-      privileged: true
     config:
       map:
         default: |-
@@ -33,3 +28,8 @@ spec:
               resources:
                 - name: nvidia.com/gpu
                   replicas: 8
+    nodeSelector:
+      nvidia.com/gpu.present: "true"
+    runtimeClassName: nvidia
+    securityContext:
+      privileged: true

--- a/kubernetes/apps/kube-system/reflector/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/reflector/helmrelease.yaml
@@ -12,7 +12,6 @@ spec:
   ref:
     tag: 10.0.33
   url: oci://ghcr.io/emberstack/helm-charts/reflector
-
 ---
 # yaml-language-server: $schema=https://kube-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
@@ -20,13 +19,13 @@ kind: HelmRelease
 metadata:
   name: reflector
 spec:
-  interval: 1h
   chartRef:
     kind: OCIRepository
     name: reflector
   install:
     remediation:
       retries: -1
+  interval: 1h
   upgrade:
     cleanupOnFail: true
     remediation:

--- a/kubernetes/apps/kube-system/reloader/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/reloader/app/helmrelease.yaml
@@ -5,25 +5,25 @@ kind: HelmRelease
 metadata:
   name: reloader
 spec:
-  interval: 30m
   chart:
     spec:
       # renovate: registryUrl=https://stakater.github.io/stakater-charts
       chart: reloader
-      version: 2.2.11
       sourceRef:
         kind: HelmRepository
         name: stakater-charts
+      version: 2.2.11
+  interval: 30m
   values:
+    deployment:
+      resources:
+        limits:
+          memory: 256Mi
+        requests:
+          cpu: 5m
+          memory: 256Mi
     podMonitor:
       enabled: true
 
     reloadStrategy: annotations
 
-    deployment:
-      resources:
-        requests:
-          cpu: 5m
-          memory: 256Mi
-        limits:
-          memory: 256Mi

--- a/kubernetes/apps/kube-system/vpa/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/vpa/app/helmrelease.yaml
@@ -5,36 +5,36 @@ kind: HelmRelease
 metadata:
   name: vpa
 spec:
-  interval: 30m
   chart:
     spec:
       chart: vpa
       # renovate: registryUrl=https://charts.fairwinds.com/stable
-      version: 4.11.0
       sourceRef:
         kind: HelmRepository
         name: fairwinds-charts
 
+      version: 4.11.0
+  interval: 30m
   values:
+    admissionController:
+      enabled: false
     recommender:
       enabled: true
-
-      resources:
-        requests:
-          cpu: 20m
-          memory: 420M
-        limits:
-          memory: 420M
 
       extraArgs:
         pod-recommendation-min-cpu-millicores: 15
         pod-recommendation-min-memory-mb: 61
-        storage: prometheus
         prometheus-address: |-
           http://kube-prometheus-stack-prometheus.observability.svc.cluster.local:9090
 
+        storage: prometheus
+      resources:
+        limits:
+          memory: 420M
+
+        requests:
+          cpu: 20m
+          memory: 420M
     updater:
       enabled: false
 
-    admissionController:
-      enabled: false

--- a/kubernetes/apps/kube-system/zot/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/zot/app/helmrelease.yaml
@@ -5,27 +5,27 @@ kind: HelmRelease
 metadata:
   name: zot
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: app-template
 
+  interval: 30m
   values:
     controllers:
       main:
-        type: statefulset
+        pod:
+          securityContext:
+            fsGroup: 568
+            fsGroupChangePolicy: OnRootMismatch
+            runAsGroup: 568
+            runAsUser: 568
+            supplementalGroups:
+              - 65542 # gladius:external-services
 
         annotations:
           reloader.stakater.com/auto: "true"
 
-        pod:
-          securityContext:
-            runAsUser: 568
-            runAsGroup: 568
-            fsGroup: 568
-            fsGroupChangePolicy: OnRootMismatch
-            supplementalGroups:
-              - 65542 # gladius:external-services
+        type: statefulset
 
         containers:
           main:
@@ -54,6 +54,12 @@ spec:
 
     route:
       main:
+        annotations:
+          glance/name: "ZOT Registry"
+          glance/show: "true"
+          glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/zot-registry.png"
+          glance/id: "System"
+
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
         parentRefs:
@@ -64,12 +70,6 @@ spec:
           - backendRefs:
               - identifier: main
                 port: *httpPort
-        annotations:
-          glance/name: "ZOT Registry"
-          glance/show: "true"
-          glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/zot-registry.png"
-          glance/id: "System"
-
     persistence:
       config-file:
         type: configMap

--- a/kubernetes/apps/longhorn-system/longhorn/app/helmrelease.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn/app/helmrelease.yaml
@@ -5,21 +5,30 @@ kind: HelmRelease
 metadata:
   name: longhorn
 spec:
-  interval: 30m
   chart:
     spec:
       # renovate: registryUrl=https://charts.longhorn.io
       chart: longhorn
-      version: 1.11.1
       sourceRef:
         kind: HelmRepository
         name: longhorn-charts
+      version: 1.11.1
+  interval: 30m
   values:
     # preUpgradeChecker and image sections are workarounds until 1.11.1 is released
     # https://github.com/longhorn/longhorn/issues/12573
-    preUpgradeChecker:
-      jobEnabled: false
-      upgradeVersionCheck: false
+    defaultSettings:
+      backupTarget: "nfs://beast:/mnt/mass_storage/longhorn-backups"
+      createDefaultDiskLabeledNodes: true
+      defaultDataLocality: best-effort
+      defaultReplicaCount: 2
+      kubernetesClusterAutoscalerEnabled: true
+
+      replicaAutoBalance: best-effort
+      storageMinimalAvailablePercentage: 10
+    global:
+      imageRegistry: docker.io
+
     image:
       longhorn:
         instanceManager:
@@ -27,23 +36,14 @@ spec:
         manager:
           tag: v1.11.0-hotfix-1
 
-    global:
-      imageRegistry: docker.io
-
+    longhornManager:
+      securityContext:
+        privileged: true
     persistence:
       defaultClass: false
       defaultClassReplicaCount: 1
       reclaimPolicy: Retain
 
-    defaultSettings:
-      defaultReplicaCount: 2
-      replicaAutoBalance: best-effort
-      defaultDataLocality: best-effort
-      backupTarget: "nfs://beast:/mnt/mass_storage/longhorn-backups"
-      createDefaultDiskLabeledNodes: true
-      storageMinimalAvailablePercentage: 10
-      kubernetesClusterAutoscalerEnabled: true
-
-    longhornManager:
-      securityContext:
-        privileged: true
+    preUpgradeChecker:
+      jobEnabled: false
+      upgradeVersionCheck: false

--- a/kubernetes/apps/mcp-system/ha-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/ha-mcp/app/helmrelease.yaml
@@ -12,8 +12,6 @@ spec:
   values:
     controllers:
       ha-mcp:
-        annotations:
-          reloader.stakater.com/auto: "true"
         pod:
           annotations:
             sidecar.istio.io/inject: "true"
@@ -24,6 +22,8 @@ spec:
             runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
+        annotations:
+          reloader.stakater.com/auto: "true"
         containers:
           app:
             image:

--- a/kubernetes/apps/mcp-system/kubectl-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/kubectl-mcp/app/helmrelease.yaml
@@ -5,11 +5,16 @@ kind: HelmRelease
 metadata:
   name: kubectl-mcp
 spec:
-  interval: 1h
   chartRef:
     kind: OCIRepository
     name: app-template
+  interval: 1h
   values:
+    defaultPodOptions:
+      securityContext:
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
     controllers:
       kubectl-mcp:
         annotations:
@@ -28,11 +33,6 @@ spec:
                 memory: 256Mi
               limits:
                 memory: 512Mi
-    defaultPodOptions:
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 1000
     service:
       app:
         controller: kubectl-mcp
@@ -57,6 +57,21 @@ spec:
                 port: 8000
 
     rbac:
+      bindings:
+        kubectl-mcp-read-all:
+          type: ClusterRoleBinding
+          roleRef:
+            identifier: kubectl-mcp-read-all
+          subjects:
+            - identifier: kubectl-mcp
+              serviceAccount: kubectl-mcp
+        kubectl-mcp-write-restricted:
+          type: RoleBinding
+          roleRef:
+            identifier: kubectl-mcp-write-restricted
+          subjects:
+            - identifier: kubectl-mcp
+              serviceAccount: kubectl-mcp
       roles:
         kubectl-mcp-read-all:
           type: ClusterRole
@@ -112,20 +127,5 @@ spec:
             - apiGroups: ["apps"]
               resources: ["deployments"]
               verbs: ["patch", "update"]
-      bindings:
-        kubectl-mcp-read-all:
-          type: ClusterRoleBinding
-          roleRef:
-            identifier: kubectl-mcp-read-all
-          subjects:
-            - identifier: kubectl-mcp
-              serviceAccount: kubectl-mcp
-        kubectl-mcp-write-restricted:
-          type: RoleBinding
-          roleRef:
-            identifier: kubectl-mcp-write-restricted
-          subjects:
-            - identifier: kubectl-mcp
-              serviceAccount: kubectl-mcp
     serviceAccount:
       kubectl-mcp: {}

--- a/kubernetes/apps/mcp-system/mcp-gateway/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/mcp-gateway/app/helmrelease.yaml
@@ -28,16 +28,16 @@ spec:
     #  pullPolicy: IfNotPresent
 
     # Controller configuration
-    controller:
-      # Enable/disable controller deployment
-      enabled: true
-
-    # Broker configuration (applied to broker-router deployed by controller)
     broker:
       # How often (in seconds) the broker pings upstream MCP servers
       pollInterval: 60
 
     # Gateway configuration
+    controller:
+      # Enable/disable controller deployment
+      enabled: true
+
+    # Broker configuration (applied to broker-router deployed by controller)
     gateway:
       create: false
       #publicHost: "mcp-gateway.mcp.${SECRET_DOMAIN}" # required for MCPGatewayExtension

--- a/kubernetes/apps/mcp-system/prometheus-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/prometheus-mcp/app/helmrelease.yaml
@@ -5,11 +5,17 @@ kind: HelmRelease
 metadata:
   name: prometheus-mcp
 spec:
-  interval: 1h
   chartRef:
     kind: OCIRepository
     name: app-template
+  interval: 1h
   values:
+    defaultPodOptions:
+      securityContext:
+        runAsGroup: 1000
+
+        runAsNonRoot: true
+        runAsUser: 1000
     controllers:
       prometheus-mcp:
         annotations:
@@ -25,22 +31,16 @@ spec:
               PROMETHEUS_MCP_BIND_HOST: 0.0.0.0
               PROMETHEUS_MCP_BIND_PORT: "8080"
               PROMETHEUS_DISABLE_LINKS: true
-            securityContext:
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: true
-              capabilities: { drop: ["ALL"] }
             resources:
               requests:
                 cpu: 10m
                 memory: 128Mi
               limits:
                 memory: 256Mi
-    defaultPodOptions:
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 1000
-
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: {drop: ["ALL"]}
     service:
       app:
         controller: prometheus-mcp

--- a/kubernetes/apps/mcp-system/whoami/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/whoami/app/helmrelease.yaml
@@ -5,22 +5,22 @@ kind: HelmRelease
 metadata:
   name: &app whoami
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: app-template
 
+  interval: 30m
   values:
     controllers:
       main:
-        type: statefulset
+        pod:
+          annotations:
+            sidecar.istio.io/inject: "true"
 
         annotations:
           reloader.stakater.com/auto: "true"
 
-        pod:
-          annotations:
-            sidecar.istio.io/inject: "true"
+        type: statefulset
 
         containers:
           main:
@@ -44,6 +44,11 @@ spec:
 
     route:
       main:
+        annotations:
+          glance/name: "Who Am I?"
+          glance/show: "true"
+          #glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/cilium.png"
+          glance/id: "Network"
         hostnames:
           - "{{ .Release.Name }}.app.${SECRET_DOMAIN}"
         parentRefs:
@@ -54,8 +59,3 @@ spec:
           - backendRefs:
               - identifier: main
                 port: *httpPort
-        annotations:
-          glance/name: "Who Am I?"
-          glance/show: "true"
-          #glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/cilium.png"
-          glance/id: "Network"

--- a/kubernetes/apps/media/gonic/app/helmrelease.yaml
+++ b/kubernetes/apps/media/gonic/app/helmrelease.yaml
@@ -42,19 +42,6 @@ spec:
               limits:
                 memory: 800M
 
-    persistence:
-      data:
-        existingClaim: gonic-data-pvc
-
-      music:
-        existingClaim: gonic-music-pvc
-
-      playlist:
-        type: emptyDir
-
-      podcasts:
-        existingClaim: gonic-podcasts-pvc
-
     service:
       main:
         controller: main
@@ -79,3 +66,16 @@ spec:
           - backendRefs:
               - identifier: main
                 port: *httpPort
+    persistence:
+      data:
+        existingClaim: gonic-data-pvc
+
+      music:
+        existingClaim: gonic-music-pvc
+
+      playlist:
+        type: emptyDir
+
+      podcasts:
+        existingClaim: gonic-podcasts-pvc
+

--- a/kubernetes/apps/media/immich/app/helmrelease.yaml
+++ b/kubernetes/apps/media/immich/app/helmrelease.yaml
@@ -9,10 +9,10 @@ spec:
     spec:
       # renovate: registryUrl=https://immich-app.github.io/immich-charts
       chart: immich
-      version: 0.11.1
       sourceRef:
         kind: HelmRepository
         name: immich-charts
+      version: 0.11.1
   interval: 30m
 
   values:
@@ -21,55 +21,55 @@ spec:
         containers:
           main:
             env:
-              REDIS_HOSTNAME: dragonfly.databases.svc.cluster.local
-              REDIS_PORT: "6379"
-              REDIS_DBINDEX: "1"
+              DB_DATABASE_NAME: immich
+
+              DB_HOSTNAME: postgres-immich-rw.databases.svc.cluster.local
+              DB_PASSWORD: immich
+              DB_USERNAME: immich
               DISABLE_REVERSE_GEOCODING: "false"
-              REVERSE_GEOCODING_PRECISION: "2"
-              LOG_LEVEL: verbose
-              IMMICH_SERVER_URL: http://immich-server.media.svc.cluster.local:3001
-              PUBLIC_IMMICH_SERVER_URL: https://immich.${SECRET_DOMAIN}
               EXTERNAL_PATH: "/external"
               IMMICH_MACHINE_LEARNING_URL: http://immich-machine-learning.media:3003
               # IMMICH_WEB_URL: http://immich-web.media.svc.cluster.local:3000
+              IMMICH_SERVER_URL: http://immich-server.media.svc.cluster.local:3001
+              LOG_LEVEL: verbose
               OAUTH_ENABLED: "false"
               # OAUTH_ISSUER_URL: "https://auth.${SECRET_DOMAIN}/.well-known/openid-configuration"
               # OAUTH_CLIENT_ID: immich
               # OAUTH_CLIENT_SECRET: "${SECRET_IMMICH_OAUTH_CLIENT_SECRET}"
               # OAUTH_AUTO_REGISTER: "true"
               # OAUTH_BUTTON_TEXT: "Login with Authelia"
-              DB_HOSTNAME: postgres-immich-rw.databases.svc.cluster.local
-              DB_USERNAME: immich
-              DB_PASSWORD: immich
-              DB_DATABASE_NAME: immich
-
+              PUBLIC_IMMICH_SERVER_URL: https://immich.${SECRET_DOMAIN}
+              REDIS_DBINDEX: "1"
+              REDIS_HOSTNAME: dragonfly.databases.svc.cluster.local
+              REDIS_PORT: "6379"
+              REVERSE_GEOCODING_PRECISION: "2"
     image:
       # renovate: datasource=github-releases depName=immich-app/immich
       tag: "v2.3.1"
 
     immich:
-      metrics:
-        enabled: true
-      logLevel: "log"
       concurrency:
         backgroundTask: 10
-        smartSearch: 5
-        metadataExtraction: 10
         faceDetection: 5
+        library: 5
+        metadataExtraction: 10
+        migration: 5
         search: 5
         sidecar: 5
-        library: 5
-        migration: 5
+        smartSearch: 5
         thumbnailGeneration: 10
         videoConversion: 1
+      enablePasswordLogin: true
+      logLevel: "log"
       machineLearning:
         clipModelName: ViT-L-16-SigLIP-256__webli
         facialRecognitionModelName: antelopev2
-      enablePasswordLogin: true
+      metrics:
+        enabled: true
       oauth:
-        issuerUrl: https://auth.${SECRET_DOMAIN}
         clientId: immich
 
+        issuerUrl: https://auth.${SECRET_DOMAIN}
       persistence:
         library:
           existingClaim: immich-upload-pvc
@@ -79,34 +79,30 @@ spec:
         main:
           containers:
             main:
+              env:
+                # Nvidia
+                MACHINE_LEARNING_PRELOAD__CLIP: "ViT-L-16-SigLIP-256__webli"
+
+                NVIDIA_DRIVER_CAPABILITIES: "all"
+                NVIDIA_VISIBLE_DEVICES: "all"
               image:
                 repository: ghcr.io/immich-app/immich-machine-learning
                 tag: v2.7.5-cuda
 
 
-              securityContext:
-                privileged: true
-
-              env:
-                # Nvidia
-                NVIDIA_VISIBLE_DEVICES: "all"
-                NVIDIA_DRIVER_CAPABILITIES: "all"
-                MACHINE_LEARNING_PRELOAD__CLIP: "ViT-L-16-SigLIP-256__webli"
-
               resources:
-                requests:
-                  cpu: 100m
-                  memory: 5G
-                  nvidia.com/gpu: 1
                 limits:
                   memory: 5G
                   nvidia.com/gpu: 1
 
+                requests:
+                  cpu: 100m
+                  memory: 5G
+                  nvidia.com/gpu: 1
+              securityContext:
+                privileged: true
+
           pod:
-            runtimeClassName: nvidia
-
-            priorityClassName: ai-gpu-critical
-
             affinity:
               nodeAffinity:
                 requiredDuringSchedulingIgnoredDuringExecution:
@@ -119,6 +115,8 @@ spec:
 
             nodeSelector:
               nvidia.com/gpu.present: "true"
+
+            priorityClassName: ai-gpu-critical
 
             probes:
               liveness:
@@ -134,6 +132,8 @@ spec:
                 spec:
                   initialDelaySeconds: 90
 
+            runtimeClassName: nvidia
+
           replicas: 2
           strategy: RollingUpdate
           type: statefulset
@@ -141,21 +141,21 @@ spec:
       persistence:
         cache:
           enabled: true
-          storageClassName: ceph-block
           size: 40G
 
+          storageClassName: ceph-block
     server:
       controllers:
         main:
           containers:
             main:
               resources:
-                requests:
-                  cpu: 15m
-                  memory: 3Gi
                 limits:
                   memory: 3Gi
 
+                requests:
+                  cpu: 15m
+                  memory: 3Gi
           replicas: 2
           strategy: RollingUpdate
           type: statefulset

--- a/kubernetes/apps/media/jellyfin/app/helmrelease.yaml
+++ b/kubernetes/apps/media/jellyfin/app/helmrelease.yaml
@@ -14,8 +14,6 @@ spec:
     controllers:
       main:
         pod:
-          priorityClassName: media-cluster-critical
-
           affinity:
             nodeAffinity:
               requiredDuringSchedulingIgnoredDuringExecution:
@@ -31,11 +29,13 @@ spec:
           nodeSelector:
             intel.feature.node.kubernetes.io/gpu: "true"
 
+          priorityClassName: media-cluster-critical
+
           securityContext:
-            runAsUser: 1000
-            runAsGroup: 1001
             fsGroup: 1001
             fsGroupChangePolicy: "OnRootMismatch"
+            runAsGroup: 1001
+            runAsUser: 1000
             supplementalGroups:
               - 1001
 
@@ -57,22 +57,6 @@ spec:
               limits:
                 gpu.intel.com/i915: 1
                 memory: 10G
-
-    persistence:
-      config:
-        existingClaim: jellyfin-config-pvc
-
-      movies:
-        existingClaim: jellyfin-movies-pvc
-
-      music:
-        existingClaim: jellyfin-music-pvc
-
-      television:
-        existingClaim: jellyfin-television-pvc
-
-      transcode:
-        type: emptyDir
 
     service:
       main:
@@ -101,3 +85,19 @@ spec:
           - backendRefs:
               - identifier: main
                 port: *httpPort
+    persistence:
+      config:
+        existingClaim: jellyfin-config-pvc
+
+      movies:
+        existingClaim: jellyfin-movies-pvc
+
+      music:
+        existingClaim: jellyfin-music-pvc
+
+      television:
+        existingClaim: jellyfin-television-pvc
+
+      transcode:
+        type: emptyDir
+

--- a/kubernetes/apps/media/lidarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/lidarr/app/helmrelease.yaml
@@ -5,27 +5,27 @@ kind: HelmRelease
 metadata:
   name: &app lidarr
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: app-template
 
+  interval: 30m
   values:
     controllers:
       main:
-        type: statefulset
-        annotations:
-          reloader.stakater.com/auto: "true"
-
         pod:
           securityContext:
-            runAsUser: 1000
-            runAsGroup: 1001
             fsGroup: 1001
             fsGroupChangePolicy: "OnRootMismatch"
+            runAsGroup: 1001
+            runAsUser: 1000
             supplementalGroups:
               - 100
 
+        annotations:
+          reloader.stakater.com/auto: "true"
+
+        type: statefulset
         containers:
           main:
             image:
@@ -45,10 +45,6 @@ spec:
               - secretRef:
                   name: *app
 
-            securityContext:
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: true
-              capabilities: {drop: ["ALL"]}
 
             resources:
               requests:
@@ -57,6 +53,10 @@ spec:
               limits:
                 memory: 4G
 
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: {drop: ["ALL"]}
     service:
       main:
         controller: main
@@ -66,6 +66,12 @@ spec:
 
     route:
       main:
+        annotations:
+          glance/name: "Lidarr"
+          glance/show: "true"
+          glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/lidarr.png"
+          glance/id: "Media"
+
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
         parentRefs:
@@ -77,21 +83,15 @@ spec:
               - identifier: main
                 port: *httpPort
 
-        annotations:
-          glance/name: "Lidarr"
-          glance/show: "true"
-          glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/lidarr.png"
-          glance/id: "Media"
-
     persistence:
       config:
         existingClaim: lidarr-config-pvc
 
-      media:
-        existingClaim: lidarr-media
-
       downloads:
         existingClaim: lidarr-downloads
+
+      media:
+        existingClaim: lidarr-media
 
       sabnzbd:
         existingClaim: lidarr-sabnzbd-downloads

--- a/kubernetes/apps/media/music-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/media/music-assistant/app/helmrelease.yaml
@@ -1,31 +1,30 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: &app music-assistant
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: app-template
 
+  interval: 30m
   values:
     controllers:
       main:
-        type: statefulset
-        annotations:
-          reloader.stakater.com/auto: "true"
-
         pod:
           securityContext:
-            runAsUser: 1000
-            runAsGroup: 1001
             fsGroup: 1001
             fsGroupChangePolicy: "OnRootMismatch"
+            runAsGroup: 1001
+            runAsUser: 1000
             supplementalGroups:
               - 100
 
+        annotations:
+          reloader.stakater.com/auto: "true"
+
+        type: statefulset
         containers:
           main:
             image:
@@ -41,10 +40,10 @@ spec:
 
     service:
       main:
-        controller: main
+        type: LoadBalancer
         annotations:
           lbipam.cilium.io/ips: ${SVC_MUSIC_ASSISTANT_ADDR}
-        type: LoadBalancer
+        controller: main
         externalTrafficPolicy: Cluster
         ports:
           http:
@@ -56,16 +55,6 @@ spec:
 
     route:
       main:
-        hostnames:
-          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-        parentRefs:
-          - name: internal
-            namespace: network
-            sectionName: https
-        rules:
-          - backendRefs:
-              - identifier: main
-                port: *httpPort
         annotations:
           startpunkt.ullberg.us/enable: "true"
           startpunkt.ullberg.us/name: "Music Assistant"
@@ -77,12 +66,22 @@ spec:
           glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/music-assistant.png"
           glance/id: "Media"
 
+        hostnames:
+          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: main
+                port: *httpPort
     persistence:
-      media:
-        existingClaim: music-assistant-music-pvc
-
       data:
         existingClaim: music-assistant-data-pvc
+
+      media:
+        existingClaim: music-assistant-music-pvc
 
       tmpfs:
         type: emptyDir

--- a/kubernetes/apps/media/radarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/radarr/app/helmrelease.yaml
@@ -5,27 +5,27 @@ kind: HelmRelease
 metadata:
   name: &app radarr
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: app-template
 
+  interval: 30m
   values:
     controllers:
       main:
-        type: statefulset
-        annotations:
-          reloader.stakater.com/auto: "true"
-
         pod:
           securityContext:
-            runAsUser: 1000
-            runAsGroup: 1001
             fsGroup: 1001
             fsGroupChangePolicy: "OnRootMismatch"
+            runAsGroup: 1001
+            runAsUser: 1000
             supplementalGroups:
               - 100
 
+        annotations:
+          reloader.stakater.com/auto: "true"
+
+        type: statefulset
         containers:
           main:
             image:
@@ -45,10 +45,6 @@ spec:
               - secretRef:
                   name: *app
 
-            securityContext:
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: true
-              capabilities: {drop: ["ALL"]}
 
             resources:
               requests:
@@ -57,6 +53,10 @@ spec:
               limits:
                 memory: 800M
 
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: {drop: ["ALL"]}
     service:
       main:
         controller: main
@@ -66,6 +66,12 @@ spec:
 
     route:
       main:
+        annotations:
+          glance/name: "Radarr"
+          glance/show: "true"
+          glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/radarr.png"
+          glance/id: "Media"
+
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
         parentRefs:
@@ -76,21 +82,15 @@ spec:
           - backendRefs:
               - identifier: main
                 port: *httpPort
-        annotations:
-          glance/name: "Radarr"
-          glance/show: "true"
-          glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/radarr.png"
-          glance/id: "Media"
-
     persistence:
       config:
         existingClaim: radarr-config-pvc
 
-      media:
-        existingClaim: radarr-media
-
       downloads:
         existingClaim: radarr-downloads
+
+      media:
+        existingClaim: radarr-media
 
       sabnzbd:
         existingClaim: sonarr-sabnzbd-downloads

--- a/kubernetes/apps/media/recyclarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/recyclarr/app/helmrelease.yaml
@@ -5,20 +5,28 @@ kind: HelmRelease
 metadata:
   name: &app recyclarr
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: app-template
+  interval: 30m
   values:
     controllers:
       recyclarr:
-        type: cronjob
+        pod:
+          securityContext:
+            fsGroup: 1001
+            fsGroupChangePolicy: OnRootMismatch
+
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1000
+        annotations:
+          reloader.stakater.com/auto: "true"
 
         cronjob:
           schedule: "@daily"
 
-        annotations:
-          reloader.stakater.com/auto: "true"
+        type: cronjob
 
         containers:
           app:
@@ -48,14 +56,6 @@ spec:
               capabilities:
                 drop:
                   - ALL
-
-        pod:
-          securityContext:
-            runAsUser: 1000
-            runAsGroup: 1001
-            fsGroup: 1001
-            runAsNonRoot: true
-            fsGroupChangePolicy: OnRootMismatch
 
     persistence:
       config:

--- a/kubernetes/apps/media/seerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/seerr/app/helmrelease.yaml
@@ -5,16 +5,23 @@ kind: HelmRelease
 metadata:
   name: &app seerr
 spec:
-  interval: 1h
   chartRef:
     kind: OCIRepository
     name: app-template
+  interval: 1h
   values:
+    defaultPodOptions:
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
     controllers:
       seerr:
-        type: statefulset
         annotations:
           reloader.stakater.com/auto: "true"
+        type: statefulset
         containers:
           app:
             image:
@@ -39,22 +46,15 @@ spec:
                   timeoutSeconds: 1
                   failureThreshold: 3
               readiness: *probes
-            securityContext:
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: true
-              capabilities: {drop: ["ALL"]}
             resources:
               requests:
                 cpu: 10m
               limits:
                 memory: 2Gi
-    defaultPodOptions:
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 1000
-        fsGroup: 1000
-        fsGroupChangePolicy: OnRootMismatch
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: {drop: ["ALL"]}
     service:
       app:
         controller: seerr
@@ -64,16 +64,6 @@ spec:
 
     route:
       app:
-        hostnames:
-          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-        parentRefs:
-          - name: internal
-            namespace: network
-            sectionName: https
-        rules:
-          - backendRefs:
-              - identifier: app
-                port: *httpPort
         annotations:
           glance/name: "Seer"
           glance/show: "true"
@@ -85,6 +75,16 @@ spec:
           startpunkt.ullberg.us/group: "media"
           startpunkt.ullberg.us/instance: "user"
 
+        hostnames:
+          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: *httpPort
     persistence:
       config:
         existingClaim: seerr-config-pvc

--- a/kubernetes/apps/media/sonarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sonarr/app/helmrelease.yaml
@@ -5,27 +5,27 @@ kind: HelmRelease
 metadata:
   name: &app sonarr
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: app-template
 
+  interval: 30m
   values:
     controllers:
       main:
-        type: statefulset
-        annotations:
-          reloader.stakater.com/auto: "true"
-
         pod:
           securityContext:
-            runAsUser: 1000
-            runAsGroup: 1001
             fsGroup: 1001
             fsGroupChangePolicy: "OnRootMismatch"
+            runAsGroup: 1001
+            runAsUser: 1000
             supplementalGroups:
               - 100
 
+        annotations:
+          reloader.stakater.com/auto: "true"
+
+        type: statefulset
         containers:
           main:
             image:
@@ -45,10 +45,6 @@ spec:
               - secretRef:
                   name: *app
 
-            securityContext:
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: true
-              capabilities: {drop: ["ALL"]}
 
             resources:
               requests:
@@ -57,6 +53,10 @@ spec:
               limits:
                 memory: 1G
 
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: {drop: ["ALL"]}
     service:
       main:
         controller: main
@@ -66,6 +66,12 @@ spec:
 
     route:
       main:
+        annotations:
+          glance/name: "Sonarr"
+          glance/show: "true"
+          glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/sonarr.png"
+          glance/id: "Media"
+
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
         parentRefs:
@@ -76,21 +82,15 @@ spec:
           - backendRefs:
               - identifier: main
                 port: *httpPort
-        annotations:
-          glance/name: "Sonarr"
-          glance/show: "true"
-          glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/sonarr.png"
-          glance/id: "Media"
-
     persistence:
       config:
         existingClaim: sonarr-config-pvc
 
-      media:
-        existingClaim: sonarr-media
-
       downloads:
         existingClaim: sonarr-downloads
+
+      media:
+        existingClaim: sonarr-media
 
       sabnzbd:
         existingClaim: sonarr-sabnzbd-downloads

--- a/kubernetes/apps/media/stash/app/helmrelease.yaml
+++ b/kubernetes/apps/media/stash/app/helmrelease.yaml
@@ -5,18 +5,18 @@ kind: HelmRelease
 metadata:
   name: &app stash
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: app-template
 
+  interval: 30m
   values:
     controllers:
       main:
-        type: statefulset
-
         annotations:
           reloader.stakater.com/auto: "true"
+
+        type: statefulset
 
         containers:
           main:
@@ -40,6 +40,12 @@ spec:
 
     route:
       main:
+        annotations:
+          glance/name: "Stash"
+          glance/show: "true"
+          glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/stash.png"
+          glance/id: "Private"
+
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
         parentRefs:
@@ -50,12 +56,6 @@ spec:
           - backendRefs:
               - identifier: main
                 port: *httpPort
-        annotations:
-          glance/name: "Stash"
-          glance/show: "true"
-          glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/stash.png"
-          glance/id: "Private"
-
     persistence:
       config:
         existingClaim: stash-config-pvc

--- a/kubernetes/apps/media/suggestarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/suggestarr/app/helmrelease.yaml
@@ -5,37 +5,33 @@ kind: HelmRelease
 metadata:
   name: &app suggestarr
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: app-template
 
+  interval: 30m
   values:
     controllers:
       main:
-        type: statefulset
-        annotations:
-          reloader.stakater.com/auto: "true"
-
         pod:
           securityContext:
-            runAsUser: 1000
-            runAsGroup: 1001
             fsGroup: 1001
             fsGroupChangePolicy: "OnRootMismatch"
+            runAsGroup: 1001
+            runAsUser: 1000
             supplementalGroups:
               - 100
 
+        annotations:
+          reloader.stakater.com/auto: "true"
+
+        type: statefulset
         containers:
           main:
             image:
               repository: docker.io/ciuse99/suggestarr
               tag: v2.4.3@sha256:79a9ec281a5486c28b59b807be8ec8e0be7f1943534eecc59adf9945fce8dd0e
 
-            securityContext:
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: true
-              capabilities: {drop: ["ALL"]}
 
             resources:
               requests:
@@ -44,6 +40,10 @@ spec:
               limits:
                 memory: 1G
 
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: {drop: ["ALL"]}
     service:
       main:
         controller: main
@@ -53,6 +53,12 @@ spec:
 
     route:
       main:
+        annotations:
+          glance/name: "Suggestarr"
+          glance/show: "true"
+          glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/suggest-arr.png"
+          glance/id: "Media"
+
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
         parentRefs:
@@ -63,12 +69,6 @@ spec:
           - backendRefs:
               - identifier: main
                 port: *port
-        annotations:
-          glance/name: "Suggestarr"
-          glance/show: "true"
-          glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/suggest-arr.png"
-          glance/id: "Media"
-
     persistence:
       config:
         existingClaim: suggestarr-config-pvc

--- a/kubernetes/apps/media/theme-park/app/helmrelease.yaml
+++ b/kubernetes/apps/media/theme-park/app/helmrelease.yaml
@@ -5,17 +5,26 @@ kind: HelmRelease
 metadata:
   name: &app theme-park
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: app-template
 
+  interval: 30m
   values:
     controllers:
       main:
-        type: statefulset
+        pod:
+          topologySpreadConstraints:
+            - maxSkew: 1
+              topologyKey: kubernetes.io/hostname
+              whenUnsatisfiable: DoNotSchedule
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: *app
+
         replicas: 2
 
+        type: statefulset
         containers:
           main:
             image:
@@ -27,15 +36,6 @@ spec:
                 memory: 64M
               limits:
                 memory: 64M
-        pod:
-          topologySpreadConstraints:
-            - maxSkew: 1
-              topologyKey: kubernetes.io/hostname
-              whenUnsatisfiable: DoNotSchedule
-              labelSelector:
-                matchLabels:
-                  app.kubernetes.io/name: *app
-
     service:
       main:
         controller: main
@@ -45,6 +45,11 @@ spec:
 
     route:
       main:
+        annotations:
+          glance/name: "Theme Park"
+          glance/show: "true"
+          glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/themepark.png"
+          glance/id: "Media"
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
         parentRefs:
@@ -55,8 +60,3 @@ spec:
           - backendRefs:
               - identifier: main
                 port: *httpPort
-        annotations:
-          glance/name: "Theme Park"
-          glance/show: "true"
-          glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/themepark.png"
-          glance/id: "Media"

--- a/kubernetes/apps/network/cloudflared/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cloudflared/app/helmrelease.yaml
@@ -5,24 +5,45 @@ kind: HelmRelease
 metadata:
   name: &app cloudflared
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: app-template
 
+  interval: 30m
   values:
     controllers:
       main:
-        replicas: 2
-        strategy: RollingUpdate
+        pod:
+          securityContext:
+            runAsGroup: 568
+            runAsNonRoot: true
+
+            runAsUser: 568
+          topologySpreadConstraints:
+            - maxSkew: 1
+              topologyKey: kubernetes.io/hostname
+              whenUnsatisfiable: DoNotSchedule
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: *app
+
         annotations:
           reloader.stakater.com/auto: "true"
 
+        replicas: 2
+        strategy: RollingUpdate
         containers:
           main:
             image:
               repository: docker.io/cloudflare/cloudflared
               tag: 2026.3.0@sha256:6b599ca3e974349ead3286d178da61d291961182ec3fe9c505e1dd02c8ac31b0
+
+            args:
+              - tunnel
+              - --config
+              - /etc/cloudflared/config/config.yaml
+              - run
+              - "$(TUNNEL_ID)"
 
             env:
               NO_AUTOUPDATE: true
@@ -36,13 +57,6 @@ spec:
                   secretKeyRef:
                     name: cloudflared-tunnel-secret
                     key: TunnelID
-
-            args:
-              - tunnel
-              - --config
-              - /etc/cloudflared/config/config.yaml
-              - run
-              - "$(TUNNEL_ID)"
 
             probes:
               liveness: &probes
@@ -60,10 +74,6 @@ spec:
               startup:
                 enabled: false
 
-            securityContext:
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: true
-              capabilities: {drop: ["ALL"]}
 
             resources:
               requests:
@@ -71,37 +81,16 @@ spec:
               limits:
                 memory: 256Mi
 
-        pod:
-          securityContext:
-            runAsUser: 568
-            runAsGroup: 568
-            runAsNonRoot: true
-
-          topologySpreadConstraints:
-            - maxSkew: 1
-              topologyKey: kubernetes.io/hostname
-              whenUnsatisfiable: DoNotSchedule
-              labelSelector:
-                matchLabels:
-                  app.kubernetes.io/name: *app
-
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: {drop: ["ALL"]}
     service:
       main:
         controller: main
         ports:
           http:
             port: *httpPort
-
-    serviceMonitor:
-      main:
-        serviceName: *app
-        endpoints:
-          - port: http
-            scheme: http
-            path: /metrics
-            interval: 1m
-            scrapeTimeout: 30s
-
     persistence:
       config:
         type: configMap
@@ -118,3 +107,14 @@ spec:
           - path: /etc/cloudflared/creds/credentials.json
             subPath: credentials.json
             readOnly: true
+
+    serviceMonitor:
+      main:
+        serviceName: *app
+        endpoints:
+          - port: http
+            scheme: http
+            path: /metrics
+            interval: 1m
+            scrapeTimeout: 30s
+

--- a/kubernetes/apps/network/envoy-gateway/app/helmrelease.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/helmrelease.yaml
@@ -17,9 +17,9 @@ spec:
     config:
       envoyGateway:
         provider:
-          type: Kubernetes
           kubernetes:
             deploy:
               type: GatewayNamespace
+          type: Kubernetes
     global:
       imageRegistry: mirror.gcr.io

--- a/kubernetes/apps/network/external-dns/app/bind/helmrelease.yaml
+++ b/kubernetes/apps/network/external-dns/app/bind/helmrelease.yaml
@@ -5,10 +5,10 @@ kind: HelmRelease
 metadata:
   name: &app external-dns-bind
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: app-template
+  interval: 30m
 
   install:
     remediation:
@@ -19,34 +19,30 @@ spec:
     remediation:
       retries: 3
 
-  uninstall:
-    keepHistory: false
-
   values:
     controllers:
       main:
-        strategy: Recreate
+        pod:
+          priorityClassName: system-cluster-critical
+
+          securityContext:
+            runAsUser: 568
+            runAsGroup: 568
+            runAsNonRoot: true
+
         annotations:
           reloader.stakater.com/auto: "true"
 
         serviceAccount:
           identifier: *app
 
+        strategy: Recreate
+
         containers:
           main:
             image:
               repository: registry.k8s.io/external-dns/external-dns
               tag: v0.17.0@sha256:85eba2727b410c8f8093d641a4b1a29671878db94d525a70a4108d10ba8eef5f
-            env:
-              EXTERNAL_DNS_RFC2136_HOST: 192.168.1.1
-              EXTERNAL_DNS_RFC2136_PORT: "53"
-              EXTERNAL_DNS_RFC2136_ZONE: thesteamedcrab.com
-              EXTERNAL_DNS_RFC2136_TSIG_AXFR: "true"
-              EXTERNAL_DNS_RFC2136_TSIG_KEYNAME: externaldns-key
-              EXTERNAL_DNS_RFC2136_TSIG_SECRET_ALG: hmac-sha256
-            envFrom:
-              - secretRef:
-                  name: external-dns-bind-secret
             args:
               - --domain-filter=thesteamedcrab.com
               - --interval=1m
@@ -61,6 +57,16 @@ spec:
               #- --source=gateway-tlsroute
               - --txt-owner-id=homelab
               - --txt-prefix=k8s.
+            env:
+              EXTERNAL_DNS_RFC2136_HOST: 192.168.1.1
+              EXTERNAL_DNS_RFC2136_PORT: "53"
+              EXTERNAL_DNS_RFC2136_TSIG_AXFR: "true"
+              EXTERNAL_DNS_RFC2136_TSIG_KEYNAME: externaldns-key
+              EXTERNAL_DNS_RFC2136_TSIG_SECRET_ALG: hmac-sha256
+              EXTERNAL_DNS_RFC2136_ZONE: thesteamedcrab.com
+            envFrom:
+              - secretRef:
+                  name: external-dns-bind-secret
             probes:
               liveness: &probes
                 enabled: true
@@ -76,23 +82,16 @@ spec:
               readiness: *probes
               startup:
                 enabled: false
-            securityContext:
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: true
-              capabilities: { drop: ["ALL"] }
             resources:
               requests:
                 cpu: 10m
                 memory: 140M
               limits:
                 memory: 140M
-        pod:
-          priorityClassName: system-cluster-critical
-
-          securityContext:
-            runAsUser: 568
-            runAsGroup: 568
-            runAsNonRoot: true
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities: { drop: ["ALL"] }
+              readOnlyRootFilesystem: true
 
     serviceAccount:
       *app: {}
@@ -113,3 +112,6 @@ spec:
             path: /metrics
             interval: 1m
             scrapeTimeout: 10s
+
+  uninstall:
+    keepHistory: false

--- a/kubernetes/apps/network/external-dns/app/cloudflare/helmrelease.yaml
+++ b/kubernetes/apps/network/external-dns/app/cloudflare/helmrelease.yaml
@@ -14,7 +14,6 @@ spec:
   url: oci://ghcr.io/home-operations/charts-mirror/external-dns
   verify:
     provider: cosign
-
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
@@ -22,42 +21,39 @@ kind: HelmRelease
 metadata:
   name: external-dns-cloudflare
 spec:
-  interval: 1h
   chartRef:
     kind: OCIRepository
     name: cloudflare-dns
 
   install:
-    disableSchemaValidation: true # Ref: https://github.com/kubernetes-sigs/external-dns/issues/5206
     crds: CreateReplace
+    disableSchemaValidation: true # Ref: https://github.com/kubernetes-sigs/external-dns/issues/5206
     remediation:
       retries: 3
 
+  interval: 1h
   upgrade:
-    disableSchemaValidation: true # Ref: https://github.com/kubernetes-sigs/external-dns/issues/5206
     cleanupOnFail: true
     crds: CreateReplace
+    disableSchemaValidation: true # Ref: https://github.com/kubernetes-sigs/external-dns/issues/5206
     remediation:
-      strategy: rollback
       retries: 3
 
+      strategy: rollback
   values:
-    fullnameOverride: &app externaldns-cloudflare
-
-    provider:
-      name: cloudflare
-
+    domainFilters:
+      - "${SECRET_DOMAIN}"
     env:
       - name: &name CF_API_EMAIL
         valueFrom:
           secretKeyRef:
-            name: &secret external-dns-cloudflare-secret
             key: *name
+            name: &secret external-dns-cloudflare-secret
       - name: &name CF_API_KEY
         valueFrom:
           secretKeyRef:
-            name: *secret
             key: *name
+            name: *secret
 
     extraArgs:
       - --cloudflare-dns-records-per-page=1000
@@ -71,14 +67,17 @@ spec:
       #- --gateway-name=external
       #- --gateway-name=tcp
 
-    policy: sync
-    sources: ["crd", "gateway-httproute", "gateway-tlsroute", "gateway-tcproute"]
-    txtOwnerId: default
-    txtPrefix: k8s.
-    domainFilters:
-      - "${SECRET_DOMAIN}"
-    serviceMonitor:
-      enabled: true
+    fullnameOverride: &app externaldns-cloudflare
 
     podAnnotations:
       secret.reloader.stakater.com/reload: *secret
+    policy: sync
+    provider:
+      name: cloudflare
+
+    serviceMonitor:
+      enabled: true
+
+    sources: ["crd", "gateway-httproute", "gateway-tlsroute", "gateway-tcproute"]
+    txtOwnerId: default
+    txtPrefix: k8s.

--- a/kubernetes/apps/network/multus/app/helmrelease.yaml
+++ b/kubernetes/apps/network/multus/app/helmrelease.yaml
@@ -10,16 +10,6 @@ spec:
     name: multus
   interval: 30m
   values:
-    multus:
-      resources:
-        requests:
-          cpu: 10m
-          memory: 62Mi
-        limits:
-          memory: 62Mi
-    cni:
-      netPath: /etc/cni/net.d
-      binPath: /opt/cni/bin
     affinity:
       nodeAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:
@@ -34,3 +24,13 @@ spec:
                   operator: In
                   values:
                     - "true"
+    cni:
+      binPath: /opt/cni/bin
+      netPath: /etc/cni/net.d
+    multus:
+      resources:
+        limits:
+          memory: 62Mi
+        requests:
+          cpu: 10m
+          memory: 62Mi

--- a/kubernetes/apps/observability/exporters/blackbox-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/exporters/blackbox-exporter/app/helmrelease.yaml
@@ -5,85 +5,85 @@ kind: HelmRelease
 metadata:
   name: &app blackbox-exporter
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: blackbox-exporter
 
+  interval: 30m
   values:
+    allowIcmp: true
+
+    config:
+      modules:
+        http_2xx:
+          http:
+            follow_redirects: true
+            preferred_ip_protocol: "ip4"
+            valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
+          prober: http
+          timeout: 5s
+        icmp:
+          icmp:
+            preferred_ip_protocol: "ip4"
+          prober: icmp
+          timeout: 30s
+        tcp_connect:
+          prober: tcp
+          tcp:
+            preferred_ip_protocol: ipv4
+          timeout: 5s
     fullnameOverride: blackbox-exporter
     image:
       registry: quay.io
 
-    securityContext:
-      allowPrivilegeEscalation: false
-      readOnlyRootFilesystem: true
-      capabilities:
-        add:
-          - NET_RAW
+    podAnnotations:
+      reloader.stakater.com/auto: "true"
 
     podSecurityContext:
       sysctls:
         - name: net.ipv4.ping_group_range
           value: "0 2147483647"
 
-    podAnnotations:
-      reloader.stakater.com/auto: "true"
-
-    allowIcmp: true
-
-    config:
-      modules:
-        http_2xx:
-          prober: http
-          timeout: 5s
-          http:
-            valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
-            follow_redirects: true
-            preferred_ip_protocol: "ip4"
-        icmp:
-          prober: icmp
-          timeout: 30s
-          icmp:
-            preferred_ip_protocol: "ip4"
-        tcp_connect:
-          prober: tcp
-          timeout: 5s
-          tcp:
-            preferred_ip_protocol: ipv4
-    serviceMonitor:
-      enabled: true
-      defaults:
-        interval: 1m
-        scrapeTimeout: 10s
-
     prometheusRule:
-      enabled: true
       additionalLabels:
         app: prometheus-operator
         release: prometheus
+      enabled: true
       rules:
         - alert: BlackboxSslCertificateWillExpireSoon
+          annotations:
+            description: |-
+              The SSL certificate for {{ $labels.instance }} will expire in less than 3 days
           expr: probe_ssl_earliest_cert_expiry - time() < 86400 * 3
           for: 5m
           labels:
             severity: critical
+        - alert: BlackboxSslCertificateExpired
           annotations:
             description: |-
-              The SSL certificate for {{ $labels.instance }} will expire in less than 3 days
-        - alert: BlackboxSslCertificateExpired
+              The SSL certificate for {{ $labels.instance }} has expired
           expr: probe_ssl_earliest_cert_expiry - time() <= 0
           for: 5m
           labels:
             severity: critical
+        - alert: BlackboxProbeFailed
           annotations:
             description: |-
-              The SSL certificate for {{ $labels.instance }} has expired
-        - alert: BlackboxProbeFailed
+              The host {{ $labels.instance }} is currently unreachable
           expr: probe_success == 0
           for: 5m
           labels:
             severity: critical
-          annotations:
-            description: |-
-              The host {{ $labels.instance }} is currently unreachable
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+          - NET_RAW
+
+      readOnlyRootFilesystem: true
+    serviceMonitor:
+      defaults:
+        interval: 1m
+        scrapeTimeout: 10s
+
+      enabled: true

--- a/kubernetes/apps/observability/exporters/dcgm-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/exporters/dcgm-exporter/app/helmrelease.yaml
@@ -4,37 +4,37 @@ kind: HelmRelease
 metadata:
   name: dcgm-exporter
 spec:
+  chart:
+    spec:
+      chart: dcgm-exporter
+      sourceRef:
+        kind: HelmRepository
+        name: dcgm-exporter
+      version: 4.8.1
   dependsOn:
     - name: nvidia-device-plugin
       namespace: kube-system
   interval: 30m
-  chart:
-    spec:
-      chart: dcgm-exporter
-      version: 4.8.1
-      sourceRef:
-        kind: HelmRepository
-        name: dcgm-exporter
   values:
-    image:
-      repository: nvcr.io/nvidia/k8s/dcgm-exporter
-      tag: 3.1.7-3.1.4-ubuntu20.04
     extraEnv:
       NVIDIA_DRIVER_CAPABILITIES: all
       NVIDIA_VISIBLE_DEVICES: all
+    image:
+      repository: nvcr.io/nvidia/k8s/dcgm-exporter
+      tag: 3.1.7-3.1.4-ubuntu20.04
     nodeSelector:
       nvidia.com/gpu.present: "true"
-    runtimeClassName: nvidia
     priorityClassName: ai-gpu-critical
     resources:
       limits:
         nvidia.com/gpu: 1
-    serviceMonitor:
-      interval: 15s
-      honorLabels: true
+    runtimeClassName: nvidia
     securityContext:
-      privileged: true
       allowPrivilegeEscalation: true
       capabilities:
         add:
           - SYS_ADMIN
+      privileged: true
+    serviceMonitor:
+      honorLabels: true
+      interval: 15s

--- a/kubernetes/apps/observability/exporters/mqtt-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/exporters/mqtt-exporter/app/helmrelease.yaml
@@ -5,11 +5,11 @@ kind: HelmRelease
 metadata:
   name: &app mqtt-exporter
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: app-template
 
+  interval: 30m
   install:
     remediation:
       retries: 3
@@ -19,11 +19,20 @@ spec:
       strategy: rollback
       retries: 3
   values:
+    defaultPodOptions:
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+      securityContext:
+        runAsGroup: 568
+        runAsNonRoot: true
+        runAsUser: 568
     controllers:
       mqtt-exporter:
-        type: statefulset
         annotations:
           reloader.stakater.com/auto: "true"
+        type: statefulset
         containers:
           app:
             image:
@@ -55,15 +64,6 @@ spec:
               capabilities:
                 drop:
                   - ALL
-    defaultPodOptions:
-      dnsConfig:
-        options:
-          - name: ndots
-            value: "1"
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 568
-        runAsGroup: 568
     service:
       app:
         controller: *app

--- a/kubernetes/apps/observability/exporters/node-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/exporters/node-exporter/app/helmrelease.yaml
@@ -5,18 +5,19 @@ kind: HelmRelease
 metadata:
   name: node-exporter
 spec:
-  interval: 30m
   chart:
     spec:
       chart: prometheus-node-exporter
-      version: 4.53.1
+      interval: 30m
       sourceRef:
         kind: HelmRepository
         name: prometheus-community-charts
-      interval: 30m
+      version: 4.53.1
+  interval: 30m
   values:
     fullnameOverride: node-exporter
 
+    hostNetwork: false
     image:
       registry: quay.io
       repository: prometheus/node-exporter
@@ -47,10 +48,9 @@ spec:
             targetLabel: instance
 
     resources:
-      requests:
-        cpu: 23m
-        memory: 100M
       limits:
         memory: 100M
 
-    hostNetwork: false
+      requests:
+        cpu: 23m
+        memory: 100M

--- a/kubernetes/apps/observability/exporters/prometheus-nut-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/exporters/prometheus-nut-exporter/app/helmrelease.yaml
@@ -5,16 +5,16 @@ kind: HelmRelease
 metadata:
   name: nut-exporter
 spec:
-  interval: 1h
   chartRef:
     kind: OCIRepository
     name: app-template
+  interval: 1h
   values:
     controllers:
       nut-exporter:
-        type: statefulset
         annotations:
           reloader.stakater.com/auto: "true"
+        type: statefulset
         containers:
           app:
             image:

--- a/kubernetes/apps/observability/exporters/smartctl-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/exporters/smartctl-exporter/app/helmrelease.yaml
@@ -5,51 +5,53 @@ kind: HelmRelease
 metadata:
   name: &app smartctl-exporter
 spec:
-  interval: 30m
   chart:
     spec:
       chart: prometheus-smartctl-exporter
-      version: 0.16.0
       sourceRef:
         kind: HelmRepository
         name: prometheus-community-charts
+      version: 0.16.0
   install:
     remediation:
       retries: 3
+  interval: 30m
+  uninstall:
+    keepHistory: false
   upgrade:
     cleanupOnFail: true
     remediation:
       retries: 3
-  uninstall:
-    keepHistory: false
   values:
+    config:
+      devices:
+        - /dev/sda
+        - /dev/sdb
+        - /dev/sdc
+        - /dev/sdd
+        - /dev/sde
+        - /dev/sdf
+        - /dev/sdg
+        - /dev/nvme0n1
+        - /dev/nvme1n1
+        - /dev/nvme2n1
     fullnameOverride: *app
     image:
       repository: ghcr.io/joryirving/smartctl_exporter
       tag: 0.14.0@sha256:24c92b081d6d583ea5de4fa4bb6c4880ce25cb28f297f7643257f288382f9074
-    config:
-      devices:
-      - /dev/sda
-      - /dev/sdb
-      - /dev/sdc
-      - /dev/sdd
-      - /dev/sde
-      - /dev/sdf
-      - /dev/sdg
-      - /dev/nvme0n1
-      - /dev/nvme1n1
-      - /dev/nvme2n1
+    prometheusRules:
+      enabled: false
     serviceMonitor:
       enabled: true
       relabelings:
-      - action: labeldrop
-        regex: (pod)
-      - action: replace
-        regex: (.*)
-        replacement: $1.${SECRET_DOMAIN}
-        sourceLabels:
-        - __meta_kubernetes_endpoint_node_name
-        targetLabel: instance
+        - action: labeldrop
+          regex: (pod)
+        - action: replace
+          regex: (.*)
+          replacement: $1.${SECRET_DOMAIN}
+          sourceLabels:
+            - __meta_kubernetes_endpoint_node_name
+          targetLabel: instance
       # - action: replace
       #   separator: ':'
       #   # regex: \b((?:sd[a-z]+|nvme\d+n\d+))\b|\b((?:cp\d+|work\d+|n\d{3}-\d{2}))\b
@@ -58,5 +60,3 @@ spec:
       #   - device
       #   - __meta_kubernetes_endpoint_node_name
       #   targetLabel: device
-    prometheusRules:
-      enabled: false

--- a/kubernetes/apps/observability/exporters/snmp-exporter/app/apc-ups/helmrelease.yaml
+++ b/kubernetes/apps/observability/exporters/snmp-exporter/app/apc-ups/helmrelease.yaml
@@ -5,51 +5,51 @@ kind: HelmRelease
 metadata:
   name: &app snmp-exporter-apc-ups
 spec:
-  interval: 30m
   chart:
     spec:
       chart: prometheus-snmp-exporter
-      version: 9.13.1
       sourceRef:
         kind: HelmRepository
         name: prometheus-community-charts
+
+      version: 9.13.1
+  dependsOn:
+    - name: kube-prometheus-stack
+      namespace: observability
 
   install:
     remediation:
       retries: 3
 
+  interval: 30m
   upgrade:
     cleanupOnFail: true
     remediation:
-      strategy: rollback
       retries: 3
 
-  dependsOn:
-    - name: kube-prometheus-stack
-      namespace: observability
-
+      strategy: rollback
   values:
-    fullnameOverride: *app
     extraArgs: ["--config.file=/config/snmp.yaml"]
     extraConfigmapMounts:
-      - name: &name apc-ups-snmp-configmap
-        mountPath: /config/snmp.yaml
-        subPath: snmp.yaml
-        configMap: *name
-        readOnly: true
+      - configMap: &name apc-ups-snmp-configmap
         defaultMode: 420
+        mountPath: /config/snmp.yaml
+        name: *name
+        readOnly: true
+        subPath: snmp.yaml
+    fullnameOverride: *app
     serviceMonitor:
       enabled: true
       params:
-        - name: apc-ups-1500
+        - auth: ["public_v1"]
           module: ["apcups"]
+          name: apc-ups-1500
           target: 192.168.5.36
-          auth: ["public_v1"]
-        - name: apc-ups-3000
+        - auth: ["public_v1"]
           module: ["apcups"]
+          name: apc-ups-3000
           target: 192.168.5.65
-          auth: ["public_v1"]
       path: /snmp
-      scrapeTimeout: 10s
       relabelings:
         - {sourceLabels: ["__param_target"], targetLabel: instance}
+      scrapeTimeout: 10s

--- a/kubernetes/apps/observability/exporters/snmp-exporter/app/dell-idrac/helmrelease.yaml
+++ b/kubernetes/apps/observability/exporters/snmp-exporter/app/dell-idrac/helmrelease.yaml
@@ -5,57 +5,57 @@ kind: HelmRelease
 metadata:
   name: &app snmp-exporter-dell-idrac
 spec:
-  interval: 30m
   chart:
     spec:
       chart: prometheus-snmp-exporter
-      version: 9.13.1
       sourceRef:
         kind: HelmRepository
         name: prometheus-community-charts
+
+      version: 9.13.1
+  dependsOn:
+    - name: kube-prometheus-stack
+      namespace: observability
 
   install:
     createNamespace: true
     remediation:
       retries: 3
 
+  interval: 30m
   upgrade:
     cleanupOnFail: true
     remediation:
-      strategy: rollback
       retries: 3
 
-  dependsOn:
-    - name: kube-prometheus-stack
-      namespace: observability
-
+      strategy: rollback
   values:
-    fullnameOverride: *app
-
-    image:
-      repository: quay.io/prometheus/snmp-exporter
     extraArgs:
       - "--config.file=/config/snmp.yaml"
 
     extraConfigmapMounts:
-      - name: *app
-        mountPath: /config/snmp.yaml
-        subPath: snmp.yaml
-        configMap: *app
-        readOnly: true
+      - configMap: *app
         defaultMode: 420
 
+        mountPath: /config/snmp.yaml
+        name: *app
+        readOnly: true
+        subPath: snmp.yaml
+    fullnameOverride: *app
+
+    image:
+      repository: quay.io/prometheus/snmp-exporter
     serviceMonitor:
       enabled: true
       namespace: observability
       params:
-        - name: dell-idrac-0
+        - auth: ["public_v2"]
           module:
             - dell
+          name: dell-idrac-0
           target: 192.168.1.22
-          auth: ["public_v2"]
       path: /snmp
-      scrapeTimeout: 10s
       relabelings:
         - sourceLabels: [__param_target]
           targetLabel: instance
+      scrapeTimeout: 10s

--- a/kubernetes/apps/observability/goldilocks/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/goldilocks/app/helmrelease.yaml
@@ -5,31 +5,31 @@ kind: HelmRelease
 metadata:
   name: goldilocks
 spec:
-  interval: 30m
   chart:
     spec:
       # renovate: registryUrl=https://charts.fairwinds.com/stable
       chart: goldilocks
-      version: 10.3.0
       sourceRef:
         kind: HelmRepository
         name: fairwinds-charts
 
+      version: 10.3.0
+  interval: 30m
   values:
     controller:
       resources:
-        requests:
-          cpu: 25m
-          memory: 200Mi
         limits:
           memory: 200Mi
 
+        requests:
+          cpu: 25m
+          memory: 200Mi
     dashboard:
       replicaCount: 1
 
       resources:
+        limits:
+          memory: 200Mi
         requests:
           cpu: 25m
-          memory: 200Mi
-        limits:
           memory: 200Mi

--- a/kubernetes/apps/observability/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/grafana/app/helmrelease.yaml
@@ -5,44 +5,277 @@ kind: HelmRelease
 metadata:
   name: &app grafana
 spec:
-  interval: 30m
   chart:
     spec:
       chart: grafana
-      version: 10.5.15
       sourceRef:
         kind: HelmRepository
         name: grafana-charts
 
+      version: 10.5.15
+  interval: 30m
   values:
-    replicas: 1
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/name
+                    operator: In
+                    values: ["grafana"]
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+    dashboardProviders:
+      dashboardproviders.yaml:
+        apiVersion: 1
+        providers:
+          - disableDeletion: false
+            editable: true
+            folder: ""
+            name: "default"
+            options:
+              path: /var/lib/grafana/dashboards/default
+            orgId: 1
+            type: file
+          - disableDeletion: false
+            editable: true
+            folder: kubernetes
+            name: Kubernetes
+            options:
+              path: /var/lib/grafana/dashboards/kubernetes
+            orgId: 1
+            type: file
+          - disableDeletion: false
+            editable: true
+            folder: cert-manager
+            name: cert-manager
+            options:
+              path: /var/lib/grafana/dashboards/cert-manager
+            orgId: 1
+            type: file
+          - disableDeletion: false
+            editable: true
+            folder: ethereum
+            name: Ethereum
+            options:
+              path: /var/lib/grafana/dashboards/ethereum
+            orgId: 1
+            type: file
+          - disableDeletion: false
+            editable: true
+            folder: flux
+            name: Flux
+            options:
+              path: /var/lib/grafana/dashboards/flux
+            orgId: 1
+            type: file
+          - disableDeletion: false
+            editable: true
+            folder: databases
+            name: Databases
+            options:
+              path: /var/lib/grafana/dashboards/databases
+            orgId: 1
+            type: file
+          - disableDeletion: false
+            editable: true
+            folder: home
+            name: Home
+            options:
+              path: /var/lib/grafana/dashboards/home
+            orgId: 1
+            type: file
+          - disableDeletion: false
+            editable: true
+            folder: power
+            name: Power
+            options:
+              path: /var/lib/grafana/dashboards/power
+            orgId: 1
+            type: file
+          - disableDeletion: false
+            editable: true
+            folder: network
+            name: Network
+            options:
+              path: /var/lib/grafana/dashboards/network
+            orgId: 1
+            type: file
+          - disableDeletion: false
+            editable: true
+            folder: Hardware
+            name: Hardware
+            options:
+              path: /var/lib/grafana/dashboards/hardware
+            orgId: 1
+            type: file
+    dashboards:
+      cert-manager:
+        overview:
+          url: https://raw.githubusercontent.com/monitoring-mixins/website/refs/heads/master/assets/cert-manager/dashboards/cert-manager-overview.json
+      databases:
+        cnpg:
+          url: https://raw.githubusercontent.com/cloudnative-pg/grafana-dashboards/refs/heads/main/charts/cluster/grafana-dashboard.json
+      ethereum:
+        geth-server:
+          datasource: Prometheus
+          gnetId: 6976
+          revision: 3
+        metrics-exporter:
+          datasource:
+            - {name: DS_PROMETHEUS, value: Prometheus}
+          gnetId: 16277
+          revision: 15
+        staking:
+          datasource: Prometheus
+          gnetId: 17846
+          revision: 3
+      flux:
+        flux-cluster:
+          datasource: Prometheus
+          url: https://raw.githubusercontent.com/fluxcd/flux2-monitoring-example/main/monitoring/configs/dashboards/cluster.json
+        flux-control-plane:
+          datasource: Prometheus
+          url: https://raw.githubusercontent.com/fluxcd/flux2-monitoring-example/main/monitoring/configs/dashboards/control-plane.json
+        flux-logs:
+          datasource: Loki
+          url: https://raw.githubusercontent.com/fluxcd/flux2-monitoring-example/main/monitoring/configs/dashboards/logs.json
+      hardware:
+        idrac:
+          datasource: Prometheus
+          gnetId: 12106
+          revision: 4
+        nvidia-dcgm:
+          datasource: Prometheus
+          url: https://raw.githubusercontent.com/NVIDIA/dcgm-exporter/main/grafana/dcgm-exporter-dashboard.json
+      home:
+        home-assistant:
+          datasource: home_assistant
+          url: https://raw.githubusercontent.com/rwlove/home-ops/main/kubernetes/apps/observability/grafana/dashboards/home_assistant.json
+      kubernetes:
+        k8s-system-api-server:
+          # renovate: dashboardName="Kubernetes / System / API Server"
+          datasource: Prometheus
+          gnetId: 15761
+          revision: 17
+        k8s-views-global:
+          # renovate: dashboardName="Kubernetes / Views / Global"
+          datasource: Prometheus
+          gnetId: 15757
+          revision: 42
+        k8s-views-namespaces:
+          # renovate: dashboardName="Kubernetes / Views / Namespaces"
+          datasource: Prometheus
+          gnetId: 15758
+          revision: 41
+        k8s-views-nodes:
+          # renovate: dashboardName="Kubernetes / Views / Nodes"
+          datasource: Prometheus
+          gnetId: 15759
+          revision: 32
+        k8s-views-pods:
+          # renovate: dashboardName="Kubernetes / Views / Pods"
+          datasource: Prometheus
+          gnetId: 15760
+          revision: 34
+        k8s-volumes:
+          # renovate: dashboardName="K8s / Storage / Volumes / Cluster"
+          datasource: Prometheus
+          gnetId: 11454
+          revision: 14
+      network:
+        cloudflared:
+          # renovate: depName="Cloudflare Tunnels (cloudflared)"
+          datasource:
+            - {name: DS_PROMETHEUS, value: Prometheus}
+          gnetId: 17457
+          revision: 6
+        external-dns:
+          # renovate: depName="External-dns"
+          datasource: Prometheus
+          gnetId: 15038
+          revision: 3
+        netdata:
+          datasource: Prometheus
+          gnetId: 7107
+          revision: 1
+        speed_test:
+          datasource: Prometheus
+        # Ref: https://grafana.com/grafana/dashboards/7845
+          gnetId: 13665
+          revision: 4
+      power:
+        ups:
+          datasource: Prometheus
+          gnetId: 12340
+          revision: 1
+    datasources:
+      datasources.yaml:
+        apiVersion: 1
+        datasources:
+          - access: proxy
+            isDefault: true
+            jsonData:
+              prometheusType: Prometheus
+            name: Prometheus
+            type: prometheus
+            url: http://kube-prometheus-stack-prometheus.observability.svc.cluster.local:9090
+          - access: proxy
+            jsonData:
+              maxLines: 1000
+            name: Loki
+            type: loki
+            url: http://loki-gateway.observability.svc.cluster.local:80
+          - access: proxy
+            jsonData:
+              implementation: prometheus
+            name: Alertmanager
+            type: alertmanager
+            uid: alertmanager
+            url: http://kube-prometheus-stack-alertmanager.observability.svc.cluster.local:9093
+          - access: proxy
+            basicAuth: false
+            database: home_assistant
+            jsonData:
+              postgresVersion: 1000
+              sslmode: disable
+            name: home_assistant
+            secureJsonData:
+              password: "home-assistant"
+            type: postgres
+            url: postgres-home-assistant-ro.databases.svc.cluster.local:5432
+            user: "home-assistant"
+            version: 1
 
-    podAnnotations:
-      secret.reloader.stakater.com/reload: &secret grafana-secret
-      configmap.reloader.stakater.com/reload: grafana-config-dashboards,grafana-dashboards-default,*app
-
+            withCredentials: false
+        deleteDatasources:
+          - {name: Alertmanager, orgId: 1}
+          - {name: Loki, orgId: 1}
+          - {name: Prometheus, orgId: 1}
+          - {name: home_assistant, orgId: 1}
     env:
-      GF_ANALYTICS_CHECK_FOR_UPDATES: false
       GF_ANALYTICS_CHECK_FOR_PLUGIN_UPDATES: false
+      GF_ANALYTICS_CHECK_FOR_UPDATES: false
       GF_ANALYTICS_REPORTING_ENABLED: false
       GF_AUTH_ANONYMOUS_ENABLED: true
-      GF_SECURITY_ALLOW_EMBEDDING: true
       GF_DATE_FORMATS_USE_BROWSER_LOCALE: true
       GF_EXPLORE_ENABLED: true
       GF_FEATURE_TOGGLES_ENABLE: publicDashboards
-      GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: natel-discrete-panel,pr0ps-trackmap-panel,panodata-map-panel
-      GF_SECURITY_COOKIE_SAMESITE: grafana
-      GF_SERVER_ROOT_URL: https://grafana.${SECRET_DOMAIN}
       GF_LOG_MODE: console
       GF_NEWS_NEWS_FEED_ENABLED: false
 
+      GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: natel-discrete-panel,pr0ps-trackmap-panel,panodata-map-panel
+      GF_SECURITY_ALLOW_EMBEDDING: true
+      GF_SECURITY_COOKIE_SAMESITE: grafana
+      GF_SERVER_ROOT_URL: https://grafana.${SECRET_DOMAIN}
     envFromSecrets:
-      - name: *secret
+      - name: &secret grafana-secret
 
     grafana.ini:
       analytics:
-        check_for_updates: false
         check_for_plugin_updates: false
+        check_for_updates: false
         reporting_enabled: false
       auth:
         disable_login_form: true
@@ -51,246 +284,13 @@ spec:
         org_role: Admin
       news:
         news_feed_enabled: false
-    dashboardProviders:
-      dashboardproviders.yaml:
-        apiVersion: 1
-        providers:
-          - name: "default"
-            orgId: 1
-            folder: ""
-            type: file
-            disableDeletion: false
-            editable: true
-            options:
-              path: /var/lib/grafana/dashboards/default
-          - name: Kubernetes
-            orgId: 1
-            folder: kubernetes
-            type: file
-            disableDeletion: false
-            editable: true
-            options:
-              path: /var/lib/grafana/dashboards/kubernetes
-          - name: cert-manager
-            orgId: 1
-            folder: cert-manager
-            type: file
-            disableDeletion: false
-            editable: true
-            options:
-              path: /var/lib/grafana/dashboards/cert-manager
-          - name: Ethereum
-            orgId: 1
-            folder: ethereum
-            type: file
-            disableDeletion: false
-            editable: true
-            options:
-              path: /var/lib/grafana/dashboards/ethereum
-          - name: Flux
-            orgId: 1
-            folder: flux
-            type: file
-            disableDeletion: false
-            editable: true
-            options:
-              path: /var/lib/grafana/dashboards/flux
-          - name: Databases
-            orgId: 1
-            folder: databases
-            type: file
-            disableDeletion: false
-            editable: true
-            options:
-              path: /var/lib/grafana/dashboards/databases
-          - name: Home
-            orgId: 1
-            folder: home
-            type: file
-            disableDeletion: false
-            editable: true
-            options:
-              path: /var/lib/grafana/dashboards/home
-          - name: Power
-            orgId: 1
-            folder: power
-            type: file
-            disableDeletion: false
-            editable: true
-            options:
-              path: /var/lib/grafana/dashboards/power
-          - name: Network
-            orgId: 1
-            folder: network
-            type: file
-            disableDeletion: false
-            editable: true
-            options:
-              path: /var/lib/grafana/dashboards/network
-          - name: Hardware
-            orgId: 1
-            folder: Hardware
-            type: file
-            disableDeletion: false
-            editable: true
-            options:
-              path: /var/lib/grafana/dashboards/hardware
-    datasources:
-      datasources.yaml:
-        apiVersion: 1
-        deleteDatasources:
-          - {name: Alertmanager, orgId: 1}
-          - {name: Loki, orgId: 1}
-          - {name: Prometheus, orgId: 1}
-          - {name: home_assistant, orgId: 1}
-        datasources:
-          - name: Prometheus
-            type: prometheus
-            access: proxy
-            url: http://kube-prometheus-stack-prometheus.observability.svc.cluster.local:9090
-            isDefault: true
-            jsonData:
-              prometheusType: Prometheus
-          - name: Loki
-            type: loki
-            access: proxy
-            url: http://loki-gateway.observability.svc.cluster.local:80
-            jsonData:
-              maxLines: 1000
-          - name: Alertmanager
-            type: alertmanager
-            uid: alertmanager
-            access: proxy
-            url: http://kube-prometheus-stack-alertmanager.observability.svc.cluster.local:9093
-            jsonData:
-              implementation: prometheus
-          - name: home_assistant
-            type: postgres
-            access: proxy
-            database: home_assistant
-            url: postgres-home-assistant-ro.databases.svc.cluster.local:5432
-            user: "home-assistant"
-            secureJsonData:
-              password: "home-assistant"
-            basicAuth: false
-            withCredentials: false
-            jsonData:
-              postgresVersion: 1000
-              sslmode: disable
-            version: 1
-
-    dashboards:
-      kubernetes:
-        k8s-system-api-server:
-          # renovate: dashboardName="Kubernetes / System / API Server"
-          gnetId: 15761
-          revision: 17
-          datasource: Prometheus
-        k8s-views-global:
-          # renovate: dashboardName="Kubernetes / Views / Global"
-          gnetId: 15757
-          revision: 42
-          datasource: Prometheus
-        k8s-views-nodes:
-          # renovate: dashboardName="Kubernetes / Views / Nodes"
-          gnetId: 15759
-          revision: 32
-          datasource: Prometheus
-        k8s-views-namespaces:
-          # renovate: dashboardName="Kubernetes / Views / Namespaces"
-          gnetId: 15758
-          revision: 41
-          datasource: Prometheus
-        k8s-views-pods:
-          # renovate: dashboardName="Kubernetes / Views / Pods"
-          gnetId: 15760
-          revision: 34
-          datasource: Prometheus
-        k8s-volumes:
-          # renovate: dashboardName="K8s / Storage / Volumes / Cluster"
-          gnetId: 11454
-          revision: 14
-          datasource: Prometheus
-      ethereum:
-        metrics-exporter:
-          gnetId: 16277
-          revision: 15
-          datasource:
-            - {name: DS_PROMETHEUS, value: Prometheus}
-        geth-server:
-          gnetId: 6976
-          revision: 3
-          datasource: Prometheus
-        staking:
-          gnetId: 17846
-          revision: 3
-          datasource: Prometheus
-      databases:
-        cnpg:
-          url: https://raw.githubusercontent.com/cloudnative-pg/grafana-dashboards/refs/heads/main/charts/cluster/grafana-dashboard.json
-      cert-manager:
-        overview:
-          url: https://raw.githubusercontent.com/monitoring-mixins/website/refs/heads/master/assets/cert-manager/dashboards/cert-manager-overview.json
-      flux:
-        flux-cluster:
-          url: https://raw.githubusercontent.com/fluxcd/flux2-monitoring-example/main/monitoring/configs/dashboards/cluster.json
-          datasource: Prometheus
-        flux-control-plane:
-          url: https://raw.githubusercontent.com/fluxcd/flux2-monitoring-example/main/monitoring/configs/dashboards/control-plane.json
-          datasource: Prometheus
-        flux-logs:
-          url: https://raw.githubusercontent.com/fluxcd/flux2-monitoring-example/main/monitoring/configs/dashboards/logs.json
-          datasource: Loki
-      home:
-        home-assistant:
-          url: https://raw.githubusercontent.com/rwlove/home-ops/main/kubernetes/apps/observability/grafana/dashboards/home_assistant.json
-          datasource: home_assistant
-      power:
-        ups:
-          gnetId: 12340
-          revision: 1
-          datasource: Prometheus
-      network:
-        speed_test:
-          gnetId: 13665
-          revision: 4
-          datasource: Prometheus
-        # Ref: https://grafana.com/grafana/dashboards/7845
-        netdata:
-          gnetId: 7107
-          revision: 1
-          datasource: Prometheus
-        cloudflared:
-          # renovate: depName="Cloudflare Tunnels (cloudflared)"
-          gnetId: 17457
-          revision: 6
-          datasource:
-            - {name: DS_PROMETHEUS, value: Prometheus}
-        external-dns:
-          # renovate: depName="External-dns"
-          gnetId: 15038
-          revision: 3
-          datasource: Prometheus
-      hardware:
-        idrac:
-          gnetId: 12106
-          revision: 4
-          datasource: Prometheus
-        nvidia-dcgm:
-          url: https://raw.githubusercontent.com/NVIDIA/dcgm-exporter/main/grafana/dcgm-exporter-dashboard.json
-          datasource: Prometheus
-    sidecar:
-      dashboards:
-        enabled: true
-        searchNamespace: ALL
-      datasources:
-        enabled: true
-        searchNamespace: ALL
-        labelValue: ""
     imageRenderer:
       enabled: true
       env:
         RENDERING_MODE: clustered
+    persistence:
+      enabled: false
+
     plugins:
       - natel-discrete-panel
       - pr0ps-trackmap-panel
@@ -304,11 +304,20 @@ spec:
       - farski-blendstat-panel
       - speakyourcode-button-panel
       - snuids-trafficlights-panel
-    serviceMonitor:
-      enabled: true
+    podAnnotations:
+      configmap.reloader.stakater.com/reload: grafana-config-dashboards,grafana-dashboards-default,*app
+
+      secret.reloader.stakater.com/reload: *secret
+    replicas: 1
 
     route:
       main:
+        annotations:
+          glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/grafana.png"
+          glance/id: "Observability"
+
+          glance/name: "Grafana"
+          glance/show: "true"
         enabled: true
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
@@ -316,26 +325,17 @@ spec:
           - name: internal
             namespace: network
             sectionName: https
-        annotations:
-          glance/name: "Grafana"
-          glance/show: "true"
-          glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/grafana.png"
-          glance/id: "Observability"
+    serviceMonitor:
+      enabled: true
 
-    persistence:
-      enabled: false
-
+    sidecar:
+      dashboards:
+        enabled: true
+        searchNamespace: ALL
+      datasources:
+        enabled: true
+        labelValue: ""
+        searchNamespace: ALL
     testFramework:
       enabled: false
 
-    affinity:
-      podAntiAffinity:
-        preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                  - key: app.kubernetes.io/name
-                    operator: In
-                    values: ["grafana"]
-              topologyKey: kubernetes.io/hostname

--- a/kubernetes/apps/observability/kromgo/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kromgo/app/helmrelease.yaml
@@ -5,26 +5,19 @@ kind: HelmRelease
 metadata:
   name: kromgo
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: app-template
 
+  interval: 30m
   values:
     controllers:
       main:
-        type: statefulset
-        replicas: 2
-        strategy: RollingUpdate
-
-        annotations:
-          reloader.stakater.com/auto: "true"
-
         pod:
           securityContext:
-            runAsUser: 568
             runAsGroup: 568
             runAsNonRoot: true
+            runAsUser: 568
           topologySpreadConstraints:
             - maxSkew: 1
               topologyKey: kubernetes.io/hostname
@@ -33,6 +26,13 @@ spec:
                 matchLabels:
                   app.kubernetes.io/name: kromgo
 
+        annotations:
+          reloader.stakater.com/auto: "true"
+
+        replicas: 2
+        strategy: RollingUpdate
+
+        type: statefulset
         containers:
           main:
             image:
@@ -40,10 +40,6 @@ spec:
               tag: v0.9.1
             env:
               PROMETHEUS_URL: http://kube-prometheus-stack-prometheus.observability.svc.cluster.local:9090
-            securityContext:
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: true
-              capabilities: {drop: ["ALL"]}
             resources:
               requests:
                 cpu: 15m
@@ -51,6 +47,10 @@ spec:
               limits:
                 memory: 64M
 
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: {drop: ["ALL"]}
     service:
       main:
         controller: main

--- a/kubernetes/apps/observability/kube-ops-view/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-ops-view/app/helmrelease.yaml
@@ -5,14 +5,17 @@ kind: HelmRelease
 metadata:
   name: kube-ops-view
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: app-template
 
+  interval: 30m
   values:
     controllers:
       main:
+        serviceAccount:
+          identifier: kube-ops-view
+
         type: statefulset
 
         containers:
@@ -21,11 +24,6 @@ spec:
               repository: hjacobs/kube-ops-view
               tag: 23.5.0@sha256:a4fae38f93d7e0475b2bcef28c72a65d39d824daed22b26c4cef0a6da89aac7e
 
-        serviceAccount:
-          identifier: kube-ops-view
-
-    serviceAccount:
-      kube-ops-view: {}
 
     service:
       main:
@@ -36,6 +34,11 @@ spec:
 
     route:
       main:
+        annotations:
+          glance/name: "Kube Ops View"
+          glance/show: "true"
+          #glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/netdata.png"
+          glance/id: "Network"
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
         parentRefs:
@@ -46,8 +49,5 @@ spec:
           - backendRefs:
               - identifier: main
                 port: *httpPort
-        annotations:
-          glance/name: "Kube Ops View"
-          glance/show: "true"
-          #glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/netdata.png"
-          glance/id: "Network"
+    serviceAccount:
+      kube-ops-view: {}

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -5,7 +5,6 @@ kind: HelmRelease
 metadata:
   name: kube-prometheus-stack
 spec:
-  interval: 1h
   chartRef:
     kind: OCIRepository
     name: kube-prometheus-stack
@@ -13,17 +12,31 @@ spec:
     - name: rook-ceph-cluster
       namespace: rook-ceph
 
+  interval: 1h
   values:
-    crds:
-      enabled: false
-    cleanPrometheusOperatorObjectNames: true
-
-    ###
-    ### Component values
-    ###
     alertmanager:
+      alertmanagerSpec:
+        alertmanagerConfiguration:
+          global:
+            resolveTimeout: 5m
+          name: alertmanager
+        externalUrl: https://alertmanager.${SECRET_DOMAIN}
+        storage:
+          volumeClaimTemplate:
+            spec:
+              resources:
+                requests:
+                  storage: 1Gi
+
+              storageClassName: ceph-block
       route:
         main:
+          annotations:
+            glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/alertmanager.png"
+            glance/id: "Observability"
+
+            glance/name: "Alert Manager"
+            glance/show: "true"
           enabled: true
           hostnames:
             - alertmanager.${SECRET_DOMAIN}
@@ -31,79 +44,13 @@ spec:
             - name: internal
               namespace: network
               sectionName: https
-          annotations:
-            glance/name: "Alert Manager"
-            glance/show: "true"
-            glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/alertmanager.png"
-            glance/id: "Observability"
+    cleanPrometheusOperatorObjectNames: true
 
-      alertmanagerSpec:
-        alertmanagerConfiguration:
-          name: alertmanager
-          global:
-            resolveTimeout: 5m
-        externalUrl: https://alertmanager.${SECRET_DOMAIN}
-        storage:
-          volumeClaimTemplate:
-            spec:
-              storageClassName: ceph-block
-              resources:
-                requests:
-                  storage: 1Gi
-
-    kubeApiServer:
-      enabled: true
-      endpoints: ["192.168.1.9", "192.168.4.9", "192.168.4.10"]
-      serviceMonitor:
-        metricRelabelings:
-          # Drop high cardinality labels
-          - action: drop
-            sourceLabels: ["__name__"]
-            regex: (apiserver|etcd|rest_client)_request(|_sli|_slo)_duration_seconds_bucket
-          - action: drop
-            sourceLabels: ["__name__"]
-            regex: (apiserver_response_sizes_bucket|apiserver_watch_events_sizes_bucket|apiserver_request_total)
-          - action: drop
-            sourceLabels: ["__name__"]
-            regex: code_verb:apiserver_request_total:increase1h[30d]
-          - action: drop
-            sourceLabels: ["__name__"]
-            regex: '.*apiserver_request_total.*'
-
-    kubeControllerManager:
-      enabled: true
-      endpoints: ["192.168.1.9", "192.168.4.9", "192.168.4.10"]
-
-    kubeEtcd:
-      enabled: true
-      endpoints: ["192.168.1.9", "192.168.4.9", "192.168.4.10"]
-
-    kubelet:
-      enabled: true
-      serviceMonitor:
-        metricRelabelings:
-          # Drop high cardinality labels
-          - action: labeldrop
-            regex: (uid)
-          - action: labeldrop
-            regex: (id|name)
-          - action: drop
-            sourceLabels: ["__name__"]
-            regex: (rest_client_request_duration_seconds_bucket|rest_client_request_duration_seconds_sum|rest_client_request_duration_seconds_count)
-
-    kubeProxy:
+    ###
+    ### Component values
+    ###
+    crds:
       enabled: false
-
-    kubeScheduler:
-      enabled: true
-      endpoints: ["192.168.1.9", "192.168.4.9", "192.168.4.10"]
-
-    kubeStateMetrics:
-      enabled: false
-
-    nodeExporter:
-      enabled: false
-
     grafana:
       enabled: false
       forceDeployDashboards: true
@@ -115,35 +62,101 @@ spec:
     ###
     ### Prometheus operator values
     ###
-    prometheusOperator:
-      resources:
-        requests:
-          cpu: 35m
-          memory: 273M
-        limits:
-          memory: 326M
+    kubeApiServer:
+      enabled: true
+      endpoints: ["192.168.1.9", "192.168.4.9", "192.168.4.10"]
+      serviceMonitor:
+        metricRelabelings:
+          # Drop high cardinality labels
+          - action: drop
+            regex: (apiserver|etcd|rest_client)_request(|_sli|_slo)_duration_seconds_bucket
+            sourceLabels: ["__name__"]
+          - action: drop
+            regex: (apiserver_response_sizes_bucket|apiserver_watch_events_sizes_bucket|apiserver_request_total)
+            sourceLabels: ["__name__"]
+          - action: drop
+            regex: code_verb:apiserver_request_total:increase1h[30d]
+            sourceLabels: ["__name__"]
+          - action: drop
+            regex: '.*apiserver_request_total.*'
 
-      prometheusConfigReloader:
-        # resource config for prometheusConfigReloader
-        resources:
-          requests:
-            cpu: 5m
-            memory: 32M
-          limits:
-            memory: 32M
+            sourceLabels: ["__name__"]
+    kubeControllerManager:
+      enabled: true
+      endpoints: ["192.168.1.9", "192.168.4.9", "192.168.4.10"]
 
-    ###
-    ### Prometheus instance values
-    ###
+    kubeEtcd:
+      enabled: true
+      endpoints: ["192.168.1.9", "192.168.4.9", "192.168.4.10"]
+    kubeProxy:
+      enabled: false
+
+    kubeScheduler:
+      enabled: true
+      endpoints: ["192.168.1.9", "192.168.4.9", "192.168.4.10"]
+
+    kubeStateMetrics:
+      enabled: false
+
+
+    kubelet:
+      enabled: true
+      serviceMonitor:
+        metricRelabelings:
+          # Drop high cardinality labels
+          - action: labeldrop
+            regex: (uid)
+          - action: labeldrop
+            regex: (id|name)
+          - action: drop
+            regex: (rest_client_request_duration_seconds_bucket|rest_client_request_duration_seconds_sum|rest_client_request_duration_seconds_count)
+
+            sourceLabels: ["__name__"]
+    nodeExporter:
+      enabled: false
+
     prometheus:
+      prometheusSpec:
+        enableRemoteWriteReceiver: true
+        externalUrl: https://prometheus.${SECRET_DOMAIN}
+        image:
+          registry: docker.io
+          repository: prompp/prompp
+          tag: 2.53.2-0.3.3
+        podMonitorSelectorNilUsesHelmValues: false
+        probeSelectorNilUsesHelmValues: false
+        resources:
+          limits:
+            memory: 3G
+          requests:
+            cpu: 100m
+            memory: 3G
+        retention: 14d
+        retentionSize: 100GB
+        ruleSelectorNilUsesHelmValues: false
+        scrapeConfigSelectorNilUsesHelmValues: false
+        scrapeInterval: 1m # Must match interval in Grafana Helm chart
+        securityContext:
+          fsGroup: 64535
+          runAsGroup: 64535
+          runAsNonRoot: true
+          runAsUser: 64535
+        serviceMonitorSelectorNilUsesHelmValues: false
+        storageSpec:
+          volumeClaimTemplate:
+            spec:
+              resources:
+                requests:
+                  storage: 110Gi
+              storageClassName: ceph-block
       route:
         main:
-          enabled: true
           annotations:
-            glance/name: "Prometheus"
-            glance/show: "true"
             glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/prometheus.png"
             glance/id: "Observability"
+            glance/name: "Prometheus"
+            glance/show: "true"
+          enabled: true
           hostnames:
             - "prometheus.${SECRET_DOMAIN}"
           parentRefs:
@@ -151,36 +164,23 @@ spec:
               namespace: network
               sectionName: https
 
-      prometheusSpec:
-        externalUrl: https://prometheus.${SECRET_DOMAIN}
-        image:
-          registry: docker.io
-          repository: prompp/prompp
-          tag: 2.53.2-0.3.3
-        securityContext:
-          runAsNonRoot: true
-          runAsUser: 64535
-          runAsGroup: 64535
-          fsGroup: 64535
-        podMonitorSelectorNilUsesHelmValues: false
-        probeSelectorNilUsesHelmValues: false
+    prometheusOperator:
+      prometheusConfigReloader:
+        # resource config for prometheusConfigReloader
         resources:
-          requests:
-            cpu: 100m
-            memory: 3G
           limits:
-            memory: 3G
-        retention: 14d
-        retentionSize: 100GB
-        enableRemoteWriteReceiver: true
-        ruleSelectorNilUsesHelmValues: false
-        scrapeConfigSelectorNilUsesHelmValues: false
-        scrapeInterval: 1m # Must match interval in Grafana Helm chart
-        serviceMonitorSelectorNilUsesHelmValues: false
-        storageSpec:
-          volumeClaimTemplate:
-            spec:
-              storageClassName: ceph-block
-              resources:
-                requests:
-                  storage: 110Gi
+            memory: 32M
+
+    ###
+    ### Prometheus instance values
+    ###
+          requests:
+            cpu: 5m
+            memory: 32M
+      resources:
+        limits:
+          memory: 326M
+
+        requests:
+          cpu: 35m
+          memory: 273M

--- a/kubernetes/apps/observability/kube-state-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-state-metrics/app/helmrelease.yaml
@@ -5,15 +5,15 @@ kind: HelmRelease
 metadata:
   name: kube-state-metrics
 spec:
-  interval: 30m
   chart:
     spec:
       chart: kube-state-metrics
-      version: 7.2.2
       interval: 30m
       sourceRef:
         kind: HelmRepository
         name: prometheus-community-charts
+      version: 7.2.2
+  interval: 30m
   values:
     fullnameOverride: kube-state-metrics
 

--- a/kubernetes/apps/observability/netdata/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/netdata/app/helmrelease.yaml
@@ -5,18 +5,21 @@ kind: HelmRelease
 metadata:
   name: netdata
 spec:
-  interval: 30m
-  releaseName: netdata
   chart:
     spec:
       # renovate: registryUrl=https://netdata.github.io/helmchart/
       chart: netdata
-      version: 3.7.164
       sourceRef:
         kind: HelmRepository
         name: netdata
 
+      version: 3.7.164
+  interval: 30m
+  releaseName: netdata
   values:
+    child:
+      enabled: false
+
     image:
       repository: ghcr.io/netdata/netdata
       tag: "v2.10.2"
@@ -24,15 +27,12 @@ spec:
     ingress:
       enabled: false
 
+    k8sState:
+      enabled: false
     parent:
-      enabled: true
       alarms:
         storageclass: "ceph-block"
       database:
         storageclass: "ceph-block"
 
-    child:
-      enabled: false
-
-    k8sState:
-      enabled: false
+      enabled: true

--- a/kubernetes/apps/observability/network-ups-tools/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/network-ups-tools/app/helmrelease.yaml
@@ -5,19 +5,19 @@ kind: HelmRelease
 metadata:
   name: &app network-ups-tools
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: app-template
 
+  interval: 30m
   values:
     controllers:
       main:
-        type: statefulset
         pod:
           annotations:
             configmap.reloader.stakater.com/reload: &config network-ups-tools-config
 
+        type: statefulset
         containers:
           main:
             image:
@@ -36,11 +36,11 @@ spec:
 
     service:
       main:
-        controller: main
         type: LoadBalancer
-        externalTrafficPolicy: Local
         annotations:
           lbipam.cilium.io/ips: ${SVC_NUT_ADDR}
+        controller: main
+        externalTrafficPolicy: Local
         ports:
           http:
             port: 3493

--- a/kubernetes/apps/observability/prometheus-operator-crds/crds/helmrelease.yaml
+++ b/kubernetes/apps/observability/prometheus-operator-crds/crds/helmrelease.yaml
@@ -5,12 +5,12 @@ kind: HelmRelease
 metadata:
   name: prometheus-operator-crds
 spec:
-  interval: 30m
   chart:
     spec:
       chart: prometheus-operator-crds
-      version: 28.0.1
       interval: 30m
       sourceRef:
         kind: HelmRepository
         name: prometheus-community-charts
+      version: 28.0.1
+  interval: 30m

--- a/kubernetes/apps/observability/speedtest-prometheus/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/speedtest-prometheus/app/helmrelease.yaml
@@ -5,24 +5,30 @@ kind: HelmRelease
 metadata:
   name: &app speedtest-prometheus
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: app-template
 
+  interval: 30m
   install:
     remediation:
       retries: 3
 
   upgrade:
+    cleanupOnFail: true
+
     remediation:
       retries: 3
       remediateLastFailure: true
-    cleanupOnFail: true
-
   values:
     controllers:
       main:
+        pod:
+          securityContext:
+            runAsGroup: 568
+            runAsNonRoot: true
+
+            runAsUser: 568
         containers:
           main:
             image:
@@ -46,18 +52,18 @@ spec:
                 drop:
                   - ALL
 
-        pod:
-          securityContext:
-            runAsUser: 568
-            runAsGroup: 568
-            runAsNonRoot: true
-
     service:
       main:
         controller: main
         ports:
           http:
             port: *httpPort
+    persistence:
+      config:
+        enabled: true
+        type: emptyDir
+        globalMounts:
+          - path: /.config
 
     serviceMonitor:
       main:
@@ -69,9 +75,3 @@ spec:
             interval: 60m
             scrapeTimeout: 5m
 
-    persistence:
-      config:
-        enabled: true
-        type: emptyDir
-        globalMounts:
-          - path: /.config

--- a/kubernetes/apps/observability/vector/agent/helmrelease.yaml
+++ b/kubernetes/apps/observability/vector/agent/helmrelease.yaml
@@ -5,27 +5,27 @@ kind: HelmRelease
 metadata:
   name: vector-agent
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: app-template
 
+  interval: 30m
   values:
     controllers:
       main:
-        type: daemonset
-        strategy: RollingUpdate
+        pod:
+          tolerations:
+            - key: node-role.kubernetes.io/master
+              effect: NoSchedule
+
         annotations:
           reloader.stakater.com/auto: "true"
 
         serviceAccount:
           identifier: vector-agent
 
-        pod:
-          tolerations:
-            - key: node-role.kubernetes.io/master
-              effect: NoSchedule
-
+        strategy: RollingUpdate
+        type: daemonset
         containers:
           main:
             image:
@@ -53,15 +53,15 @@ spec:
                     apiVersion: v1
                     fieldPath: metadata.namespace
 
-            securityContext:
-              privileged: true
-
             resources:
               requests:
                 cpu: 23m
                 memory: 918M
               limits:
                 memory: 918M
+
+            securityContext:
+              privileged: true
 
     persistence:
       config:
@@ -77,22 +77,6 @@ spec:
         globalMounts:
           - path: /vector-data-dir
 
-      var-log:
-        type: hostPath
-        hostPath: /var/log
-        hostPathType: Directory
-        globalMounts:
-          - path: /var/log
-            readOnly: true
-
-      var-lib:
-        type: hostPath
-        hostPath: /var/lib
-        hostPathType: Directory
-        globalMounts:
-          - path: /var/lib
-            readOnly: true
-
       procfs:
         type: hostPath
         hostPath: /proc
@@ -107,6 +91,22 @@ spec:
         hostPathType: Directory
         globalMounts:
           - path: /host/sys
+            readOnly: true
+
+      var-lib:
+        type: hostPath
+        hostPath: /var/lib
+        hostPathType: Directory
+        globalMounts:
+          - path: /var/lib
+            readOnly: true
+
+      var-log:
+        type: hostPath
+        hostPath: /var/log
+        hostPathType: Directory
+        globalMounts:
+          - path: /var/log
             readOnly: true
 
     podMonitor:

--- a/kubernetes/apps/observability/vector/aggregator/helmrelease.yaml
+++ b/kubernetes/apps/observability/vector/aggregator/helmrelease.yaml
@@ -3,25 +3,35 @@
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
+  name: &app vector-aggregator
   labels:
     app.kubernetes.io/instance: vector-aggregator
     app.kubernetes.io/name: vector-aggregator
-  name: &app vector-aggregator
 spec:
-  interval: 30m
   chartRef:
     kind: OCIRepository
     name: app-template
 
+  interval: 30m
   values:
     controllers:
       main:
-        replicas: 2
 
-        strategy: RollingUpdate
+        pod:
+          topologySpreadConstraints:
+            - maxSkew: 1
+              topologyKey: kubernetes.io/hostname
+              whenUnsatisfiable: DoNotSchedule
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: *app
 
         annotations:
           reloader.stakater.com/auto: "true"
+
+        replicas: 2
+
+        strategy: RollingUpdate
 
         initContainers:
           init-geoip:
@@ -44,22 +54,12 @@ spec:
               repository: docker.io/timberio/vector
               tag: 0.54.0-debian@sha256:099732c890b095d5222f59bdc82a0579ae3d48b9e2407f3680586dd8d2f75f64
             args: ["--config", "/etc/vector/vector.yaml"]
-
-        pod:
-          topologySpreadConstraints:
-            - maxSkew: 1
-              topologyKey: kubernetes.io/hostname
-              whenUnsatisfiable: DoNotSchedule
-              labelSelector:
-                matchLabels:
-                  app.kubernetes.io/name: *app
-
     service:
       main:
-        controller: main
         type: LoadBalancer
         annotations:
           lbipam.cilium.io/ips: ${SVC_VECTOR_ADDR}
+        controller: main
         externalTrafficPolicy: Cluster
         ports:
           http:

--- a/kubernetes/apps/observability/watch-your-lan/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/watch-your-lan/app/helmrelease.yaml
@@ -5,10 +5,10 @@ kind: HelmRelease
 metadata:
   name: watch-your-lan
 spec:
-  interval: 1h
   chartRef:
     kind: OCIRepository
     name: app-template
+  interval: 1h
   values:
     controllers:
       watch-your-lan:

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -50,9 +50,9 @@ spec:
 
       mgr:
         modules:
-          - name: rook
-            enabled: true
+          - enabled: true
 
+            name: rook
       resources:
         mgr:
           limits:
@@ -83,30 +83,30 @@ spec:
         config:
           osdsPerDevice: "1"
         nodes:
-          - name: "master1.${SECRET_DOMAIN}"
-            devices:
+          - devices:
               - name: "/dev/disk/by-id/nvme-WD_Blue_SN570_2TB_23172Q802011_1-part1"
-          - name: "worker2.${SECRET_DOMAIN}"
-            devices:
+            name: "master1.${SECRET_DOMAIN}"
+          - devices:
               - name: "/dev/disk/by-id/nvme-WD_Blue_SN570_2TB_23172Q802600_1-part2"
-          - name: "worker3.${SECRET_DOMAIN}"
-            devices:
+            name: "worker2.${SECRET_DOMAIN}"
+          - devices:
               - name: "/dev/disk/by-id/nvme-eui.e8238fa6bf530001001b448b4cec4fe7"
-          - name: "worker4.${SECRET_DOMAIN}"
-            devices:
+            name: "worker3.${SECRET_DOMAIN}"
+          - devices:
               - name: "/dev/disk/by-id/nvme-WD_Blue_SN570_2TB_23172Q802182_1-part2"
-          - name: "worker5.${SECRET_DOMAIN}"
-            devices:
+            name: "worker4.${SECRET_DOMAIN}"
+          - devices:
               - name: "/dev/vdb"
-          - name: "worker6.${SECRET_DOMAIN}"
-            devices:
+            name: "worker5.${SECRET_DOMAIN}"
+          - devices:
               - name: "/dev/vdb"
-          - name: "worker7.${SECRET_DOMAIN}"
-            devices:
+            name: "worker6.${SECRET_DOMAIN}"
+          - devices:
               - name: "/dev/vdb"
-          - name: "worker8.${SECRET_DOMAIN}"
-            devices:
+            name: "worker7.${SECRET_DOMAIN}"
+          - devices:
               - name: "/dev/vdb"
+            name: "worker8.${SECRET_DOMAIN}"
         useAllDevices: false
         useAllNodes: false
 
@@ -115,9 +115,9 @@ spec:
         spec:
           dataPools:
             - failureDomain: host
+              name: data0
               replicated:
                 size: 3
-              name: data0
           metadataPool:
             replicated:
               size: 3
@@ -194,10 +194,10 @@ spec:
     route:
       dashboard:
         annotations:
-          glance/name: "Rook"
-          glance/show: "true"
           glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/rook.svg"
           glance/id: "Storage"
+          glance/name: "Rook"
+          glance/show: "true"
         host:
           name: "rook.${SECRET_DOMAIN}"
           path: /

--- a/kubernetes/apps/selfhosted/webhook/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/webhook/app/helmrelease.yaml
@@ -54,13 +54,11 @@ spec:
                 drop:
                   - ALL
               readOnlyRootFilesystem: true
-    persistence:
-      config:
-        type: configMap
-        defaultMode: 0775
-        name: webhook-configmap
-        globalMounts:
-          - readOnly: true
+    service:
+      app:
+        ports:
+          http:
+            port: *port
     route:
       app:
         hostnames:
@@ -69,8 +67,10 @@ spec:
           - name: external
             namespace: network
             sectionName: https
-    service:
-      app:
-        ports:
-          http:
-            port: *port
+    persistence:
+      config:
+        type: configMap
+        defaultMode: 0775
+        name: webhook-configmap
+        globalMounts:
+          - readOnly: true

--- a/kubernetes/apps/storage/garage/app/helmrelease.yaml
+++ b/kubernetes/apps/storage/garage/app/helmrelease.yaml
@@ -48,22 +48,6 @@ spec:
               allowPrivilegeEscalation: false
               capabilities: {drop: [ALL]}
               readOnlyRootFilesystem: true
-    persistence:
-      config:
-        type: configMap
-        enabled: true
-        name: garage-configmap
-        globalMounts:
-          - path: /etc/garage.toml
-            subPath: configuration.toml
-      data:
-        existingClaim: garage-data-pvc
-        globalMounts:
-          - path: /data
-      meta:
-        existingClaim: garage-meta-pvc
-        globalMounts:
-          - path: /meta
     service:
       app:
         ports:
@@ -82,3 +66,19 @@ spec:
           - backendRefs:
               - name: *app
                 port: *port
+    persistence:
+      config:
+        enabled: true
+        type: configMap
+        name: garage-configmap
+        globalMounts:
+          - path: /etc/garage.toml
+            subPath: configuration.toml
+      data:
+        existingClaim: garage-data-pvc
+        globalMounts:
+          - path: /data
+      meta:
+        existingClaim: garage-meta-pvc
+        globalMounts:
+          - path: /meta

--- a/kubernetes/apps/storage/garage/webui/helmrelease.yaml
+++ b/kubernetes/apps/storage/garage/webui/helmrelease.yaml
@@ -45,7 +45,7 @@ spec:
                 memory: 128Mi
             securityContext:
               allowPrivilegeEscalation: false
-              capabilities: { drop: [ALL] }
+              capabilities: {drop: [ALL]}
               readOnlyRootFilesystem: true
 
     service:
@@ -73,8 +73,8 @@ spec:
 
     persistence:
       config:
-        type: configMap
         enabled: true
+        type: configMap
         name: garage-configmap
         globalMounts:
           - path: /etc/garage.toml

--- a/kubernetes/apps/vpn/downloads-gateway/app/helmrelease.yaml
+++ b/kubernetes/apps/vpn/downloads-gateway/app/helmrelease.yaml
@@ -16,6 +16,8 @@ spec:
   interval: 30m
 
   values:
+    DNS: 172.16.1.1
+
     addons:
       netshoot:
         enabled: true
@@ -65,8 +67,6 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
         type: statefulset
-
-    DNS: 172.16.1.1
 
     image:
       repository: ghcr.io/angelnu/pod-gateway


### PR DESCRIPTION
## Summary

- Sorted all 110 `helmrelease.yaml` files across `kubernetes/apps/` for consistent key ordering
- 17 files were already sorted; 2 files with parse quirks were handled manually

## What changed

Pure key reordering — no values were modified. Applied the project's sorting conventions:

- **Top-level**: `apiVersion → kind → metadata → spec`
- **metadata**: `name → namespace → annotations → labels`
- **app-template HelmReleases** (73 files): `spec` ordered as `chartRef, interval, dependsOn, install, upgrade, values`; `values` ordered as `defaultPodOptions, controllers, service, route, persistence`; controller sections with `pod` first and `initContainers/containers` last; `enabled` field first within any section
- **Regular HelmReleases** (56 files): `spec` and `spec.values` sorted fully alphabetically

## Reviewer notes

This is a pure cosmetic/consistency change. Flux behavior is unaffected. Diffs are noisy but contain no functional changes.