### PR TITLE
fix(home-assistant): config-sync CronJob never worked

### DIFF
--- a/kubernetes/apps/home/home-assistant/app/sync-cronjob.yaml
+++ b/kubernetes/apps/home/home-assistant/app/sync-cronjob.yaml
@@ -15,10 +15,11 @@ spec:
       template:
         spec:
           restartPolicy: OnFailure
-          securityContext:
-            runAsUser: 568
-            runAsGroup: 568
-            fsGroup: 568
+          # Run as root so apk add can install git/curl/openssh. /config is
+          # chmod 777 and HA writes its own files as uid 568, so root-created
+          # files written by `git pull` remain accessible to HA. The
+          # safe.directory line below stops git's CVE-2022-24765 check from
+          # tripping on the uid mismatch.
           containers:
             - name: sync
               image: docker.io/library/alpine:3.23
@@ -37,6 +38,10 @@ spec:
                   chmod 700 "$HOME/.ssh"
                   chmod 600 "$HOME/.ssh/id_ed25519"
                   chmod 644 "$HOME/.ssh/known_hosts"
+
+                  # /config is owned by uid 568 (HA); we run as root.
+                  # CVE-2022-24765 makes git refuse without this opt-in.
+                  git config --global --add safe.directory /config
 
                   cd /config
 


### PR DESCRIPTION
## Summary
Two stacked bugs made the home-assistant config-sync CronJob silently fail since launch:

1. **`apk add` runs as non-root.** The pod has `runAsUser: 568`. `apk add git curl openssh-client` needs root to install — exits 99. `set -eu` kills the script. The failure was hidden because stderr was redirected to `/dev/null`.

2. **Git's CVE-2022-24765 ownership check.** Even if apk had worked, `/config` is owned by uid 568 (HA) but git would be running as a different user → `fatal: detected dubious ownership in repository at '/config'`.

## Fix
- Drop `runAsUser`/`runAsGroup` from the pod spec so the sync container runs as root and `apk add` works.
- Add `git config --global --add safe.directory /config` to the script so git's ownership check is satisfied with the uid mismatch.

`/config` is `chmod 777` and HA continues to write its own files as uid 568, so root-created files from `git pull` remain readable/writable through the world-writable parent dir.

## Verification
Reproduced the failure in a debug pod with same securityContext + image:
- Without securityContext (running as root): `apk add` succeeds, then `git status` fails with dubious-ownership.
- With `git config safe.directory /config`: `git status` works and reports the actual /config state (1 dirty file, expected).

## Test plan
- [ ] Next CronJob run completes successfully (job status `Succeeded`, not `Failed`)
- [ ] If /config has uncommitted edits, the script logs "Working tree dirty" and exits 0
- [ ] If clean, fetches and pulls origin main; if HEAD changed, hits HA reload API

🤖 Generated with [Claude Code](https://claude.com/claude-code)