### PR TITLE
fix(downloads-gateway): make postStart non-blocking

### DIFF
--- a/kubernetes/apps/vpn/downloads-gateway/app/helmrelease.yaml
+++ b/kubernetes/apps/vpn/downloads-gateway/app/helmrelease.yaml
@@ -40,7 +40,13 @@ spec:
             # connectivity check BEFORE establishing the VXLAN tunnel. Pod-gateway's
             # gateway_init.sh sets `iptables INPUT policy DROP` and only accepts
             # VXLAN/DHCP/loopback — ICMP from clients is dropped, so the client init
-            # fails with "100% packet loss". Allow ICMP via postStart.
+            # fails with "100% packet loss". Insert an ICMP ACCEPT rule via postStart.
+            #
+            # postStart blocks the container from being marked "Started", so it
+            # MUST NOT wait synchronously for gateway_init.sh (the container's main
+            # command) — that's a deadlock. Instead, fork a background poller that
+            # tries to insert the rule for ~30s, then exit immediately. The rule is
+            # idempotent: -C checks first, -I inserts at position 1 if missing.
             lifecycle:
               postStart:
                 exec:
@@ -48,11 +54,18 @@ spec:
                     - /bin/sh
                     - -c
                     - |
-                      until iptables -L INPUT -n 2>/dev/null | head -1 | grep -q 'policy DROP'; do
-                        sleep 1
-                      done
-                      iptables -C INPUT -p icmp -j ACCEPT 2>/dev/null || \
-                        iptables -I INPUT 1 -p icmp -j ACCEPT
+                      (
+                        for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
+                          if iptables -C INPUT -p icmp -j ACCEPT 2>/dev/null; then
+                            exit 0
+                          fi
+                          if iptables -I INPUT 1 -p icmp -j ACCEPT 2>/dev/null; then
+                            exit 0
+                          fi
+                          sleep 2
+                        done
+                      ) >/dev/null 2>&1 &
+                      exit 0
           gluetun:
             enabled: true
             dependsOn: main


### PR DESCRIPTION
## Summary
The earlier postStart hook in #11136 (372159be80) created a startup **deadlock**:

- postStart blocks the container from being marked \`Started\` until the exec returns.
- The hook waited synchronously for \`iptables INPUT policy DROP\` to appear — set by \`gateway_init.sh\`, which is the container's main command.
- Main can't run until postStart returns; postStart can't return until main runs.

Helm timed out the StatefulSet at 5 min and rolled back. \`downloads-gateway-pod-gateway-main-0\` was stuck in \`PodInitializing\`.

Fork the poller into the background and exit immediately. The poller still inserts the ICMP ACCEPT rule once iptables is reachable. Idempotent (\`-C\` first, \`-I\` only if missing). Bounded ~30s.

## Test plan
- [ ] After Flux reconcile, \`kubectl -n vpn get pods -l app.kubernetes.io/instance=downloads-gateway\` reaches Running.
- [ ] \`kubectl -n vpn exec downloads-gateway-pod-gateway-main-0 -c main -- iptables -L INPUT -n\` shows \`ACCEPT icmp\` near the top.
- [ ] \`kubectl -n downloads delete pods --all\` → all download pods reach \`Running 2/2\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)