### PR TITLE
refactor(webhook): dedicated script for pump-package hook

### DIFF
--- a/kubernetes/apps/selfhosted/webhook/app/kustomization.yaml
+++ b/kubernetes/apps/selfhosted/webhook/app/kustomization.yaml
@@ -11,6 +11,7 @@ configMapGenerator:
   - files:
       - hooks.yaml=./resources/hooks.yaml
       - github-renovate-operator.sh=./resources/github-renovate-operator.sh
+      - github-rwlove-pump-package.sh=./resources/github-rwlove-pump-package.sh
     name: webhook-configmap
 generatorOptions:
   annotations:

--- a/kubernetes/apps/selfhosted/webhook/app/resources/github-rwlove-pump-package.sh
+++ b/kubernetes/apps/selfhosted/webhook/app/resources/github-rwlove-pump-package.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Triggers the rwlove-pump RenovateJob, which is scoped to
+# kubernetes/apps/collab/pump/app/helmrelease.yaml only.
+JOB="rwlove-pump"
+NAMESPACE="renovate"
+PROJECT="rwlove/home-ops"
+RENOVATE_OPERATOR_WEBHOOK_URL="http://renovate-operator.renovate.svc.cluster.local:8082"
+
+# URL encode the project name
+PROJECT=$(echo "${PROJECT}" | jq -Rr @uri)
+
+curl -v -X POST \
+  "${RENOVATE_OPERATOR_WEBHOOK_URL}/webhook/v1/schedule?job=${JOB}&namespace=${NAMESPACE}&project=${PROJECT}"

--- a/kubernetes/apps/selfhosted/webhook/app/resources/hooks.yaml
+++ b/kubernetes/apps/selfhosted/webhook/app/resources/hooks.yaml
@@ -111,20 +111,7 @@
                     source: payload
                     name: pull_request.user.login
 - id: github-rwlove-pump-package
-  execute-command: /config/github-renovate-operator.sh
-  pass-arguments-to-command:
-    - # job name
-      source: string
-      name: rwlove-pump
-    - # namespace
-      source: string
-      name: renovate
-    - # project (Renovate scans home-ops, not pump)
-      source: string
-      name: rwlove/home-ops
-    - # Renovate Operator webhook URL
-      source: string
-      name: http://renovate-operator.renovate.svc.cluster.local:8082
+  execute-command: /config/github-rwlove-pump-package.sh
   trigger-rule:
     and:
       - # Validate the webhook secret


### PR DESCRIPTION
## Summary
- New script `github-rwlove-pump-package.sh` with `rwlove-pump` job values hardcoded.
- Hook `github-rwlove-pump-package` now calls the new script and no longer needs `pass-arguments-to-command`.
- Configmap generator updated to mount the new script.

Decouples the pump trigger from the shared `github-renovate-operator.sh` used by the Renovate dashboard / PR hooks.

## Test plan
- [ ] Flux reconciles, configmap rolls, webhook pod restarts via Stakater Reloader.
- [ ] Trigger a pump container publish; confirm the RenovateJob `rwlove-pump` runs and the other hooks still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)