### PR TITLE
chore(allowlist): allow docker.io/rclone/rclone

### DIFF
--- a/.github/image-registry-allowlist.txt
+++ b/.github/image-registry-allowlist.txt
@@ -42,3 +42,4 @@ docker.io/dxflrs/garage
 docker.io/khairul169/garage-webui
 docker.io/hjacobs/kube-ops-view         # upstream archived 2020
 docker.io/prompp/prompp                 # Prom++ Docker Hub only
+docker.io/rclone/rclone                 # ghcr.io/rclone/rclone has no stable semver tags


### PR DESCRIPTION
## Summary
- Add `docker.io/rclone/rclone` to the image registry allowlist
- `ghcr.io/rclone/rclone` exists but only publishes `master`/`beta`/sha tags — no stable semver
- Unblocks Renovate PR #11188 (rclone 1.69.0 → 1.74.0)

## Test plan
- [ ] Image Registry Check workflow passes on this PR
- [ ] After merge, re-run #11188 and confirm `Check new images` turns green

🤖 Generated with [Claude Code](https://claude.com/claude-code)