### PR TITLE
chore: lint batch — yannh schema directives for core k8s manifests

### DIFF
--- a/kubernetes/apps/ai/comfyui/app/longhorn-pvc.yaml
+++ b/kubernetes/apps/ai/comfyui/app/longhorn-pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/kubernetes/apps/ai/comfyui/app/nfs-pvc.yaml
+++ b/kubernetes/apps/ai/comfyui/app/nfs-pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolume-v1.json
 apiVersion: v1
 kind: PersistentVolume
 metadata:

--- a/kubernetes/apps/ai/ollama/app/longhorn-pvc.yaml
+++ b/kubernetes/apps/ai/ollama/app/longhorn-pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/kubernetes/apps/ai/paperless-ai/app/longhorn-pvc.yaml
+++ b/kubernetes/apps/ai/paperless-ai/app/longhorn-pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/kubernetes/apps/ai/priority-class.yaml
+++ b/kubernetes/apps/ai/priority-class.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/priorityclass-scheduling-v1.json
 apiVersion: scheduling.k8s.io/v1
 description: Used for pods that must run on a node with a GPU.
 kind: PriorityClass

--- a/kubernetes/apps/auth/kanidm/app/longhorn-pvc.yaml
+++ b/kubernetes/apps/auth/kanidm/app/longhorn-pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/kubernetes/apps/auth/pocket-id/app/longhorn-pvc.yaml
+++ b/kubernetes/apps/auth/pocket-id/app/longhorn-pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/kubernetes/apps/collab/exercisediary/app/longhorn-pvc.yaml
+++ b/kubernetes/apps/collab/exercisediary/app/longhorn-pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/kubernetes/apps/collab/mealie/app/longhorn-pvc.yaml
+++ b/kubernetes/apps/collab/mealie/app/longhorn-pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/kubernetes/apps/collab/nextcloud/app/longhorn-pvc.yaml
+++ b/kubernetes/apps/collab/nextcloud/app/longhorn-pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/kubernetes/apps/collab/obsidian-couchdb/app/longhorn-pvc.yaml
+++ b/kubernetes/apps/collab/obsidian-couchdb/app/longhorn-pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/kubernetes/apps/collab/open-webui/app/longhorn-pvc.yaml
+++ b/kubernetes/apps/collab/open-webui/app/longhorn-pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/kubernetes/apps/collab/paperless/app/longhorn-pvc.yaml
+++ b/kubernetes/apps/collab/paperless/app/longhorn-pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/kubernetes/apps/collab/swiparr/app/longhorn-pvc.yaml
+++ b/kubernetes/apps/collab/swiparr/app/longhorn-pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/kubernetes/apps/databases/cloudnative-pg/config/immich/service.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/immich/service.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/service-v1.json
 apiVersion: v1
 kind: Service
 metadata:

--- a/kubernetes/apps/databases/priority-class.yaml
+++ b/kubernetes/apps/databases/priority-class.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/priorityclass-scheduling-v1.json
 apiVersion: scheduling.k8s.io/v1
 description: Used for home critical pods that must run in the cluster for WAF, but can be
   moved to another node if necessary.

--- a/kubernetes/apps/downloads/jdownloader2/app/longhorn-pvc.yaml
+++ b/kubernetes/apps/downloads/jdownloader2/app/longhorn-pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/kubernetes/apps/downloads/jdownloader2/app/nfs-pvc.yaml
+++ b/kubernetes/apps/downloads/jdownloader2/app/nfs-pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolume-v1.json
 apiVersion: v1
 kind: PersistentVolume
 metadata:

--- a/kubernetes/apps/downloads/prowlarr/app/longhorn-pvc.yaml
+++ b/kubernetes/apps/downloads/prowlarr/app/longhorn-pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/kubernetes/apps/downloads/qbittorrent/app/longhorn-pvc.yaml
+++ b/kubernetes/apps/downloads/qbittorrent/app/longhorn-pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/kubernetes/apps/downloads/qbittorrent/app/nfs-pvc.yaml
+++ b/kubernetes/apps/downloads/qbittorrent/app/nfs-pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolume-v1.json
 apiVersion: v1
 kind: PersistentVolume
 metadata:

--- a/kubernetes/apps/downloads/sabnzbd/app/longhorn-pvc.yaml
+++ b/kubernetes/apps/downloads/sabnzbd/app/longhorn-pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/kubernetes/apps/downloads/sabnzbd/app/nfs-pvc.yaml
+++ b/kubernetes/apps/downloads/sabnzbd/app/nfs-pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolume-v1.json
 apiVersion: v1
 kind: PersistentVolume
 metadata:

--- a/kubernetes/apps/downloads/slskd/app/longhorn-pvc.yaml
+++ b/kubernetes/apps/downloads/slskd/app/longhorn-pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/kubernetes/apps/downloads/slskd/app/nfs-pvc.yaml
+++ b/kubernetes/apps/downloads/slskd/app/nfs-pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolume-v1.json
 apiVersion: v1
 kind: PersistentVolume
 metadata:

--- a/kubernetes/apps/flux-system/flux-instance/app/cluster-config.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/cluster-config.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/configmap-v1.json
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/kubernetes/apps/home/esphome/app/longhorn-pvc.yaml
+++ b/kubernetes/apps/home/esphome/app/longhorn-pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/kubernetes/apps/home/frigate/app/longhorn-pvc.yaml
+++ b/kubernetes/apps/home/frigate/app/longhorn-pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/kubernetes/apps/home/frigate/app/nfs-pvc.yaml
+++ b/kubernetes/apps/home/frigate/app/nfs-pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolume-v1.json
 apiVersion: v1
 kind: PersistentVolume
 metadata:

--- a/kubernetes/apps/home/home-assistant/app/longhorn-pvc.yaml
+++ b/kubernetes/apps/home/home-assistant/app/longhorn-pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/kubernetes/apps/home/matter-server/app/longhorn-pvc.yaml
+++ b/kubernetes/apps/home/matter-server/app/longhorn-pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/kubernetes/apps/home/node-red/app/longhorn-pvc.yaml
+++ b/kubernetes/apps/home/node-red/app/longhorn-pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/kubernetes/apps/home/priority-class.yaml
+++ b/kubernetes/apps/home/priority-class.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/priorityclass-scheduling-v1.json
 apiVersion: scheduling.k8s.io/v1
 description: Used for home critical pods that must run in the cluster for WAF, but can be
   moved to another node if necessary.

--- a/kubernetes/apps/home/zigbee2mqtt/app/longhorn-pvc.yaml
+++ b/kubernetes/apps/home/zigbee2mqtt/app/longhorn-pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/kubernetes/apps/home/zwave-js-ui/app/longhorn-pvc.yaml
+++ b/kubernetes/apps/home/zwave-js-ui/app/longhorn-pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/kubernetes/apps/kube-system/zot/app/longhorn-pvc.yaml
+++ b/kubernetes/apps/kube-system/zot/app/longhorn-pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/kubernetes/apps/media/beets/app/longhorn-pvc.yaml
+++ b/kubernetes/apps/media/beets/app/longhorn-pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/kubernetes/apps/media/beets/app/nfs-pvc.yaml
+++ b/kubernetes/apps/media/beets/app/nfs-pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolume-v1.json
 apiVersion: v1
 kind: PersistentVolume
 metadata:

--- a/kubernetes/apps/media/gonic/app/longhorn-pvc.yaml
+++ b/kubernetes/apps/media/gonic/app/longhorn-pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/kubernetes/apps/media/gonic/app/nfs-pvc.yaml
+++ b/kubernetes/apps/media/gonic/app/nfs-pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolume-v1.json
 apiVersion: v1
 kind: PersistentVolume
 metadata:

--- a/kubernetes/apps/media/immich/app/nfs-pvc.yaml
+++ b/kubernetes/apps/media/immich/app/nfs-pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolume-v1.json
 apiVersion: v1
 kind: PersistentVolume
 metadata:

--- a/kubernetes/apps/media/jellyfin/app/longhorn-pvc.yaml
+++ b/kubernetes/apps/media/jellyfin/app/longhorn-pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/kubernetes/apps/media/jellyfin/app/nfs-pvc.yaml
+++ b/kubernetes/apps/media/jellyfin/app/nfs-pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolume-v1.json
 apiVersion: v1
 kind: PersistentVolume
 metadata:

