### PR TITLE
fix(kubeclaw): switch state PVCs to ceph-filesystem (RWX)

### DIFF
--- a/kubernetes/apps/ai/kubeclaw/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/kubeclaw/app/helmrelease.yaml
@@ -62,12 +62,20 @@ spec:
           }
         }
     persistence:
-      storageClass: ceph-block
+      # RWX so the kubeclaw-gateway StatefulSet and the qmd-embed/qmd-update
+      # CronJobs can all mount the shared state volume concurrently.
+      # On ceph-block (RWO) the CronJobs hit Multi-Attach errors whenever
+      # the gateway is up.
+      accessModes:
+        - ReadWriteMany
+      storageClass: ceph-filesystem
       size: 10Gi
     obsidian:
       enabled: true
       persistence:
-        storageClass: ceph-block
+        accessModes:
+          - ReadWriteMany
+        storageClass: ceph-filesystem
         size: 5Gi
     chromium:
       enabled: true


### PR DESCRIPTION
## Summary
The kubeclaw chart wants three workloads (gateway StatefulSet + qmd-embed/qmd-update CronJobs) to share a state PVC. On `ceph-block` that PVC is RWO, so when the gateway is up nothing else can mount it — qmd CronJobs sit in `Init:0/2` indefinitely with `Multi-Attach error`.

Switches `persistence.storageClass` to `ceph-filesystem` and adds `accessModes: [ReadWriteMany]` for both the main state PVC and the obsidian persistence sub-config.

## Manual followup (post-merge)

Kubernetes will not mutate an existing bound PVC's spec. After this PR merges and Flux reconciles, run:

```sh
kubectl delete pvc -n ai kubeclaw-state-kubeclaw-gateway-0
# if obsidian PVC exists:
kubectl delete pvc -n ai kubeclaw-vault-kubeclaw-gateway-0
# force-recycle the gateway pod so the new PVCs bind:
kubectl delete pod -n ai kubeclaw-gateway-0 --grace-period=0 --force
```

State (qmd embeddings, etc.) will be regenerated by the next `qmd-update` / `qmd-embed` run.

## Test plan
- [ ] After PVC delete + pod restart, both PVCs come up RWX on ceph-filesystem.
- [ ] Next CronJob run completes (qmd-embed / qmd-update finish in seconds, not stuck in Init).
- [ ] Gateway pod still serves traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)