### PR TITLE
feat(network): cert migration canary — flux-webhook on per-app listener

### DIFF
--- a/kubernetes/apps/flux-system/flux-instance/app/github/webhooks/httproute.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/github/webhooks/httproute.yaml
@@ -10,7 +10,7 @@ spec:
   parentRefs:
     - name: external
       namespace: network
-      sectionName: https
+      sectionName: https-flux-webhook
   rules:
     - backendRefs:
         - name: webhook-receiver

--- a/kubernetes/apps/network/envoy-gateway/config/external.yaml
+++ b/kubernetes/apps/network/envoy-gateway/config/external.yaml
@@ -34,6 +34,17 @@ spec:
         certificateRefs:
           - kind: Secret
             name: "${SECRET_DOMAIN/./-}-tls"
+    - name: https-flux-webhook
+      protocol: HTTPS
+      port: 443
+      hostname: "flux-webhook.${SECRET_DOMAIN}"
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        certificateRefs:
+          - kind: Secret
+            name: flux-webhook-tls
 
 ---
 # yaml-language-server: $schema=https://kube-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json


### PR DESCRIPTION
## Summary
Retry of Phase 2 canary after the previous attempt (#11139) hit a snag because cert-manager's gateway-shim wasn't enabled. Since then:
- #11142 turned on the shim (`config.enableGatewayAPI: true`)
- Pre-flight test confirmed shim creates Certificates for new Secret refs
- Runbook updated with the lessons (#11146)

## Change
- New `https-flux-webhook` listener on the `external` Gateway with `hostname: flux-webhook.${SECRET_DOMAIN}` and its own `flux-webhook-tls` Secret ref.
- `github-webhook` HTTPRoute flipped from `sectionName: https` (wildcard) to `https-flux-webhook` (per-app).

## Why this target
- On the `external` Gateway (where Phase 0 was verified safe — manual Certificate already owns the wildcard Secret in-namespace).
- Low-stakes: it's a webhook receiver, not user-facing. GitHub retries failed deliveries.
- Tolerates the ~30s gap between merge and ACME issuance landing.

## Test plan
- [ ] cert-manager creates `flux-webhook-tls` Certificate in `network` namespace within ~30s of the listener appearing
- [ ] Certificate reaches `Ready: True` (one ACME issuance against the 50/week budget — 49 → 48 remaining)
- [ ] `flux-webhook.thesteamedcrab.com` serves the new per-app cert (SAN = single hostname, duration ~7d)
- [ ] A GitHub push triggers Flux reconcile (i.e. webhook still works end-to-end)
- [ ] Soak ≥24h + observe one auto-renewal cycle (~day 5) before scaling to wave migration

## Rollback
Revert this PR — the route falls back to `sectionName: https` (wildcard listener untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)