--- a/kubernetes/apps/media/lidarr/app/longhorn-pvc.yaml
+++ b/kubernetes/apps/media/lidarr/app/longhorn-pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/kubernetes/apps/media/lidarr/app/nfs-pvc.yaml
+++ b/kubernetes/apps/media/lidarr/app/nfs-pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolume-v1.json
 apiVersion: v1
 kind: PersistentVolume
 metadata:

--- a/kubernetes/apps/media/music-assistant/app/longhorn-pvc.yaml
+++ b/kubernetes/apps/media/music-assistant/app/longhorn-pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/kubernetes/apps/media/music-assistant/app/nfs-pvc.yaml
+++ b/kubernetes/apps/media/music-assistant/app/nfs-pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolume-v1.json
 apiVersion: v1
 kind: PersistentVolume
 metadata:

--- a/kubernetes/apps/media/priority-class.yaml
+++ b/kubernetes/apps/media/priority-class.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/priorityclass-scheduling-v1.json
 apiVersion: scheduling.k8s.io/v1
 description: Used for home critical pods that must run in the cluster for WAF, but can be
   moved to another node if necessary.

--- a/kubernetes/apps/media/radarr/app/longhorn-pvc.yaml
+++ b/kubernetes/apps/media/radarr/app/longhorn-pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/kubernetes/apps/media/radarr/app/nfs-pvc.yaml
+++ b/kubernetes/apps/media/radarr/app/nfs-pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolume-v1.json
 apiVersion: v1
 kind: PersistentVolume
 metadata:

--- a/kubernetes/apps/media/seerr/app/ceph-pvc.yaml
+++ b/kubernetes/apps/media/seerr/app/ceph-pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/kubernetes/apps/media/seerr/app/longhorn-pvc.yaml
+++ b/kubernetes/apps/media/seerr/app/longhorn-pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/kubernetes/apps/media/sonarr/app/longhorn-pvc.yaml
+++ b/kubernetes/apps/media/sonarr/app/longhorn-pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/kubernetes/apps/media/sonarr/app/nfs-pvc.yaml
+++ b/kubernetes/apps/media/sonarr/app/nfs-pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolume-v1.json
 apiVersion: v1
 kind: PersistentVolume
 metadata:

--- a/kubernetes/apps/media/soularr/app/ceph-pvc.yaml
+++ b/kubernetes/apps/media/soularr/app/ceph-pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/kubernetes/apps/media/soularr/app/nfs-pvc.yaml
+++ b/kubernetes/apps/media/soularr/app/nfs-pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolume-v1.json
 apiVersion: v1
 kind: PersistentVolume
 metadata:

--- a/kubernetes/apps/media/stash/app/longhorn-pvc.yaml
+++ b/kubernetes/apps/media/stash/app/longhorn-pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/kubernetes/apps/media/stash/app/nfs-pvc.yaml
+++ b/kubernetes/apps/media/stash/app/nfs-pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/kubernetes/apps/media/suggestarr/app/longhorn-pvc.yaml
+++ b/kubernetes/apps/media/suggestarr/app/longhorn-pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/kubernetes/apps/media/videodupfinder/app/nfs-pvc.yaml
+++ b/kubernetes/apps/media/videodupfinder/app/nfs-pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolume-v1.json
 apiVersion: v1
 kind: PersistentVolume
 metadata:

--- a/kubernetes/apps/storage/garage/app/nfs-pvc.yaml
+++ b/kubernetes/apps/storage/garage/app/nfs-pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolume-v1.json
 apiVersion: v1
 kind: PersistentVolume
 metadata:


### PR DESCRIPTION
## Summary
Schema directive on line 2 of 61 core k8s manifests:
- 38 PersistentVolumeClaim
- 17 PersistentVolume
- 4 PriorityClass
- 1 Service
- 1 ConfigMap

Schema URLs per `.agents/instructions/schema.correction.md`. Mechanical, no behavior change. Continuation of the lint sweep — datreeio-schema CRDs (CNPG, monitoring, cert-manager) and TODO-tagged files come in follow-up batches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)