### PR TITLE
fix(istio): remove cert-manager gateway-shim annotations

### DIFF
--- a/kubernetes/apps/istio-system/gateway/gateway.yaml
+++ b/kubernetes/apps/istio-system/gateway/gateway.yaml
@@ -6,9 +6,12 @@ metadata:
   name: istio
   annotations:
     external-dns.alpha.kubernetes.io/target: &hostname gateway-istio.${SECRET_DOMAIN}
-    cert-manager.io/cluster-issuer: letsencrypt-production
-    cert-manager.io/duration: "168h"
-    cert-manager.io/renew-before: "48h"
+    # cert-manager gateway-shim deliberately NOT enabled here: the listeners
+    # reference the reflector-mirrored thesteamedcrab-com-tls Secret. With
+    # the shim active in this namespace, cert-manager creates a Certificate
+    # locally that fights with reflector for ownership of the Secret. Wait
+    # to add the annotations until istio HTTPRoutes are migrated to per-app
+    # listeners with their own Secret names.
 spec:
   gatewayClassName: istio
   infrastructure:


### PR DESCRIPTION
## Summary
Removes the cert-manager.io/cluster-issuer + duration + renew-before annotations from the istio Gateway. These were added in #11138 and were inert until #11142 enabled the gateway-shim, at which point cert-manager created a Certificate in istio-system that fights with the reflector pattern mirroring `thesteamedcrab-com-tls` from `network/`.

## Damage report
- 1 ACME issuance against the 50/week ceiling (the shim's Certificate triggered an immediate reissue with `reason="IncorrectIssuer"`)
- Two Certificate objects now claim the same Secret name across namespaces, with reflector and cert-manager fighting over managedFields

## Followup
After this merges, manually delete the rogue `istio-system/thesteamedcrab-com-tls` Certificate so the reflector can resume owning the Secret without conflict.

The istio Gateway can be re-annotated later, after its HTTPRoutes are migrated to per-app listeners with unique Secret names — at which point the reflector dependency goes away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)