### PR TITLE
feat(obsidian-couchdb): bump PVC to 10Gi and memory to 512Mi

### DIFF
--- a/kubernetes/apps/collab/obsidian-couchdb/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/obsidian-couchdb/app/helmrelease.yaml
@@ -55,9 +55,9 @@ spec:
             resources:
               requests:
                 cpu: 15m
-                memory: 200M
+                memory: 512Mi
               limits:
-                memory: 200M
+                memory: 512Mi
 
     service:
       app:

--- a/kubernetes/apps/collab/obsidian-couchdb/app/longhorn-pvc.yaml
+++ b/kubernetes/apps/collab/obsidian-couchdb/app/longhorn-pvc.yaml
@@ -10,7 +10,7 @@ spec:
   volumeMode: Filesystem
   resources:
     requests:
-      storage: 2Gi
+      storage: 10Gi
   volumeName: obsidian-data-pv
   storageClassName: obsidian-data-storage-class
 
@@ -25,7 +25,7 @@ metadata:
     recurring-job-group.longhorn.io/daily-snapshot: enabled
 spec:
   capacity:
-    storage: 2Gi
+    storage: 10Gi
   volumeMode: Filesystem
   accessModes:
     - ReadWriteOnce


### PR DESCRIPTION
## Summary
- Bump CouchDB PVC + PV from 2Gi → 10Gi to fit a second LiveSync database (Claude vault) alongside the existing personal vault
- Bump CouchDB pod memory requests/limits from 200M → 512Mi to handle two databases under E2E-encrypted-replication load

## Context
Phase 5 of the Claude+Obsidian vault restructure. The new `claude` LiveSync database will live in the same CouchDB instance as `personal`, so the underlying storage and memory headroom need to grow before that vault comes online.

## Test plan
- [ ] Flux reconciles `obsidian-couchdb` HelmRelease + PVC manifest cleanly
- [ ] Pod restarts on the new memory limits without OOM
- [ ] PVC reports new capacity (`kubectl get pvc -n collab obsidian-data-pvc`)
- [ ] If PV stays at 2Gi: expand the underlying Longhorn volume via Longhorn UI, then verify PV catches up
- [ ] Existing personal-vault LiveSync resumes replication post-restart

## Notes
- Custom-PV pattern (`obsidian-data-storage-class` is a label, not a real StorageClass with `allowVolumeExpansion`), so a manual Longhorn-side expansion may be required after Flux applies the manifest
- No client-side change required for the personal vault — brief sync pause during pod roll, then auto-reconnect