### PR TITLE
docs(claude): fix broken sorting instructions import

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,7 @@
-@.agents/instructions/sorting.instructions.md
+@.agents/instructions/flux.sorting.instructions.md
+@.agents/instructions/helmfile.sorting.instructions.md
+@.agents/instructions/kustomize.config.sorting.instructions.md
+@.agents/instructions/schema.correction.md
 
 # Home Operations - AI Assistant Guide
 


### PR DESCRIPTION
Replace the import of a non-existent sorting.instructions.md with the four files that actually exist.