### PR TITLE
fix(vector-agent): declare metrics container port for PodMonitor

### DIFF
--- a/kubernetes/apps/observability/vector/agent/helmrelease.yaml
+++ b/kubernetes/apps/observability/vector/agent/helmrelease.yaml
@@ -42,6 +42,11 @@ spec:
 
             args: ["--config", "/etc/vector/vector.yaml"]
 
+            ports:
+              - name: metrics
+                containerPort: 9598
+                protocol: TCP
+
             env:
               PROCFS_ROOT: /host/proc
               SYSFS_ROOT: /host/sys

--- a/kubernetes/apps/observability/vector/agent/podmonitor.yaml
+++ b/kubernetes/apps/observability/vector/agent/podmonitor.yaml
@@ -16,7 +16,7 @@ spec:
   podMetricsEndpoints:
     - interval: 30s
       path: /metrics
-      targetPort: 9598
+      port: metrics
       scheme: http
       scrapeTimeout: 10s
   selector:


### PR DESCRIPTION
## Summary

The vector-agent PodMonitor (added in #11194, switched to \`targetPort\` in #11200) is registered in Prometheus but not producing any targets — \`up{job=\"observability/vector-agent\"}\` is empty.

## Root cause

App-template's \`service.metrics\` block creates a Service on port 9598 but **does not** propagate a containerPort onto the pod. Prometheus's generated scrape config has this relabel rule:

\`\`\`yaml
- action: keep
  regex: '9598'
  source_labels:
  - __meta_kubernetes_pod_container_port_number
\`\`\`

Without a declared containerPort, that label is empty for every pod, so all targets get dropped before reaching the active list. Direct \`curl pod-ip:9598/metrics\` works fine — it's purely a discovery problem.

## Fix

- Declare a named container port on \`controllers.main.containers.main.ports\` (\`metrics\`/9598/TCP)
- Revert PodMonitor back to the canonical \`port: metrics\` form

## Test plan
- [ ] flux-local CI passes
- [ ] After merge + Flux reconcile + DS rollout: \`up{job="observability/vector-agent"}\` returns N=node_count, all 1
- [ ] \`vector_*\` metrics appear in Prometheus

🤖 Generated with [Claude Code](https://claude.com/claude-code)