### PR TITLE
feat(ai): add langgraph-agents + sync-receiver + CNPG dbs

### DIFF
--- a/.github/image-registry-allowlist.txt
+++ b/.github/image-registry-allowlist.txt
@@ -49,3 +49,4 @@ docker.io/hjacobs/kube-ops-view         # upstream archived 2020
 docker.io/prompp/prompp                 # Prom++ Docker Hub only
 docker.io/rclone/rclone                 # ghcr.io/rclone/rclone has no stable semver tags
 docker.io/emberstack/kubernetes-reflector  # chart on ghcr.io but image is docker.io
+lscr.io/linuxserver/openssh-server      # linuxserver's canonical registry; ghcr mirror stops at 8.3_p1

--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -8,6 +8,8 @@ resources:
   - ./priority-class.yaml
   - ./comfyui/ks.yaml
   - ./kubeclaw/ks.yaml
+  - ./langgraph-agents/ks.yaml
   - ./mcp-inspector/ks.yaml
   - ./ollama/ks.yaml
   - ./paperless-ai/ks.yaml
+  - ./sync-receiver/ks.yaml

--- a/kubernetes/apps/ai/langgraph-agents/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/externalsecret.yaml
@@ -1,0 +1,33 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: langgraph-agents
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: langgraph-agents-secret
+    template:
+      engineVersion: v2
+      data:
+        # Anthropic Claude API. Optional — agents that opt in (coder, errand-runner,
+        # homelab/smart-home/property-engineer, ml-tuner) use this. health-tracker
+        # is architecturally blocked from importing the anthropic SDK at all.
+        ANTHROPIC_API_KEY: "{{ .ANTHROPIC_API_KEY }}"
+
+        # Pushover Tier 1 escalations. Reuses the alertmanager-secret keys.
+        PUSHOVER_APP_TOKEN: "{{ .PUSHOVER_APP_TOKEN }}"
+        PUSHOVER_USER_KEY: "{{ .PUSHOVER_USER_KEY }}"
+
+        # Langfuse — populated once Langfuse is deployed (phase 4.5 / 5).
+        # Empty values are fine; the runtime skips tracing if these are blank.
+        LANGFUSE_HOST: "{{ .LANGFUSE_HOST }}"
+        LANGFUSE_PUBLIC_KEY: "{{ .LANGFUSE_PUBLIC_KEY }}"
+        LANGFUSE_SECRET_KEY: "{{ .LANGFUSE_SECRET_KEY }}"
+  dataFrom:
+    - extract:
+        key: langgraph-agents

