### PR TITLE
fix(webhook): match PUMP repo name case-insensitively

### DIFF
--- a/kubernetes/apps/selfhosted/webhook/app/resources/hooks.yaml
+++ b/kubernetes/apps/selfhosted/webhook/app/resources/hooks.yaml
@@ -129,10 +129,10 @@
           parameter:
             source: payload
             name: repository.owner.login
-      - # Trigger only for the pump repo
+      - # Trigger only for the pump repo (case-insensitive; GitHub stores it as "PUMP")
         match:
-          type: value
-          value: pump
+          type: regex
+          regex: ^(?i)pump$
           parameter:
             source: payload
             name: repository.name


### PR DESCRIPTION
## Summary
The pump repo is stored on GitHub as `rwlove/PUMP` (uppercase). Our trigger rule was an exact-value match against the literal `pump`, so the `release.published` deliveries had `repository.name: "PUMP"` and never matched.

Switch to a case-insensitive regex so it matches regardless of repo casing.

## Test plan
- [ ] Publish a release on `rwlove/PUMP` after Flux reconciles. Webhook log should show `200 | … POST /hooks/github-rwlove-pump-package` and the rwlove-pump RenovateJob should fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)