### PR TITLE
feat(zulip): deploy Zulip 12.0 to collab via official helm chart

### DIFF
--- a/kubernetes/apps/collab/kustomization.yaml
+++ b/kubernetes/apps/collab/kustomization.yaml
@@ -28,3 +28,4 @@ resources:
   # start.${SECRET_DOMAIN}. Directory remains on disk and the Authelia
   # client / 1P entry are intact; re-add to roll back.
   - ./swiparr/ks.yaml
+  - ./zulip/ks.yaml

--- a/kubernetes/apps/collab/zulip/app/externalsecret.yaml
+++ b/kubernetes/apps/collab/zulip/app/externalsecret.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: zulip
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: zulip-secret
+    template:
+      engineVersion: v2
+      data:
+        # Consumed by the HelmRelease via valuesFrom (targetPath into chart values).
+        # Postgres credentials are NOT here — they live in the CNPG-managed
+        # postgres-zulip-app Secret and are wired into the chart via
+        # externalPostgresql.password.valueFrom.
+        SECRET_KEY: "{{ .SECRET_KEY }}"
+        ZULIP_ADMINISTRATOR: "{{ .ZULIP_ADMINISTRATOR }}"
+        RABBITMQ_PASS: "{{ .RABBITMQ_PASS }}"
+        RABBITMQ_ERLANG_COOKIE: "{{ .RABBITMQ_ERLANG_COOKIE }}"
+  dataFrom:
+    - extract:
+        key: zulip

--- a/kubernetes/apps/collab/zulip/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/zulip/app/helmrelease.yaml
@@ -1,0 +1,135 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: zulip
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: zulip
+
+  interval: 30m
+  install:
+    # Zulip first-boot runs schema bootstrap + migrations; the chart
+    # startupProbe gives 5 minutes (failureThreshold 30 × periodSeconds 10),
+    # which can still race helm-controller. See
+    # project_helmrelease_disablewait.md.
+    disableWait: true
+  upgrade:
+    disableWait: true
+
+  valuesFrom:
+    - kind: Secret
+      name: zulip-secret
+      valuesKey: SECRET_KEY
+      targetPath: zulip.environment.SECRETS_secret_key
+    - kind: Secret
+      name: zulip-secret
+      valuesKey: ZULIP_ADMINISTRATOR
+      targetPath: zulip.environment.SETTING_ZULIP_ADMINISTRATOR
+    - kind: Secret
+      name: zulip-secret
+      valuesKey: RABBITMQ_PASS
+      targetPath: rabbitmq.auth.password
+    - kind: Secret
+      name: zulip-secret
+      valuesKey: RABBITMQ_ERLANG_COOKIE
+      targetPath: rabbitmq.auth.erlangCookie
+
+  values:
+    image:
+      repository: ghcr.io/zulip/zulip-server
+      tag: 12.0-0
+
+    service:
+      type: ClusterIP
+      port: 80
+
+    ingress:
+      enabled: false  # using a sibling HTTPRoute on the external Gateway
+
+    resources:
+      requests:
+        cpu: 200m
+        memory: 1Gi
+      limits:
+        memory: 2Gi
+
+    # docker-zulip / zulip-server runs supervisord as root and writes
+    # to / at boot; can't honor cluster-default non-root + RO rootfs.
+    podSecurityContext:
+      fsGroup: 0
+      runAsUser: 0
+      runAsGroup: 0
+    securityContext:
+      runAsNonRoot: false
+      runAsUser: 0
+      readOnlyRootFilesystem: false
+
+    zulip:
+      environment:
+        SETTING_EXTERNAL_HOST: chat.${SECRET_DOMAIN}
+        # SETTING_ZULIP_ADMINISTRATOR + SECRETS_secret_key injected via valuesFrom
+        SETTING_ZULIP_ADMINISTRATOR: placeholder@example.com
+        SECRETS_secret_key: placeholder
+        TRUST_GATEWAY_IP: true
+      persistence:
+        enabled: true
+        accessMode: ReadWriteOnce
+        size: 40Gi
+        storageClass: ceph-block
+
+    # External Postgres (CNPG). Credentials come from the CNPG-managed
+    # postgres-zulip-app Secret, populated when CNPG's initdb runs with
+    # owner=zulip, database=zulip.
+    postgresql:
+      enabled: false
+    externalPostgresql:
+      host: postgres-zulip-rw.databases.svc.cluster.local
+      port: 5432
+      user: zulip
+      database: zulip
+      password:
+        valueFrom:
+          secretKeyRef:
+            name: postgres-zulip-app
+            key: password
+
+    # External Redis (shared dragonfly, no auth)
+    redis:
+      enabled: false
+    externalRedis:
+      host: dragonfly.databases.svc.cluster.local
+      port: 6379
+      password: ""
+
+    # Bundled RabbitMQ (Bitnami subchart). Password + erlang cookie
+    # injected via valuesFrom. NOTE: chart pins bitnamilegacy/rabbitmq —
+    # upstream notes the image is no longer updated; revisit if security
+    # flags it.
+    rabbitmq:
+      enabled: true
+      persistence:
+        enabled: true
+        storageClass: ceph-block
+        size: 4Gi
+      auth:
+        username: zulip
+        # password + erlangCookie injected via HelmRelease.spec.valuesFrom
+        # (empty strings here satisfy chart schema; real values are
+        # merged from zulip-secret before helm render)
+        password: ""
+        erlangCookie: ""
+
+    # Bundled Memcached (Bitnami subchart). Ephemeral cache — no
+    # persistence needed. NOTE: same bitnamilegacy concern as rabbitmq.
+    memcached:
+      enabled: true
+
+    # Required by chart when bundled postgres is disabled (otherwise the
+    # global.security.allowInsecureImages flag gates the bundled-postgres
+    # image override; harmless when external).
+    global:
+      security:
+        allowInsecureImages: true

