### PR TITLE
feat(app): add workoutdiary to collab namespace

### DIFF
--- a/kubernetes/apps/collab/kustomization.yaml
+++ b/kubernetes/apps/collab/kustomization.yaml
@@ -23,3 +23,4 @@ resources:
   - ./startpunkt-crds/ks.yaml
   - ./startpunkt-user/ks.yaml
   - ./swiparr/ks.yaml
+  - ./workoutdiary/ks.yaml

--- a/kubernetes/apps/collab/workoutdiary/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/workoutdiary/app/helmrelease.yaml
@@ -1,0 +1,62 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app workoutdiary
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+
+  interval: 30m
+  values:
+    controllers:
+      main:
+        annotations:
+          reloader.stakater.com/auto: "true"
+
+        type: statefulset
+        containers:
+          main:
+            image:
+              repository: ghcr.io/rwlove/workoutdiary-api
+              tag: 0.3
+
+            resources:
+              requests:
+                cpu: 15m
+                memory: 128M
+              limits:
+                memory: 256M
+
+    service:
+      main:
+        controller: main
+        ports:
+          http:
+            port: &httpPort 8851
+
+    route:
+      main:
+        annotations:
+          glance/name: "Workout Diary"
+          glance/show: "true"
+          glance/id: "Collaboration"
+
+        hostnames:
+          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: main
+                port: *httpPort
+
+    persistence:
+      data:
+        existingClaim: workoutdiary-data-pvc
+        globalMounts:
+          - path: /data/WorkoutDiary

--- a/kubernetes/apps/collab/workoutdiary/app/kustomization.yaml
+++ b/kubernetes/apps/collab/workoutdiary/app/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../components/repos/app-template
+
+resources:
+  - ./helmrelease.yaml
+  - ./longhorn-pvc.yaml

--- a/kubernetes/apps/collab/workoutdiary/app/longhorn-pvc.yaml
+++ b/kubernetes/apps/collab/workoutdiary/app/longhorn-pvc.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: workoutdiary-data-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: 2Gi
+  volumeName: workoutdiary-data-pv
+  storageClassName: workoutdiary-data-storage-class
+
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: workoutdiary-data-pv
+  labels:
+    type: longhorn
+    recurring-job-group.longhorn.io/weekly-backup: enabled
+    recurring-job-group.longhorn.io/daily-snapshot: enabled
+spec:
+  capacity:
+    storage: 2Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: workoutdiary-data-storage-class
+  csi:
+    driver: driver.longhorn.io
+    fsType: xfs
+    volumeAttributes:
+      numberOfReplicas: "2"
+      staleReplicaTimeout: "2880"
+    volumeHandle: workoutdiary-data-xfs

--- a/kubernetes/apps/collab/workoutdiary/ks.yaml
+++ b/kubernetes/apps/collab/workoutdiary/ks.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: workoutdiary
+  labels:
+    substitution.flux.home.arpa/enabled: "true"
+spec:
+  targetNamespace: collab
+  path: ./kubernetes/apps/collab/workoutdiary/app
+  interval: 30m
+  timeout: 3m
+  prune: true
+  wait: false
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: longhorn
+      namespace: longhorn-system


### PR DESCRIPTION
## Summary

- Adds `workoutdiary` application to the `collab` namespace
- Uses `ghcr.io/rwlove/workoutdiary-api:0.3` via app-template HelmRelease
- Internal-only access via internal gateway at `workoutdiary.${SECRET_DOMAIN}`
- 2Gi Longhorn PVC at `/data/WorkoutDiary` with daily snapshots and weekly backups

## Notes

- Image digest not yet added — update `tag` in helmrelease once image is pushed to GHCR
- Longhorn volume `workoutdiary-data-xfs` must be created before first deploy

## Test plan

- [ ] Flux reconciles `workoutdiary` Kustomization successfully
- [ ] Pod starts and reaches Running state
- [ ] App accessible at `workoutdiary.<domain>` on internal network
- [ ] PVC bound to Longhorn volume

🤖 Generated with [Claude Code](https://claude.com/claude-code)