### PR TITLE
fix(webhook): drop | js filter from HMAC secret templates

### DIFF
--- a/kubernetes/apps/selfhosted/webhook/app/resources/hooks.yaml
+++ b/kubernetes/apps/selfhosted/webhook/app/resources/hooks.yaml
@@ -20,7 +20,7 @@
         match:
           type: payload-hmac-sha1
           secret: >-
-            {{ getenv "GITHUB_WEBHOOK_SECRET" | js }}
+            {{ getenv "GITHUB_WEBHOOK_SECRET" }}
           parameter:
             source: header
             name: x-hub-signature
@@ -118,7 +118,7 @@
         match:
           type: payload-hmac-sha1
           secret: >-
-            {{ getenv "GITHUB_WEBHOOK_SECRET" | js }}
+            {{ getenv "GITHUB_WEBHOOK_SECRET" }}
           parameter:
             source: header
             name: x-hub-signature


### PR DESCRIPTION
## Summary
The `secret:` field on every webhook trigger-rule passed `GITHUB_WEBHOOK_SECRET` through Go's `text/template` `js` function. That function escapes `=`, `'`, `"`, `<`, `>`, `&`, `\` for JavaScript string contexts — silently corrupting any HMAC key that contains those characters. Base64-padded secrets (`…BuyM=`) become `…BuyM\u003D` inside the webhook process while GitHub still signs with the original `=`. Result: signatures never match, hooks return 500.

The `>-` block scalar already handles whitespace; HMAC keys don't need HTML/JS escaping. Drop the filter on both hooks.

## Test plan
- [ ] After Flux reconciles and the webhook ConfigMap rolls, redeliver any failed delivery on the `github-rwlove-pump-package` GitHub webhook. Expected: `200` with the renovate-operator's curl output in the body.
- [ ] Edit a comment on the Renovate dashboard issue in `rwlove/home-ops`. Expected: matching `200` line in `kubectl logs -n selfhosted -l app.kubernetes.io/name=webhook`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)