### PR TITLE
feat(av1corrector): deploy AV1 → HEVC re-encoder gated via Authelia

### DIFF
--- a/.github/image-registry-allowlist.txt
+++ b/.github/image-registry-allowlist.txt
@@ -27,6 +27,7 @@ docker.io/ollama/ollama
 docker.io/kanidm/server                 # ghcr is `devel`-only, no stable tags
 docker.io/glanceapp/glance
 docker.io/library/couchdb               # ghcr/apache/couchdb is devcontainer-only
+docker.io/alpine/k8s                    # alpine-based kubectl/helm; registry.k8s.io/kubectl is distroless
 docker.io/library/alpine
 docker.io/library/busybox               # uclibc variant not on home-operations mirror
 docker.io/rhasspy/wyoming-openwakeword

--- a/kubernetes/apps/auth/authelia/app/configmap.yaml
+++ b/kubernetes/apps/auth/authelia/app/configmap.yaml
@@ -174,6 +174,26 @@ data:
               - 'code'
             userinfo_signed_response_alg: 'none'
             token_endpoint_auth_method: 'client_secret_post'
+          - client_id: 'av1corrector-oauth2-proxy'
+            client_name: 'AV1 Corrector (oauth2-proxy)'
+            client_secret: '$argon2id$v=19$m=65536,t=3,p=4$lefMbdj3u1h9ZR7Z/Ph/pg$byHKBOplo5rkhZrW4JE6dJU9Z1V1U4FUYW/gdgXFK+8'
+            public: false
+            authorization_policy: 'one_factor'
+            require_pkce: true
+            pkce_challenge_method: 'S256'
+            redirect_uris:
+              - 'https://av1corrector.thesteamedcrab.com/oauth2/callback'
+            scopes:
+              - 'openid'
+              - 'profile'
+              - 'email'
+              - 'groups'
+            grant_types:
+              - 'authorization_code'
+            response_types:
+              - 'code'
+            userinfo_signed_response_alg: 'none'
+            token_endpoint_auth_method: 'client_secret_basic'
           - client_id: 'frigate-oauth2-proxy'
             client_name: 'Frigate (oauth2-proxy)'
             client_secret: '$argon2id$v=19$m=65536,t=3,p=4$CxGhmQ1ufAJrxoznbbs08w$q+/SQ/11JjeeQGtH3SykIZj4XZgt1Cgx7W+OoCI97Q0'

--- a/kubernetes/apps/databases/cloudnative-pg/config/av1corrector/cluster.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/av1corrector/cluster.yaml
@@ -1,0 +1,47 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/cluster_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgres-av1corrector
+spec:
+  instances: 3
+
+  imageName: ghcr.io/cloudnative-pg/postgresql:17.5
+
+  primaryUpdateStrategy: unsupervised
+
+  postgresql:
+    parameters:
+      pg_stat_statements.max: "10000"
+      pg_stat_statements.track: all
+      timezone: "America/New_York"
+
+  storage:
+    size: 5Gi
+    storageClass: ceph-block
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 512Mi
+
+  enableSuperuserAccess: true
+  superuserSecret:
+    name: cloudnative-pg
+
+  monitoring:
+    enablePodMonitor: true
+
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters: &params
+        barmanObjectName: garage-av1corrector
+        serverName: postgres-av1corrector-backup
+
+  externalClusters:
+    - name: source
+      plugin:
+        name: barman-cloud.cloudnative-pg.io
+        parameters: *params

--- a/kubernetes/apps/databases/cloudnative-pg/config/av1corrector/externalsecret.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/av1corrector/externalsecret.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: av1corrector
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: av1corrector-secret
+    template:
+      data:
+        # S3
+        AWS_ACCESS_KEY_ID: "{{ .GARAGE_AWS_ACCESS_KEY_ID }}"
+        AWS_SECRET_ACCESS_KEY: "{{ .GARAGE_AWS_SECRET_ACCESS_KEY }}"
+  dataFrom:
+    - extract:
+        key: av1corrector

--- a/kubernetes/apps/databases/cloudnative-pg/config/av1corrector/kustomization.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/av1corrector/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./cluster.yaml
+  - ./externalsecret.yaml
+  - ./objectstore.yaml
+  - ./scheduledbackup.yaml

