### PR TITLE
docs(renovate): explain the  namespace placeholder

### DIFF
--- a/kubernetes/apps/renovate/namespace.yaml
+++ b/kubernetes/apps/renovate/namespace.yaml
@@ -1,4 +1,8 @@
 ---
+# The `_` placeholder is rewritten to "renovate" by the parent
+# kustomization.yaml's `namespace:` directive. Don't change this name
+# in isolation — it must remain the literal underscore so Kustomize
+# can find and substitute it.
 apiVersion: v1
 kind: Namespace
 metadata:


### PR DESCRIPTION
Adds a comment so reading the file in isolation isn't confusing.