### PR TITLE
fix(container): update ghcr.io/rwlove/pump ( v0.0.83 → v0.0.84 )

### DIFF
--- a/kubernetes/apps/collab/pump/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump/app/helmrelease.yaml
@@ -32,7 +32,7 @@ spec:
           pump:
             image:
               repository: ghcr.io/rwlove/pump
-              tag: v0.0.83@sha256:b265e9320c11873c133c64d6296f1728c86dcac1a16c79981d261fda26961156
+              tag: v0.0.84@sha256:301871a912c4d1ecfa12f8a300b3d6d6a141ee9f8c86deb716cd94dc368f00a2
 
             env:
               # Activates the /api/cv/* proxy in pump (see internal/web/exercise.go).


### PR DESCRIPTION
Wall page UX:
- Camera tiles moved into the left column under the date/clock, 2-up grid at fixed 16:9.
- Per-exercise color now spans the contiguous group of sets visually (one continuous strip across the merged card).

Image: ghcr.io/rwlove/pump:v0.0.84@sha256:301871a912c4d1ecfa12f8a300b3d6d6a141ee9f8c86deb716cd94dc368f00a2

Source PR: https://github.com/rwlove/PUMP/pull/19