--- a/kubernetes/apps/databases/cloudnative-pg/config/av1corrector/objectstore.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/av1corrector/objectstore.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/barmancloud.cnpg.io/objectstore_v1.json
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: garage-av1corrector
+spec:
+  configuration:
+    data:
+      compression: bzip2
+    destinationPath: s3://postgres-av1corrector-backup/
+    endpointURL: http://garage.storage.svc.cluster.local:3900
+    s3Credentials:
+      accessKeyId:
+        name: av1corrector-secret
+        key: AWS_ACCESS_KEY_ID
+      secretAccessKey:
+        name: av1corrector-secret
+        key: AWS_SECRET_ACCESS_KEY
+    wal:
+      compression: bzip2
+      maxParallel: 4
+  retentionPolicy: 30d

--- a/kubernetes/apps/databases/cloudnative-pg/config/av1corrector/scheduledbackup.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/av1corrector/scheduledbackup.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/scheduledbackup_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: postgres-av1corrector-backup
+spec:
+  schedule: "@weekly"
+  immediate: true
+  backupOwnerReference: self
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io
+  cluster:
+    name: postgres-av1corrector

--- a/kubernetes/apps/databases/cloudnative-pg/ks.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/ks.yaml
@@ -445,6 +445,36 @@ spec:
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
+  name: av1corrector
+  labels:
+    substitution.flux.home.arpa/enabled: "true"
+spec:
+  targetNamespace: databases
+  path: ./kubernetes/apps/databases/cloudnative-pg/config/av1corrector
+  interval: 30m
+  timeout: 5m
+  prune: true
+  wait: true
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: cloudnative-pg
+      namespace: databases
+    - name: garage
+      namespace: storage
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  healthCheckExprs:
+    - apiVersion: postgresql.cnpg.io/v1
+      kind: Cluster
+      current: status.phase in ['Cluster in healthy state']
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
   name: cutvideo
   labels:
     substitution.flux.home.arpa/enabled: "true"

--- a/kubernetes/apps/media/av1corrector-oauth2-proxy/app/externalsecret.yaml
+++ b/kubernetes/apps/media/av1corrector-oauth2-proxy/app/externalsecret.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: av1corrector-oauth2-proxy
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: av1corrector-oauth2-proxy-secret
+    creationPolicy: Owner
+    template:
+      data:
+        OAUTH2_PROXY_CLIENT_SECRET: "{{ .OAUTH_CLIENT_SECRET }}"
+        OAUTH2_PROXY_COOKIE_SECRET: "{{ .COOKIE_SECRET }}"
+  dataFrom:
+    - extract:
+        key: av1corrector-oauth2-proxy

--- a/kubernetes/apps/media/av1corrector-oauth2-proxy/app/helmrelease.yaml
+++ b/kubernetes/apps/media/av1corrector-oauth2-proxy/app/helmrelease.yaml
@@ -1,0 +1,68 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app av1corrector-oauth2-proxy
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 30m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+      strategy: rollback
+  values:
+    controllers:
+      av1corrector-oauth2-proxy:
+        annotations:
+          reloader.stakater.com/auto: "true"
+
+        containers:
+          app:
+            image:
+              repository: quay.io/oauth2-proxy/oauth2-proxy
+              tag: v7.15.2
+
+            args:
+              - --provider=oidc
+              - --oidc-issuer-url=https://auth.${SECRET_DOMAIN}
+              - --client-id=av1corrector-oauth2-proxy
+              - --redirect-url=https://av1corrector.${SECRET_DOMAIN}/oauth2/callback
+              - --upstream=http://av1corrector.media.svc.cluster.local:8000
+              - --http-address=0.0.0.0:4180
+              - --cookie-domain=.${SECRET_DOMAIN}
+              - --cookie-name=_oauth2_proxy_av1corrector
+              - --cookie-secure=true
+              - --cookie-samesite=lax
+              - --email-domain=*
+              - --whitelist-domain=.${SECRET_DOMAIN}
+              - --reverse-proxy=true
+              - --pass-user-headers=true
+              - --set-xauthrequest=true
+              - --skip-provider-button=true
+              - --scope=openid email profile groups
+              - --code-challenge-method=S256
+
+            envFrom:
+              - secretRef:
+                  name: av1corrector-oauth2-proxy-secret
+
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 128Mi
+
+    service:
+      app:
+        controller: av1corrector-oauth2-proxy
+        ports:
+          http:
+            port: 4180

