### PR TITLE
fix(tools): keep run-on-all-nodes.sh going on per-node failures

### DIFF
--- a/tools/run-on-all-nodes.sh
+++ b/tools/run-on-all-nodes.sh
@@ -12,5 +12,5 @@ nodes=$(kubectl get nodes -o jsonpath='{.items[*].metadata.name}')
 
 for node in ${nodes}; do
   echo "## node ${node}"
-  ssh "root@${node}" "$@"
+  ssh "root@${node}" "$@" || true
 done


### PR DESCRIPTION
## Summary
- `set -e` plus the unguarded `ssh` was making `tools/run-on-all-nodes.sh` bail at the first non-zero exit, so a command like `systemctl is-active firewalld` (exits 3 when inactive) reported only master1 and silently skipped the other 9 nodes.
- One-line fix: append `|| true` so per-node failures don't stop the sweep.

## Test plan
- [x] `tools/run-on-all-nodes.sh 'systemctl is-enabled firewalld 2>/dev/null; systemctl is-active firewalld 2>/dev/null'` now reports every node (verified — all 10 return `disabled / inactive`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)