### PR TITLE
docs(webhook): warn against | js filter on HMAC secret templates

### DIFF
--- a/kubernetes/apps/selfhosted/webhook/app/resources/hooks.yaml
+++ b/kubernetes/apps/selfhosted/webhook/app/resources/hooks.yaml
@@ -1,4 +1,11 @@
 ---
+# WARNING: Do NOT pipe HMAC secret template values through `| js`.
+# Go's text/template `js` function escapes `=`, `'`, `"`, `<`, `>`, `&`,
+# `\` for use as JavaScript string literals. It silently corrupts any
+# secret containing those characters (very common with base64-padded
+# random keys), producing signatures that never match what GitHub sends.
+# The `>-` block scalar already strips trailing whitespace; HMAC keys
+# do not need any additional escaping in this context.
 - id: github-rwlove-renovate
   execute-command: /config/github-renovate-operator.sh
   pass-arguments-to-command:


### PR DESCRIPTION
Pin a warning comment at the top of hooks.yaml so the recently-fixed bug doesn't regress.