### PR TITLE
chore: lint batch — final schema sweep

### DIFF
--- a/kubernetes/apps/cert-manager/cert-manager/issuers/cluster-internal-ca.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/issuers/cluster-internal-ca.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cert-manager.io/certificate_v1.json
 # Self-signed root CA used to issue per-listener certificates for the
 # internal Gateway's HTTPRoutes. Not browser-trusted by default — devices
 # that visit *.thesteamedcrab.com on the internal LB must import the

--- a/kubernetes/apps/databases/cloudnative-pg/config/onetimebackup.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/onetimebackup.yaml
@@ -1,4 +1,5 @@
 ---
+# TODO: apply schema
 apiVersion: postgresql.cnpg.io/v1
 kind: Backup
 metadata:

--- a/kubernetes/apps/external-secrets/onepassword-connect/app/clustersecretstore.yaml
+++ b/kubernetes/apps/external-secrets/onepassword-connect/app/clustersecretstore.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/clustersecretstore_v1.json
 apiVersion: external-secrets.io/v1
 kind: ClusterSecretStore
 metadata:

--- a/kubernetes/apps/flux-system/flux-instance/app/github/webhooks/allow-webhooks-from-gateway.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/github/webhooks/allow-webhooks-from-gateway.yaml
@@ -1,6 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/networkpolicy-networking-v1.json
 # I thnk the allow-webhooks network policy created by flux only works for ingress and you need this network policy to get packets/flows from a gateway.
 # See if this can be removed after recreating the cluster and moving to the flux operator.
----
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/kubernetes/apps/home/esphome/net-attach/net-attach.yaml
+++ b/kubernetes/apps/home/esphome/net-attach/net-attach.yaml
@@ -1,4 +1,5 @@
 ---
+# TODO: apply schema
 apiVersion: "k8s.cni.cncf.io/v1"
 kind: NetworkAttachmentDefinition
 metadata:

--- a/kubernetes/apps/home/frigate/net-attach/net-attach.yaml
+++ b/kubernetes/apps/home/frigate/net-attach/net-attach.yaml
@@ -1,4 +1,5 @@
 ---
+# TODO: apply schema
 apiVersion: "k8s.cni.cncf.io/v1"
 kind: NetworkAttachmentDefinition
 metadata:

--- a/kubernetes/apps/home/home-assistant/app/sync-cronjob.yaml
+++ b/kubernetes/apps/home/home-assistant/app/sync-cronjob.yaml
@@ -1,4 +1,5 @@
 ---
+# TODO: apply schema
 apiVersion: batch/v1
 kind: CronJob
 metadata:

--- a/kubernetes/apps/home/home-assistant/net-attach/net-attach.yaml
+++ b/kubernetes/apps/home/home-assistant/net-attach/net-attach.yaml
@@ -1,4 +1,5 @@
 ---
+# TODO: apply schema
 apiVersion: "k8s.cni.cncf.io/v1"
 kind: NetworkAttachmentDefinition
 metadata:

--- a/kubernetes/apps/home/matter-server/net-attach/net-attach.yaml
+++ b/kubernetes/apps/home/matter-server/net-attach/net-attach.yaml
@@ -1,4 +1,5 @@
 ---
+# TODO: apply schema
 apiVersion: "k8s.cni.cncf.io/v1"
 kind: NetworkAttachmentDefinition
 metadata:

--- a/kubernetes/apps/home/node-red/net-attach/net-attach.yaml
+++ b/kubernetes/apps/home/node-red/net-attach/net-attach.yaml
@@ -1,4 +1,5 @@
 ---
+# TODO: apply schema
 apiVersion: "k8s.cni.cncf.io/v1"
 kind: NetworkAttachmentDefinition
 metadata:

--- a/kubernetes/apps/kube-system/cilium/config/pool.yaml
+++ b/kubernetes/apps/kube-system/cilium/config/pool.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumloadbalancerippool_v2.json
 apiVersion: cilium.io/v2
 kind: CiliumLoadBalancerIPPool
 metadata:

--- a/kubernetes/apps/kube-system/etcd-defrag/cron-job.yaml
+++ b/kubernetes/apps/kube-system/etcd-defrag/cron-job.yaml
@@ -1,4 +1,5 @@
 ---
+# TODO: apply schema
 apiVersion: batch/v1
 kind: CronJob
 metadata:

--- a/kubernetes/apps/kube-system/k8tz/app/pki.yaml
+++ b/kubernetes/apps/kube-system/k8tz/app/pki.yaml
@@ -1,4 +1,5 @@
 ---
+# TODO: apply schema
 # Create a selfsigned Issuer, in order to create a root CA certificate for
 # signing webhook serving certificates
 apiVersion: cert-manager.io/v1

--- a/kubernetes/apps/kube-system/kube-vip/daemon-set.yaml
+++ b/kubernetes/apps/kube-system/kube-vip/daemon-set.yaml
@@ -1,4 +1,5 @@
 ---
