### PR TITLE
fix(jdownloader2): disable Helm wait/rollback so configMap fix sticks

### DIFF
--- a/kubernetes/apps/downloads/jdownloader2/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/jdownloader2/app/helmrelease.yaml
@@ -10,6 +10,18 @@ spec:
     name: app-template
   interval: 30m
 
+  # Don't wait for the StatefulSet to be Ready — pod-gateway-routed pods take
+  # time to come up, and the failure during wait causes Helm to roll back to
+  # an earlier spec (without the configMap fix), creating a permanent loop.
+  install:
+    disableWait: true
+    remediation:
+      retries: -1
+  upgrade:
+    disableWait: true
+    remediation:
+      retries: -1
+
   values:
     controllers:
       main:


### PR DESCRIPTION
Helm was rolling back the configMap-mount upgrade because the SS took too long to be Ready. With disableWait+retries:-1, Helm applies the spec and moves on, breaking the rollback loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)