### PR TITLE
chore: lint batch — Namespace schema directives

### DIFF
--- a/kubernetes/apps/actions-runner-system/namespace.yaml
+++ b/kubernetes/apps/actions-runner-system/namespace.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/namespace-v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/kubernetes/apps/ai/namespace.yaml
+++ b/kubernetes/apps/ai/namespace.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/namespace-v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/kubernetes/apps/auth/namespace.yaml
+++ b/kubernetes/apps/auth/namespace.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/namespace-v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/kubernetes/apps/cert-manager/namespace.yaml
+++ b/kubernetes/apps/cert-manager/namespace.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/namespace-v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/kubernetes/apps/collab/namespace.yaml
+++ b/kubernetes/apps/collab/namespace.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/namespace-v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/kubernetes/apps/databases/namespace.yaml
+++ b/kubernetes/apps/databases/namespace.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/namespace-v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/kubernetes/apps/downloads/namespace.yaml
+++ b/kubernetes/apps/downloads/namespace.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/namespace-v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/kubernetes/apps/external-secrets/namespace.yaml
+++ b/kubernetes/apps/external-secrets/namespace.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/namespace-v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/kubernetes/apps/flux-system/namespace.yaml
+++ b/kubernetes/apps/flux-system/namespace.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/namespace-v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/kubernetes/apps/home/namespace.yaml
+++ b/kubernetes/apps/home/namespace.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/namespace-v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/kubernetes/apps/istio-system/namespace.yaml
+++ b/kubernetes/apps/istio-system/namespace.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/namespace-v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/kubernetes/apps/kuadrant/namespace.yaml
+++ b/kubernetes/apps/kuadrant/namespace.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/namespace-v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/kubernetes/apps/kube-system/namespace.yaml
+++ b/kubernetes/apps/kube-system/namespace.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/namespace-v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/kubernetes/apps/longhorn-system/namespace.yaml
+++ b/kubernetes/apps/longhorn-system/namespace.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/namespace-v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/kubernetes/apps/mcp-system/namespace.yaml
+++ b/kubernetes/apps/mcp-system/namespace.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/namespace-v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/kubernetes/apps/media/namespace.yaml
+++ b/kubernetes/apps/media/namespace.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/namespace-v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/kubernetes/apps/network/namespace.yaml
+++ b/kubernetes/apps/network/namespace.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/namespace-v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/kubernetes/apps/observability/namespace.yaml
+++ b/kubernetes/apps/observability/namespace.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/namespace-v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/kubernetes/apps/renovate/namespace.yaml
+++ b/kubernetes/apps/renovate/namespace.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/namespace-v1.json
 # The `_` placeholder is rewritten to "renovate" by the parent
 # kustomization.yaml's `namespace:` directive. Don't change this name
 # in isolation — it must remain the literal underscore so Kustomize

--- a/kubernetes/apps/rook-ceph/namespace.yaml
+++ b/kubernetes/apps/rook-ceph/namespace.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/namespace-v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/kubernetes/apps/selfhosted/namespace.yaml
+++ b/kubernetes/apps/selfhosted/namespace.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/namespace-v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/kubernetes/apps/storage/namespace.yaml
+++ b/kubernetes/apps/storage/namespace.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/namespace-v1.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/kubernetes/apps/vpn/namespace.yaml
+++ b/kubernetes/apps/vpn/namespace.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/namespace-v1.json
 apiVersion: v1
 kind: Namespace
 metadata:


### PR DESCRIPTION
## Summary
Adds `# yaml-language-server: $schema=...` directive on line 2 of 23 `namespace.yaml` files. Schema URL per `.agents/instructions/schema.correction.md`.

Mechanical change, no behavior impact. First of several batches to bring the repo into compliance with the schema rule (~168 more YAMLs across PVC/PV/CNPG/etc still to go).

🤖 Generated with [Claude Code](https://claude.com/claude-code)