### PR TITLE
chore(allowlist): permit docker.io/qdrant/qdrant + docker.io/robustadev/holmes

### DIFF
--- a/.github/image-registry-allowlist.txt
+++ b/.github/image-registry-allowlist.txt
@@ -49,3 +49,5 @@ docker.io/hjacobs/kube-ops-view         # upstream archived 2020
 docker.io/prompp/prompp                 # Prom++ Docker Hub only
 docker.io/rclone/rclone                 # ghcr.io/rclone/rclone has no stable semver tags
 docker.io/emberstack/kubernetes-reflector  # chart on ghcr.io but image is docker.io
+docker.io/qdrant/qdrant                 # ghcr.io/qdrant/qdrant ships only dev-*/master-* tags
+docker.io/robustadev/holmes             # no ghcr.io publication (ghcr.io/robusta-dev/holmes 403)


### PR DESCRIPTION
## Summary
- Allowlist `docker.io/qdrant/qdrant` (ghcr.io publication only ships `dev-*`/`master-*` tags, no stable semver).
- Allowlist `docker.io/robustadev/holmes` (no ghcr.io publication — `ghcr.io/robusta-dev/holmes` returns 403).

Both images are already in use under `kubernetes/apps/databases/qdrant` and `kubernetes/apps/observability/holmesgpt`. Unblocks Renovate PRs #11367 (qdrant `v1.13.0` → `v1.18.0`) and #11370 (holmes `0.28.0` → `0.29.0`).

## Test plan
- [ ] CI passes (`Image Registry Check` green on this PR)
- [ ] After merge, rebase #11367 and #11370 → both go CLEAN

🤖 Generated with [Claude Code](https://claude.com/claude-code)