### PR TITLE
fix(ai): mount langgraph-vault RW so agents can write drafts

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
@@ -152,8 +152,11 @@ spec:
         advancedMounts:
           langgraph-agents:
             app:
+              # Agents read personas + skills from this PVC AND write drafts
+              # to /vault/inbox/drafts/ + research findings to /vault/reports/.
+              # readOnly:true was the initial conservative default; revisit
+              # post-deploy when the agent fleet's write footprint is bounded.
               - path: /vault
-                readOnly: true
 
       # Writable tmp because the rootfs is read-only.
       tmp:


### PR DESCRIPTION
End-to-end /inbox smoke hit `OSError: [Errno 30] Read-only file system: '/vault/inbox'` in smart-home-engineer's write_draft() call. The initial deploy's read-only mount was conservative but breaks the agent's normal output path (inbox/drafts/, reports/research/).

Removing `readOnly: true`. Pod still constrained by non-root user, readOnlyRootFilesystem, dropped caps.