### PR TITLE
fix(container): update ghcr.io/rwlove/pump ( v0.0.84 → v0.0.85 )

### DIFF
--- a/kubernetes/apps/collab/pump/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump/app/helmrelease.yaml
@@ -32,7 +32,7 @@ spec:
           pump:
             image:
               repository: ghcr.io/rwlove/pump
-              tag: v0.0.84@sha256:301871a912c4d1ecfa12f8a300b3d6d6a141ee9f8c86deb716cd94dc368f00a2
+              tag: v0.0.85@sha256:2a405076e447d6725fb7ff3ce2fd77346640a3f8a0ac9fe87a3f56dbf6645914
 
             env:
               # Activates the /api/cv/* proxy in pump (see internal/web/exercise.go).


### PR DESCRIPTION
Group-wrapper rewrite of the per-exercise color stripe (PR rwlove/PUMP#20). Image: ghcr.io/rwlove/pump:v0.0.85@sha256:2a405076e447d6725fb7ff3ce2fd77346640a3f8a0ac9fe87a3f56dbf6645914