### PR TITLE
fix(multus): enable SA token mount after bjw-s common v5 bump

### DIFF
--- a/kubernetes/apps/network/multus/app/helmrelease.yaml
+++ b/kubernetes/apps/network/multus/app/helmrelease.yaml
@@ -10,6 +10,8 @@ spec:
     name: multus
   interval: 30m
   values:
+    defaultPodOptions:
+      automountServiceAccountToken: true
     affinity:
       nodeAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
## Summary
- Restore `automountServiceAccountToken: true` for the multus DaemonSet via `defaultPodOptions`.
- Renovate PR #11187 bumped the bjw-s `multus` chart 1.2.1 → 1.3.0, whose only change is "Update common library to v5.0.0". Common v5 flips the default for `automountServiceAccountToken` from `true` → `false`, which removes the projected SA volume from the pod.
- Without the SA volume, multus exits immediately with `failed to create multus kubeconfig: file /var/run/secrets/kubernetes.io/serviceaccount/ca.crt not found` and the rolling DaemonSet update has been crash-looping any node it reaches (worker4 and worker5 so far).

## Test plan
- [ ] Merge to main, let Flux reconcile the HelmRelease
- [ ] Confirm the rendered DaemonSet has `automountServiceAccountToken: true` and the projected `kube-api-access-*` volume is back
- [ ] Confirm new multus pods start cleanly on worker4 and worker5 (no `failed to create multus kubeconfig` errors)
- [ ] Watch the rest of the DaemonSet roll without regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)