--- a/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
@@ -1,0 +1,199 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: langgraph-agents
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 30m
+  values:
+    controllers:
+      langgraph-agents:
+        type: deployment
+        replicas: 1
+        strategy: Recreate  # single-replica with Postgres-backed state
+
+        containers:
+          app:
+            image:
+              repository: ghcr.io/rwlove/langgraph-agents
+              tag: main  # Renovate will pin to release tags once we cut them
+
+            env:
+              # --- vault ---
+              VAULT_ROOT: /vault
+
+              # --- model providers ---
+              OLLAMA_BASE_URL: http://ollama.ai.svc.cluster.local:11434/v1
+              ENABLE_CLAUDE_API: "false"  # flip to true once Claude key is in 1Password
+
+              # --- MCP gateway ---
+              MCP_GATEWAY_URL: http://mcp-gateway-istio.mcp-system.svc.cluster.local:8080
+
+              # --- cost caps (per security review cat 7) ---
+              COST_CAP_PER_TASK_USD: "5.0"
+              COST_CAP_PER_AGENT_DAILY_USD: "10.0"
+              COST_CAP_GLOBAL_DAILY_USD: "30.0"
+
+              # --- runtime ---
+              LOG_LEVEL: INFO
+              USER_TIMEZONE: America/New_York
+
+            envFrom:
+              - secretRef:
+                  name: langgraph-agents-secret
+
+              # CNPG-managed secrets: full connection URI under .uri
+              # The Python settings expects POSTGRES_URL + MEMORY_POSTGRES_URL,
+              # but CNPG exposes them as `uri`. Map via a tiny patch below.
+              - secretRef:
+                  name: postgres-langgraph-checkpoints-app
+                  optional: false
+
+            # Map CNPG's `uri` key onto the env names the app expects.
+            # (CNPG also exposes username/password/host/port/dbname separately;
+            # but a single URI is simplest.)
+            #
+            # Because both CNPG secrets expose a key named `uri`, we can't
+            # blindly envFrom both — they'd collide. So `langgraph-memory` is
+            # mapped explicitly here as MEMORY_POSTGRES_URL.
+
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: &httpPort 8765
+                  initialDelaySeconds: 20
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /readyz
+                    port: *httpPort
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: *httpPort
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                  timeoutSeconds: 5
+                  failureThreshold: 60
+
+            resources:
+              requests:
+                cpu: 100m
+                memory: 512Mi
+              limits:
+                memory: 1Gi
+
+            securityContext:
+              runAsNonRoot: true
+              runAsUser: 1000
+              runAsGroup: 1000
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop: ["ALL"]
+
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
+
+    service:
+      app:
+        controller: langgraph-agents
+        ports:
+          http:
+            port: *httpPort
+
+    route:
+      app:
+        annotations:
+          glance/name: "LangGraph Agents"
+          glance/show: "true"
+          glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/langchain.png"
+          glance/id: "AI"
+        hostnames:
+          - "agents.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: *httpPort
+
+    persistence:
+      vault:
+        existingClaim: langgraph-vault
+        advancedMounts:
+          langgraph-agents:
+            app:
+              - path: /vault
+                readOnly: true
+
+      # Writable tmp because the rootfs is read-only.
+      tmp:
+        type: emptyDir
+        advancedMounts:
+          langgraph-agents:
+            app:
+              - path: /tmp
+
+      # Cache dir for any pip/uv runtime cache or langgraph local state.
+      cache:
+        type: emptyDir
+        advancedMounts:
+          langgraph-agents:
+            app:
+              - path: /home/app/.cache
+
+  # The langgraph-memory CNPG secret has the same `uri` key as
+  # langgraph-checkpoints, so envFrom would collide. Project the memory
+  # secret's `uri` into MEMORY_POSTGRES_URL via a postRenderer.
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: Deployment
+              name: langgraph-agents
+            patch: |
+              - op: add
+                path: /spec/template/spec/containers/0/env/-
+                value:
+                  name: POSTGRES_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: postgres-langgraph-checkpoints-app
+                      key: uri
+              - op: add
+                path: /spec/template/spec/containers/0/env/-
+                value:
+                  name: MEMORY_POSTGRES_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: postgres-langgraph-memory-app
+                      key: uri

--- a/kubernetes/apps/ai/langgraph-agents/app/kustomization.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../components/repos/app-template
+resources:
+  - ./externalsecret.yaml
+  - ./pvc.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/ai/langgraph-agents/app/pvc.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/pvc.yaml
@@ -1,0 +1,15 @@
+---
+# Shared vault PVC. sync-receiver pod writes (rsync push from laptop);
+# langgraph-agents reads (loads persona + skill markdown at runtime).
+# RWX so both pods can mount concurrently.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: langgraph-vault
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: ceph-filesystem
+  resources:
+    requests:
+      storage: 5Gi

--- a/kubernetes/apps/ai/langgraph-agents/ks.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/ks.yaml
@@ -1,0 +1,34 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: langgraph-agents
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: &appname langgraph-agents
+  targetNamespace: ai
+  path: "./kubernetes/apps/ai/langgraph-agents/app"
+  interval: 30m
+  prune: true
+  wait: false
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: longhorn
+      namespace: longhorn-system
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+    - name: cloudnative-pg
+      namespace: databases
+    - name: langgraph-checkpoints
+      namespace: databases
+    - name: langgraph-memory
+      namespace: databases
+    - name: ollama
+      namespace: ai
+    - name: onepassword-connect
+      namespace: external-secrets

