### PR TITLE
fix(silence-operator): correct user@*.service regex (was invalid RE2 escape)

### DIFF
--- a/kubernetes/apps/observability/silence-operator/silences/node.yaml
+++ b/kubernetes/apps/observability/silence-operator/silences/node.yaml
@@ -9,7 +9,7 @@ spec:
     - name: alertname
       value: NodeSystemdServiceFailed
     - name: name
-      value: user\@.*service
+      value: user@.*\.service
       matchType: "=~"
 
 ---
@@ -23,5 +23,5 @@ spec:
     - name: alertname
       value: HostSystemdServiceCrashed
     - name: name
-      value: user\@.*service
+      value: user@.*\.service
       matchType: "=~"


### PR DESCRIPTION
## Summary
Silences for `user@<UID>.service` failures used `user\@.*service` — `\@` is not a valid RE2 escape, so the regex never matched and 6 alerts kept firing on brain. Fixed to `user@.*\.service`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)