### PR TITLE
feat(network): cert migration canary — glance on per-app listener

### DIFF
--- a/kubernetes/apps/collab/glance/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/glance/app/helmrelease.yaml
@@ -89,7 +89,7 @@ spec:
         parentRefs:
           - name: internal
             namespace: network
-            sectionName: https
+            sectionName: https-glance
         rules:
           - backendRefs:
               - name: *app

--- a/kubernetes/apps/network/envoy-gateway/config/internal.yaml
+++ b/kubernetes/apps/network/envoy-gateway/config/internal.yaml
@@ -32,6 +32,17 @@ spec:
         certificateRefs:
           - kind: Secret
             name: "${SECRET_DOMAIN/./-}-tls"
+    - name: https-glance
+      protocol: HTTPS
+      port: 443
+      hostname: "glance.${SECRET_DOMAIN}"
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        certificateRefs:
+          - kind: Secret
+            name: glance-tls
 
 ---
 # yaml-language-server: $schema=https://kube-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json


### PR DESCRIPTION
## Summary
- Adds a `https-glance` listener on the `internal` Gateway with `hostname: glance.${SECRET_DOMAIN}` and its own `glance-tls` certificateRef.
- Flips the glance HTTPRoute's `sectionName` from `https` (wildcard) to `https-glance` (per-app).
- cert-manager's gateway-shim auto-provisions a Certificate from the Phase 0 annotations on the Gateway (`letsencrypt-production`, `duration: 168h`, `renew-before: 48h`).

This is Phase 2 of the per-route cert migration (`docs/src/per-route-cert-migration.md`). Glance was chosen as canary: low-stakes, internal-only, immediate visual verification.

## Test plan
- [ ] cert-manager creates a `glance-tls` Certificate in `network` ns, reaches `Ready: True`
- [ ] `glance.${SECRET_DOMAIN}` serves the new per-app cert (SAN = single hostname, duration ~7d)
- [ ] Glance dashboard loads in browser without TLS warnings
- [ ] Soak 24h + observe one auto-renewal (~day 5) before scaling to wave migration

## Rollback
Revert this PR — the route falls back to `sectionName: https` (wildcard listener still present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)