### PR TITLE
fix(backup): rclone [garage] region must be us-east-1 (SigV4 scope)

### DIFF
--- a/kubernetes/apps/collab/paperless/app/externalsecret-offsite-backup.yaml
+++ b/kubernetes/apps/collab/paperless/app/externalsecret-offsite-backup.yaml
@@ -42,7 +42,9 @@ spec:
           access_key_id = {{ .GARAGE_ACCESS_KEY_ID }}
           secret_access_key = {{ .GARAGE_SECRET_ACCESS_KEY }}
           endpoint = http://garage.storage.svc.cluster.local:3900
-          region = garage
+          # Garage signs SigV4 with us-east-1 by default; using "garage" here
+          # makes ListObjects fail with AuthorizationHeaderMalformed.
+          region = us-east-1
   dataFrom:
     - extract:
         key: paperless-offsite-backup

--- a/kubernetes/apps/media/immich/app/externalsecret-offsite-backup.yaml
+++ b/kubernetes/apps/media/immich/app/externalsecret-offsite-backup.yaml
@@ -42,7 +42,9 @@ spec:
           access_key_id = {{ .GARAGE_ACCESS_KEY_ID }}
           secret_access_key = {{ .GARAGE_SECRET_ACCESS_KEY }}
           endpoint = http://garage.storage.svc.cluster.local:3900
-          region = garage
+          # Garage signs SigV4 with us-east-1 by default; using "garage" here
+          # makes ListObjects fail with AuthorizationHeaderMalformed.
+          region = us-east-1
   dataFrom:
     - extract:
         key: immich-offsite-backup


### PR DESCRIPTION
## Summary

- Hotfix to #11235. The first `paperless-backup-initial` run failed the DB sync stanza with `AuthorizationHeaderMalformed: unexpected scope: '…/garage/…', expected: '…/us-east-1/…'`.
- Garage validates the SigV4 authorization scope against its configured default region (`us-east-1`), regardless of what the rclone remote section is named. Setting `region = us-east-1` matches.

## Test plan

- [ ] Merge → ESO refresh → secret rclone.conf is regenerated
- [ ] Re-run `paperless-backup-initial` Job
- [ ] Confirm both `crypt:media` and `crypt:db` populate without errors
- [ ] Next immich CronJob run also writes `crypt:db` successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)