### PR TITLE
chore: yamllint clean — fix 11 violations + scope config

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,10 +1,14 @@
 ---
 ignore: |
   *.sops.*
+  **/resources/
 
 extends: default
 
 rules:
+  braces:
+    max-spaces-inside: 1
+    min-spaces-inside: 0
   brackets:
     max-spaces-inside: 1
     min-spaces-inside: 0

--- a/bootstrap/helmfile.d/00-crds.yaml
+++ b/bootstrap/helmfile.d/00-crds.yaml
@@ -27,10 +27,10 @@ releases:
     chart: oci://ghcr.io/home-operations/charts-mirror/external-dns
     version: 1.21.1
 
-  #- name: keda
-  #  namespace: kube-system
-  #  chart: oci://ghcr.io/home-operations/charts-mirror/keda
-  #  version: 2.18.1
+  # - name: keda
+  #   namespace: kube-system
+  #   chart: oci://ghcr.io/home-operations/charts-mirror/keda
+  #   version: 2.18.1
 
   - name: kube-prometheus-stack
     namespace: observability

--- a/init/clusterconfiguration.yaml
+++ b/init/clusterconfiguration.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kubeadm.k8s.io/v1beta4
 bootstrapTokens:
 - groups:

--- a/kubernetes/apps/collab/medikeep/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/medikeep/app/helmrelease.yaml
@@ -19,7 +19,7 @@ spec:
             fsGroupChangePolicy: OnRootMismatch
 
             runAsGroup: 999
-            #runAsNonRoot: true
+            # runAsNonRoot: true
             runAsUser: 999
         annotations:
           reloader.stakater.com/auto: "true"

--- a/kubernetes/apps/downloads/jdownloader2/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/jdownloader2/app/helmrelease.yaml
@@ -30,8 +30,8 @@ spec:
             fsGroup: 1001
             fsGroupChangePolicy: OnRootMismatch
             runAsGroup: 1001
-             #runAsNonRoot: true
-             #runAsUser: 100
+            # runAsNonRoot: true
+            # runAsUser: 100
         annotations:
           reloader.stakater.com/auto: "true"
         type: statefulset

--- a/kubernetes/apps/downloads/slskd/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/slskd/app/helmrelease.yaml
@@ -15,10 +15,10 @@ spec:
       securityContext:
         fsGroup: 1001
         fsGroupChangePolicy: OnRootMismatch
-        #runAsGroup: 1001
-        #runAsNonRoot: true
-        #runAsUser: 1000
-        #seccompProfile: {type: RuntimeDefault}
+        # runAsGroup: 1001
+        # runAsNonRoot: true
+        # runAsUser: 1000
+        # seccompProfile: {type: RuntimeDefault}
 
     controllers:
       slskd:

--- a/kubernetes/flux/cluster/ks.yaml
+++ b/kubernetes/flux/cluster/ks.yaml
@@ -22,7 +22,7 @@ spec:
         name: cluster-secrets
   deletionPolicy: WaitForTermination
   patches:
-      # Add Kustomization defaults for all child Kustomizations
+    # Add Kustomization defaults for all child Kustomizations
     - patch: |-
         apiVersion: kustomize.toolkit.fluxcd.io/v1
         kind: Kustomization


### PR DESCRIPTION
## Summary
Brings the tree to **0 yamllint errors / 0 warnings**.

### .yamllint.yaml
- Adds `**/resources/` to the ignore list. Those directories hold app-specific YAML (beets/config.yaml, slskd/slskd.yml, recyclarr/recyclarr.yml, etc.) that's not a k8s manifest. The schema-correction rule already excludes `resources/` directories; this aligns yamllint scope with the same convention.
- Adds a `braces` rule with the same `max-spaces-inside: 1` settings as the existing `brackets` rule, so flow mappings like `{type: RuntimeDefault}` with at most one inside-space don't fail.

### Code fixes (6 files)
- `medikeep`, `jdownloader2`, `slskd` HelmReleases + `bootstrap/helmfile.d/00-crds.yaml`: add space after `#` on commented-out lines.
- `flux/cluster/ks.yaml`: comment dedented 6 → 4 spaces to match the surrounding list.
- `init/clusterconfiguration.yaml`: add leading `---`.

CI's yamllint job will pass (it already passed on the schema-batch PRs since it lints only changed files; this brings the *whole* tree into compliance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)