+# TODO: apply schema
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/kubernetes/apps/kube-system/kube-vip/rbac.yaml
+++ b/kubernetes/apps/kube-system/kube-vip/rbac.yaml
@@ -1,4 +1,5 @@
 ---
+# TODO: apply schema
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/kubernetes/apps/kube-system/node-feature-discovery/rules/barcode-device.yaml
+++ b/kubernetes/apps/kube-system/node-feature-discovery/rules/barcode-device.yaml
@@ -1,4 +1,5 @@
 ---
+# TODO: apply schema
 apiVersion: nfd.k8s-sigs.io/v1alpha1
 kind: NodeFeatureRule
 metadata:

--- a/kubernetes/apps/kube-system/node-feature-discovery/rules/coral-device.yaml
+++ b/kubernetes/apps/kube-system/node-feature-discovery/rules/coral-device.yaml
@@ -1,4 +1,5 @@
 ---
+# TODO: apply schema
 apiVersion: nfd.k8s-sigs.io/v1alpha1
 kind: NodeFeatureRule
 metadata:

--- a/kubernetes/apps/kube-system/node-feature-discovery/rules/intel-gpu.yaml
+++ b/kubernetes/apps/kube-system/node-feature-discovery/rules/intel-gpu.yaml
@@ -1,4 +1,5 @@
 ---
+# TODO: apply schema
 apiVersion: nfd.k8s-sigs.io/v1alpha1
 kind: NodeFeatureRule
 metadata:

--- a/kubernetes/apps/kube-system/node-feature-discovery/rules/nvidia-gpu.yaml
+++ b/kubernetes/apps/kube-system/node-feature-discovery/rules/nvidia-gpu.yaml
@@ -1,4 +1,5 @@
 ---
+# TODO: apply schema
 apiVersion: nfd.k8s-sigs.io/v1alpha1
 kind: NodeFeatureRule
 metadata:

--- a/kubernetes/apps/kube-system/node-feature-discovery/rules/skyconnect-device.yaml
+++ b/kubernetes/apps/kube-system/node-feature-discovery/rules/skyconnect-device.yaml
@@ -1,4 +1,5 @@
 ---
+# TODO: apply schema
 apiVersion: nfd.k8s-sigs.io/v1alpha1
 kind: NodeFeatureRule
 metadata:

--- a/kubernetes/apps/kube-system/node-feature-discovery/rules/vlan-device.yaml
+++ b/kubernetes/apps/kube-system/node-feature-discovery/rules/vlan-device.yaml
@@ -1,4 +1,5 @@
 ---
+# TODO: apply schema
 apiVersion: nfd.k8s-sigs.io/v1alpha1
 kind: NodeFeatureRule
 metadata:

--- a/kubernetes/apps/kube-system/node-feature-discovery/rules/zigbee-device.yaml
+++ b/kubernetes/apps/kube-system/node-feature-discovery/rules/zigbee-device.yaml
@@ -1,4 +1,5 @@
 ---
+# TODO: apply schema
 apiVersion: nfd.k8s-sigs.io/v1alpha1
 kind: NodeFeatureRule
 metadata:

--- a/kubernetes/apps/kube-system/node-feature-discovery/rules/zwave-device.yaml
+++ b/kubernetes/apps/kube-system/node-feature-discovery/rules/zwave-device.yaml
@@ -1,4 +1,5 @@
 ---
+# TODO: apply schema
 apiVersion: nfd.k8s-sigs.io/v1alpha1
 kind: NodeFeatureRule
 metadata:

--- a/kubernetes/apps/kube-system/nvidia-device-plugin/app/runtimeclass.yaml
+++ b/kubernetes/apps/kube-system/nvidia-device-plugin/app/runtimeclass.yaml
@@ -1,4 +1,5 @@
 ---
+# TODO: apply schema
 apiVersion: node.k8s.io/v1
 kind: RuntimeClass
 metadata:

--- a/kubernetes/apps/longhorn-system/longhorn/config/recurring-jobs.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn/config/recurring-jobs.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/longhorn.io/recurringjob_v1beta2.json
 apiVersion: longhorn.io/v1beta2
 kind: RecurringJob
 metadata:

--- a/kubernetes/apps/mcp-system/frigate-mcp/mcp/mcpserverregistration.yaml
+++ b/kubernetes/apps/mcp-system/frigate-mcp/mcp/mcpserverregistration.yaml
@@ -1,4 +1,5 @@
 ---
+# TODO: apply schema
 apiVersion: mcp.kuadrant.io/v1alpha1
 kind: MCPServerRegistration
 metadata:

--- a/kubernetes/apps/mcp-system/grafana-mcp/mcp/mcpserverregistration.yaml
+++ b/kubernetes/apps/mcp-system/grafana-mcp/mcp/mcpserverregistration.yaml
@@ -1,4 +1,5 @@
 ---
+# TODO: apply schema
 apiVersion: mcp.kuadrant.io/v1alpha1
 kind: MCPServerRegistration
 metadata:

--- a/kubernetes/apps/mcp-system/ha-mcp/mcp/mcpserverregistration.yaml
+++ b/kubernetes/apps/mcp-system/ha-mcp/mcp/mcpserverregistration.yaml
@@ -1,4 +1,5 @@
 ---
