### PR TITLE
fix(prowlarr): use unprivileged port 9696 instead of port 80

### DIFF
--- a/kubernetes/apps/downloads/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/prowlarr/app/helmrelease.yaml
@@ -29,16 +29,9 @@ spec:
               repository: ghcr.io/home-operations/prowlarr
               tag: rolling@sha256:da6b1f914ad22778c347d554a59b6e40110f654b40528c8de516616382db5148
 
-            # Bind on port 80 requires CAP_NET_BIND_SERVICE; the app-template
-            # common library defaults to capabilities.drop: ALL.
-            securityContext:
-              capabilities:
-                add:
-                  - NET_BIND_SERVICE
-
             env:
               PROWLARR__INSTANCE_NAME: Prowlarr
-              PROWLARR__PORT: &httpPort 80
+              PROWLARR__SERVER__PORT: &port 9696
               PROWLARR__LOG_LEVEL: info
 
             envFrom:
@@ -56,7 +49,7 @@ spec:
       main:
         ports:
           http:
-            port: *httpPort
+            port: *port
 
     route:
       main:
@@ -74,7 +67,7 @@ spec:
         rules:
           - backendRefs:
               - identifier: main
-                port: *httpPort
+                port: *port
 
     persistence:
       config:


### PR DESCRIPTION
Follow-up to #11143. `NET_BIND_SERVICE` alone isn't enough for uid 568 to bind <1024 — the cap needs to be inherited via setcap on the binary or allowPrivilegeEscalation, neither of which apply here. Switch to upstream-default port 9696 via `PROWLARR__SERVER__PORT` env var.

🤖 Generated with [Claude Code](https://claude.com/claude-code)