### PR TITLE
fix(ai): pin langgraph-agents to 0.1.0

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/langgraph-agents
-              tag: main  # Renovate will pin to release tags once we cut them
+              tag: 0.1.0  # versioned release; Renovate tracks subsequent bumps
 
             env:
               # --- vault ---


### PR DESCRIPTION
## Summary

The initial deploy (PR #11383) used \`:main\` tag + \`imagePullPolicy: IfNotPresent\`, which meant kubelet kept the first cached image across pod restarts. Two Dockerfile bugs surfaced and were fixed in the [langgraph-agents repo](https://github.com/rwlove/langgraph-agents):

1. **venv shebangs broken across stages** — multi-stage Dockerfile built at \`/build/.venv\` and copied to \`/app/.venv\`, but the shebang lines uv writes into binary scripts hardcode the absolute path. Result: every Python entrypoint failed with "No such file or directory" because \`/build/.venv/bin/python\` doesn't exist at runtime. Fix: build at \`/app\` to match runtime path.
2. **CMD pointed at non-existent log config** — uvicorn's \`--log-config /app/src/agents/logging.json\` referenced a file I never authored. Dropped the flag.

Both fixes shipped in commit \`bb4e62a\`. Tagged as \`v0.1.0\`; image published at \`ghcr.io/rwlove/langgraph-agents:0.1.0\`.

This PR pins the HelmRelease to that version. Once merged, Flux reconciles and replaces the in-cluster image (I patched the deployment in-cluster as a temporary unblock; Flux's reconcile would otherwise revert to the broken \`:main\` cache).

Verified the pinned image starts cleanly in cluster: pod 1/1 Running, \`/healthz\` 200, fleet graph compiles, \`/admin/agents\` lists all 13.

## Known follow-up

\`/inbox\` returns 500 because the vault PVC is empty — the persona loader can't find \`/vault/agents/workspaces/triager/\`. Next operational step is to push vault content via sync-receiver (rsync from laptop). The pod is healthy regardless; it just can't service requests until persona files land.

## Test plan

- [ ] Merge → Flux reconciles → \`langgraph-agents\` pod restarts using \`:0.1.0\`
- [ ] \`kubectl -n ai get pods\` shows langgraph-agents 1/1 Running with the new digest
- [ ] \`curl https://agents.\${SECRET_DOMAIN}/healthz\` returns ok
- [ ] Push vault content via sync-receiver
- [ ] \`/inbox\` smoke test returns either \`paused\` or \`complete\` (not 500)