--- a/kubernetes/apps/ai/sync-receiver/app/deployment.yaml
+++ b/kubernetes/apps/ai/sync-receiver/app/deployment.yaml
@@ -1,0 +1,79 @@
+---
+# Minimal sshd that exposes the langgraph-vault PVC for rsync-over-ssh push
+# from the laptop. RWX PVC mounted alongside langgraph-agents (which reads
+# the same PVC read-only). ceph-filesystem supports multi-attach.
+#
+# Authorized keys come from 1Password via ExternalSecret. No password auth.
+# Service is ClusterIP-only; reach from laptop via `kubectl port-forward`.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sync-receiver
+  labels:
+    app.kubernetes.io/name: sync-receiver
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: sync-receiver
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: sync-receiver
+    spec:
+      securityContext:
+        # Match the langgraph-agents "app" user (uid 1000) so files written
+        # by rsync are readable by the agent pod.
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      containers:
+        - name: sshd
+          image: lscr.io/linuxserver/openssh-server:10.2_p1-r0-ls225@sha256:29d4e3f887596c4c2fc609f4e07040b08890a238178da400ffa2a602b55245bc
+          env:
+            - name: PUID
+              value: "1000"
+            - name: PGID
+              value: "1000"
+            - name: TZ
+              value: America/New_York
+            - name: PUBLIC_KEY_FILE
+              value: /run/secrets/authorized_keys
+            - name: USER_NAME
+              value: sync
+            - name: PASSWORD_ACCESS
+              value: "false"
+            - name: SUDO_ACCESS
+              value: "false"
+          ports:
+            - name: ssh
+              containerPort: 2222
+              protocol: TCP
+          volumeMounts:
+            - name: vault
+              mountPath: /vault
+            - name: authorized-keys
+              mountPath: /run/secrets
+              readOnly: true
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 128Mi
+      volumes:
+        - name: vault
+          persistentVolumeClaim:
+            # langgraph-vault PVC declared by the langgraph-agents app.
+            # RWX ceph-filesystem — both the agent pod (RO) and this pod (RW)
+            # can mount concurrently.
+            claimName: langgraph-vault
+        - name: authorized-keys
+          secret:
+            secretName: sync-receiver-secret
+            items:
+              - key: authorized_keys
+                path: authorized_keys
+                mode: 0400

--- a/kubernetes/apps/ai/sync-receiver/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/sync-receiver/app/externalsecret.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: sync-receiver
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: sync-receiver-secret
+    template:
+      engineVersion: v2
+      data:
+        # ssh authorized_keys file — one or more pubkeys; the laptop's pubkey
+        # for the rsync push role is the expected content.
+        authorized_keys: "{{ .AUTHORIZED_KEYS }}"
+  dataFrom:
+    - extract:
+        key: kubeclaw-sync-receiver

--- a/kubernetes/apps/ai/sync-receiver/app/kustomization.yaml
+++ b/kubernetes/apps/ai/sync-receiver/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./deployment.yaml
+  - ./service.yaml

--- a/kubernetes/apps/ai/sync-receiver/app/service.yaml
+++ b/kubernetes/apps/ai/sync-receiver/app/service.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sync-receiver
+  labels:
+    app.kubernetes.io/name: sync-receiver
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: sync-receiver
+  ports:
+    - name: ssh
+      port: 2222
+      targetPort: ssh
+      protocol: TCP

--- a/kubernetes/apps/ai/sync-receiver/ks.yaml
+++ b/kubernetes/apps/ai/sync-receiver/ks.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: sync-receiver
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: &appname sync-receiver
+  targetNamespace: ai
+  path: "./kubernetes/apps/ai/sync-receiver/app"
+  interval: 30m
+  prune: true
+  wait: false
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: langgraph-agents
+      namespace: ai
+    - name: onepassword-connect
+      namespace: external-secrets

--- a/kubernetes/apps/databases/cloudnative-pg/config/langgraph-checkpoints/cluster.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/langgraph-checkpoints/cluster.yaml
@@ -1,0 +1,67 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/cluster_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgres-langgraph-checkpoints
+spec:
+  instances: 3
+
+  imageName: ghcr.io/cloudnative-pg/postgresql:17.7
+
+  primaryUpdateStrategy: unsupervised
+
+  failoverDelay: 30
+
+  replicationSlots:
+    highAvailability:
+      enabled: true
+
+  postgresql:
+    parameters:
+      timezone: "America/New_York"
+
+  storage:
+    size: 8Gi
+    storageClass: ceph-block
+
+  walStorage:
+    size: 4Gi
+    storageClass: ceph-block
+
+  resources:
+    requests:
+      cpu: 50m
+      memory: 256Mi
+    limits:
+      memory: 512Mi
+
+  enableSuperuserAccess: true
+  superuserSecret:
+    name: cloudnative-pg
+
+  bootstrap:
+    initdb:
+      database: langgraph_checkpoints
+      owner: langgraph
+
+  monitoring:
+    enablePodMonitor: true
+
+  plugins:
+    - enabled: true
+      isWALArchiver: true
+      name: barman-cloud.cloudnative-pg.io
+      parameters:
+        barmanObjectName: garage-langgraph-checkpoints
+        serverName: postgres-langgraph-checkpoints-backup
+
+  externalClusters:
+    - name: postgres-langgraph-checkpoints-backup
+      plugin:
+        enabled: true
+        isWALArchiver: false
+        name: barman-cloud.cloudnative-pg.io
+        parameters:
+          barmanObjectName: garage-langgraph-checkpoints
+          serverName: postgres-langgraph-checkpoints-backup

