### PR TITLE
fix(app-template-v5): restore SA token mount + tame slow vector rollout

### DIFF
--- a/kubernetes/apps/collab/glance/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/glance/app/helmrelease.yaml
@@ -18,6 +18,8 @@ spec:
       strategy: rollback
       retries: 3
   values:
+    defaultPodOptions:
+      automountServiceAccountToken: true
     controllers:
       glance:
         pod:

--- a/kubernetes/apps/network/external-dns/app/bind/helmrelease.yaml
+++ b/kubernetes/apps/network/external-dns/app/bind/helmrelease.yaml
@@ -20,6 +20,8 @@ spec:
       retries: 3
 
   values:
+    defaultPodOptions:
+      automountServiceAccountToken: true
     controllers:
       main:
         pod:

--- a/kubernetes/apps/observability/vector/agent/helmrelease.yaml
+++ b/kubernetes/apps/observability/vector/agent/helmrelease.yaml
@@ -10,6 +10,12 @@ spec:
     name: app-template
 
   interval: 30m
+
+  install:
+    disableWait: true
+  upgrade:
+    disableWait: true
+
   values:
     controllers:
       main:


### PR DESCRIPTION
## Summary

Three fallout fixes from the app-template 4.6.2 → 5.0.0 bump in #11189.

| HR | Symptom | Fix |
|----|---------|-----|
| **glance** | StatefulSet pod CrashLoopBackOff (k8s-extension sidecar can't reach apiserver) | \`defaultPodOptions.automountServiceAccountToken: true\` |
| **external-dns-bind** | Pod CrashLoopBackOff: \`open /var/run/secrets/.../token: no such file or directory\` | \`defaultPodOptions.automountServiceAccountToken: true\` |
| **vector-agent** | HR Failed (helm-controller 5min wait timed out on DaemonSet rollout); DS itself was rolling cleanly | \`install.disableWait\` + \`upgrade.disableWait\` (the pattern memorialized in memory) |

## Why v5 broke this

v5 changed \`automountServiceAccountToken\` to default \`false\` for "improved security posture." Apps that talk to the apiserver from in-cluster code (glance's k8s-extension sidecar, external-dns reading services/HTTPRoutes) now must opt in.

\`vector-agent\`'s SA token still mounts because its serviceAccount-named structure happens to land on the SA-side mount, not the pod-side default. So \`disableWait\` is the only thing it needs.

## User-facing impact (during the broken window)

- glance.\${SECRET_DOMAIN} returning errors
- bind DNS records for cluster services not syncing (cloudflare-dns unaffected — different chart)
- vector still shipping logs (DS pods rolled successfully despite HR Failed)

## Test plan
- [ ] flux-local CI passes
- [ ] After merge + Flux reconcile:
  - \`kubectl get pod -n collab glance-0\` Ready 2/2
  - \`kubectl get pod -n network -l app.kubernetes.io/name=external-dns-bind\` Ready 1/1
  - \`flux get hr -A\` shows all three Ready True

🤖 Generated with [Claude Code](https://claude.com/claude-code)