### PR TITLE
chore: ignore per-session .claude/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 Thumbs.db
 *.iso
 # Temp folders
+.claude/
 .ignore/
 .logs/
 .task/


### PR DESCRIPTION
## Summary
- Add \`.claude/\` to \`.gitignore\` alongside the other temp folder entries.
- Claude Code creates a per-session \`.claude/\` directory for hooks, settings, and scratch state. It's per-checkout and never meant to be committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)