### PR TITLE
fix(app-template-v5): SA token round-2 + vector PodMonitor targetPort

### DIFF
--- a/kubernetes/apps/collab/startpunkt-user/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/startpunkt-user/app/helmrelease.yaml
@@ -11,6 +11,8 @@ spec:
 
   interval: 30m
   values:
+    defaultPodOptions:
+      automountServiceAccountToken: true
     controllers:
       main:
         annotations:

--- a/kubernetes/apps/mcp-system/kubectl-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/kubectl-mcp/app/helmrelease.yaml
@@ -10,6 +10,8 @@ spec:
     name: app-template
   interval: 1h
   values:
+    defaultPodOptions:
+      automountServiceAccountToken: true
     controllers:
       kubectl-mcp:
         pod:

--- a/kubernetes/apps/observability/vector/agent/helmrelease.yaml
+++ b/kubernetes/apps/observability/vector/agent/helmrelease.yaml
@@ -17,6 +17,8 @@ spec:
     disableWait: true
 
   values:
+    defaultPodOptions:
+      automountServiceAccountToken: true
     controllers:
       main:
         pod:

--- a/kubernetes/apps/observability/vector/agent/podmonitor.yaml
+++ b/kubernetes/apps/observability/vector/agent/podmonitor.yaml
@@ -16,7 +16,7 @@ spec:
   podMetricsEndpoints:
     - interval: 30s
       path: /metrics
-      port: metrics
+      targetPort: 9598
       scheme: http
       scrapeTimeout: 10s
   selector:


### PR DESCRIPTION
## Summary

Round 2 of v5 fallout. PR #11197 fixed glance, external-dns-bind, and added \`disableWait\` for vector-agent — but missed three more cases that surfaced during verification.

| App | State before this PR | Why missed in #11197 |
|-----|----------------------|----------------------|
| **vector-agent** | 2 of 8 pods CrashLoopBackOff (newer rollouts) | Sampled pod was pre-fix with stale token; assumed serviceAccount block was enough |
| **startpunkt-user** | Running but \`0 URLs\` (can't list HTTPRoutes) | Silent degradation — HR Ready=True |
| **kubectl-mcp** | Running but kubectl tools fail at apiserver | Silent degradation — HR Ready=True |

All three: add \`defaultPodOptions.automountServiceAccountToken: true\`.

## Vector PodMonitor fix

The PodMonitor I added in #11194 used \`port: metrics\` but never matched anything — \`app-template\`'s \`service.metrics\` block creates a Service on port 9598 but doesn't propagate a *named* containerPort to the pod. PodMonitor's \`port:\` resolves to a named container port, not a service port.

Switched to \`targetPort: 9598\` — Prometheus scrapes the pod IP directly on the prometheus_exporter sink port. Confirmed via the live Service that 9598 is reachable.

## Test plan
- [ ] flux-local CI passes
- [ ] After merge + Flux reconcile:
  - All vector-agent pods 1/1 Running (no CrashLoopBackOff)
  - \`up{job="observability/vector-agent"}\` returns N=node_count, all 1
  - \`vector_*\` metrics appear in Prometheus
  - startpunkt-user reports >0 URLs in its availability check log
  - kubectl-mcp can actually exec kubectl commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)