### PR TITLE
fix(webhook): accept release.released action too

### DIFF
--- a/kubernetes/apps/selfhosted/webhook/app/resources/hooks.yaml
+++ b/kubernetes/apps/selfhosted/webhook/app/resources/hooks.yaml
@@ -143,10 +143,10 @@
           parameter:
             source: header
             name: x-github-event
-      - # Trigger only when a release is published (new tag)
+      - # Trigger on release published or released (GitHub fires both for non-draft/non-prerelease)
         match:
-          type: value
-          value: published
+          type: regex
+          regex: ^(published|released)$
           parameter:
             source: payload
             name: action


### PR DESCRIPTION
## Summary
GitHub fires both `release.published` and `release.released` events when a non-draft, non-prerelease release is published. The cluster was only matching `published`. Confirmed via a real delivery to the pump webhook that `action` came through as `released`.

Switch the action match to a regex that accepts either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)