### PR TITLE
fix(ai): cap ollama at one loaded model

### DIFF
--- a/kubernetes/apps/ai/ollama/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/ollama/app/helmrelease.yaml
@@ -51,6 +51,13 @@ spec:
               OLLAMA_FLASH_ATTENTION: 1
               OLLAMA_CONTEXT_LENGTH: 16384
               OLLAMA_NUM_PARALLEL: 4
+              # P40 VRAM budget is tight (24G total, ~15G steady-used by
+              # Frigate/Immich/etc). Without this, ollama tries to keep
+              # multiple models resident concurrently and OOMs when a
+              # langgraph-agents specialist (qwen2.5:14b, 9GB) is invoked
+              # while the triager's qwen2.5:7b (11GB) is still in keep-alive.
+              # Temporary until L40S/Spark lands per project_gpu_upgrade_decision.
+              OLLAMA_MAX_LOADED_MODELS: 1
 
             resources:
               requests:


### PR DESCRIPTION
## Summary

Set \`OLLAMA_MAX_LOADED_MODELS=1\` on the ollama HelmRelease so it unloads the previous model before loading a new one. Fixes \`httpx.RemoteProtocolError: Server disconnected\` mid-inference when a langgraph-agents specialist (qwen2.5:14b) is invoked while the triager's qwen2.5:7b is still resident under its 5m keep-alive.

## Why now

Smoke-tested langgraph-agents \`/inbox\` end-to-end after vault content landed in the PVC. Triager classified correctly (qwen2.5:7b, ~48s on a contested P40). The specialist call to qwen2.5:14b failed: P40 has 24 GiB, Frigate+Immich+others sit at ~15 GiB steady, the 7b model was already CPU/GPU-split at 19%/81% due to pressure, and 9 GiB for 14b on top oversubscribes.

## Trade-off

- **Cost:** ~30s cold-start whenever ollama switches between 7b and 14b
- **Benefit:** predictable VRAM usage, no failed inferences

The proper fix is more VRAM (L40S or Spark per \`project_gpu_upgrade_decision\` memory); this is the bridge.

## Blast radius

Only affects ollama consumers — paperless-ai, OpenWebUI, HolmesGPT, langgraph-agents. They'll see the ~30s cold-start when switching between different models. Most callers use qwen2.5:7b, so within a model the keep-alive still applies.

**Unaffected:** Frigate (own NVIDIA inference), Immich CLIP (own immich-machine-learning container), ComfyUI (own GPU allocation), anything that doesn't go through ollama.

## Test plan

- [ ] Merge → Flux reconciles → ollama pod restarts with the new env var
- [ ] \`kubectl -n ai exec ollama-0 -- printenv OLLAMA_MAX_LOADED_MODELS\` returns \`1\`
- [ ] \`POST /inbox\` to langgraph-agents with the porch-light example: triager → smart-home-engineer completes without RemoteProtocolError