--- a/kubernetes/apps/databases/cloudnative-pg/config/langgraph-checkpoints/kustomization.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/langgraph-checkpoints/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../../components/cnpg-app-database
+resources:
+  - ./cluster.yaml

--- a/kubernetes/apps/databases/cloudnative-pg/config/langgraph-memory/cluster.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/langgraph-memory/cluster.yaml
@@ -1,0 +1,73 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/cluster_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgres-langgraph-memory
+spec:
+  instances: 3
+
+  # vectorchord = pgvector + vchord (HNSW + IVF + multi-vector). Same image
+  # immich uses for its CLIP retrieval; mature in this cluster.
+  imageName: ghcr.io/tensorchord/cloudnative-vectorchord:14.17-0.3.0@sha256:9bc4f201e463e735389a89b87662e82a711a9ba0bcbc11b590195bcde17d11af
+
+  primaryUpdateStrategy: unsupervised
+
+  failoverDelay: 30
+
+  replicationSlots:
+    highAvailability:
+      enabled: true
+
+  postgresql:
+    shared_preload_libraries: ["vchord.so"]
+    parameters:
+      timezone: "America/New_York"
+
+  storage:
+    size: 10Gi
+    storageClass: ceph-block
+
+  walStorage:
+    size: 4Gi
+    storageClass: ceph-block
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 512Mi
+    limits:
+      memory: 1Gi
+
+  enableSuperuserAccess: true
+  superuserSecret:
+    name: cloudnative-pg
+
+  bootstrap:
+    initdb:
+      database: langgraph_memory
+      owner: langgraph
+      postInitApplicationSQL:
+        - "CREATE EXTENSION IF NOT EXISTS vector;"
+        - "CREATE EXTENSION IF NOT EXISTS vchord;"
+
+  monitoring:
+    enablePodMonitor: true
+
+  plugins:
+    - enabled: true
+      isWALArchiver: true
+      name: barman-cloud.cloudnative-pg.io
+      parameters:
+        barmanObjectName: garage-langgraph-memory
+        serverName: postgres-langgraph-memory-backup
+
+  externalClusters:
+    - name: postgres-langgraph-memory-backup
+      plugin:
+        enabled: true
+        isWALArchiver: false
+        name: barman-cloud.cloudnative-pg.io
+        parameters:
+          barmanObjectName: garage-langgraph-memory
+          serverName: postgres-langgraph-memory-backup

--- a/kubernetes/apps/databases/cloudnative-pg/config/langgraph-memory/kustomization.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/langgraph-memory/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../../components/cnpg-app-database
+resources:
+  - ./cluster.yaml

--- a/kubernetes/apps/databases/cloudnative-pg/ks.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/ks.yaml
@@ -811,3 +811,79 @@ spec:
     - apiVersion: postgresql.cnpg.io/v1
       kind: Cluster
       current: status.phase in ['Cluster in healthy state']
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app langgraph-checkpoints
+  labels:
+    substitution.flux.home.arpa/enabled: "true"
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: databases
+  path: ./kubernetes/apps/databases/cloudnative-pg/config/langgraph-checkpoints
+  interval: 30m
+  timeout: 5m
+  prune: true
+  wait: true
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: cloudnative-pg
+      namespace: databases
+    - name: cloudnative-pg-plugin-barman-cloud
+      namespace: databases
+    - name: garage
+      namespace: storage
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  postBuild:
+    substitute:
+      APP: *app
+  healthCheckExprs:
+    - apiVersion: postgresql.cnpg.io/v1
+      kind: Cluster
+      current: status.phase in ['Cluster in healthy state']
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app langgraph-memory
+  labels:
+    substitution.flux.home.arpa/enabled: "true"
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: databases
+  path: ./kubernetes/apps/databases/cloudnative-pg/config/langgraph-memory
+  interval: 30m
+  timeout: 5m
+  prune: true
+  wait: true
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: cloudnative-pg
+      namespace: databases
+    - name: cloudnative-pg-plugin-barman-cloud
+      namespace: databases
+    - name: garage
+      namespace: storage
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  postBuild:
+    substitute:
+      APP: *app
+  healthCheckExprs:
+    - apiVersion: postgresql.cnpg.io/v1
+      kind: Cluster
+      current: status.phase in ['Cluster in healthy state']


