### PR TITLE
feat(observability): close scrape gaps and prep app-template v5

### DIFF
--- a/kubernetes/apps/home/netbox/app/kustomization.yaml
+++ b/kubernetes/apps/home/netbox/app/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - ./helmrelease.yaml
   - ./httproute.yaml
   - ./ocirepository.yaml
+  - ./servicemonitor.yaml

--- a/kubernetes/apps/home/netbox/app/servicemonitor.yaml
+++ b/kubernetes/apps/home/netbox/app/servicemonitor.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/servicemonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: netbox
+  labels:
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/instance: netbox
+    app.kubernetes.io/name: netbox
+    prometheus: kube-prometheus
+spec:
+  endpoints:
+    - interval: 30s
+      path: /metrics
+      port: http
+      scheme: http
+      scrapeTimeout: 10s
+  namespaceSelector:
+    matchNames:
+      - home
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: netbox
+      app.kubernetes.io/name: netbox

--- a/kubernetes/apps/istio-system/istio/app/istiod/kustomization.yaml
+++ b/kubernetes/apps/istio-system/istio/app/istiod/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./helmrelease.yaml
   - ./helmrepository.yaml
+  - ./servicemonitor.yaml

--- a/kubernetes/apps/istio-system/istio/app/istiod/servicemonitor.yaml
+++ b/kubernetes/apps/istio-system/istio/app/istiod/servicemonitor.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/servicemonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: istiod
+  labels:
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/instance: istiod
+    app.kubernetes.io/name: istiod
+    prometheus: kube-prometheus
+spec:
+  endpoints:
+    - interval: 30s
+      path: /metrics
+      port: http-monitoring
+      scheme: http
+      scrapeTimeout: 10s
+  namespaceSelector:
+    matchNames:
+      - istio-system
+  selector:
+    matchLabels:
+      app: istiod
+      istio: pilot

--- a/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
@@ -22,6 +22,11 @@ spec:
       repository: mirror.gcr.io/coredns/coredns
     k8sAppLabelOverride: kube-dns
     priorityClassName: system-cluster-critical
+    prometheus:
+      monitor:
+        enabled: true
+      service:
+        enabled: true
     replicaCount: 3
     servers:
       - plugins:

--- a/kubernetes/apps/longhorn-system/longhorn/app/kustomization.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn/app/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./helmrelease.yaml
   - ./helmrepository.yaml
   - ./httproute.yaml
+  - ./servicemonitor.yaml

--- a/kubernetes/apps/longhorn-system/longhorn/app/servicemonitor.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn/app/servicemonitor.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/servicemonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: longhorn
+  labels:
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/name: longhorn
+    prometheus: kube-prometheus
+spec:
+  endpoints:
+    - interval: 30s
+      path: /metrics
+      port: manager
+      scheme: http
+      scrapeTimeout: 10s
+  namespaceSelector:
+    matchNames:
+      - longhorn-system
+  selector:
+    matchLabels:
+      app: longhorn-manager

--- a/kubernetes/apps/media/immich/app/kustomization.yaml
+++ b/kubernetes/apps/media/immich/app/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - ./helmrepository.yaml
   - ./httproute.yaml
   - ./nfs-pvc.yaml
+  - ./servicemonitor.yaml

--- a/kubernetes/apps/media/immich/app/servicemonitor.yaml
+++ b/kubernetes/apps/media/immich/app/servicemonitor.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/servicemonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: immich
+  labels:
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/instance: immich
+    app.kubernetes.io/name: immich
+    prometheus: kube-prometheus
+spec:
+  endpoints:
+    - interval: 30s
+      path: /metrics
+      port: metrics
+      scheme: http
+      scrapeTimeout: 10s
+  namespaceSelector:
+    matchNames:
+      - media
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: immich

--- a/kubernetes/apps/observability/vector/agent/helmrelease.yaml
+++ b/kubernetes/apps/observability/vector/agent/helmrelease.yaml
@@ -109,8 +109,5 @@ spec:
           - path: /var/log
             readOnly: true
 
-    podMonitor:
-      enabled: true
-
     serviceAccount:
       vector-agent: {}


### PR DESCRIPTION
## Summary
- Add Prometheus scraping for 5 apps that emit metrics but had no ServiceMonitor/PodMonitor
- Drop dead `podMonitor: enabled: true` block from vector-agent (unblocks Renovate PR #11189 — app-template 5.0.0 schema rejects it)

## Coverage added

| App | Approach | Port |
|-----|----------|------|
| coredns | chart-native (`prometheus.service.enabled`, `prometheus.monitor.enabled`) | metrics :9153 |
| immich | sibling ServiceMonitor | metrics |
| longhorn | sibling ServiceMonitor | manager :9500 |
| istiod | sibling ServiceMonitor | http-monitoring :15014 |
| netbox | sibling ServiceMonitor | http (`metricsEnabled: true`) |

## vector-agent

The HelmRelease had `podMonitor: enabled: true`, but:
1. App-template v4 silently ignored it (PodMonitor support is new in v5)
2. `vector.yaml` has no `prometheus_exporter` sink, so nothing would be scraped even with a working PodMonitor

Removed. Enabling real Vector internal metrics (sink + service + monitor) is left for a follow-up.

## Out of scope

- Istio sidecar metrics (large PodMonitor + relabel rules)
- Apps that need exporter sidecars to emit metrics: \*arr stack, qbittorrent, sabnzbd, jellyfin, frigate, mealie, paperless, ollama, garage, wg-easy, onepassword-connect, kuadrant

## Test plan
- [ ] flux-local CI passes (the v5 schema check that previously failed on vector-agent)
- [ ] After merge + Flux reconcile, check Prometheus targets:
  - `up{job="coredns"}` = 1
  - `up{namespace="media", service=~"immich.*"}` returns rows
  - `up{namespace="longhorn-system"}` = 1
  - `up{namespace="istio-system", job="istiod"}` = 1
  - `up{namespace="home", service="netbox"}` = 1
- [ ] If any selector/port-name guesses are wrong (best-effort based on chart conventions), the corresponding target shows as down — easy to spot and fix in a follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)