--- a/kubernetes/apps/collab/zulip/app/httproute.yaml
+++ b/kubernetes/apps/collab/zulip/app/httproute.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: zulip
+  annotations:
+    glance/name: "Zulip"
+    glance/show: "true"
+    glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/zulip.png"
+    glance/id: "Collaboration"
+spec:
+  parentRefs:
+    - name: external
+      namespace: network
+      sectionName: https
+  hostnames:
+    - chat.${SECRET_DOMAIN}
+  rules:
+    - backendRefs:
+        - name: zulip
+          port: 80

--- a/kubernetes/apps/collab/zulip/app/kustomization.yaml
+++ b/kubernetes/apps/collab/zulip/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./httproute.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/collab/zulip/app/ocirepository.yaml
+++ b/kubernetes/apps/collab/zulip/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/refs/heads/main/ocirepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: zulip
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 1.12.0
+  url: oci://ghcr.io/zulip/helm-charts/zulip

--- a/kubernetes/apps/collab/zulip/ks.yaml
+++ b/kubernetes/apps/collab/zulip/ks.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app zulip
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: collab
+  path: ./kubernetes/apps/collab/zulip/app
+  interval: 30m
+  timeout: 5m
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: zulip
+      namespace: databases
+    - name: dragonfly-cluster
+      namespace: databases
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+    - name: onepassword-connect
+      namespace: external-secrets
+  retryInterval: 1m

--- a/kubernetes/apps/databases/cloudnative-pg/config/zulip/cluster.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/zulip/cluster.yaml
@@ -1,0 +1,67 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/cluster_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgres-zulip
+spec:
+  instances: 3
+
+  imageName: ghcr.io/cloudnative-pg/postgresql:17.7
+
+  primaryUpdateStrategy: unsupervised
+
+  failoverDelay: 30
+
+  replicationSlots:
+    highAvailability:
+      enabled: true
+
+  postgresql:
+    parameters:
+      timezone: "America/New_York"
+
+  storage:
+    size: 20Gi
+    storageClass: ceph-block
+
+  walStorage:
+    size: 8Gi
+    storageClass: ceph-block
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 512Mi
+    limits:
+      memory: 1Gi
+
+  enableSuperuserAccess: true
+  superuserSecret:
+    name: cloudnative-pg
+
+  bootstrap:
+    initdb:
+      database: zulip
+      owner: zulip
+
+  monitoring:
+    enablePodMonitor: true
+
+  plugins:
+    - enabled: true
+      isWALArchiver: true
+      name: barman-cloud.cloudnative-pg.io
+      parameters:
+        barmanObjectName: garage-zulip
+        serverName: postgres-zulip-backup
+
+  externalClusters:
+    - name: postgres-zulip-backup
+      plugin:
+        enabled: true
+        isWALArchiver: false
+        name: barman-cloud.cloudnative-pg.io
+        parameters:
+          barmanObjectName: garage-zulip
+          serverName: postgres-zulip-backup

--- a/kubernetes/apps/databases/cloudnative-pg/config/zulip/kustomization.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/zulip/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../../components/cnpg-app-database
+resources:
+  - ./cluster.yaml