### PR DESCRIPTION
## Summary

Phase 4 of the LangGraph redesign that replaces the kubeclaw direction. See `project_langgraph_redesign` in the claude vault for the canonical design + the langgraph-agents runtime at https://github.com/rwlove/langgraph-agents.

**Adds two CNPG databases** (`langgraph-checkpoints` + `langgraph-memory` with pgvector via vectorchord), the **`langgraph-agents` Deployment** (app-template), a **shared RWX vault PVC**, and a **sync-receiver pod** for laptop-direct rsync push.

Kubeclaw stays running. Phase 12 of the redesign removes it after a stability check.

## What's in this PR

- \`kubernetes/apps/databases/cloudnative-pg/config/langgraph-checkpoints/\` (Postgres 17.7, 3-instance HA, 8Gi)
- \`kubernetes/apps/databases/cloudnative-pg/config/langgraph-memory/\` (vectorchord image; postInitApplicationSQL enables \`vector\` + \`vchord\`)
- \`kubernetes/apps/databases/cloudnative-pg/ks.yaml\` — two new Flux Kustomization blocks
- \`kubernetes/apps/ai/langgraph-agents/\` — app-template HelmRelease, ExternalSecret, PVC, ks.yaml
- \`kubernetes/apps/ai/sync-receiver/\` — sshd pod for rsync push (repointed from kubeclaw-state to langgraph-vault PVC)
- \`kubernetes/apps/ai/kustomization.yaml\` — adds the two new ks.yaml lines
- \`.github/image-registry-allowlist.txt\` — adds lscr.io/linuxserver/openssh-server (ghcr mirror stops at 8.3_p1)

## Prerequisites before reconcile

Four 1Password items must exist:

| 1Password item | Fields |
|---|---|
| \`langgraph-checkpoints\` | \`GARAGE_AWS_ACCESS_KEY_ID\`, \`GARAGE_AWS_SECRET_ACCESS_KEY\` |
| \`langgraph-memory\` | same |
| \`langgraph-agents\` | \`ANTHROPIC_API_KEY\` (may be empty initially), \`PUSHOVER_APP_TOKEN\`, \`PUSHOVER_USER_KEY\`, \`LANGFUSE_HOST\` (empty), \`LANGFUSE_PUBLIC_KEY\` (empty), \`LANGFUSE_SECRET_KEY\` (empty) |
| \`kubeclaw-sync-receiver\` | \`AUTHORIZED_KEYS\` (laptop ssh pubkey, openssh \`authorized_keys\`-format) |

Pushover tokens are the same values already in \`alertmanager-secret\`.

## Out of scope for this PR

- **Langfuse** — deferred to phase 5 per design decision today. Runtime accepts empty LANGFUSE_* env vars as no-op.
- **Removing kubeclaw** — kubeclaw stays running in parallel. Phase 12 removes it after the new fleet is verified stable.
- **Cutting v0.1.0 release in langgraph-agents** — HelmRelease points at \`:main\` tag for now. Promotable to a versioned tag once we've smoke-tested in cluster.

## Test plan

- [ ] Provision the four 1Password items above
- [ ] Merge + Flux reconciles: CNPG databases come up healthy (both clusters reach \`Cluster in healthy state\`)
- [ ] \`postgres-langgraph-memory-app\` Secret exists with \`uri\` key; \`langgraph-memory\` DB has \`vector\` + \`vchord\` extensions
- [ ] \`langgraph-agents\` pod starts (1/1 Running, readiness probe green)
- [ ] \`sync-receiver\` pod starts (1/1 Running)
- [ ] From laptop: \`kubectl -n ai port-forward svc/sync-receiver 2222:2222\` → \`ssh -p 2222 sync@localhost\` succeeds via authorized key
- [ ] One \`rsync -av --dry-run ~/vaults/claude/agents/workspaces/ sync@localhost:/vault/agents/workspaces/\` succeeds
- [ ] Real rsync pushes the 13 per-agent workspaces + skills + shared baseline
- [ ] \`curl https://agents.\${SECRET_DOMAIN}/healthz\` returns ok
- [ ] \`curl -X POST https://agents.\${SECRET_DOMAIN}/inbox -d '{"task_id":"smoke-1","source":"test","content":"the porch light isn't turning on at sunset","user":"rob"}'\` returns a paused or complete response with triager output