--- a/kubernetes/apps/media/av1corrector-oauth2-proxy/app/kustomization.yaml
+++ b/kubernetes/apps/media/av1corrector-oauth2-proxy/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../components/repos/app-template
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/media/av1corrector-oauth2-proxy/ks.yaml
+++ b/kubernetes/apps/media/av1corrector-oauth2-proxy/ks.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: av1corrector-oauth2-proxy
+spec:
+  targetNamespace: media
+  path: ./kubernetes/apps/media/av1corrector-oauth2-proxy/app
+  interval: 1h
+  timeout: 5m
+  prune: true
+  wait: false
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: authelia
+      namespace: auth
+    - name: av1corrector
+      namespace: media
+    - name: onepassword-connect
+      namespace: external-secrets

--- a/kubernetes/apps/media/av1corrector/app/helmrelease.yaml
+++ b/kubernetes/apps/media/av1corrector/app/helmrelease.yaml
@@ -1,0 +1,98 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app av1corrector
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+
+  interval: 30m
+  values:
+    controllers:
+      main:
+        annotations:
+          reloader.stakater.com/auto: "true"
+
+        type: statefulset
+
+        initContainers:
+          init-db:
+            image:
+              repository: ghcr.io/home-operations/postgres-init
+              tag: 18.3.0@sha256:6fa1f331cddd2eb0b6afa7b8d3685c864127a81ab01c3d9400bc3ff5263a51cf
+
+            envFrom: &envFrom
+              - secretRef:
+                  name: av1corrector-secret
+
+        containers:
+          main:
+            image:
+              repository: ghcr.io/rwlove/av1corrector
+              tag: v0.1.0
+
+            env:
+              AV1CORRECTOR_LIBRARY_PATH: /library
+              AV1CORRECTOR_LISTEN_ADDR: ":8000"
+              AV1CORRECTOR_LOG_FORMAT: json
+
+            envFrom: *envFrom
+
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: &httpPort 8000
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 3
+                  failureThreshold: 3
+              readiness: *probes
+              startup:
+                enabled: false
+
+            resources:
+              requests:
+                cpu: 500m
+                memory: 512Mi
+              limits:
+                memory: 4Gi
+
+    service:
+      main:
+        controller: main
+        ports:
+          http:
+            port: *httpPort
+
+    route:
+      main:
+        annotations:
+          glance/name: "AV1 Corrector"
+          glance/show: "true"
+          glance/id: "Media"
+
+        hostnames:
+          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - kind: Service
+                name: av1corrector-oauth2-proxy
+                port: 4180
+
+    persistence:
+      library:
+        type: persistentVolumeClaim
+        existingClaim: av1corrector-library-pvc
+        globalMounts:
+          - path: /library

--- a/kubernetes/apps/media/av1corrector/app/kustomization.yaml
+++ b/kubernetes/apps/media/av1corrector/app/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../components/repos/app-template
+
+resources:
+  - ./helmrelease.yaml
+  - ./nfs-pvc.yaml

--- a/kubernetes/apps/media/av1corrector/app/nfs-pvc.yaml
+++ b/kubernetes/apps/media/av1corrector/app/nfs-pvc.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolume-v1.json
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: av1corrector-library-pv
+  labels:
+    type: nfs
+spec:
+  storageClassName: av1corrector-library-storage-class
+  capacity:
+    storage: 20Ti
+  accessModes:
+    - ReadWriteOnce
+  nfs:
+    server: "${NFS_HOST}"
+    path: "${NFS_PATH}"
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: av1corrector-library-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: 20Ti
+  volumeName: av1corrector-library-pv
+  storageClassName: av1corrector-library-storage-class

