### PR TITLE
ci(webhook): validate hooks.yaml on PR

### DIFF
--- a/.github/workflows/webhook-validate.yaml
+++ b/.github/workflows/webhook-validate.yaml
@@ -1,0 +1,111 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Webhook Validate
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  filter-changes:
+    name: Filter changes
+    runs-on: ubuntu-latest
+    outputs:
+      changed-files: ${{ steps.changed-files.outputs.changed_files }}
+    steps:
+      - name: Get changed files
+        id: changed-files
+        uses: bjw-s-labs/action-changed-files@a9a36fb08ce06db9b02fbd8026cc2c0945eb9841 # v0.6.0
+        with:
+          patterns: |-
+            kubernetes/apps/selfhosted/webhook/**
+
+  validate:
+    name: Validate webhook hooks.yaml
+    if: ${{ needs.filter-changes.outputs.changed-files != '[]' }}
+    runs-on: ubuntu-latest
+    needs:
+      - filter-changes
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      # The HMAC `| js` filter silently corrupts secrets containing =, ', ",
+      # <, >, &, or \. Block any new occurrences in webhook hook configs.
+      - name: Reject `| js` on HMAC secret templates
+        shell: bash
+        run: |
+          set -euo pipefail
+          file="kubernetes/apps/selfhosted/webhook/app/resources/hooks.yaml"
+          if [[ ! -f "$file" ]]; then
+            echo "$file not found, skipping"
+            exit 0
+          fi
+          if grep -nE '^\s*secret:.*\| *js' "$file"; then
+            echo "::error file=$file::secret: fields must not pipe through | js (corrupts HMAC keys containing =, ', \", <, >, &, \\)"
+            exit 1
+          fi
+          # Multi-line case: secret: >- ... {{ ... | js }}
+          if awk '
+            /^[[:space:]]*secret:/ { in_secret=1; next }
+            in_secret && /\| *js/ { print FILENAME ":" NR ": " $0; found=1 }
+            in_secret && /^[[:space:]]*[a-zA-Z_-]+:/ && !/^[[:space:]]*secret:/ { in_secret=0 }
+            END { exit found ? 1 : 0 }
+          ' "$file"; then
+            echo "OK: no | js filter found on secret: templates"
+          else
+            echo "::error file=$file::Multi-line secret: block uses | js — see lines above"
+            exit 1
+          fi
+
+      # Run the same webhook image used in-cluster against the hooks file.
+      # If parsing or template substitution fails, webhook exits non-zero.
+      - name: Parse hooks.yaml with adnanh/webhook
+        shell: bash
+        env:
+          GITHUB_WEBHOOK_SECRET: ci-placeholder-secret
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            -e GITHUB_WEBHOOK_SECRET \
+            -v "${PWD}/kubernetes/apps/selfhosted/webhook/app/resources:/config:ro" \
+            --entrypoint /app/bin/webhook \
+            ghcr.io/home-operations/webhook:2.8.3 \
+            -hooks /config/hooks.yaml \
+            -template \
+            -verbose \
+            -port 0 \
+            &
+          PID=$!
+          # Give it a couple seconds to load the file, then stop it.
+          sleep 3
+          if ! kill -0 "$PID" 2>/dev/null; then
+            echo "::error::webhook exited unexpectedly while loading hooks.yaml"
+            wait "$PID" || true
+            exit 1
+          fi
+          kill -TERM "$PID" 2>/dev/null || true
+          wait "$PID" 2>/dev/null || true
+          echo "OK: webhook loaded hooks.yaml without error"
+
+  webhook-validate-success:
+    needs:
+      - validate
+    if: ${{ !cancelled() }}
+    name: Webhook Validate successful
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check job status
+        if: ${{ contains(needs.*.result, 'failure') }}
+        run: exit 1


### PR DESCRIPTION
Two-step validation: a grep that rejects `| js` on `secret:` fields, and a smoke test that boots the webhook image against hooks.yaml.