### PR TITLE
fix(prowlarr): add NET_BIND_SERVICE for port 80 bind

### DIFF
--- a/kubernetes/apps/downloads/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/prowlarr/app/helmrelease.yaml
@@ -29,6 +29,13 @@ spec:
               repository: ghcr.io/home-operations/prowlarr
               tag: rolling@sha256:da6b1f914ad22778c347d554a59b6e40110f654b40528c8de516616382db5148
 
+            # Bind on port 80 requires CAP_NET_BIND_SERVICE; the app-template
+            # common library defaults to capabilities.drop: ALL.
+            securityContext:
+              capabilities:
+                add:
+                  - NET_BIND_SERVICE
+
             env:
               PROWLARR__INSTANCE_NAME: Prowlarr
               PROWLARR__PORT: &httpPort 80


### PR DESCRIPTION
Adds CAP_NET_BIND_SERVICE so prowlarr (uid 568) can bind to its configured port 80. The app-template common library drops ALL capabilities by default; without this cap, bind() returns EACCES.

Discovered while debugging downloads-namespace pods after the v7 pod-gateway upgrade refreshed pod state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)