### PR TITLE
fix(renovate): disable dependency dashboard for pump job

### DIFF
--- a/kubernetes/apps/renovate/renovate-operator/jobs/pump.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/jobs/pump.yaml
@@ -28,6 +28,10 @@ spec:
     - name: RENOVATE_INCLUDE_PATHS
       value: >-
         ["kubernetes/apps/collab/pump/app/helmrelease.yaml"]
+    # Don't rewrite the global "Renovate Dashboard 🤖" issue from this
+    # narrow run — the rwlove-home-ops job owns it.
+    - name: RENOVATE_DEPENDENCY_DASHBOARD
+      value: "false"
   image: ghcr.io/renovatebot/renovate:43.160.4@sha256:00185c0d63462acec8331cc9a94dcd74a763f2765fca0edcc3ff568af1dc8104
   parallelism: 1
   provider:


### PR DESCRIPTION
## Summary
The `rwlove-pump` RenovateJob uses `RENOVATE_INCLUDE_PATHS` to scope its scan to `kubernetes/apps/collab/pump/app/helmrelease.yaml`. With dashboard enabled (the global default in `.github/renovate.json5`), each webhook-triggered run overwrites the shared `Renovate Dashboard 🤖` issue with just that one file's view, hiding everything tracked by `rwlove-home-ops` until the next hourly run restores it.

Setting `RENOVATE_DEPENDENCY_DASHBOARD=false` on the pump job lets it scan and PR without touching the issue.

## Test plan
- [ ] Trigger the pump webhook (publish a release on PUMP).
- [ ] Confirm the dashboard issue is unchanged after the pump run completes.
- [ ] Confirm the next hourly `rwlove-home-ops` run keeps producing the full dashboard view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)