--- a/kubernetes/apps/media/av1corrector/ks.yaml
+++ b/kubernetes/apps/media/av1corrector/ks.yaml
@@ -1,0 +1,50 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: av1corrector-secrets
+spec:
+  targetNamespace: media
+  path: ./kubernetes/apps/media/av1corrector/secrets
+  interval: 30m
+  timeout: 5m
+  prune: true
+  wait: true
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: onepassword-connect
+      namespace: external-secrets
+  healthCheckExprs:
+    - apiVersion: external-secrets.io/v1
+      kind: ExternalSecret
+      current: status.conditions.exists(c, c.type == 'Ready' && c.status == 'True')
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: av1corrector
+spec:
+  targetNamespace: media
+  path: ./kubernetes/apps/media/av1corrector/app
+  interval: 30m
+  timeout: 5m
+  prune: true
+  wait: false
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: av1corrector
+      namespace: databases
+    - name: av1corrector-secrets
+      namespace: media
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: av1corrector-secret

--- a/kubernetes/apps/media/av1corrector/secrets/externalsecret.yaml
+++ b/kubernetes/apps/media/av1corrector/secrets/externalsecret.yaml
@@ -1,0 +1,41 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: av1corrector
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: av1corrector-secret
+    template:
+      engineVersion: v2
+      metadata:
+        annotations:
+          # Mirror this secret into flux-system so Flux can substituteFrom it
+          # (postBuild.substituteFrom requires same-namespace source).
+          reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+          reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "flux-system"
+          reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+          reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "flux-system"
+      data:
+        # App
+        AV1CORRECTOR_DATABASE_URL: postgres://{{ .POSTGRES_USER }}:{{ .POSTGRES_PASS }}@postgres-av1corrector-rw.databases.svc.cluster.local:5432/av1corrector
+
+        # NFS source for the library PV (consumed by Flux postBuild.substituteFrom)
+        NFS_HOST: "{{ .NFS_HOST }}"
+        NFS_PATH: "{{ .NFS_PATH }}"
+
+        # Postgres Init
+        INIT_POSTGRES_DBNAME: av1corrector
+        INIT_POSTGRES_HOST: postgres-av1corrector-rw.databases.svc.cluster.local
+        INIT_POSTGRES_USER: "{{ .POSTGRES_USER }}"
+        INIT_POSTGRES_PASS: "{{ .POSTGRES_PASS }}"
+        INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
+  dataFrom:
+    - extract:
+        key: cloudnative-pg
+    - extract:
+        key: av1corrector

--- a/kubernetes/apps/media/av1corrector/secrets/kustomization.yaml
+++ b/kubernetes/apps/media/av1corrector/secrets/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml

--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -8,6 +8,8 @@ components:
 resources:
   - ./namespace.yaml
   - ./priority-class.yaml
+  - ./av1corrector/ks.yaml
+  - ./av1corrector-oauth2-proxy/ks.yaml
   - ./beets/ks.yaml
   - ./cutvideo/ks.yaml
   - ./flaresolverr/ks.yaml


### PR DESCRIPTION
## Summary

- Adds `rwlove/av1corrector` v0.1.0 in `media`, fronted by a per-app `oauth2-proxy` for Authelia one-factor gating (mirrors the `frigate` pattern).
- New CNPG cluster `postgres-av1corrector` (3 instances, ceph-block PGData, Garage-backed barman backups in bucket `postgres-av1corrector-backup`).
- Library NFS PV (`20Ti`, RWO) with `NFS_HOST`/`NFS_PATH` substituted from the `av1corrector` secret.
- New Authelia OIDC client `av1corrector-oauth2-proxy` (PKCE S256, one_factor).

## Test plan

- [ ] Flux reconciles `av1corrector` Kustomization in `databases` (CNPG cluster healthy)
- [ ] `av1corrector-secret` lands in `media` (and is reflected to `flux-system`)
- [ ] `av1corrector-library-pvc` binds against the NFS PV
- [ ] `av1corrector` HelmRelease pod becomes Ready, `/healthz` returns 200
- [ ] `av1corrector-oauth2-proxy` HelmRelease pod becomes Ready
- [ ] `https://av1corrector.${SECRET_DOMAIN}` redirects to Authelia, then loads the app on success

🤖 Generated with [Claude Code](https://claude.com/claude-code)