### PR TITLE
fix(jdownloader2): opt init-users-fix configmap out of Flux substitute

### DIFF
--- a/kubernetes/apps/downloads/jdownloader2/app/kustomization.yaml
+++ b/kubernetes/apps/downloads/jdownloader2/app/kustomization.yaml
@@ -10,6 +10,10 @@ configMapGenerator:
       - 10-init-users.sh=init-users-fix.sh
     options:
       disableNameSuffixHash: true
+      annotations:
+        # Flux postBuild.substitute would blank out the ${var} shell expansions
+        # in the script otherwise. Opt this resource out of substitution.
+        kustomize.toolkit.fluxcd.io/substitute: disabled
 
 resources:
   - ./helmrelease.yaml


### PR DESCRIPTION
Follow-up to #11145 + #11147. The script uses \${var} shell expansions which Flux's postBuild.substitute eats, producing syntax-broken script. Opt out via kustomize.toolkit.fluxcd.io/substitute: disabled annotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)