### PR TITLE
fix(prometheus-mcp): bump memory limit 256Mi → 1Gi

### DIFF
--- a/kubernetes/apps/mcp-system/prometheus-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/prometheus-mcp/app/helmrelease.yaml
@@ -36,7 +36,7 @@ spec:
                 cpu: 10m
                 memory: 128Mi
               limits:
-                memory: 256Mi
+                memory: 1Gi
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true


### PR DESCRIPTION
## Summary
prometheus-mcp OOMKilled today; steady-state is ~67Mi but query spikes blow past 256Mi. Bumping limit to 1Gi (request stays 128Mi).

🤖 Generated with [Claude Code](https://claude.com/claude-code)