### PR TITLE
chore: lint batch — datreeio schema directives for CRDs

### DIFF
--- a/kubernetes/apps/cert-manager/cert-manager/issuers/letsencrypt-production.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/issuers/letsencrypt-production.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cert-manager.io/clusterissuer_v1.json
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:

--- a/kubernetes/apps/cert-manager/cert-manager/issuers/letsencrypt-staging.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/issuers/letsencrypt-staging.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cert-manager.io/clusterissuer_v1.json
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:

--- a/kubernetes/apps/cert-manager/cert-manager/issuers/selfsigned-bootstrap.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/issuers/selfsigned-bootstrap.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cert-manager.io/clusterissuer_v1.json
 # Bootstrap ClusterIssuer used to sign the private CA root Certificate.
 # Not used for any other certs.
 apiVersion: cert-manager.io/v1

--- a/kubernetes/apps/cert-manager/cert-manager/prometheus-rule.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/prometheus-rule.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/prometheusrule_v1.json
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/kubernetes/apps/databases/cloudnative-pg/config/atuin/cluster.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/atuin/cluster.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/cluster_v1.json
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:

--- a/kubernetes/apps/databases/cloudnative-pg/config/atuin/objectstore.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/atuin/objectstore.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/barmancloud.cnpg.io/objectstore_v1.json
 apiVersion: barmancloud.cnpg.io/v1
 kind: ObjectStore
 metadata:

--- a/kubernetes/apps/databases/cloudnative-pg/config/atuin/scheduledbackup.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/atuin/scheduledbackup.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/scheduledbackup_v1.json
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
 metadata:

--- a/kubernetes/apps/databases/cloudnative-pg/config/cutvideo/cluster.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/cutvideo/cluster.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/cluster_v1.json
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:

--- a/kubernetes/apps/databases/cloudnative-pg/config/cutvideo/objectstore.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/cutvideo/objectstore.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/barmancloud.cnpg.io/objectstore_v1.json
 apiVersion: barmancloud.cnpg.io/v1
 kind: ObjectStore
 metadata:

--- a/kubernetes/apps/databases/cloudnative-pg/config/cutvideo/scheduledbackup.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/cutvideo/scheduledbackup.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/scheduledbackup_v1.json
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
 metadata:

--- a/kubernetes/apps/databases/cloudnative-pg/config/home-assistant/cluster.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/home-assistant/cluster.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/cluster_v1.json
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:

--- a/kubernetes/apps/databases/cloudnative-pg/config/home-assistant/objectstore.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/home-assistant/objectstore.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/barmancloud.cnpg.io/objectstore_v1.json
 apiVersion: barmancloud.cnpg.io/v1
 kind: ObjectStore
 metadata:

--- a/kubernetes/apps/databases/cloudnative-pg/config/home-assistant/scheduledbackup.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/home-assistant/scheduledbackup.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/scheduledbackup_v1.json
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
 metadata:

--- a/kubernetes/apps/databases/cloudnative-pg/config/immich/cluster.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/immich/cluster.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/cluster_v1.json
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:

--- a/kubernetes/apps/databases/cloudnative-pg/config/immich/objectstore.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/immich/objectstore.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/barmancloud.cnpg.io/objectstore_v1.json
 apiVersion: barmancloud.cnpg.io/v1
 kind: ObjectStore
 metadata:

--- a/kubernetes/apps/databases/cloudnative-pg/config/immich/scheduledbackup.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/immich/scheduledbackup.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/scheduledbackup_v1.json
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
 metadata:

--- a/kubernetes/apps/databases/cloudnative-pg/config/lldap/cluster.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/lldap/cluster.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/cluster_v1.json
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:

--- a/kubernetes/apps/databases/cloudnative-pg/config/lldap/objectstore.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/lldap/objectstore.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/barmancloud.cnpg.io/objectstore_v1.json
 apiVersion: barmancloud.cnpg.io/v1
 kind: ObjectStore
 metadata:

