### PR TITLE
fix(zot): add install/upgrade.disableWait

### DIFF
--- a/kubernetes/apps/kube-system/zot/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/zot/app/helmrelease.yaml
@@ -10,6 +10,12 @@ spec:
     name: app-template
 
   interval: 30m
+
+  install:
+    disableWait: true
+  upgrade:
+    disableWait: true
+
   values:
     controllers:
       main:


### PR DESCRIPTION
## Summary
Hit the helm-controller wait race during the zot PVC cutover — a transient pod startup error outlasted the 5min wait, helm rolled back the release, reverting the persistence claim to the now-deleted static PVC. Adds `disableWait: true` so the release commits as soon as the StatefulSet update is applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)