### PR TITLE
feat(renovate): auto-merge pump container image PRs

### DIFF
--- a/.github/renovate/autoMerge.json5
+++ b/.github/renovate/autoMerge.json5
@@ -67,5 +67,13 @@
       matchPackageNames: ["/external-dns/", "/gateway-api/", "/prometheus-operator/"],
       ignoreTests: true,
     },
+    {
+      description: "Auto-merge pump container images",
+      matchDatasources: ["docker"],
+      automerge: true,
+      automergeType: "pr",
+      matchPackageNames: ["/^ghcr\\.io\\/rwlove\\/pump/"],
+      ignoreTests: false,
+    },
   ],
 }


### PR DESCRIPTION
## Summary
- Adds an autoMerge rule matching `ghcr.io/rwlove/pump-*` (covers `pump-api` and `pump-frontend`).
- All update types are eligible since the project is owned by the cluster operator.
- Completes the pump build → webhook → scoped RenovateJob → auto-merge pipeline.

## Test plan
- [ ] On the next pump publish, confirm Renovate opens a PR and auto-merges it once required checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)