--- a/kubernetes/apps/databases/cloudnative-pg/config/lldap/scheduledbackup.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/lldap/scheduledbackup.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/scheduledbackup_v1.json
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
 metadata:

--- a/kubernetes/apps/databases/cloudnative-pg/config/medikeep/cluster.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/medikeep/cluster.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/cluster_v1.json
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:

--- a/kubernetes/apps/databases/cloudnative-pg/config/medikeep/objectstore.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/medikeep/objectstore.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/barmancloud.cnpg.io/objectstore_v1.json
 apiVersion: barmancloud.cnpg.io/v1
 kind: ObjectStore
 metadata:

--- a/kubernetes/apps/databases/cloudnative-pg/config/medikeep/scheduledbackup.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/medikeep/scheduledbackup.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/scheduledbackup_v1.json
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
 metadata:

--- a/kubernetes/apps/databases/cloudnative-pg/config/nametag/cluster.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/nametag/cluster.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/cluster_v1.json
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:

--- a/kubernetes/apps/databases/cloudnative-pg/config/nametag/objectstore.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/nametag/objectstore.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/barmancloud.cnpg.io/objectstore_v1.json
 apiVersion: barmancloud.cnpg.io/v1
 kind: ObjectStore
 metadata:

--- a/kubernetes/apps/databases/cloudnative-pg/config/nametag/scheduledbackup.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/nametag/scheduledbackup.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/scheduledbackup_v1.json
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
 metadata:

--- a/kubernetes/apps/databases/cloudnative-pg/config/netbox/cluster.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/netbox/cluster.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/cluster_v1.json
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:

--- a/kubernetes/apps/databases/cloudnative-pg/config/netbox/objectstore.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/netbox/objectstore.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/barmancloud.cnpg.io/objectstore_v1.json
 apiVersion: barmancloud.cnpg.io/v1
 kind: ObjectStore
 metadata:

--- a/kubernetes/apps/databases/cloudnative-pg/config/netbox/scheduledbackup.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/netbox/scheduledbackup.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/scheduledbackup_v1.json
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
 metadata:

--- a/kubernetes/apps/databases/cloudnative-pg/config/nextcloud/cluster.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/nextcloud/cluster.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/cluster_v1.json
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:

--- a/kubernetes/apps/databases/cloudnative-pg/config/nextcloud/objectstore.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/nextcloud/objectstore.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/barmancloud.cnpg.io/objectstore_v1.json
 apiVersion: barmancloud.cnpg.io/v1
 kind: ObjectStore
 metadata:

--- a/kubernetes/apps/databases/cloudnative-pg/config/paperless/cluster.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/paperless/cluster.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/cluster_v1.json
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:

--- a/kubernetes/apps/databases/cloudnative-pg/config/paperless/objectstore.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/paperless/objectstore.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/barmancloud.cnpg.io/objectstore_v1.json
 apiVersion: barmancloud.cnpg.io/v1
 kind: ObjectStore
 metadata:

--- a/kubernetes/apps/databases/cloudnative-pg/config/paperless/scheduledbackup.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/paperless/scheduledbackup.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/scheduledbackup_v1.json
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
 metadata:

--- a/kubernetes/apps/databases/cloudnative-pg/config/pocket-id/cluster.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/pocket-id/cluster.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/cluster_v1.json
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:

--- a/kubernetes/apps/databases/cloudnative-pg/config/pocket-id/objectstore.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/pocket-id/objectstore.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/barmancloud.cnpg.io/objectstore_v1.json
 apiVersion: barmancloud.cnpg.io/v1
 kind: ObjectStore
 metadata:

--- a/kubernetes/apps/databases/cloudnative-pg/config/pocket-id/scheduledbackup.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/pocket-id/scheduledbackup.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/scheduledbackup_v1.json
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
 metadata:

--- a/kubernetes/apps/databases/cloudnative-pg/config/romm/cluster.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/romm/cluster.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/cluster_v1.json
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:

