### PR TITLE
Revert "feat(network): cert migration canary — glance on per-app listener" (#11139)

### DIFF
--- a/kubernetes/apps/collab/glance/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/glance/app/helmrelease.yaml
@@ -89,7 +89,7 @@ spec:
         parentRefs:
           - name: internal
             namespace: network
-            sectionName: https-glance
+            sectionName: https
         rules:
           - backendRefs:
               - name: *app

--- a/kubernetes/apps/network/envoy-gateway/config/internal.yaml
+++ b/kubernetes/apps/network/envoy-gateway/config/internal.yaml
@@ -32,17 +32,6 @@ spec:
         certificateRefs:
           - kind: Secret
             name: "${SECRET_DOMAIN/./-}-tls"
-    - name: https-glance
-      protocol: HTTPS
-      port: 443
-      hostname: "glance.${SECRET_DOMAIN}"
-      allowedRoutes:
-        namespaces:
-          from: All
-      tls:
-        certificateRefs:
-          - kind: Secret
-            name: glance-tls
 
 ---
 # yaml-language-server: $schema=https://kube-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json


### PR DESCRIPTION
## Summary
Reverts #11139 — glance is currently returning 404 because the `https-glance` listener is `Programmed: False`.

## Root cause
cert-manager's gateway-shim is not enabled in this cluster. The Phase 0 verification I ran was a false negative: no duplicate Certificate was created in the scratch test because **no shim was running**, not because the shim is Secret-aware. Controller args confirm: cert-manager v1.17.1 deployment is missing `--enable-gateway-api` (or the equivalent Helm chart enablement), so gateway-shim never runs.

Without the shim, `glance-tls` Secret was never created, listener stayed invalid, HTTPRoute is bound only via `sectionName` so no fallback path.

## Next steps (separate PR)
Enable gateway-shim in cert-manager Helm values, verify with a fresh scratch test that an unmanaged Secret reference results in shim-created Certificate, then redo the canary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)