### PR TITLE
fix(cnpg): make DatabaseDeadlockConflicts alert rate-based

### DIFF
--- a/kubernetes/apps/databases/cloudnative-pg/app/prometheusrule.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/app/prometheusrule.yaml
@@ -58,10 +58,10 @@ spec:
             severity: warning
         - alert: DatabaseDeadlockConflicts
           annotations:
-            description: There are over 10 deadlock conflicts in {{ $labels.pod }}
-            summary: Checks the number of database conflicts
+            description: More than 10 deadlocks in the last hour on {{ $labels.pod }} ({{ $labels.datname }})
+            summary: Active deadlock rate is elevated
           expr: |-
-            cnpg_pg_stat_database_deadlocks > 10
-          for: 1m
+            increase(cnpg_pg_stat_database_deadlocks[1h]) > 10
+          for: 5m
           labels:
             severity: warning


### PR DESCRIPTION
## Summary
- The previous `cnpg_pg_stat_database_deadlocks > 10` expression watched a cumulative counter that never decreased — once a DB hit 11 deadlocks since its last stats reset, the alert latched on forever (currently the case for `postgres-atuin-2`).
- Switched to `increase(cnpg_pg_stat_database_deadlocks[1h]) > 10` so the alert tracks active deadlock rate and clears on its own.
- Bumped `for` from 1m → 5m to filter brief bursts.

## Test plan
- [x] Verified PromQL syntax against `cnpg_pg_stat_database_deadlocks` series in cluster
- [ ] After merge + reconcile, confirm the latched `DatabaseDeadlockConflicts` alert for `postgres-atuin-2` clears within ~1h

🤖 Generated with [Claude Code](https://claude.com/claude-code)