### PR TITLE
docs(renovate): document the discovery-bootstrap chicken/egg

### DIFF
--- a/kubernetes/apps/renovate/renovate-operator/jobs/pump.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/jobs/pump.yaml
@@ -41,6 +41,16 @@ spec:
       cpu: 100m
       memory: 128Mi
   # Webhook-driven; cron set to once a year so scheduled runs are effectively a no-op.
+  #
+  # NOTE on bootstrap: the operator only honors webhook-triggered schedule
+  # calls for projects that a previous discovery run has registered. With
+  # an effectively-yearly schedule, a brand-new job has no discovery history
+  # and webhook calls return 500 ("failed to run renovate for project").
+  #
+  # First-time bootstrap: temporarily bump the schedule with kubectl patch
+  # (e.g. */1 * * * *), wait for one rwlove-pump-discovery-* pod to complete,
+  # then revert (Flux will reconcile back to the yearly schedule on its
+  # next pass anyway).
   schedule: 0 0 1 1 *
   secretRef: github-auth-token-secret
   webhook:


### PR DESCRIPTION
Captures the workaround for new webhook-only RenovateJobs needing one initial discovery run before the operator will accept webhook schedules.