### PR TITLE
feat(pump): oauth2-proxy + Authelia OIDC; expose pump-cv via Service; wall live previews

### DIFF
--- a/kubernetes/apps/auth/authelia/app/configmap.yaml
+++ b/kubernetes/apps/auth/authelia/app/configmap.yaml
@@ -638,3 +638,23 @@ data:
               - 'code'
             userinfo_signed_response_alg: 'none'
             token_endpoint_auth_method: 'client_secret_basic'
+          - client_id: 'pump-oauth2-proxy'
+            client_name: 'PUMP (oauth2-proxy)'
+            client_secret: '$argon2id$v=19$m=65536,t=3,p=4$p/ozuAhwtZWvL6hs3OJrkQ$6o5pXt7fM5wiGWosD2l/j8HjMZhrEv6QcpZbmNw4M8k'
+            public: false
+            authorization_policy: 'admin_only'
+            require_pkce: true
+            pkce_challenge_method: 'S256'
+            redirect_uris:
+              - 'https://pump.thesteamedcrab.com/oauth2/callback'
+            scopes:
+              - 'openid'
+              - 'profile'
+              - 'email'
+              - 'groups'
+            grant_types:
+              - 'authorization_code'
+            response_types:
+              - 'code'
+            userinfo_signed_response_alg: 'none'
+            token_endpoint_auth_method: 'client_secret_basic'

--- a/kubernetes/apps/collab/kustomization.yaml
+++ b/kubernetes/apps/collab/kustomization.yaml
@@ -22,6 +22,7 @@ resources:
   - ./paperless/ks.yaml
   - ./pump/ks.yaml
   - ./pump-cv/ks.yaml
+  - ./pump-oauth2-proxy/ks.yaml
   - ./searxng/ks.yaml
   # startpunkt-oauth2-proxy retired in favour of glance-user at
   # start.thesteamedcrab.com. Directory remains on disk and the Authelia

--- a/kubernetes/apps/collab/pump-cv/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump-cv/app/helmrelease.yaml
@@ -94,6 +94,15 @@ spec:
                 memory: 2Gi
                 nvidia.com/gpu: 1
 
+    # In-cluster Service so pump can proxy /api/cv/* (admin panel,
+    # camera list, live snapshot polling) to pump-cv's healthd.
+    service:
+      app:
+        controller: pump-cv
+        ports:
+          http:
+            port: 8080
+
     persistence:
       config-template:
         type: configMap

--- a/kubernetes/apps/collab/pump-oauth2-proxy/app/externalsecret.yaml
+++ b/kubernetes/apps/collab/pump-oauth2-proxy/app/externalsecret.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: pump-oauth2-proxy
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: pump-oauth2-proxy-secret
+    creationPolicy: Owner
+    template:
+      data:
+        OAUTH2_PROXY_CLIENT_SECRET: "{{ .OAUTH_CLIENT_SECRET }}"
+        OAUTH2_PROXY_COOKIE_SECRET: "{{ .COOKIE_SECRET }}"
+  dataFrom:
+    - extract:
+        key: pump-oauth2-proxy

--- a/kubernetes/apps/collab/pump-oauth2-proxy/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump-oauth2-proxy/app/helmrelease.yaml
@@ -1,0 +1,67 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app pump-oauth2-proxy
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 30m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+      strategy: rollback
+  values:
+    controllers:
+      pump-oauth2-proxy:
+        annotations:
+          reloader.stakater.com/auto: "true"
+
+        containers:
+          app:
+            image:
+              repository: quay.io/oauth2-proxy/oauth2-proxy
+              tag: v7.15.2
+
+            args:
+              - --provider=oidc
+              - --oidc-issuer-url=https://auth.${SECRET_DOMAIN}
+              - --client-id=pump-oauth2-proxy
+              - --redirect-url=https://pump.${SECRET_DOMAIN}/oauth2/callback
+              - --upstream=http://pump-frontend.collab.svc.cluster.local:8080
+              - --http-address=0.0.0.0:4180
+              - --cookie-name=_oauth2_proxy_pump
+              - --cookie-secure=true
+              - --cookie-samesite=lax
+              - --email-domain=*
+              - --whitelist-domain=.${SECRET_DOMAIN}
+              - --reverse-proxy=true
+              - --pass-user-headers=true
+              - --set-xauthrequest=true
+              - --skip-provider-button=true
+              - --scope=openid email profile groups
+              - --code-challenge-method=S256
+
+            envFrom:
+              - secretRef:
+                  name: pump-oauth2-proxy-secret
+
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 128Mi
+
+    service:
+      app:
+        controller: pump-oauth2-proxy
+        ports:
+          http:
+            port: 4180

