### PR TITLE
feat(node-tuning): persist fs.inotify sysctls via DaemonSet

### DIFF
--- a/kubernetes/apps/kube-system/kustomization.yaml
+++ b/kubernetes/apps/kube-system/kustomization.yaml
@@ -17,6 +17,7 @@ resources:
   - ./metrics-server/ks.yaml
   - ./node-feature-discovery/ks.yaml
   - ./node-problem-detector/ks.yaml
+  - ./node-tuning
   - ./nvidia-device-plugin/ks.yaml
   - ./reflector
   - ./reloader/ks.yaml

--- a/kubernetes/apps/kube-system/node-tuning/daemonset.yaml
+++ b/kubernetes/apps/kube-system/node-tuning/daemonset.yaml
@@ -1,0 +1,66 @@
+---
+# Persists node-level sysctl tunings that can't be set per-pod.
+#
+# Currently:
+#   fs.inotify.max_user_instances=8192   # default 128 is too low for clusters
+#                                        # with many file-watching apps (slskd,
+#                                        # prowlarr, etc.). Hitting it shows up
+#                                        # as "configured user limit (128) on
+#                                        # the number of inotify instances has
+#                                        # been reached".
+#
+# Implementation: a privileged DaemonSet whose initContainer applies the sysctl
+# at pod start (i.e. node boot, since the DaemonSet pod restarts with the
+# node). The main container is a no-op `pause` so kubelet keeps the pod
+# scheduled and re-runs the initContainer if the kubelet restarts.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: node-tuning
+  labels:
+    app.kubernetes.io/name: node-tuning
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: node-tuning
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: node-tuning
+    spec:
+      hostPID: true
+      tolerations:
+        - operator: Exists
+      initContainers:
+        - name: apply-sysctls
+          image: busybox:1.36
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eux
+              sysctl -w fs.inotify.max_user_instances=8192
+              sysctl -w fs.inotify.max_user_watches=524288
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: 1m
+              memory: 8Mi
+      containers:
+        - name: pause
+          image: registry.k8s.io/pause:3.10
+          resources:
+            requests:
+              cpu: 1m
+              memory: 8Mi
+            limits:
+              memory: 16Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65535
+            seccompProfile: { type: RuntimeDefault }

--- a/kubernetes/apps/kube-system/node-tuning/kustomization.yaml
+++ b/kubernetes/apps/kube-system/node-tuning/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - daemonset.yaml


### PR DESCRIPTION
Persists the runtime sysctl bump we ran tonight (workers 2/4/5/6/7/8 + masters were at default 128, only worker3 was at 8192). Without this, the bump won't survive node reboots and apps like slskd will start failing again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)