### PR TITLE
chore(ci): allowlist quay.io/cilium, quay.io/kiali, docker.io/emberstack/kubernetes-reflector

### DIFF
--- a/.github/image-registry-allowlist.txt
+++ b/.github/image-registry-allowlist.txt
@@ -17,6 +17,8 @@
 # These projects publish to a non-ghcr registry as their *primary*
 # home. Moving to ghcr would be a downgrade.
 quay.io/prometheus/                     # Prometheus project canonical
+quay.io/cilium/                         # Cilium project canonical
+quay.io/kiali/                          # Kiali project canonical
 nvcr.io/nvidia/                         # NVIDIA NGC catalog
 mirror.gcr.io/                          # Google pull-through mirror
 registry.k8s.io/                        # Kubernetes project canonical
@@ -46,3 +48,4 @@ docker.io/khairul169/garage-webui
 docker.io/hjacobs/kube-ops-view         # upstream archived 2020
 docker.io/prompp/prompp                 # Prom++ Docker Hub only
 docker.io/rclone/rclone                 # ghcr.io/rclone/rclone has no stable semver tags
+docker.io/emberstack/kubernetes-reflector  # chart on ghcr.io but image is docker.io


### PR DESCRIPTION
## Summary
Three image registries that have been running in the cluster for prior versions, but the registry-check workflow's tag-aware image diff treats version bumps as "new images" and fails validation. Adding the prefixes to the allowlist unblocks Renovate PRs for these three apps.

## Affected PRs
- #11352 fix(helm): update cilium ( 1.19.3 → 1.19.4 )
- #11343 fix(container): update ghcr.io/emberstack/helm-charts/reflector ( 10.0.41 → 10.0.42 )
- #11321 feat(helm): update kiali-operator ( 2.25.0 → 2.26.0 )

## Why these are legitimate exceptions
- **quay.io/cilium/** — Cilium project canonical home; no ghcr.io publication exists
- **quay.io/kiali/** — Kiali project canonical home; no ghcr.io publication
- **docker.io/emberstack/kubernetes-reflector** — chart source is already on ghcr.io but the chart pulls the image from docker.io

## Test plan
- [ ] CI passes on this PR
- [ ] After merge, the three downstream PRs clear the "Check new images" gate on rebase