### PR TITLE
fix(frigate): unblock snapshot cronjob (image + envsubst escape)

### DIFF
--- a/kubernetes/apps/home/frigate/app/snapshot-cronjob.yaml
+++ b/kubernetes/apps/home/frigate/app/snapshot-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
           # container then commits and pushes via the shared script.
           initContainers:
             - name: dump-config
-              image: docker.io/bitnami/kubectl:1.35.4
+              image: docker.io/alpine/k8s:1.35.4@sha256:d9aeef2665287b9918bc57c539ba95382ba4c8d52c8b1310df5666a89d9a3d04
               command:
                 - /bin/sh
                 - -c

--- a/kubernetes/apps/home/frigate/app/snapshot-script-cm.yaml
+++ b/kubernetes/apps/home/frigate/app/snapshot-script-cm.yaml
@@ -4,6 +4,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: frigate-snapshot-script
+  annotations:
+    kustomize.toolkit.fluxcd.io/substitute: disabled
 data:
   snapshot.sh: |
     #!/bin/sh


### PR DESCRIPTION
## Summary

Two latent bugs surfaced when running the `frigate-snapshot` CronJob end-to-end for the first time:

1. **`bitnami/kubectl:1.35.4` no longer exists.** Bitnami's image migration removed per-patch kubectl tags, so the init container was failing with `manifest unknown` from both Docker Hub and the local pull-through cache. Swapped to `docker.io/alpine/k8s:1.35.4` (digest-pinned). I considered `registry.k8s.io/kubectl:v1.35.4` but it's **distroless** — no `/bin/sh` — and the init container needs a real userland for the shell-redirect + `chmod` + `wc` logic.
2. **Flux postBuild envsubst was eating shell parameter expansions.** The snapshot script uses `${CONFIG_FILE:-/config/config.yml}` so it can run in either sidecar mode (PVC mount) or CronJob mode (shared emptyDir). But Flux's `postBuild.substitute` is envsubst, which recognizes the *same* `${VAR:-default}` syntax — so it pre-resolved each expansion to its default at deploy time, baking `CONFIG_FILE="/config/config.yml"` into the deployed ConfigMap regardless of what env var the container set. Annotated the ConfigMap with `kustomize.toolkit.fluxcd.io/substitute: disabled` to opt out of envsubst for that resource only.

## Test plan

- [x] `dump-config` init container succeeds: `Dumped 826 lines from frigate-0:/config/config.yml`
- [x] `snapshot` main container succeeds: SSH auth's against `github.com`, `git clone` succeeds (deploy key works), `git diff --quiet` shows no change, exits 0 cleanly
- [x] Deployed ConfigMap retains `${CONFIG_FILE:-/config/config.yml}` raw (envsubst skipped)
- [ ] First scheduled run at 03:00 ET will produce a real commit when Frigate's live config drifts from the snapshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)