### PR TITLE
fix(zot): grow PVC 100Gi→200Gi and tighten retention

### DIFF
--- a/kubernetes/apps/kube-system/zot/app/config/config.json
+++ b/kubernetes/apps/kube-system/zot/app/config/config.json
@@ -16,10 +16,10 @@
           "deleteUntagged": true,
           "keepTags": [
             {
-              "mostRecentlyPushedCount": 5,
-              "mostRecentlyPulledCount": 5,
-              "pulledWithin": "720h",
-              "pushedWithin": "720h"
+              "mostRecentlyPushedCount": 3,
+              "mostRecentlyPulledCount": 3,
+              "pulledWithin": "168h",
+              "pushedWithin": "168h"
             }
           ]
         }

--- a/kubernetes/apps/kube-system/zot/app/longhorn-pvc.yaml
+++ b/kubernetes/apps/kube-system/zot/app/longhorn-pvc.yaml
@@ -10,7 +10,7 @@ spec:
   volumeMode: Filesystem
   resources:
     requests:
-      storage: 100Gi
+      storage: 200Gi
   volumeName: zot-data-pv
   storageClassName: zot-data-storage-class
 
@@ -25,7 +25,7 @@ metadata:
     recurring-job-group.longhorn.io/weekly-snapshot: enabled
 spec:
   capacity:
-    storage: 100Gi
+    storage: 200Gi
   volumeMode: Filesystem
   accessModes:
     - ReadWriteOnce


### PR DESCRIPTION
## Summary
- `zot-data-pvc` is **99.997%** full on 100Gi (KubePersistentVolumeFillingUp critical, currently silenced — silence-operator may not be effective).
- Existing GC/retention isn't evicting fast enough given the wide on-demand sync (docker.io, gcr.io, ghcr.io, quay.io, registry.k8s.io, public.ecr.aws).
- PVC grown to 200Gi (Longhorn online expand) to stop the bleed.
- `keepTags` tightened: 720h → 168h pull/push window, 5 → 3 keep counts.

## Test plan
- [ ] After merge: confirm Longhorn expands `zot-data-xfs` online without remount
- [ ] Within 24h, confirm fill % drops below 90% as next GC cycle runs against the tighter policy
- [ ] Confirm pulls of recently-used images still hit cache (not constant upstream re-fetch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)