### PR TITLE
fix(jdownloader2): use 'type: custom' for configMap mount

### DIFF
--- a/kubernetes/apps/downloads/jdownloader2/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/jdownloader2/app/helmrelease.yaml
@@ -77,12 +77,15 @@ spec:
       # and /etc/passwd from /containers/storage/.../userdata/, making them
       # mount points that rm can't delete (EBUSY). The script aborts via set -e.
       # Override with a copy that uses `: > FILE` (truncate) instead of rm+touch.
+      # Chart v4.6.2 doesn't accept `type: configMap`; use custom + volumeSpec.
       init-users-fix:
-        type: configMap
-        name: jdownloader2-init-users-fix
-        defaultMode: 0755
+        type: custom
+        volumeSpec:
+          configMap:
+            name: jdownloader2-init-users-fix
+            defaultMode: 0755
         advancedMounts:
           main:
             main:
-              - mountPath: /etc/cont-init.d/10-init-users.sh
+              - path: /etc/cont-init.d/10-init-users.sh
                 subPath: 10-init-users.sh


### PR DESCRIPTION
Follow-up fix for #11145 — chart v4.6.2 doesn't accept `type: configMap` directly. Switch to `type: custom` with `volumeSpec.configMap`, and use `path` (not `mountPath`) in advancedMounts items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)