### PR TITLE
fix(silence-operator): dedupe 13 PVC fill alerts for beast NFS share

### DIFF
--- a/kubernetes/apps/observability/silence-operator/silences/beast-mass-storage-pvc.yaml
+++ b/kubernetes/apps/observability/silence-operator/silences/beast-mass-storage-pvc.yaml
@@ -1,0 +1,33 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/observability.giantswarm.io/silence_v1alpha2.json
+#
+# All these PVCs are NFS subpaths of beast.thesteamedcrab.com:/mnt/mass_storage,
+# so they all report the same fill % and trigger one alert each for a single
+# underlying signal. NodeFilesystemAlmostOutOfSpace on beast (default 5%/3%
+# free) remains in place to catch real saturation; remove this silence if
+# you ever migrate one of these PVCs off the shared NFS share.
+apiVersion: observability.giantswarm.io/v1alpha2
+kind: Silence
+metadata:
+  name: kubepersistentvolumefillingup-beast-mass-storage
+spec:
+  matchers:
+    - name: alertname
+      value: KubePersistentVolumeFillingUp
+    - matchType: "=~"
+      name: persistentvolumeclaim
+      value: comfyui-output-pvc|frigate-exports-pvc|gonic-music-pvc|immich-external-library-pvc|immich-managed-library-pvc|jellyfin-movies-pvc|jellyfin-music-pvc|lidarr-media|music-assistant-music-pvc|radarr-media|soularr-music-pvc|stash-media-pvc|videodupfinder-scan-pvc
+
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/observability.giantswarm.io/silence_v1alpha2.json
+apiVersion: observability.giantswarm.io/v1alpha2
+kind: Silence
+metadata:
+  name: kubepersistentvolumeinodesfillingup-beast-mass-storage
+spec:
+  matchers:
+    - name: alertname
+      value: KubePersistentVolumeInodesFillingUp
+    - matchType: "=~"
+      name: persistentvolumeclaim
+      value: comfyui-output-pvc|frigate-exports-pvc|gonic-music-pvc|immich-external-library-pvc|immich-managed-library-pvc|jellyfin-movies-pvc|jellyfin-music-pvc|lidarr-media|music-assistant-music-pvc|radarr-media|soularr-music-pvc|stash-media-pvc|videodupfinder-scan-pvc

--- a/kubernetes/apps/observability/silence-operator/silences/kustomization.yaml
+++ b/kubernetes/apps/observability/silence-operator/silences/kustomization.yaml
@@ -3,6 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./beast-mass-storage-pvc.yaml
   - ./ceph.yaml
   - ./frigate-media-pvc.yaml
   - ./high-gpu-usage.yaml


### PR DESCRIPTION
## Summary
13 `KubePersistentVolumeFillingUp` alerts all reflect a single signal: beast's `/mnt/mass_storage` NFS share (61T raid6, currently 87% used). Adds a regex silence covering all 13 PVCs (and the corresponding inodes alert). Real saturation still alerts via stock `NodeFilesystemAlmostOutOfSpace` on beast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)