### PR TITLE
feat(zot): add new dynamic 200Gi PVC (step 1 of static→dynamic migration)

### DIFF
--- a/kubernetes/apps/kube-system/zot/app/kustomization.yaml
+++ b/kubernetes/apps/kube-system/zot/app/kustomization.yaml
@@ -7,6 +7,7 @@ components:
 resources:
   - ./helmrelease.yaml
   - ./longhorn-pvc.yaml
+  - ./pvc.yaml
 configMapGenerator:
   - files:
       - ./config/config.json

--- a/kubernetes/apps/kube-system/zot/app/pvc.yaml
+++ b/kubernetes/apps/kube-system/zot/app/pvc.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: zot-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 200Gi
+  storageClassName: longhorn
+  volumeMode: Filesystem


### PR DESCRIPTION
## Summary
Step 1 of moving zot off the static PV+PVC pattern to a dynamically-provisioned Longhorn PVC.

- Adds `zot-data` PVC (200Gi, `longhorn` SC, 1 replica per SC default).
- Existing `zot-data-pvc` (static, 100Gi, 2 replicas) stays intact during migration.
- Data copy + HelmRelease cutover + old PVC removal will follow in step 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)