### PR TITLE
feat(cert-manager): bootstrap private CA for internal Gateway certs

### DIFF
--- a/kubernetes/apps/cert-manager/cert-manager/issuers/cluster-internal-ca.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/issuers/cluster-internal-ca.yaml
@@ -1,0 +1,34 @@
+---
+# Self-signed root CA used to issue per-listener certificates for the
+# internal Gateway's HTTPRoutes. Not browser-trusted by default — devices
+# that visit *.thesteamedcrab.com on the internal LB must import the
+# root CA cert (export with: kubectl get secret -n cert-manager
+# cluster-internal-ca-tls -o jsonpath='{.data.tls\.crt}' | base64 -d).
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: cluster-internal-ca
+  namespace: cert-manager
+spec:
+  isCA: true
+  commonName: thesteamedcrab.com Internal CA
+  duration: 87600h    # 10y root
+  renewBefore: 720h   # 30d
+  secretName: cluster-internal-ca-tls
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: selfsigned-bootstrap
+    kind: ClusterIssuer
+---
+# ClusterIssuer that uses the root above to issue per-listener certs.
+# Reference this from the internal Gateway's
+# `cert-manager.io/cluster-issuer` annotation in Phase 0.2.
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: cluster-internal-ca
+spec:
+  ca:
+    secretName: cluster-internal-ca-tls

--- a/kubernetes/apps/cert-manager/cert-manager/issuers/kustomization.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/issuers/kustomization.yaml
@@ -3,6 +3,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - cluster-internal-ca.yaml
   - externalsecret.yaml
   - letsencrypt-production.yaml
   - letsencrypt-staging.yaml
+  - selfsigned-bootstrap.yaml

--- a/kubernetes/apps/cert-manager/cert-manager/issuers/selfsigned-bootstrap.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/issuers/selfsigned-bootstrap.yaml
@@ -1,0 +1,9 @@
+---
+# Bootstrap ClusterIssuer used to sign the private CA root Certificate.
+# Not used for any other certs.
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: selfsigned-bootstrap
+spec:
+  selfSigned: {}


### PR DESCRIPTION
## Summary
Phase 1 of the per-route cert migration. Bootstraps a private CA in cert-manager so the internal Gateway's per-app listeners can get short-lived certs without burning Let's Encrypt rate-limit budget.

Three resources:
- `selfsigned-bootstrap` ClusterIssuer (only used to sign the CA root)
- `cluster-internal-ca` Certificate — a 10y self-signed root, ECDSA P-256, stored in `cert-manager/cluster-internal-ca-tls`
- `cluster-internal-ca` ClusterIssuer of kind `ca`, references the root Secret

## After this lands
1. Export the root cert and import into every device that visits internal hostnames:
   ```sh
   kubectl get secret -n cert-manager cluster-internal-ca-tls \
     -o jsonpath='{.data.tls\.crt}' | base64 -d > internal-ca.crt
   ```
2. Once trust is distributed, swap the internal Gateway's annotation from `letsencrypt-production` to `cluster-internal-ca`. The gateway-shim will then issue per-app private certs in `network` namespace for any new internal listener.

## Test plan
- [ ] `kubectl get certificate -n cert-manager cluster-internal-ca` reaches Ready
- [ ] `kubectl get clusterissuer cluster-internal-ca` shows Ready=True
- [ ] No impact on existing certs

🤖 Generated with [Claude Code](https://claude.com/claude-code)