### PR TITLE
fix(home-assistant): TTL stale failed config-sync jobs

### DIFF
--- a/kubernetes/apps/home/home-assistant/app/sync-cronjob.yaml
+++ b/kubernetes/apps/home/home-assistant/app/sync-cronjob.yaml
@@ -1,5 +1,5 @@
 ---
-# TODO: apply schema
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/cronjob-batch-v1.json
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -12,6 +12,7 @@ spec:
   jobTemplate:
     spec:
       backoffLimit: 1
+      ttlSecondsAfterFinished: 86400
       template:
         spec:
           restartPolicy: OnFailure


### PR DESCRIPTION
## Summary
3 stale `KubeJobFailed` alerts on home-assistant-config-sync jobs from 2026-05-03; subsequent runs succeed. Adding `ttlSecondsAfterFinished: 86400` so finished jobs auto-delete after 24h. Real recurring failures still alert within their first day. Also fixes schema TODO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)