### PR TITLE
fix(renovate): repair jobs kustomization and dockerhub secret refs

### DIFF
--- a/kubernetes/apps/renovate/renovate-operator/jobs/home-ops.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/jobs/home-ops.yaml
@@ -22,12 +22,12 @@ spec:
     - name: DOCKERHUB_USERNAME
       valueFrom:
         secretKeyRef:
-          name: github-auth-token-secret
+          name: renovate-operator-secret
           key: DOCKERHUB_USERNAME
     - name: DOCKERHUB_TOKEN
       valueFrom:
         secretKeyRef:
-          name: github-auth-token-secret
+          name: renovate-operator-secret
           key: DOCKERHUB_TOKEN
     - name: RENOVATE_HOST_RULES
       value: >-

--- a/kubernetes/apps/renovate/renovate-operator/jobs/kustomization.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/jobs/kustomization.yaml
@@ -3,6 +3,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./externalsecret.yaml
   - ./home-ops.yaml
   - ./pump.yaml


### PR DESCRIPTION
## Summary
Two regressions from the common-auth refactor:

1. `jobs/kustomization.yaml` still listed `./externalsecret.yaml` after the file moved to `auth/`. `kubectl kustomize jobs/` errored, so the `renovate-operator-jobs` Flux Kustomization couldn't reconcile.
2. `jobs/home-ops.yaml` looked up `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` in `github-auth-token-secret`. Those keys live in `renovate-operator-secret`. Pod would fail with `CreateContainerConfigError`.

## Test plan
- [x] `kubectl kustomize kubernetes/apps/renovate/renovate-operator/jobs` succeeds.
- [ ] Flux reconciles `renovate-operator-jobs`; next scheduled `rwlove-home-ops` run starts cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)