### PR TITLE
feat(ai): split langgraph-vault into RO persona content + RW outputs

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
@@ -147,16 +147,40 @@ spec:
                 port: *httpPort
 
     persistence:
-      vault:
+      # Vault content is split into two PVCs (pvc.yaml).
+      #
+      # `vault-rw` provides the writable surface mounted at /vault; agents
+      # write drafts/reports/activity logs here. It's small (2Gi) since
+      # it holds only agent outputs.
+      #
+      # `vault-ro` is the persona content sync-receiver pulls from laptop.
+      # It overlays onto /vault/agents/{workspaces,skills} via subPath
+      # mounts so the agent code sees one unified /vault tree without
+      # knowing about the split.
+      vault-rw:
+        existingClaim: langgraph-vault-rw
+        advancedMounts:
+          langgraph-agents:
+            app:
+              - path: /vault
+
+      vault-ro-workspaces:
         existingClaim: langgraph-vault
         advancedMounts:
           langgraph-agents:
             app:
-              # Agents read personas + skills from this PVC AND write drafts
-              # to /vault/inbox/drafts/ + research findings to /vault/reports/.
-              # readOnly:true was the initial conservative default; revisit
-              # post-deploy when the agent fleet's write footprint is bounded.
-              - path: /vault
+              - path: /vault/agents/workspaces
+                subPath: agents/workspaces
+                readOnly: true
+
+      vault-ro-skills:
+        existingClaim: langgraph-vault
+        advancedMounts:
+          langgraph-agents:
+            app:
+              - path: /vault/agents/skills
+                subPath: agents/skills
+                readOnly: true
 
       # Writable tmp because the rootfs is read-only.
       tmp:

--- a/kubernetes/apps/ai/langgraph-agents/app/pvc.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/pvc.yaml
@@ -1,7 +1,19 @@
 ---
-# Shared vault PVC. sync-receiver pod writes (rsync push from laptop);
-# langgraph-agents reads (loads persona + skill markdown at runtime).
-# RWX so both pods can mount concurrently.
+# Vault content split into two PVCs:
+#
+# langgraph-vault    — persona content written by sync-receiver (laptop push);
+#                      mounted RO by langgraph-agents at /vault/agents/{workspaces,skills}.
+#                      Owns agents/workspaces/ and agents/skills/ subdirs.
+#
+# langgraph-vault-rw — output content written by langgraph-agents (drafts,
+#                      reports, per-agent activity logs). Mounted RW at /vault.
+#                      Owns inbox/, reports/, and agents/<id>/memory/ subdirs.
+#                      Sync-receiver does NOT touch this PVC — outputs flow
+#                      laptop-ward via separate (future) pull mechanism.
+#
+# The nested mount layout lets the application code stay path-agnostic: it
+# sees a single /vault tree, but writes to inbox/reports land on vault-rw
+# while reads from workspaces/skills come from vault.
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -13,3 +25,15 @@ spec:
   resources:
     requests:
       storage: 5Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: langgraph-vault-rw
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: ceph-filesystem
+  resources:
+    requests:
+      storage: 2Gi


### PR DESCRIPTION
## Summary

Architectural cleanup of the langgraph-agents vault: persona content (workspaces, skills) is now read-only from the agent pod's perspective; agent outputs (drafts, reports, activity logs) live on a separate writable PVC.

The original PR #11395 made the whole vault RW to unblock the smoke test. That worked but lost the read-only safety on persona content. This PR is the proper version of that — keeps the safety on the immutable content, retains RW on the output paths.

## Implementation: zero code change

The agent code continues to see one \`/vault\` tree. The split happens at the k8s mount layer via nested mounts:

| Path | PVC | Mode | Owner |
|---|---|---|---|
| \`/vault\` | \`langgraph-vault-rw\` (new, 2Gi) | RW | langgraph-agents writes here |
| \`/vault/agents/workspaces\` | \`langgraph-vault\` (existing, subPath) | RO overlay | sync-receiver writes here |
| \`/vault/agents/skills\` | \`langgraph-vault\` (existing, subPath) | RO overlay | sync-receiver writes here |

Writes to \`/vault/inbox/drafts/\`, \`/vault/reports/research/\`, \`/vault/agents/<id>/memory/\` land on the RW PVC. Reads from the persona/skill paths hit the existing RO PVC.

## sync-receiver unchanged

sync-receiver continues to write only to \`langgraph-vault\` (the persona PVC). It doesn't need to touch \`langgraph-vault-rw\` because nothing is rsync'd from laptop into that path — those are agent-generated outputs.

## Migration

- New \`langgraph-vault-rw\` starts empty
- The smoke-test draft \`/vault/inbox/drafts/smart-home-smoke-rw.md\` on the existing PVC becomes orphaned (was just a test artifact — acceptable loss)
- No data migration needed; future agent runs land fresh on the new RW PVC

## Test plan

- [ ] Merge → Flux reconciles → new PVC bound, pod restarts with both mounts
- [ ] \`kubectl -n ai exec sync-receiver-... -- ls /vault/agents/workspaces/\` — still shows persona content (this is the RO PVC, sync-receiver mounted RW)
- [ ] \`kubectl -n ai exec langgraph-agents-... -- mount | grep vault\` — shows three mounts (rw root + two ro overlays)
- [ ] \`curl POST /inbox\` smoke: draft lands in \`/vault/inbox/drafts/\` (which is the new RW PVC)
- [ ] \`kubectl -n ai exec langgraph-agents-... -- touch /vault/agents/workspaces/foo\` — fails with read-only filesystem