### PR TITLE
feat(network): cert migration Phase 0 — gateway-shim annotations

### DIFF
--- a/kubernetes/apps/istio-system/gateway/gateway.yaml
+++ b/kubernetes/apps/istio-system/gateway/gateway.yaml
@@ -6,6 +6,9 @@ metadata:
   name: istio
   annotations:
     external-dns.alpha.kubernetes.io/target: &hostname gateway-istio.${SECRET_DOMAIN}
+    cert-manager.io/cluster-issuer: letsencrypt-production
+    cert-manager.io/duration: "168h"
+    cert-manager.io/renew-before: "48h"
 spec:
   gatewayClassName: istio
   infrastructure:

--- a/kubernetes/apps/network/envoy-gateway/config/external.yaml
+++ b/kubernetes/apps/network/envoy-gateway/config/external.yaml
@@ -6,6 +6,9 @@ metadata:
   name: external
   annotations:
     external-dns.alpha.kubernetes.io/target: &hostname "external.${SECRET_DOMAIN}"
+    cert-manager.io/cluster-issuer: letsencrypt-production
+    cert-manager.io/duration: "168h"
+    cert-manager.io/renew-before: "48h"
   labels:
     type: external
 spec:

--- a/kubernetes/apps/network/envoy-gateway/config/internal.yaml
+++ b/kubernetes/apps/network/envoy-gateway/config/internal.yaml
@@ -6,6 +6,9 @@ metadata:
   name: internal
   annotations:
     external-dns.alpha.kubernetes.io/target: &hostname gateway-int.${SECRET_DOMAIN}
+    cert-manager.io/cluster-issuer: letsencrypt-production
+    cert-manager.io/duration: "168h"
+    cert-manager.io/renew-before: "48h"
 spec:
   gatewayClassName: envoy
   infrastructure:


### PR DESCRIPTION
## Summary
- Adds `cert-manager.io/cluster-issuer`, `duration: 168h`, `renew-before: 48h` annotations to the `external`, `internal`, and `istio` Gateways.
- Verified safe against the running cert-manager v1.17.1 gateway-shim on 2026-05-02: existing manual Certificate already owns the wildcard listener's Secret, so the shim is a no-op for that listener.
- mcp-gateway intentionally skipped — terminates plain HTTP, no TLS to manage.

This is Phase 0 of the per-route cert migration runbook (`docs/src/per-route-cert-migration.md`). It changes nothing functionally — future per-app listeners will pick up the annotations automatically.

## Test plan
- [ ] Flux reconciles the three Gateways without changing any existing Certificate
- [ ] `kubectl get certificate -A` count is unchanged after reconcile
- [ ] HTTPRoute hostnames continue to serve the existing wildcard cert (no SAN changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)