--- a/kubernetes/apps/databases/cloudnative-pg/ks.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/ks.yaml
@@ -735,3 +735,41 @@ spec:
     - apiVersion: postgresql.cnpg.io/v1
       kind: Cluster
       current: status.phase in ['Cluster in healthy state']
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app zulip
+  labels:
+    substitution.flux.home.arpa/enabled: "true"
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: databases
+  path: ./kubernetes/apps/databases/cloudnative-pg/config/zulip
+  interval: 30m
+  timeout: 5m
+  prune: true
+  wait: true
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: cloudnative-pg
+      namespace: databases
+    - name: cloudnative-pg-plugin-barman-cloud
+      namespace: databases
+    - name: garage
+      namespace: storage
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  postBuild:
+    substitute:
+      APP: *app
+  healthCheckExprs:
+    - apiVersion: postgresql.cnpg.io/v1
+      kind: Cluster
+      current: status.phase in ['Cluster in healthy state']


### PR DESCRIPTION
## Summary

- New app `zulip` in the `collab` namespace, reachable at `chat.${SECRET_DOMAIN}` via the external Gateway
- Uses the upstream **official** Zulip Helm chart (`oci://ghcr.io/zulip/helm-charts/zulip:1.12.0`, appVersion `12.0-0` → `ghcr.io/zulip/zulip-server`) rather than the deprecated all-in-one `zulip/docker-zulip` image
- External Postgres via CNPG (`postgres-zulip` cluster, ceph-block 20Gi data + 8Gi WAL, Barman→Garage backups) and external Redis via the existing `dragonfly`
- Bundled RabbitMQ (persistent on ceph-block, 4Gi) and Memcached (ephemeral) via the chart's Bitnami subcharts

## Architecture decisions

- **Credentials**: Postgres password sourced from CNPG-generated `postgres-zulip-app` Secret via `externalPostgresql.password.valueFrom.secretKeyRef`. CNPG `bootstrap.initdb` creates `database=zulip, owner=zulip` on first boot — no separate `postgres-init` initContainer needed.
- **Secrets path**: `SECRETS_secret_key`, `SETTING_ZULIP_ADMINISTRATOR`, `RABBITMQ_PASS`, `RABBITMQ_ERLANG_COOKIE` injected via `HelmRelease.spec.valuesFrom` from a 1Password-backed `zulip-secret`. Chart values keep empty-string placeholders so the schema validates pre-merge.
- **Exposure**: HTTPRoute on the external Gateway (Cloudflare Tunnel front). Zulip orgs are invite-only by default — no Authelia gate needed for the initial deploy.
- **disableWait**: install + upgrade `disableWait: true` — chart's startup probe gives 5 min but first-boot schema migrations can still race helm-controller.

## Known caveats

- Chart's `rabbitmq` and `memcached` subcharts pin `bitnamilegacy/*` images; upstream notes those images are no longer updated. Functional but won't get version bumps; revisit if security flags it.
- `SECRETS_secret_key` lands as a plaintext `value:` in the rendered StatefulSet (chart limitation — `zulip.environment` is a string map). The Secret in git is templated from 1P; only the in-cluster manifest holds the plaintext. Same posture as `envFrom: secretRef` in other apps.

## Draft — blocked on LAN-only work

1. Create Garage bucket `postgres-zulip-backup` + S3 key with read+write+owner
2. Add `GARAGE_AWS_ACCESS_KEY_ID` / `GARAGE_AWS_SECRET_ACCESS_KEY` to the `zulip` 1P item (loud-fail gate: the `cnpg-app-database` ExternalSecret refuses to render until those fields exist)

After both steps, take this out of draft and merge.

## Test plan

- [ ] Garage bucket + S3 key created
- [ ] 1P `zulip` item populated with GARAGE_AWS_* fields
- [ ] After merge: `flux get kustomization zulip -n flux-system` shows healthy
- [ ] CNPG cluster `postgres-zulip` reaches "Cluster in healthy state"
- [ ] Zulip StatefulSet pod reaches Ready (allow 5+ min for first-boot migrations)
- [ ] `kubectl exec zulip-0 -c zulip -- runuser -u zulip -- /home/zulip/deployments/current/manage.py generate_realm_creation_link` produces an invite link
- [ ] Realm creation flow completes via `chat.${SECRET_DOMAIN}`
- [ ] First admin account can log in and send a test message
- [ ] CNPG ScheduledBackup runs successfully to Garage on first weekly trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)