+# TODO: apply schema
 apiVersion: mcp.kuadrant.io/v1alpha1
 kind: MCPServerRegistration
 metadata:

--- a/kubernetes/apps/mcp-system/kubectl-mcp/mcp/mcpserverregistration.yaml
+++ b/kubernetes/apps/mcp-system/kubectl-mcp/mcp/mcpserverregistration.yaml
@@ -1,4 +1,5 @@
 ---
+# TODO: apply schema
 apiVersion: mcp.kuadrant.io/v1alpha1
 kind: MCPServerRegistration
 metadata:

--- a/kubernetes/apps/mcp-system/mealie-mcp/mcp/mcpserverregistration.yaml
+++ b/kubernetes/apps/mcp-system/mealie-mcp/mcp/mcpserverregistration.yaml
@@ -1,4 +1,5 @@
 ---
+# TODO: apply schema
 apiVersion: mcp.kuadrant.io/v1alpha1
 kind: MCPServerRegistration
 metadata:

--- a/kubernetes/apps/mcp-system/netbox-mcp/mcp/mcpserverregistration.yaml
+++ b/kubernetes/apps/mcp-system/netbox-mcp/mcp/mcpserverregistration.yaml
@@ -1,4 +1,5 @@
 ---
+# TODO: apply schema
 apiVersion: mcp.kuadrant.io/v1alpha1
 kind: MCPServerRegistration
 metadata:

--- a/kubernetes/apps/mcp-system/paperless-mcp/mcp/mcpserverregistration.yaml
+++ b/kubernetes/apps/mcp-system/paperless-mcp/mcp/mcpserverregistration.yaml
@@ -1,4 +1,5 @@
 ---
+# TODO: apply schema
 apiVersion: mcp.kuadrant.io/v1alpha1
 kind: MCPServerRegistration
 metadata:

--- a/kubernetes/apps/mcp-system/prometheus-mcp/app/mcpserverregistration.yaml
+++ b/kubernetes/apps/mcp-system/prometheus-mcp/app/mcpserverregistration.yaml
@@ -1,4 +1,5 @@
 ---
+# TODO: apply schema
 apiVersion: mcp.kuadrant.io/v1alpha1
 kind: MCPServerRegistration
 metadata:

--- a/kubernetes/apps/mcp-system/searxng-mcp/mcp/mcpserverregistration.yaml
+++ b/kubernetes/apps/mcp-system/searxng-mcp/mcp/mcpserverregistration.yaml
@@ -1,4 +1,5 @@
 ---
+# TODO: apply schema
 apiVersion: mcp.kuadrant.io/v1alpha1
 kind: MCPServerRegistration
 metadata:

--- a/kubernetes/apps/network/cloudflared/app/dnsendpoint.yaml
+++ b/kubernetes/apps/network/cloudflared/app/dnsendpoint.yaml
@@ -1,4 +1,5 @@
 ---
+# TODO: apply schema
 apiVersion: externaldns.k8s.io/v1alpha1
 kind: DNSEndpoint
 metadata:

--- a/kubernetes/apps/network/external-dns/app/bind/rbac.yaml
+++ b/kubernetes/apps/network/external-dns/app/bind/rbac.yaml
@@ -1,4 +1,5 @@
 ---
+# TODO: apply schema
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/kubernetes/apps/observability/exporters/prometheus-nut-exporter/app/servicemonitor.yaml
+++ b/kubernetes/apps/observability/exporters/prometheus-nut-exporter/app/servicemonitor.yaml
@@ -1,5 +1,5 @@
-# yaml-language-server: $schema=https://kube-schemas.pages.dev/monitoring.coreos.com/servicemonitor_v1.json
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/servicemonitor_v1.json
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -40,8 +40,8 @@ spec:
         - action: labeldrop
           regex: pod
 
-# yaml-language-server: $schema=https://kube-schemas.pages.dev/monitoring.coreos.com/servicemonitor_v1.json
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/servicemonitor_v1.json
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/kubernetes/apps/observability/kube-ops-view/app/rbac.yaml
+++ b/kubernetes/apps/observability/kube-ops-view/app/rbac.yaml
@@ -1,4 +1,5 @@
 ---
+# TODO: apply schema
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/kubernetes/apps/observability/vector/agent/rbac.yaml
+++ b/kubernetes/apps/observability/vector/agent/rbac.yaml
@@ -1,4 +1,5 @@
 ---
+# TODO: apply schema
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/kubernetes/apps/vpn/downloads-gateway/app/networkpolicy.yaml
+++ b/kubernetes/apps/vpn/downloads-gateway/app/networkpolicy.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:


### PR DESCRIPTION
Wraps up the schema-directive lint sweep. Mapped what's in the table, TODOs the rest, and fixes 2 files with malformed directive placement.

Together with the prior batches (#11161 namespace, #11162 yannh, #11163 datreeio), this brings the repo into compliance with the schema-on-line-2 rule for everything except Helm values files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)