### PR TITLE
fix(ai): bump langgraph-agents to 0.2.1

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/langgraph-agents
-              tag: 0.2.0  # versioned release; Renovate tracks subsequent bumps
+              tag: 0.2.1  # versioned release; Renovate tracks subsequent bumps
 
             env:
               # --- vault ---


### PR DESCRIPTION
Defaults specialists to qwen2.5:7b. Bridge until GPU upgrade — see commit message and `project_gpu_upgrade_decision` memory.

After merge: `kubectl -n ai exec ollama-0 -- ollama ps` will show at most qwen2.5:7b resident; subsequent /inbox runs avoid the 14b cold-load OOM.