--- a/kubernetes/apps/collab/pump-oauth2-proxy/app/kustomization.yaml
+++ b/kubernetes/apps/collab/pump-oauth2-proxy/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../components/repos/app-template
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/collab/pump-oauth2-proxy/ks.yaml
+++ b/kubernetes/apps/collab/pump-oauth2-proxy/ks.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app pump-oauth2-proxy
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: collab
+  path: ./kubernetes/apps/collab/pump-oauth2-proxy/app
+  interval: 1h
+  timeout: 5m
+  prune: true
+  wait: false
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: authelia
+      namespace: auth
+    - name: pump
+      namespace: collab
+    - name: onepassword-connect
+      namespace: external-secrets

--- a/kubernetes/apps/collab/pump/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump/app/helmrelease.yaml
@@ -76,6 +76,10 @@ spec:
             namespace: network
             sectionName: https
         rules:
+          # Inbound auth lives on oauth2-proxy (Authelia OIDC). pump itself
+          # ships with no inbound APIKeyMiddleware as of v0.0.83+; never
+          # point this route at pump-frontend directly.
           - backendRefs:
-              - identifier: frontend
-                port: *httpPort
+              - kind: Service
+                name: pump-oauth2-proxy
+                port: 4180

--- a/kubernetes/apps/collab/pump/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump/app/helmrelease.yaml
@@ -34,6 +34,12 @@ spec:
               repository: ghcr.io/rwlove/pump
               tag: v0.0.82@sha256:58809b095ef85d638236652f09f834175465b7e42197acddaeb7572fd238ee72
 
+            env:
+              # Activates the /api/cv/* proxy in pump (see internal/web/exercise.go).
+              # The wall page's live camera previews and the admin panel both
+              # depend on this being reachable.
+              PUMP_CV_URL: http://pump-cv:8080
+
             envFrom:
               - secretRef:
                   name: pump-secret


### PR DESCRIPTION
## Summary
Cluster-side companion to https://github.com/rwlove/PUMP/pull/18.

- **pump-cv Service.** New ClusterIP on port 8080 in `collab/`. Lights up pump's `/api/cv/*` proxy and the new wall page's snapshot polling.
- **PUMP_CV_URL on pump.** Wired so the proxy resolves to `http://pump-cv:8080`.
- **pump-oauth2-proxy.** New HelmRelease (oauth2-proxy v7.15.2) using the standard glance/holmesgpt/kube-ops-view pattern: OIDC against Authelia, admin_only policy, cookie isolated to `_oauth2_proxy_pump`.
- **Authelia client.** Added a `pump-oauth2-proxy` block to the auth configmap with the argon2id hash of the new client secret. Plaintext + cookie secret stored in 1Password item `Kubernetes/pump-oauth2-proxy` (created during this work).
- **Pump HTTPRoute flip.** `pump.${SECRET_DOMAIN}` backendRef moves from `pump-frontend:8080` → `pump-oauth2-proxy:4180`.

## Commits

- `32ad435` feat(pump): expose pump-cv via Service + wire PUMP_CV_URL on pump
- `e2b57f0` feat(pump): front pump with oauth2-proxy + Authelia OIDC

## Blocked on
- [ ] PUMP PR #18 merged
- [ ] `pump-v0.0.83` and `pump-cv-v0.3.3` tagged
- [ ] CI publishes new images
- [ ] Image pins bumped on this branch (final commit before merge)

Without the new pump image (v0.0.83) the inbound `APIKeyMiddleware` is still active and will reject every browser request once oauth2-proxy is in front — so do **not** merge this PR until the pump image is bumped to v0.0.83+.

## Test plan
- [ ] `flux reconcile ks pump-oauth2-proxy -n flux-system` succeeds; pod runs.
- [ ] Authelia logs show the new `pump-oauth2-proxy` client at startup.
- [ ] `https://pump.${SECRET_DOMAIN}` redirects to Authelia, then lands on workout page.
- [ ] Direct hit `curl -k https://pump-frontend.collab.svc.cluster.local:8080/` (in-cluster) still works (no inbound auth on pump itself by design — the gateway is the auth boundary).
- [ ] `/wall/` shows live camera tiles with working toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)