### PR TITLE
feat(ai): bump langgraph-agents to 0.2.0

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/langgraph-agents
-              tag: 0.1.0  # versioned release; Renovate tracks subsequent bumps
+              tag: 0.2.0  # versioned release; Renovate tracks subsequent bumps
 
             env:
               # --- vault ---


### PR DESCRIPTION
## Summary

Bump langgraph-agents from \`0.1.0\` to \`0.2.0\`. The new image (released in [langgraph-agents](https://github.com/rwlove/langgraph-agents/releases/tag/v0.2.0)) implements the admin endpoints PR #11385's n8n workflows reference, adds activity-log writing per node, wires up OpenAI-compat \`/v1/chat/completions\` for OpenWebUI, and adds the doc-writer agent (TODO 9).

## What this unblocks

- **n8n awaiting-user-sweep + cost-cap-watcher** workflows now have real endpoints to call (previously returned 404)
- **OpenWebUI integration** — register \`https://agents.\${SECRET_DOMAIN}/v1\` as an OpenAI-compatible endpoint; 14 agents appear as models in OpenWebUI's picker
- **Reporter's daily-digest aggregation** — activity logs now actually get written under \`vault/agents/<id>/memory/activity-log.md\`

## What still depends on you

- **Vault content push via sync-receiver** — until persona files reach the langgraph-vault PVC, both \`/inbox\` and \`/v1/chat/completions\` return 503/500. This is the immediate next operational step.
- **Importing n8n workflows** (PR #11385 merged but workflows still need manual UI import via the README procedure)

## Test plan

- [ ] Merge → Flux reconciles → pod restarts with \`:0.2.0\`
- [ ] \`kubectl -n ai get pods\` shows langgraph-agents 1/1 Running with the new digest
- [ ] \`curl https://agents.\${SECRET_DOMAIN}/v1/models\` returns 14 agents (was 404 before)
- [ ] \`curl https://agents.\${SECRET_DOMAIN}/admin/costs/today\` returns the zero-spend stub shape (was 404 before)