### PR TITLE
feat(renovate): branch-level auto-merge for pump images

### DIFF
--- a/.github/renovate/autoMerge.json5
+++ b/.github/renovate/autoMerge.json5
@@ -68,12 +68,12 @@
       ignoreTests: true,
     },
     {
-      description: "Auto-merge pump container images",
+      description: "Auto-merge pump container images (branch + PR)",
       matchDatasources: ["docker"],
       automerge: true,
-      automergeType: "pr",
+      automergeType: "branch",
       matchPackageNames: ["/^ghcr\\.io\\/rwlove\\/pump/"],
-      ignoreTests: false,
+      ignoreTests: true,
     },
   ],
 }


### PR DESCRIPTION
## Summary
Switch the pump auto-merge rule from `automergeType: "pr"` to `"branch"` so renovate bumps for `ghcr.io/rwlove/pump-*` land directly on main without a PR roundtrip.

`ignoreTests: true` matches the pattern used elsewhere for `automergeType: "branch"` rules. The pump project's own CI validates the image before publishing, so the cluster's repo-level checks aren't adding meaningful safety here.

If branch protections force a PR (e.g. signed commits required), Renovate falls back to PR automerge automatically — so this is strictly faster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)