### PR TITLE
feat(media): add soularr

### DIFF
--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -20,6 +20,7 @@ resources:
   - ./recyclarr/ks.yaml
   - ./seerr/ks.yaml
   - ./sonarr/ks.yaml
+  - ./soularr/ks.yaml
   - ./stash/ks.yaml
   - ./suggestarr/ks.yaml
   - ./theme-park/ks.yaml

--- a/kubernetes/apps/media/soularr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/soularr/app/helmrelease.yaml
@@ -1,0 +1,72 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app soularr
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 30m
+  values:
+    controllers:
+      main:
+        pod:
+          securityContext:
+            fsGroup: 568
+            fsGroupChangePolicy: OnRootMismatch
+            runAsGroup: 568
+            runAsUser: 568
+
+        annotations:
+          reloader.stakater.com/auto: "true"
+
+        containers:
+          main:
+            image:
+              repository: mrusse08/soularr
+              tag: 1.1.0@sha256:06e4829433b5c6f4cc08fef10c70d90973b48c4c3dc0207679b7e80e63f574aa
+
+            resources:
+              requests:
+                cpu: 10m
+                memory: 128Mi
+              limits:
+                memory: 128Mi
+
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+
+    service:
+      main:
+        controller: main
+        ports:
+          http:
+            port: 1000
+
+    route:
+      main:
+        hostnames:
+          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: main
+                port: 1000
+
+    persistence:
+      data:
+        existingClaim: soularr-data-pvc
+        globalMounts:
+          - path: /data
+
+      downloads:
+        existingClaim: slskd-downloads-pvc

--- a/kubernetes/apps/media/soularr/app/kustomization.yaml
+++ b/kubernetes/apps/media/soularr/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../components/repos/app-template
+resources:
+  - ./helmrelease.yaml
+  - ./longhorn-pvc.yaml

--- a/kubernetes/apps/media/soularr/app/longhorn-pvc.yaml
+++ b/kubernetes/apps/media/soularr/app/longhorn-pvc.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: soularr-data-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn
+  resources:
+    requests:
+      storage: 2Gi

--- a/kubernetes/apps/media/soularr/ks.yaml
+++ b/kubernetes/apps/media/soularr/ks.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app soularr
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: media
+  path: ./kubernetes/apps/media/soularr/app
+  interval: 30m
+  timeout: 3m
+  prune: true
+  wait: false
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: lidarr
+      namespace: media
+    - name: slskd
+      namespace: downloads
+  postBuild:
+    substitute:
+      APP: *app


### PR DESCRIPTION
## Summary

- Adds soularr (`mrusse08/soularr:1.1.0`) to the media namespace
- Deployed as a stateless deployment with app-template
- Depends on `lidarr` and `slskd` Kustomizations
- Mounts a 2Gi Longhorn PVC at `/data` and the shared `slskd-downloads-pvc` NFS volume
- Internal ingress route at `soularr.${SECRET_DOMAIN}`

## Test plan

- [ ] Flux reconciles `soularr` Kustomization successfully
- [ ] Pod starts and reaches Running state
- [ ] `/data` and downloads volumes mount correctly
- [ ] Web UI accessible at `soularr.<domain>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)