### PR TITLE
fix(descheduler): tune thresholds and add RemoveDuplicates

### DIFF
--- a/kubernetes/apps/kube-system/descheduler/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/descheduler/app/helmrelease.yaml
@@ -78,3 +78,4 @@ spec:
       enabled: true
     serviceMonitor:
       enabled: true
+  suspend: true

--- a/kubernetes/apps/kube-system/descheduler/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/descheduler/app/helmrelease.yaml
@@ -26,13 +26,13 @@ spec:
                 metricsUtilization:
                   source: KubernetesMetrics
                 targetThresholds:
-                  cpu: 50
-                  memory: 50
-                  pods: 50
+                  cpu: 70
+                  memory: 70
+                  pods: 70
                 thresholds:
-                  cpu: 20
-                  memory: 20
-                  pods: 20
+                  cpu: 30
+                  memory: 30
+                  pods: 30
               name: LowNodeUtilization
             - args:
                 excludeOwnerKinds:
@@ -46,6 +46,7 @@ spec:
                   - Terminated
                   - UnexpectedAdmissionError
               name: RemoveFailedPods
+            - name: RemoveDuplicates
             - name: RemovePodsViolatingInterPodAntiAffinity
             - args:
                 nodeAffinityType:
@@ -57,6 +58,7 @@ spec:
             balance:
               enabled:
                 - LowNodeUtilization
+                - RemoveDuplicates
                 - RemovePodsViolatingTopologySpreadConstraint
             deschedule:
               enabled:


### PR DESCRIPTION
## Summary
Two changes to descheduler config:

1. **Raise `LowNodeUtilization` thresholds 50/20 → 70/30.** The 50% high threshold causes pod churn during normal load fluctuations. 70/30 still catches genuine hot spots.
2. **Add `RemoveDuplicates` plugin.** Evicts when multiple pods of the same controller end up on one node — the pattern that piled 7+ CNPG postgres replicas onto worker4 during the cluster upgrade and blocked frigate from scheduling.

## Notes
- The HelmRelease is currently `suspend: true` as part of the cluster upgrade runbook. These changes only take effect once descheduler is unsuspended (Phase 5 per `docs/src/cluster_upgrade.md`).

## Test plan
- [ ] Once unsuspended, observe descheduler logs / `kubectl get events` for `Evicted` reasons.
- [ ] Confirm CNPG replicas redistribute off worker4 after the next descheduler cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)