### PR TITLE
fix(webhook): drop secret refresh interval to 5m

### DIFF
--- a/kubernetes/apps/selfhosted/webhook/app/externalsecret.yaml
+++ b/kubernetes/apps/selfhosted/webhook/app/externalsecret.yaml
@@ -5,7 +5,10 @@ kind: ExternalSecret
 metadata:
   name: webhook
 spec:
-  refreshInterval: 12h
+  # Short refresh so HMAC secret rotations propagate within minutes,
+  # not hours. The secret is tiny and rarely changes; 5m is well below
+  # 1Password Connect rate limits.
+  refreshInterval: 5m
   secretStoreRef:
     kind: ClusterSecretStore
     name: onepassword-connect


### PR DESCRIPTION
Cuts the rotation-to-cluster propagation window from 12h to 5m for the HMAC webhook secret.