### PR TITLE
feat(webhook): trigger pump hook on release.published

### DIFF
--- a/kubernetes/apps/selfhosted/webhook/app/resources/hooks.yaml
+++ b/kubernetes/apps/selfhosted/webhook/app/resources/hooks.yaml
@@ -136,24 +136,17 @@
           parameter:
             source: payload
             name: repository.name
-      - # Trigger on GitHub package events
+      - # Trigger on GitHub release events
         match:
           type: value
-          value: package
+          value: release
           parameter:
             source: header
             name: x-github-event
-      - # Trigger only on package publish
+      - # Trigger only when a release is published (new tag)
         match:
           type: value
           value: published
           parameter:
             source: payload
             name: action
-      - # Trigger only for container packages
-        match:
-          type: value
-          value: CONTAINER
-          parameter:
-            source: payload
-            name: package.package_type


### PR DESCRIPTION
## Summary
Switch the `github-rwlove-pump-package` hook from listening on `package`/`CONTAINER`/`published` events to `release`/`published` events. This fires once when a new tag is cut on `rwlove/pump`, instead of every container digest push.

## Test plan
- [ ] Update the GitHub webhook on `rwlove/pump` to subscribe to **Releases** instead of (or in addition to) **Packages**.
- [ ] Publish a release on `rwlove/pump`; confirm the `rwlove-pump` RenovateJob runs and a PR opens for the new tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)