### PR TITLE
docs(cert-migration): clarify what cert-manager.io/duration does

### DIFF
--- a/docs/src/per-route-cert-migration.md
+++ b/docs/src/per-route-cert-migration.md
@@ -198,6 +198,20 @@ metadata:
     cert-manager.io/renew-before: "48h"
 ```
 
+> **What `duration` actually does.** Let's Encrypt's default profile
+> always issues 90-day certificates regardless of the `duration`
+> requested by ACME. The `cert-manager.io/duration` annotation controls
+> only cert-manager's *renewal cadence* — it tells cert-manager "treat
+> this cert as expiring after 168h" so it renews early. You still get
+> 90-day certs, just rotated every ~5 days.
+>
+> For actually-short LE certs, opt into the `tlsserver` profile (~6-day
+> validity) by adding `acme.cert-manager.io/order-profile-name:
+> tlsserver` on the per-listener Certificate or via cert-manager's
+> issuer-level configuration. That changes the LE order profile and
+> the issued cert is genuinely short-lived. Verify with
+> `openssl s_client … | openssl x509 -noout -dates` after issuance.
+
 For the `internal` Gateway, swap the issuer to the private CA once
 Phase 1 is done:
 


### PR DESCRIPTION
## Summary
The flux-webhook canary (#11148) issued a 90-day cert from Let's Encrypt despite the `cert-manager.io/duration: 168h` annotation on the Gateway. That's because LE's default profile is a fixed 90-day cert; the duration annotation only controls cert-manager's renewal cadence (it'll renew at 5d age into a fresh 90d cert).

This adds a callout in the Phase 0 section explaining the distinction, plus a pointer to LE's `tlsserver` profile (~6d certs) if genuinely short-lived certs are wanted.

## Test plan
- [ ] Docs only — re-read the Phase 0.2 callout, confirm it's accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)