### PR TITLE
chore(renovate): unpin renovate runtime image digests

### DIFF
--- a/kubernetes/apps/renovate/renovate-operator/jobs/home-ops.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/jobs/home-ops.yaml
@@ -38,7 +38,7 @@ spec:
       value: enabled
     - name: RENOVATE_CACHE_PRIVATE_PACKAGES
       value: "true"
-  image: ghcr.io/renovatebot/renovate:43.160.4@sha256:00185c0d63462acec8331cc9a94dcd74a763f2765fca0edcc3ff568af1dc8104
+  image: ghcr.io/renovatebot/renovate:43.160.4
   parallelism: 5
   provider:
     name: github

--- a/kubernetes/apps/renovate/renovate-operator/jobs/pump.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/jobs/pump.yaml
@@ -32,7 +32,7 @@ spec:
     # narrow run — the rwlove-home-ops job owns it.
     - name: RENOVATE_DEPENDENCY_DASHBOARD
       value: "false"
-  image: ghcr.io/renovatebot/renovate:43.160.4@sha256:00185c0d63462acec8331cc9a94dcd74a763f2765fca0edcc3ff568af1dc8104
+  image: ghcr.io/renovatebot/renovate:43.160.4
   parallelism: 1
   provider:
     name: github


### PR DESCRIPTION
Removes `@sha256:` from the Renovate runtime image in both jobs. Tag pin retained.