### PR TITLE
fix(home-assistant): qualify alpine image for CRI-O short-name enforcement

### DIFF
--- a/kubernetes/apps/home/home-assistant/app/sync-cronjob.yaml
+++ b/kubernetes/apps/home/home-assistant/app/sync-cronjob.yaml
@@ -20,7 +20,7 @@ spec:
             fsGroup: 568
           containers:
             - name: sync
-              image: alpine:3.23
+              image: docker.io/library/alpine:3.23
               command:
                 - /bin/sh
                 - -c


### PR DESCRIPTION
## Summary
- CRI-O on the cluster runs with `short-name-mode = enforcing`, so bare `alpine:3.23` was rejected with `ImageInspectError: short name mode is enforcing, but image name alpine:3.20 returns ambiguous list`, leaving the home-assistant config-sync CronJob stuck.
- Qualify the image as `docker.io/library/alpine:3.23` so the node can resolve it without policy intervention.

## Test plan
- [ ] Flux reconciles `home-assistant-config-sync` CronJob with the new image
- [ ] Next scheduled run pulls successfully and exits 0 (or `Working tree dirty, skipping pull`)
- [ ] No new `ImageInspectError` events in `kubectl get events -n home`

🤖 Generated with [Claude Code](https://claude.com/claude-code)