### PR TITLE
fix(cert-manager): enable gateway-shim for per-route certs

### DIFF
--- a/kubernetes/apps/cert-manager/cert-manager/app/values.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/app/values.yaml
@@ -2,6 +2,11 @@
 crds:
   enabled: true
 
+config:
+  apiVersion: controller.config.cert-manager.io/v1alpha1
+  kind: ControllerConfiguration
+  enableGatewayAPI: true
+
 dns01RecursiveNameservers: https://1.1.1.1:443/dns-query,https://1.0.0.1:443/dns-query
 dns01RecursiveNameserversOnly: true
 


### PR DESCRIPTION
## Summary
- Adds `config.enableGatewayAPI: true` to cert-manager Helm values.
- Without this, cert-manager v1.17.1's gateway-shim controller is dormant — the `cert-manager.io/cluster-issuer` annotations added to Gateways in #11138 are inert.

## Root cause
Discovered while running the per-route cert migration canary on glance (#11139, reverted in #11141). The new `https-glance` listener stayed `Programmed=False` because the `glance-tls` Secret was never created. Controller args confirmed no `--enable-gateway-api`.

The chart's `config:` block maps to a ControllerConfiguration object, and the `enableGatewayAPI: true` field is the supported way to turn the shim on in v1.17+.

## Test plan
- [ ] cert-manager rolls out cleanly
- [ ] `kubectl get deploy -n cert-manager cert-manager -o yaml` shows the new arg or config wired in
- [ ] Re-run the scratch test using a brand-new Secret name; cert-manager should now create the Certificate automatically
- [ ] Re-do the canary on glance after verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)