### PR TITLE
feat(home-assistant): auto-sync /config from GitHub via CronJob

### DIFF
--- a/kubernetes/apps/home/home-assistant/app/kustomization.yaml
+++ b/kubernetes/apps/home/home-assistant/app/kustomization.yaml
@@ -8,3 +8,5 @@ resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./longhorn-pvc.yaml
+  - ./sync-externalsecret.yaml
+  - ./sync-cronjob.yaml

--- a/kubernetes/apps/home/home-assistant/app/sync-cronjob.yaml
+++ b/kubernetes/apps/home/home-assistant/app/sync-cronjob.yaml
@@ -1,0 +1,103 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: home-assistant-config-sync
+spec:
+  schedule: "*/5 * * * *"
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      template:
+        spec:
+          restartPolicy: OnFailure
+          securityContext:
+            runAsUser: 568
+            runAsGroup: 568
+            fsGroup: 568
+          containers:
+            - name: sync
+              image: alpine:3.20
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -eu
+                  apk add --no-cache --quiet git curl openssh-client > /dev/null
+
+                  # Set up SSH for GitHub deploy key
+                  export HOME=/tmp/git-home
+                  mkdir -p "$HOME/.ssh"
+                  cp /ssh/ssh-private-key "$HOME/.ssh/id_ed25519"
+                  cp /ssh/known-hosts "$HOME/.ssh/known_hosts"
+                  chmod 700 "$HOME/.ssh"
+                  chmod 600 "$HOME/.ssh/id_ed25519"
+                  chmod 644 "$HOME/.ssh/known_hosts"
+
+                  cd /config
+
+                  # Don't clobber UI/manual edits — bail if working tree is dirty
+                  if [ -n "$(git status --porcelain)" ]; then
+                    echo "Working tree dirty, skipping pull. Commit/push from code-server first."
+                    git status --short
+                    exit 0
+                  fi
+
+                  BEFORE=$(git rev-parse HEAD)
+                  # Use the deploy key for this single command without rewriting the persistent remote URL
+                  # (so code-server's HTTPS auth keeps working independently)
+                  GIT_SSH_COMMAND="ssh -i $HOME/.ssh/id_ed25519 -o UserKnownHostsFile=$HOME/.ssh/known_hosts" \
+                    git -c url."git@github.com:".insteadOf="https://github.com/" \
+                        fetch --quiet origin main
+                  GIT_SSH_COMMAND="ssh -i $HOME/.ssh/id_ed25519 -o UserKnownHostsFile=$HOME/.ssh/known_hosts" \
+                    git -c url."git@github.com:".insteadOf="https://github.com/" \
+                        pull --ff-only --quiet origin main
+                  AFTER=$(git rev-parse HEAD)
+
+                  if [ "$BEFORE" != "$AFTER" ]; then
+                    echo "Updated $BEFORE -> $AFTER"
+                    # Trigger HA to reload everything reloadable; restart for unreloadable changes
+                    # (this only reloads — for new packages or integrations a full restart is still needed)
+                    curl -sSf -X POST \
+                      -H "Authorization: Bearer $HA_TOKEN" \
+                      -H "Content-Type: application/json" \
+                      http://home-assistant.home.svc.cluster.local:8123/api/services/homeassistant/reload_all \
+                      -d '{}' > /dev/null
+                    echo "Triggered HA reload_all"
+                  else
+                    echo "No changes (HEAD=$AFTER)"
+                  fi
+              env:
+                - name: HA_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: home-assistant-config-sync
+                      key: ha-token
+              volumeMounts:
+                - name: config
+                  mountPath: /config
+                - name: ssh
+                  mountPath: /ssh
+                  readOnly: true
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 64Mi
+                limits:
+                  memory: 128Mi
+          volumes:
+            - name: config
+              persistentVolumeClaim:
+                claimName: home-assistant-config-pvc
+            - name: ssh
+              secret:
+                secretName: home-assistant-config-sync
+                defaultMode: 0400
+                items:
+                  - key: ssh-private-key
+                    path: ssh-private-key
+                  - key: known-hosts
+                    path: known-hosts

--- a/kubernetes/apps/home/home-assistant/app/sync-externalsecret.yaml
+++ b/kubernetes/apps/home/home-assistant/app/sync-externalsecret.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: home-assistant-config-sync
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: home-assistant-config-sync
+    creationPolicy: Owner
+    template:
+      data:
+        ssh-private-key: "{{ index . `ssh-private-key` }}"
+        ha-token: "{{ index . `ha-token` }}"
+        known-hosts: "{{ index . `known-hosts` }}"
+  dataFrom:
+    - extract:
+        key: home-assistant-config-sync


### PR DESCRIPTION
## Summary
Closes the deploy gap between [`home-assistant-config`](https://github.com/rwlove/home-assistant-config) and the live HA `/config` PVC. PRs to that repo were merging but never reaching the running pod.

Adds a CronJob that runs every 5 minutes:
- **Skips if dirty** — `git status --porcelain` non-empty means UI/manual edits are pending, so we leave the PVC alone (you commit/push from code-server, then auto-sync resumes).
- **Fast-forward only** — never force-resets. If the PVC has diverged, it bails.
- **Triggers `homeassistant/reload_all`** if HEAD moved.

## Files
- `sync-externalsecret.yaml` — pulls credentials from the new 1Password item `home-assistant-config-sync`
- `sync-cronjob.yaml` — the schedule + script
- `kustomization.yaml` — wires them in

## Required out-of-band setup (already done at PR-author time)
- 1Password item `home-assistant-config-sync` exists with fields:
  - `ssh-private-key` (private half of a read-only deploy key on `rwlove/home-assistant-config`)
  - `ha-token` (HA long-lived access token, scope: full)
  - `known-hosts` (the three github.com host keys)
- The matching public deploy key is registered on GitHub (read-only).

## Test plan
- [ ] Watch the first scheduled run: `kubectl logs -n home -l job-name=home-assistant-config-sync-XXXX` (or via Grafana / Glance).
- [ ] Confirm "No changes (HEAD=...)" on the first run if PVC is up to date.
- [ ] Force a follow-up: merge a small PR on `home-assistant-config`, wait 5 min, check that the CronJob log says "Updated <oldsha> -> <newsha>" and "Triggered HA reload_all".
- [ ] Verify HA UI doesn't show new errors after the auto-reload.
- [ ] Make a UI edit (e.g. tweak an automation), confirm the next run logs "Working tree dirty, skipping pull" rather than wiping it.

## Risks
- If a YAML change requires a full restart (new integration, new package), `reload_all` won't be enough. Restart manually if needed.
- The 5-min schedule + `Forbid` concurrency means a slow run won't double-fire, but a hung pull would block subsequent runs until the failed Job is cleaned up. `failedJobsHistoryLimit: 3` keeps history short.

🤖 Generated with [Claude Code](https://claude.com/claude-code)