--- a/kubernetes/apps/databases/cloudnative-pg/config/romm/objectstore.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/romm/objectstore.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/barmancloud.cnpg.io/objectstore_v1.json
 apiVersion: barmancloud.cnpg.io/v1
 kind: ObjectStore
 metadata:

--- a/kubernetes/apps/databases/cloudnative-pg/config/romm/scheduledbackup.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/romm/scheduledbackup.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/scheduledbackup_v1.json
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
 metadata:

--- a/kubernetes/apps/databases/cloudnative-pg/config/sparkyfitness/cluster.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/sparkyfitness/cluster.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/cluster_v1.json
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:

--- a/kubernetes/apps/databases/cloudnative-pg/config/sparkyfitness/objectstore.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/sparkyfitness/objectstore.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/barmancloud.cnpg.io/objectstore_v1.json
 apiVersion: barmancloud.cnpg.io/v1
 kind: ObjectStore
 metadata:

--- a/kubernetes/apps/databases/cloudnative-pg/config/sparkyfitness/scheduledbackup.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/sparkyfitness/scheduledbackup.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/scheduledbackup_v1.json
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
 metadata:

--- a/kubernetes/apps/databases/cloudnative-pg/config/videodupfinder/cluster.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/videodupfinder/cluster.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/cluster_v1.json
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:

--- a/kubernetes/apps/databases/cloudnative-pg/config/videodupfinder/objectstore.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/videodupfinder/objectstore.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/barmancloud.cnpg.io/objectstore_v1.json
 apiVersion: barmancloud.cnpg.io/v1
 kind: ObjectStore
 metadata:

--- a/kubernetes/apps/databases/cloudnative-pg/config/videodupfinder/scheduledbackup.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/videodupfinder/scheduledbackup.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/scheduledbackup_v1.json
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
 metadata:

--- a/kubernetes/apps/databases/cloudnative-pg/config/watch-your-lan/cluster.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/watch-your-lan/cluster.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/cluster_v1.json
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:

--- a/kubernetes/apps/databases/cloudnative-pg/config/watch-your-lan/scheduledbackup.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/watch-your-lan/scheduledbackup.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/scheduledbackup_v1.json
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
 metadata:

--- a/kubernetes/apps/databases/cloudnative-pg/config/workoutdiary/cluster.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/workoutdiary/cluster.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/cluster_v1.json
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:

--- a/kubernetes/apps/databases/cloudnative-pg/config/workoutdiary/objectstore.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/workoutdiary/objectstore.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/barmancloud.cnpg.io/objectstore_v1.json
 apiVersion: barmancloud.cnpg.io/v1
 kind: ObjectStore
 metadata:

--- a/kubernetes/apps/databases/cloudnative-pg/config/workoutdiary/scheduledbackup.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/workoutdiary/scheduledbackup.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/scheduledbackup_v1.json
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
 metadata:

--- a/kubernetes/apps/databases/dragonfly/cluster/podmonitor.yaml
+++ b/kubernetes/apps/databases/dragonfly/cluster/podmonitor.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/podmonitor_v1.json
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:

--- a/kubernetes/apps/network/envoy-gateway/config/podmonitor.yaml
+++ b/kubernetes/apps/network/envoy-gateway/config/podmonitor.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/podmonitor_v1.json
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:

--- a/kubernetes/apps/observability/exporters/dcgm-exporter/app/monitoring/alerts.yaml
+++ b/kubernetes/apps/observability/exporters/dcgm-exporter/app/monitoring/alerts.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/prometheusrule_v1.json
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/kubernetes/apps/observability/exporters/prometheus-nut-exporter/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/exporters/prometheus-nut-exporter/app/prometheusrule.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/prometheusrule_v1.json
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/kubernetes/apps/observability/speedtest-prometheus/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/speedtest-prometheus/app/prometheusrule.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/prometheusrule_v1.json
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:


### PR DESCRIPTION
Schema directive on line 2 of 55 CRD-managed manifests (CNPG, monitoring, cert-manager). Mechanical, no behavior change. Continuation of the lint sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)