### PR TITLE
docs(webhook): explain substitute: disabled on the configmap

### DIFF
--- a/kubernetes/apps/selfhosted/webhook/app/kustomization.yaml
+++ b/kubernetes/apps/selfhosted/webhook/app/kustomization.yaml
@@ -15,5 +15,12 @@ configMapGenerator:
     name: webhook-configmap
 generatorOptions:
   annotations:
+    # Flux post-build variable substitution (e.g. ${SECRET_DOMAIN}) is
+    # disabled on this configmap because hooks.yaml uses `{{ getenv ... }}`
+    # Go-template syntax that webhook itself expands at runtime, and the
+    # github-renovate-operator.sh script contains its own ${VAR} bash
+    # syntax. Letting Flux substitute would either explode on undefined
+    # variables or silently rewrite shell expansions. The webhook tool
+    # has its own template engine; keep them separate.
     kustomize.toolkit.fluxcd.io/substitute: disabled
   disableNameSuffixHash: true


### PR DESCRIPTION
Comment-only change explaining why this configmap opts out of Flux post-build substitution.