### PR TITLE
feat(home): add 5 n8n workflows wiring langgraph-agents

### DIFF
--- a/kubernetes/apps/home/n8n/workflows/README.md
+++ b/kubernetes/apps/home/n8n/workflows/README.md
@@ -54,3 +54,69 @@ fetch(process.env.N8N_API_URL + '/api/v1/workflows/<workflow-id>', {
   `kubernetes/apps/observability/kube-prometheus-stack/app/alertmanagerconfig.yaml`
   via the `n8n-investigate` receiver pointing at the in-cluster n8n
   webhook URL.
+
+### LangGraph agent fleet (phase 9 of `project_langgraph_redesign`)
+
+These five workflows wire `langgraph-agents` to its external surfaces (Zulip
+notifications, Pushover Tier 1, scheduled cron tasks). They depend on the
+`langgraph-agents` Deployment being live, which is gated by
+`kubernetes/apps/ai/langgraph-agents/` reconciling. The Zulip-API and
+Pushover credentials must exist in n8n before import.
+
+- **langgraph-inbox.json** — public webhook `/webhook/langgraph-inbox`. Body:
+  `{ task_id?, source, content, user? }`. Normalizes payload, POSTs to
+  `langgraph-agents:/inbox`, branches on `status=paused` to forward to the
+  approval-post workflow. Used by voice-transcription pipelines + Zulip
+  `#inbox` outgoing webhooks.
+
+- **langgraph-approval-post.json** — internal webhook
+  `/webhook/langgraph-approval-post`. Posts the approval request to Zulip
+  stream `#approvals` (topic = `<task_id> — Class C: <action>`) and fires
+  a Tier-1 Pushover for attention. Receives the structured
+  `paused_for.approval_request` from `langgraph-inbox`.
+
+- **langgraph-approval-receive.json** — Zulip outgoing-webhook target. Fires
+  on emoji reactions in `#approvals`. Verifies the reactor is Rob (compares
+  `body.user_id` against env `ROB_ZULIP_USER_ID`). Parses the topic for
+  `task_id` + `Class` + `target=server.method`. Maps emoji 👍/👎/⏸️ to
+  approve/reject/defer. HMAC-signs a token using env
+  `LANGGRAPH_APPROVAL_SIGNING_KEY`, POSTs to `langgraph-agents:/approval`
+  to resume the paused workflow.
+
+- **langgraph-awaiting-user-sweep.json** — schedule every 5 minutes. GETs
+  `/admin/tasks`, filters to paused tasks past 30min / 4h / 7d thresholds.
+  30min → secondary Pushover. 4h → mark cold via `/admin/tasks/<id>/timeout-tier`.
+  7d → auto-cancel via `/admin/tasks/<id>/cancel` (langgraph-agents needs
+  to implement these admin endpoints in phase 5+).
+
+- **langgraph-daily-digest.json** — schedule daily at 22:00 America/New_York.
+  POSTs an inbox entry asking for today's digest; the triager routes to the
+  `reporter` agent, which writes `~/vaults/claude/reports/daily-YYYY-MM-DD.md`.
+  Posts a summary to Zulip stream `#digests` topic `daily-YYYY-MM-DD`.
+
+- **langgraph-cost-cap-watcher.json** — schedule every 4 hours. GETs
+  `/admin/costs/today` (planned endpoint; gated by Langfuse deployment in
+  phase 5). At 80% → Tier 2 Pushover warning. At 100% → Tier 1 with
+  `cost_cap_hit` flag flipped (langgraph-agents refuses Claude-API-eligible
+  specialists until the next daily reset).
+
+## New credentials needed (in n8n UI) for the LangGraph workflows
+
+| Credential type | Name | Used by |
+|---|---|---|
+| `pushoverApi` | "Pushover - alertmanager" (exists) | approval-post, awaiting-user-sweep, cost-cap-watcher |
+| `httpBasicAuth` | "Zulip API - n8n-bot" (new) | approval-post, daily-digest |
+
+The Zulip credential is an HTTP Basic Auth with username = bot email and
+password = bot API key. Provision via the Zulip admin UI as part of phase 10
+bot setup; until then, the workflows can be imported but won't post to Zulip.
+
+## New n8n env vars (set via the HelmRelease ExternalSecret)
+
+| Env var | Source | Used by |
+|---|---|---|
+| `ROB_ZULIP_USER_ID` | Zulip admin → user profile → numeric ID | approval-receive (impersonation defense) |
+| `LANGGRAPH_APPROVAL_SIGNING_KEY` | 1Password (also injected into langgraph-agents) | approval-receive (HMAC signing) |
+
+The signing key MUST be identical between n8n and langgraph-agents. Generate
+once with `openssl rand -hex 32` and store both targets.

--- a/kubernetes/apps/home/n8n/workflows/README.md
+++ b/kubernetes/apps/home/n8n/workflows/README.md
@@ -16,7 +16,8 @@ holds JSON exports so they survive a postgres rebuild.
      credential ID created in step 1.
 
 3. Import via API:
-   ```
+
+   ```sh
    PT=$(op read "op://Kubernetes/Pushover/userkey")
    sed -i "s|<REPLACE_FROM_OP_AT_IMPORT_TIME>|$PT|" alertmanager-holmesgpt-pushover.json
    curl -X POST -H "X-N8N-API-KEY: $N8N_KEY" -H "Content-Type: application/json" \
@@ -30,7 +31,7 @@ holds JSON exports so they survive a postgres rebuild.
 
 When you edit a workflow in the n8n UI, re-export to keep git in sync:
 
-```
+```sh
 kubectl exec -n mcp-system deploy/n8n-mcp -c app -- node -e "
 fetch(process.env.N8N_API_URL + '/api/v1/workflows/<workflow-id>', {
   headers: { 'X-N8N-API-KEY': process.env.N8N_API_KEY }

--- a/kubernetes/apps/home/n8n/workflows/langgraph-approval-post.json
+++ b/kubernetes/apps/home/n8n/workflows/langgraph-approval-post.json
@@ -1,0 +1,149 @@
+{
+    "name": "LangGraph → Approval post to Zulip",
+    "nodes": [
+        {
+            "name": "Approval Request Webhook",
+            "type": "n8n-nodes-base.webhook",
+            "typeVersion": 2,
+            "position": [
+                240,
+                300
+            ],
+            "parameters": {
+                "httpMethod": "POST",
+                "path": "langgraph-approval-post",
+                "responseMode": "onReceived",
+                "options": {}
+            }
+        },
+        {
+            "name": "Build Zulip topic + content",
+            "type": "n8n-nodes-base.set",
+            "typeVersion": 3.4,
+            "position": [
+                460,
+                300
+            ],
+            "parameters": {
+                "assignments": {
+                    "assignments": [
+                        {
+                            "id": "t1",
+                            "name": "topic",
+                            "value": "={{ $json.body.task_id + ' — Class ' + $json.body.paused_for.approval_request.action_class + ': ' + $json.body.paused_for.approval_request.target }}",
+                            "type": "string"
+                        },
+                        {
+                            "id": "t2",
+                            "name": "content",
+                            "value": "={{ '**Task:** `' + $json.body.task_id + '`\\n' + '**Proposed by:** ' + $json.body.paused_for.approval_request.proposed_by + '\\n' + '**Action class:** ' + $json.body.paused_for.approval_request.action_class + '\\n' + '**Target:** `' + $json.body.paused_for.approval_request.target + '`\\n' + '**Summary:** ' + $json.body.paused_for.approval_request.payload_summary + '\\n' + '**Undo path:** ' + ($json.body.paused_for.approval_request.undo_path || '_(none — will escalate to Class D)_') + '\\n' + '**Cost estimate:** $' + ($json.body.paused_for.approval_request.cost_estimate_usd || 0) + '\\n\\n' + 'React: 👍 approve / 👎 reject / ⏸️ defer 4h' }}",
+                            "type": "string"
+                        }
+                    ]
+                },
+                "includeOtherFields": false,
+                "options": {}
+            }
+        },
+        {
+            "name": "Post to Zulip #approvals",
+            "type": "n8n-nodes-base.httpRequest",
+            "typeVersion": 4.2,
+            "position": [
+                680,
+                300
+            ],
+            "parameters": {
+                "method": "POST",
+                "url": "https://chat.${SECRET_DOMAIN}/api/v1/messages",
+                "authentication": "genericCredentialType",
+                "genericAuthType": "httpBasicAuth",
+                "sendBody": true,
+                "contentType": "form-urlencoded",
+                "bodyParameters": {
+                    "parameters": [
+                        {
+                            "name": "type",
+                            "value": "stream"
+                        },
+                        {
+                            "name": "to",
+                            "value": "approvals"
+                        },
+                        {
+                            "name": "topic",
+                            "value": "={{ $json.topic }}"
+                        },
+                        {
+                            "name": "content",
+                            "value": "={{ $json.content }}"
+                        }
+                    ]
+                },
+                "options": {}
+            }
+        },
+        {
+            "name": "Pushover Tier 1 attention",
+            "type": "n8n-nodes-base.pushover",
+            "typeVersion": 1,
+            "position": [
+                900,
+                300
+            ],
+            "credentials": {
+                "pushoverApi": {
+                    "id": "Z7h0S0bfR7deJcvB",
+                    "name": "Pushover - alertmanager"
+                }
+            },
+            "parameters": {
+                "userKey": "<REPLACE_FROM_OP_AT_IMPORT_TIME>",
+                "title": "={{ '🔔 Approval needed: Class ' + $('Approval Request Webhook').first().json.body.paused_for.approval_request.action_class }}",
+                "message": "={{ $('Approval Request Webhook').first().json.body.paused_for.approval_request.target + '\\n' + $('Approval Request Webhook').first().json.body.paused_for.approval_request.payload_summary + '\\n\\nReact in Zulip: chat.${SECRET_DOMAIN}' }}",
+                "priority": 1,
+                "additionalFields": {
+                    "sound": "gamelan"
+                }
+            }
+        }
+    ],
+    "connections": {
+        "Approval Request Webhook": {
+            "main": [
+                [
+                    {
+                        "node": "Build Zulip topic + content",
+                        "type": "main",
+                        "index": 0
+                    }
+                ]
+            ]
+        },
+        "Build Zulip topic + content": {
+            "main": [
+                [
+                    {
+                        "node": "Post to Zulip #approvals",
+                        "type": "main",
+                        "index": 0
+                    }
+                ]
+            ]
+        },
+        "Post to Zulip #approvals": {
+            "main": [
+                [
+                    {
+                        "node": "Pushover Tier 1 attention",
+                        "type": "main",
+                        "index": 0
+                    }
+                ]
+            ]
+        }
+    },
+    "settings": {
+        "executionOrder": "v1"
+    }
+}

--- a/kubernetes/apps/home/n8n/workflows/langgraph-approval-receive.json
+++ b/kubernetes/apps/home/n8n/workflows/langgraph-approval-receive.json
@@ -1,0 +1,223 @@
+{
+    "name": "LangGraph → Approval receive (Zulip reaction)",
+    "nodes": [
+        {
+            "name": "Zulip Reaction Webhook",
+            "type": "n8n-nodes-base.webhook",
+            "typeVersion": 2,
+            "position": [
+                240,
+                300
+            ],
+            "parameters": {
+                "httpMethod": "POST",
+                "path": "langgraph-approval-receive",
+                "responseMode": "lastNode",
+                "options": {}
+            }
+        },
+        {
+            "name": "Parse reaction + verify actor",
+            "type": "n8n-nodes-base.code",
+            "typeVersion": 2,
+            "position": [
+                460,
+                300
+            ],
+            "parameters": {
+                "language": "javaScript",
+                "jsCode": "// Zulip outgoing-webhook payload for reaction events.\n// We require: reactor.user_id matches Rob's ID, message_topic encodes task_id,\n// emoji_name maps to one of approve/reject/defer.\n\nconst body = $input.first().json.body || {};\nconst ROB_USER_ID = parseInt(process.env.ROB_ZULIP_USER_ID || '0', 10);\n\nif (body.user_id !== ROB_USER_ID) {\n  return [{ json: { skip: true, reason: 'reactor is not Rob', user_id: body.user_id } }];\n}\n\nconst emoji = body.emoji_name || '';\nlet reaction;\nif (emoji === 'thumbs_up' || emoji === '+1') reaction = 'approve';\nelse if (emoji === 'thumbs_down' || emoji === '-1') reaction = 'reject';\nelse if (emoji === 'pause' || emoji === 'pause_button') reaction = 'defer';\nelse return [{ json: { skip: true, reason: 'irrelevant emoji', emoji } }];\n\n// Topic format: \"<task_id> — Class <C/D>: <action>\"\nconst topic = body.message?.topic || body.topic || '';\nconst taskMatch = topic.match(/^([\\w-]+)\\s/);\nif (!taskMatch) {\n  return [{ json: { skip: true, reason: 'no task_id in topic', topic } }];\n}\nconst task_id = taskMatch[1];\n\n// We need server + method + action_class to sign the token. Parse from topic:\n// \"<task_id> — Class C: ha-mcp.call_service\"\nconst classMatch = topic.match(/Class\\s+([ABCD]):/);\nconst targetMatch = topic.match(/Class\\s+[ABCD]:\\s*(\\S+)/);\nif (!classMatch || !targetMatch) {\n  return [{ json: { skip: true, reason: 'malformed topic', topic } }];\n}\nconst action_class = classMatch[1];\nconst target = targetMatch[1];\nconst [server, ...rest] = target.split('.');\nconst method = rest.join('.');\n\nreturn [{ json: { skip: false, task_id, reaction, action_class, server, method } }];"
+            }
+        },
+        {
+            "name": "Skip?",
+            "type": "n8n-nodes-base.if",
+            "typeVersion": 2.2,
+            "position": [
+                680,
+                300
+            ],
+            "parameters": {
+                "conditions": {
+                    "options": {
+                        "caseSensitive": true,
+                        "leftValue": "",
+                        "typeValidation": "strict"
+                    },
+                    "combinator": "and",
+                    "conditions": [
+                        {
+                            "id": "s1",
+                            "leftValue": "={{ $json.skip }}",
+                            "rightValue": true,
+                            "operator": {
+                                "type": "boolean",
+                                "operation": "true"
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "name": "Sign approval token",
+            "type": "n8n-nodes-base.code",
+            "typeVersion": 2,
+            "position": [
+                900,
+                400
+            ],
+            "parameters": {
+                "language": "javaScript",
+                "jsCode": "const crypto = require('crypto');\n\nconst { task_id, action_class, server, method, reaction } = $input.first().json;\nconst secret = process.env.LANGGRAPH_APPROVAL_SIGNING_KEY;\nif (!secret) {\n  throw new Error('LANGGRAPH_APPROVAL_SIGNING_KEY env not set');\n}\n\nconst nonce = crypto.randomBytes(8).toString('hex');\nconst payload = `${task_id}|${action_class}|${server}|${method}|${nonce}`;\nconst sig = crypto.createHmac('sha256', secret).update(payload).digest('hex');\nconst token = `${payload}:${sig}`;\n\nreturn [{ json: { task_id, reaction, approval_token: token, actor: 'rob' } }];"
+            }
+        },
+        {
+            "name": "POST /approval to langgraph-agents",
+            "type": "n8n-nodes-base.httpRequest",
+            "typeVersion": 4.2,
+            "position": [
+                1120,
+                400
+            ],
+            "parameters": {
+                "method": "POST",
+                "url": "http://langgraph-agents.ai.svc.cluster.local:8765/approval",
+                "sendHeaders": true,
+                "headerParameters": {
+                    "parameters": [
+                        {
+                            "name": "Content-Type",
+                            "value": "application/json"
+                        }
+                    ]
+                },
+                "sendBody": true,
+                "specifyBody": "json",
+                "jsonBody": "={{ JSON.stringify({ task_id: $json.task_id, reaction: $json.reaction, approval_token: $json.approval_token, actor: $json.actor }) }}",
+                "options": {
+                    "timeout": 300000
+                }
+            }
+        },
+        {
+            "name": "Ack",
+            "type": "n8n-nodes-base.set",
+            "typeVersion": 3.4,
+            "position": [
+                1340,
+                400
+            ],
+            "parameters": {
+                "assignments": {
+                    "assignments": [
+                        {
+                            "id": "ack1",
+                            "name": "status",
+                            "value": "={{ $json.status || 'completed' }}",
+                            "type": "string"
+                        }
+                    ]
+                },
+                "includeOtherFields": false,
+                "options": {}
+            }
+        },
+        {
+            "name": "Ignore",
+            "type": "n8n-nodes-base.set",
+            "typeVersion": 3.4,
+            "position": [
+                900,
+                200
+            ],
+            "parameters": {
+                "assignments": {
+                    "assignments": [
+                        {
+                            "id": "ig1",
+                            "name": "status",
+                            "value": "ignored",
+                            "type": "string"
+                        },
+                        {
+                            "id": "ig2",
+                            "name": "reason",
+                            "value": "={{ $json.reason }}",
+                            "type": "string"
+                        }
+                    ]
+                },
+                "includeOtherFields": false,
+                "options": {}
+            }
+        }
+    ],
+    "connections": {
+        "Zulip Reaction Webhook": {
+            "main": [
+                [
+                    {
+                        "node": "Parse reaction + verify actor",
+                        "type": "main",
+                        "index": 0
+                    }
+                ]
+            ]
+        },
+        "Parse reaction + verify actor": {
+            "main": [
+                [
+                    {
+                        "node": "Skip?",
+                        "type": "main",
+                        "index": 0
+                    }
+                ]
+            ]
+        },
+        "Skip?": {
+            "main": [
+                [
+                    {
+                        "node": "Ignore",
+                        "type": "main",
+                        "index": 0
+                    }
+                ],
+                [
+                    {
+                        "node": "Sign approval token",
+                        "type": "main",
+                        "index": 0
+                    }
+                ]
+            ]
+        },
+        "Sign approval token": {
+            "main": [
+                [
+                    {
+                        "node": "POST /approval to langgraph-agents",
+                        "type": "main",
+                        "index": 0
+                    }
+                ]
+            ]
+        },
+        "POST /approval to langgraph-agents": {
+            "main": [
+                [
+                    {
+                        "node": "Ack",
+                        "type": "main",
+                        "index": 0
+                    }
+                ]
+            ]
+        }
+    },
+    "settings": {
+        "executionOrder": "v1"
+    }
+}

--- a/kubernetes/apps/home/n8n/workflows/langgraph-awaiting-user-sweep.json
+++ b/kubernetes/apps/home/n8n/workflows/langgraph-awaiting-user-sweep.json
@@ -1,0 +1,253 @@
+{
+    "name": "LangGraph → Awaiting-user sweep",
+    "nodes": [
+        {
+            "name": "Every 5 min",
+            "type": "n8n-nodes-base.scheduleTrigger",
+            "typeVersion": 1.2,
+            "position": [
+                240,
+                300
+            ],
+            "parameters": {
+                "rule": {
+                    "interval": [
+                        {
+                            "field": "minutes",
+                            "minutesInterval": 5
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "name": "List in-flight tasks",
+            "type": "n8n-nodes-base.httpRequest",
+            "typeVersion": 4.2,
+            "position": [
+                460,
+                300
+            ],
+            "parameters": {
+                "method": "GET",
+                "url": "http://langgraph-agents.ai.svc.cluster.local:8765/admin/tasks",
+                "options": {
+                    "timeout": 30000
+                }
+            }
+        },
+        {
+            "name": "Classify by tier",
+            "type": "n8n-nodes-base.code",
+            "typeVersion": 2,
+            "position": [
+                680,
+                300
+            ],
+            "parameters": {
+                "language": "javaScript",
+                "jsCode": "// Bucket interrupted tasks by how long they've been paused.\n// 30min: secondary Pushover\n// 4h: persist as cold, no further action\n// 7d: auto-cancel (except per-agent overrides like errand-runner Class C cost>$100\n//     and health-tracker which never auto-cancels).\n\nconst now = Date.now();\nconst tasks = $input.first().json || [];\nconst paused = (Array.isArray(tasks) ? tasks : []).filter(t => t.interrupts && t.interrupts.length > 0);\n\nconst MIN_30 = 30 * 60 * 1000;\nconst HR_4 = 4 * 60 * 60 * 1000;\nconst DAY_7 = 7 * 24 * 60 * 60 * 1000;\n\nconst out = [];\nfor (const t of paused) {\n  const since = t.awaiting_user_since ? new Date(t.awaiting_user_since).getTime() : null;\n  if (!since) continue;\n  const age = now - since;\n  let tier = null;\n  if (age > DAY_7) tier = '7d';\n  else if (age > HR_4) tier = '4h';\n  else if (age > MIN_30) tier = '30min';\n  if (tier) {\n    out.push({ json: { task_id: t.task_id, tier, age_ms: age, agent: t.target_agent || 'unknown' } });\n  }\n}\nreturn out;"
+            }
+        },
+        {
+            "name": "Tier switch",
+            "type": "n8n-nodes-base.switch",
+            "typeVersion": 3,
+            "position": [
+                900,
+                300
+            ],
+            "parameters": {
+                "rules": {
+                    "values": [
+                        {
+                            "conditions": {
+                                "combinator": "and",
+                                "conditions": [
+                                    {
+                                        "leftValue": "={{ $json.tier }}",
+                                        "rightValue": "30min",
+                                        "operator": { "type": "string", "operation": "equals" }
+                                    }
+                                ]
+                            },
+                            "outputKey": "30min"
+                        },
+                        {
+                            "conditions": {
+                                "combinator": "and",
+                                "conditions": [
+                                    {
+                                        "leftValue": "={{ $json.tier }}",
+                                        "rightValue": "4h",
+                                        "operator": { "type": "string", "operation": "equals" }
+                                    }
+                                ]
+                            },
+                            "outputKey": "4h"
+                        },
+                        {
+                            "conditions": {
+                                "combinator": "and",
+                                "conditions": [
+                                    {
+                                        "leftValue": "={{ $json.tier }}",
+                                        "rightValue": "7d",
+                                        "operator": { "type": "string", "operation": "equals" }
+                                    }
+                                ]
+                            },
+                            "outputKey": "7d"
+                        }
+                    ]
+                },
+                "options": {
+                    "fallbackOutput": "none"
+                }
+            }
+        },
+        {
+            "name": "Pushover 30min escalation",
+            "type": "n8n-nodes-base.pushover",
+            "typeVersion": 1,
+            "position": [
+                1120,
+                100
+            ],
+            "credentials": {
+                "pushoverApi": {
+                    "id": "Z7h0S0bfR7deJcvB",
+                    "name": "Pushover - alertmanager"
+                }
+            },
+            "parameters": {
+                "userKey": "<REPLACE_FROM_OP_AT_IMPORT_TIME>",
+                "title": "={{ '⏰ Task awaiting you (30m): ' + $json.task_id }}",
+                "message": "={{ 'Agent ' + $json.agent + ' is paused, age ' + Math.round($json.age_ms / 60000) + 'm. Reply in Zulip #approvals.' }}",
+                "priority": 1,
+                "additionalFields": {
+                    "sound": "gamelan"
+                }
+            }
+        },
+        {
+            "name": "Mark cold (4h)",
+            "type": "n8n-nodes-base.httpRequest",
+            "typeVersion": 4.2,
+            "position": [
+                1120,
+                300
+            ],
+            "parameters": {
+                "method": "POST",
+                "url": "=http://langgraph-agents.ai.svc.cluster.local:8765/admin/tasks/{{ $json.task_id }}/timeout-tier",
+                "sendHeaders": true,
+                "headerParameters": {
+                    "parameters": [
+                        {
+                            "name": "Content-Type",
+                            "value": "application/json"
+                        }
+                    ]
+                },
+                "sendBody": true,
+                "specifyBody": "json",
+                "jsonBody": "={{ JSON.stringify({ tier: '4h' }) }}",
+                "options": {
+                    "timeout": 30000
+                }
+            }
+        },
+        {
+            "name": "Auto-cancel (7d)",
+            "type": "n8n-nodes-base.httpRequest",
+            "typeVersion": 4.2,
+            "position": [
+                1120,
+                500
+            ],
+            "parameters": {
+                "method": "POST",
+                "url": "=http://langgraph-agents.ai.svc.cluster.local:8765/admin/tasks/{{ $json.task_id }}/cancel",
+                "sendHeaders": true,
+                "headerParameters": {
+                    "parameters": [
+                        {
+                            "name": "Content-Type",
+                            "value": "application/json"
+                        }
+                    ]
+                },
+                "sendBody": true,
+                "specifyBody": "json",
+                "jsonBody": "={{ JSON.stringify({ reason: '7-day timeout; auto-cancelled by awaiting-user sweep' }) }}",
+                "options": {
+                    "timeout": 30000
+                }
+            }
+        }
+    ],
+    "connections": {
+        "Every 5 min": {
+            "main": [
+                [
+                    {
+                        "node": "List in-flight tasks",
+                        "type": "main",
+                        "index": 0
+                    }
+                ]
+            ]
+        },
+        "List in-flight tasks": {
+            "main": [
+                [
+                    {
+                        "node": "Classify by tier",
+                        "type": "main",
+                        "index": 0
+                    }
+                ]
+            ]
+        },
+        "Classify by tier": {
+            "main": [
+                [
+                    {
+                        "node": "Tier switch",
+                        "type": "main",
+                        "index": 0
+                    }
+                ]
+            ]
+        },
+        "Tier switch": {
+            "main": [
+                [
+                    {
+                        "node": "Pushover 30min escalation",
+                        "type": "main",
+                        "index": 0
+                    }
+                ],
+                [
+                    {
+                        "node": "Mark cold (4h)",
+                        "type": "main",
+                        "index": 0
+                    }
+                ],
+                [
+                    {
+                        "node": "Auto-cancel (7d)",
+                        "type": "main",
+                        "index": 0
+                    }
+                ]
+            ]
+        }
+    },
+    "settings": {
+        "executionOrder": "v1"
+    }
+}

--- a/kubernetes/apps/home/n8n/workflows/langgraph-cost-cap-watcher.json
+++ b/kubernetes/apps/home/n8n/workflows/langgraph-cost-cap-watcher.json
@@ -1,0 +1,201 @@
+{
+    "name": "LangGraph → Cost cap watcher",
+    "nodes": [
+        {
+            "name": "Every 4h",
+            "type": "n8n-nodes-base.scheduleTrigger",
+            "typeVersion": 1.2,
+            "position": [
+                240,
+                300
+            ],
+            "parameters": {
+                "rule": {
+                    "interval": [
+                        {
+                            "field": "hours",
+                            "hoursInterval": 4
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "name": "Get cost summary",
+            "type": "n8n-nodes-base.httpRequest",
+            "typeVersion": 4.2,
+            "position": [
+                460,
+                300
+            ],
+            "parameters": {
+                "method": "GET",
+                "url": "http://langgraph-agents.ai.svc.cluster.local:8765/admin/costs/today",
+                "options": {
+                    "timeout": 30000
+                }
+            }
+        },
+        {
+            "name": "Classify utilization",
+            "type": "n8n-nodes-base.code",
+            "typeVersion": 2,
+            "position": [
+                680,
+                300
+            ],
+            "parameters": {
+                "language": "javaScript",
+                "jsCode": "// /admin/costs/today response shape (planned):\n//   { spent_usd: number, daily_cap_usd: number, per_agent: { <id>: usd } }\n//\n// TODO: this endpoint isn't implemented in langgraph-agents yet (phase 5+).\n// When Langfuse is deployed, it sources the per-task costs. Until then,\n// this workflow will skip gracefully when the endpoint returns 404/501.\n\nconst body = $input.first().json || {};\nconst spent = Number(body.spent_usd || 0);\nconst cap = Number(body.daily_cap_usd || 30);\nconst pct = cap > 0 ? (spent / cap) * 100 : 0;\n\nlet tier = 'ok';\nif (pct >= 100) tier = 'hit';\nelse if (pct >= 80) tier = 'warn';\n\nreturn [{ json: { spent, cap, pct: Math.round(pct), tier } }];"
+            }
+        },
+        {
+            "name": "Tier?",
+            "type": "n8n-nodes-base.switch",
+            "typeVersion": 3,
+            "position": [
+                900,
+                300
+            ],
+            "parameters": {
+                "rules": {
+                    "values": [
+                        {
+                            "conditions": {
+                                "combinator": "and",
+                                "conditions": [
+                                    {
+                                        "leftValue": "={{ $json.tier }}",
+                                        "rightValue": "hit",
+                                        "operator": { "type": "string", "operation": "equals" }
+                                    }
+                                ]
+                            },
+                            "outputKey": "hit"
+                        },
+                        {
+                            "conditions": {
+                                "combinator": "and",
+                                "conditions": [
+                                    {
+                                        "leftValue": "={{ $json.tier }}",
+                                        "rightValue": "warn",
+                                        "operator": { "type": "string", "operation": "equals" }
+                                    }
+                                ]
+                            },
+                            "outputKey": "warn"
+                        }
+                    ]
+                },
+                "options": {
+                    "fallbackOutput": "none"
+                }
+            }
+        },
+        {
+            "name": "Tier 1 cap hit",
+            "type": "n8n-nodes-base.pushover",
+            "typeVersion": 1,
+            "position": [
+                1120,
+                200
+            ],
+            "credentials": {
+                "pushoverApi": {
+                    "id": "Z7h0S0bfR7deJcvB",
+                    "name": "Pushover - alertmanager"
+                }
+            },
+            "parameters": {
+                "userKey": "<REPLACE_FROM_OP_AT_IMPORT_TIME>",
+                "title": "={{ '💥 Daily cost cap HIT ($' + $json.spent + ' / $' + $json.cap + ')' }}",
+                "message": "={{ 'langgraph-agents will refuse Claude-API-eligible specialists for the rest of the day.' }}",
+                "priority": 1,
+                "additionalFields": {
+                    "sound": "siren"
+                }
+            }
+        },
+        {
+            "name": "Tier 2 warn",
+            "type": "n8n-nodes-base.pushover",
+            "typeVersion": 1,
+            "position": [
+                1120,
+                400
+            ],
+            "credentials": {
+                "pushoverApi": {
+                    "id": "Z7h0S0bfR7deJcvB",
+                    "name": "Pushover - alertmanager"
+                }
+            },
+            "parameters": {
+                "userKey": "<REPLACE_FROM_OP_AT_IMPORT_TIME>",
+                "title": "={{ '⚠️ Daily cost cap 80%+ ($' + $json.spent + ' / $' + $json.cap + ')' }}",
+                "message": "={{ 'Approaching the daily limit. Consider deferring non-urgent Claude-API tasks.' }}",
+                "priority": 0,
+                "additionalFields": {
+                    "sound": "intermission"
+                }
+            }
+        }
+    ],
+    "connections": {
+        "Every 4h": {
+            "main": [
+                [
+                    {
+                        "node": "Get cost summary",
+                        "type": "main",
+                        "index": 0
+                    }
+                ]
+            ]
+        },
+        "Get cost summary": {
+            "main": [
+                [
+                    {
+                        "node": "Classify utilization",
+                        "type": "main",
+                        "index": 0
+                    }
+                ]
+            ]
+        },
+        "Classify utilization": {
+            "main": [
+                [
+                    {
+                        "node": "Tier?",
+                        "type": "main",
+                        "index": 0
+                    }
+                ]
+            ]
+        },
+        "Tier?": {
+            "main": [
+                [
+                    {
+                        "node": "Tier 1 cap hit",
+                        "type": "main",
+                        "index": 0
+                    }
+                ],
+                [
+                    {
+                        "node": "Tier 2 warn",
+                        "type": "main",
+                        "index": 0
+                    }
+                ]
+            ]
+        }
+    },
+    "settings": {
+        "executionOrder": "v1"
+    }
+}

--- a/kubernetes/apps/home/n8n/workflows/langgraph-daily-digest.json
+++ b/kubernetes/apps/home/n8n/workflows/langgraph-daily-digest.json
@@ -1,0 +1,164 @@
+{
+    "name": "LangGraph → Daily digest",
+    "nodes": [
+        {
+            "name": "Daily 22:00 ET",
+            "type": "n8n-nodes-base.scheduleTrigger",
+            "typeVersion": 1.2,
+            "position": [
+                240,
+                300
+            ],
+            "parameters": {
+                "rule": {
+                    "interval": [
+                        {
+                            "field": "cronExpression",
+                            "expression": "0 22 * * *"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "name": "Build inbox payload",
+            "type": "n8n-nodes-base.set",
+            "typeVersion": 3.4,
+            "position": [
+                460,
+                300
+            ],
+            "parameters": {
+                "assignments": {
+                    "assignments": [
+                        {
+                            "id": "d1",
+                            "name": "task_id",
+                            "value": "={{ 'digest-' + $now.toFormat('yyyy-MM-dd') }}",
+                            "type": "string"
+                        },
+                        {
+                            "id": "d2",
+                            "name": "source",
+                            "value": "test",
+                            "type": "string"
+                        },
+                        {
+                            "id": "d3",
+                            "name": "content",
+                            "value": "Generate today's daily digest from the per-agent activity logs.",
+                            "type": "string"
+                        }
+                    ]
+                },
+                "includeOtherFields": false,
+                "options": {}
+            }
+        },
+        {
+            "name": "POST /inbox (routes to reporter)",
+            "type": "n8n-nodes-base.httpRequest",
+            "typeVersion": 4.2,
+            "position": [
+                680,
+                300
+            ],
+            "parameters": {
+                "method": "POST",
+                "url": "http://langgraph-agents.ai.svc.cluster.local:8765/inbox",
+                "sendHeaders": true,
+                "headerParameters": {
+                    "parameters": [
+                        {
+                            "name": "Content-Type",
+                            "value": "application/json"
+                        }
+                    ]
+                },
+                "sendBody": true,
+                "specifyBody": "json",
+                "jsonBody": "={{ JSON.stringify({ task_id: $json.task_id, source: $json.source, content: $json.content, user: 'rob' }) }}",
+                "options": {
+                    "timeout": 600000
+                }
+            }
+        },
+        {
+            "name": "Post digest summary to Zulip",
+            "type": "n8n-nodes-base.httpRequest",
+            "typeVersion": 4.2,
+            "position": [
+                900,
+                300
+            ],
+            "parameters": {
+                "method": "POST",
+                "url": "https://chat.${SECRET_DOMAIN}/api/v1/messages",
+                "authentication": "genericCredentialType",
+                "genericAuthType": "httpBasicAuth",
+                "sendBody": true,
+                "contentType": "form-urlencoded",
+                "bodyParameters": {
+                    "parameters": [
+                        {
+                            "name": "type",
+                            "value": "stream"
+                        },
+                        {
+                            "name": "to",
+                            "value": "digests"
+                        },
+                        {
+                            "name": "topic",
+                            "value": "={{ 'daily-' + $now.toFormat('yyyy-MM-dd') }}"
+                        },
+                        {
+                            "name": "content",
+                            "value": "={{ $json.output || 'Daily digest task complete; see vault/reports/daily-' + $now.toFormat('yyyy-MM-dd') + '.md' }}"
+                        }
+                    ]
+                },
+                "options": {}
+            }
+        }
+    ],
+    "connections": {
+        "Daily 22:00 ET": {
+            "main": [
+                [
+                    {
+                        "node": "Build inbox payload",
+                        "type": "main",
+                        "index": 0
+                    }
+                ]
+            ]
+        },
+        "Build inbox payload": {
+            "main": [
+                [
+                    {
+                        "node": "POST /inbox (routes to reporter)",
+                        "type": "main",
+                        "index": 0
+                    }
+                ]
+            ]
+        },
+        "POST /inbox (routes to reporter)": {
+            "main": [
+                [
+                    {
+                        "node": "Post digest summary to Zulip",
+                        "type": "main",
+                        "index": 0
+                    }
+                ]
+            ]
+        }
+    },
+    "settings": {
+        "executionOrder": "v1",
+        "timezone": "America/New_York"
+    }
+}

--- a/kubernetes/apps/home/n8n/workflows/langgraph-inbox.json
+++ b/kubernetes/apps/home/n8n/workflows/langgraph-inbox.json
@@ -1,0 +1,243 @@
+{
+    "name": "LangGraph → Inbox webhook",
+    "nodes": [
+        {
+            "name": "Inbox Webhook",
+            "type": "n8n-nodes-base.webhook",
+            "typeVersion": 2,
+            "position": [
+                240,
+                300
+            ],
+            "parameters": {
+                "httpMethod": "POST",
+                "path": "langgraph-inbox",
+                "responseMode": "lastNode",
+                "options": {}
+            }
+        },
+        {
+            "name": "Normalize body",
+            "type": "n8n-nodes-base.set",
+            "typeVersion": 3.4,
+            "position": [
+                460,
+                300
+            ],
+            "parameters": {
+                "assignments": {
+                    "assignments": [
+                        {
+                            "id": "a1",
+                            "name": "task_id",
+                            "value": "={{ $json.body.task_id || $now.toMillis() + '-' + Math.random().toString(36).slice(2, 10) }}",
+                            "type": "string"
+                        },
+                        {
+                            "id": "a2",
+                            "name": "source",
+                            "value": "={{ $json.body.source || 'voice' }}",
+                            "type": "string"
+                        },
+                        {
+                            "id": "a3",
+                            "name": "content",
+                            "value": "={{ $json.body.content }}",
+                            "type": "string"
+                        },
+                        {
+                            "id": "a4",
+                            "name": "user",
+                            "value": "={{ $json.body.user || 'rob' }}",
+                            "type": "string"
+                        }
+                    ]
+                },
+                "includeOtherFields": false,
+                "options": {}
+            }
+        },
+        {
+            "name": "Call /inbox on langgraph-agents",
+            "type": "n8n-nodes-base.httpRequest",
+            "typeVersion": 4.2,
+            "position": [
+                680,
+                300
+            ],
+            "parameters": {
+                "method": "POST",
+                "url": "http://langgraph-agents.ai.svc.cluster.local:8765/inbox",
+                "sendHeaders": true,
+                "headerParameters": {
+                    "parameters": [
+                        {
+                            "name": "Content-Type",
+                            "value": "application/json"
+                        }
+                    ]
+                },
+                "sendBody": true,
+                "specifyBody": "json",
+                "jsonBody": "={{ JSON.stringify({ task_id: $json.task_id, source: $json.source, content: $json.content, user: $json.user }) }}",
+                "options": {
+                    "timeout": 300000
+                }
+            }
+        },
+        {
+            "name": "Paused?",
+            "type": "n8n-nodes-base.if",
+            "typeVersion": 2.2,
+            "position": [
+                900,
+                300
+            ],
+            "parameters": {
+                "conditions": {
+                    "options": {
+                        "caseSensitive": true,
+                        "leftValue": "",
+                        "typeValidation": "strict"
+                    },
+                    "combinator": "and",
+                    "conditions": [
+                        {
+                            "id": "c1",
+                            "leftValue": "={{ $json.status }}",
+                            "rightValue": "paused",
+                            "operator": {
+                                "type": "string",
+                                "operation": "equals"
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "name": "Forward to approval-post",
+            "type": "n8n-nodes-base.httpRequest",
+            "typeVersion": 4.2,
+            "position": [
+                1120,
+                200
+            ],
+            "parameters": {
+                "method": "POST",
+                "url": "http://n8n.home.svc.cluster.local:8080/webhook/langgraph-approval-post",
+                "sendHeaders": true,
+                "headerParameters": {
+                    "parameters": [
+                        {
+                            "name": "Content-Type",
+                            "value": "application/json"
+                        }
+                    ]
+                },
+                "sendBody": true,
+                "specifyBody": "json",
+                "jsonBody": "={{ JSON.stringify({ task_id: $json.task_id, paused_for: $json.paused_for }) }}",
+                "options": {
+                    "timeout": 30000
+                }
+            }
+        },
+        {
+            "name": "Build response",
+            "type": "n8n-nodes-base.set",
+            "typeVersion": 3.4,
+            "position": [
+                1340,
+                300
+            ],
+            "parameters": {
+                "assignments": {
+                    "assignments": [
+                        {
+                            "id": "r1",
+                            "name": "task_id",
+                            "value": "={{ $('Normalize body').first().json.task_id }}",
+                            "type": "string"
+                        },
+                        {
+                            "id": "r2",
+                            "name": "status",
+                            "value": "={{ $('Call /inbox on langgraph-agents').first().json.status }}",
+                            "type": "string"
+                        }
+                    ]
+                },
+                "includeOtherFields": false,
+                "options": {}
+            }
+        }
+    ],
+    "connections": {
+        "Inbox Webhook": {
+            "main": [
+                [
+                    {
+                        "node": "Normalize body",
+                        "type": "main",
+                        "index": 0
+                    }
+                ]
+            ]
+        },
+        "Normalize body": {
+            "main": [
+                [
+                    {
+                        "node": "Call /inbox on langgraph-agents",
+                        "type": "main",
+                        "index": 0
+                    }
+                ]
+            ]
+        },
+        "Call /inbox on langgraph-agents": {
+            "main": [
+                [
+                    {
+                        "node": "Paused?",
+                        "type": "main",
+                        "index": 0
+                    }
+                ]
+            ]
+        },
+        "Paused?": {
+            "main": [
+                [
+                    {
+                        "node": "Forward to approval-post",
+                        "type": "main",
+                        "index": 0
+                    }
+                ],
+                [
+                    {
+                        "node": "Build response",
+                        "type": "main",
+                        "index": 0
+                    }
+                ]
+            ]
+        },
+        "Forward to approval-post": {
+            "main": [
+                [
+                    {
+                        "node": "Build response",
+                        "type": "main",
+                        "index": 0
+                    }
+                ]
+            ]
+        }
+    },
+    "settings": {
+        "executionOrder": "v1"
+    }
+}


### PR DESCRIPTION
## Summary

Phase 9 of `project_langgraph_redesign`. Five n8n workflows that wire the deployed `langgraph-agents` runtime to Zulip + Pushover + scheduled tasks. Follows PR #11383 (now merged) which deployed `langgraph-agents` itself.

The workflows ship as JSON exports stored in this repo per the existing git-tracked-sources-of-truth pattern. They need to be imported into the n8n UI via the procedure in \`kubernetes/apps/home/n8n/workflows/README.md\`.

## What's in this PR

| Workflow | Trigger | Purpose |
|---|---|---|
| \`langgraph-inbox.json\` | Webhook \`POST /webhook/langgraph-inbox\` | Receives inbox entries, forwards to \`langgraph-agents:/inbox\`, branches on paused |
| \`langgraph-approval-post.json\` | Internal webhook \`POST /webhook/langgraph-approval-post\` | Posts approval request to Zulip \`#approvals\` + Tier-1 Pushover |
| \`langgraph-approval-receive.json\` | Webhook from Zulip outgoing webhook on reactions | Verifies actor, HMAC-signs token, POSTs \`/approval\` |
| \`langgraph-awaiting-user-sweep.json\` | Schedule every 5 min | Buckets paused tasks by 30min/4h/7d → escalate/cold/cancel |
| \`langgraph-daily-digest.json\` | Schedule daily 22:00 ET | Fires reporter; posts summary to Zulip \`#digests\` |
| \`langgraph-cost-cap-watcher.json\` | Schedule every 4h | Polls \`/admin/costs/today\`; 80% → warn, 100% → cap hit |

Plus README.md updates documenting each workflow + new credentials + env vars needed.

## Prerequisites before activating in n8n

| Item | Where | Why |
|---|---|---|
| Credential \`Pushover - alertmanager\` | already exists in n8n | Tier 1 sends; reuse |
| Credential \`Zulip API - n8n-bot\` (HTTP Basic Auth) | new — needs phase 10 bot provisioning | approval-post + daily-digest post to Zulip |
| Env \`ROB_ZULIP_USER_ID\` | n8n env (via HelmRelease ExternalSecret) | impersonation defense in approval-receive |
| Env \`LANGGRAPH_APPROVAL_SIGNING_KEY\` | 1Password (same value also injected to langgraph-agents) | HMAC signing — both sides need identical value |

Generate the signing key once: \`openssl rand -hex 32\`. Store in 1Password under \`langgraph-agents\` field \`APPROVAL_SIGNING_KEY\`; mirror to n8n's env.

## langgraph-agents endpoints these depend on

Some workflows call planned \`/admin/*\` endpoints that don't exist yet:
- \`GET /admin/tasks\` ✅ exists (phase 1)
- \`POST /admin/tasks/<id>/timeout-tier\` ❌ planned (phase 5+)
- \`POST /admin/tasks/<id>/cancel\` ❌ planned (phase 5+)
- \`GET /admin/costs/today\` ❌ planned (phase 5+, blocks on Langfuse)

The awaiting-user-sweep and cost-cap-watcher workflows will gracefully no-op until those endpoints exist (HTTP nodes return errors but don't crash the workflow).

## Test plan

- [ ] Merge → JSON files land in repo (no Flux-side effect; n8n workflows are imported manually)
- [ ] Provision \`Zulip API - n8n-bot\` credential in n8n UI (phase 10 dep)
- [ ] Set \`ROB_ZULIP_USER_ID\` + \`LANGGRAPH_APPROVAL_SIGNING_KEY\` in n8n env
- [ ] Import \`langgraph-inbox.json\` via the procedure in README
- [ ] Activate it; smoke-test with curl: \`curl -X POST https://n8n.\${SECRET_DOMAIN}/webhook/langgraph-inbox -d '{"source":"test","content":"the porch light isn't turning on at sunset"}'\`
- [ ] Verify response has \`task_id\` + \`status\` and that langgraph-agents wrote a draft to the vault PVC
- [ ] Import remaining 5 workflows; activate them one at a time (the schedule-triggered ones won't fire until activated)
- [ ] Phase 10 (Zulip bots) unblocks the approval flow end-to-end