### PR TITLE
feat(ai): mount langgraph-vault-rw RO on sync-receiver

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/externalsecret.yaml
@@ -28,6 +28,11 @@ spec:
         LANGFUSE_HOST: "{{ .LANGFUSE_HOST }}"
         LANGFUSE_PUBLIC_KEY: "{{ .LANGFUSE_PUBLIC_KEY }}"
         LANGFUSE_SECRET_KEY: "{{ .LANGFUSE_SECRET_KEY }}"
+
+        # HMAC key for /approval requests posted by n8n's approval-receive
+        # workflow. MUST match the value n8n sees (sourced from the same
+        # 1Password item — see kubernetes/apps/home/n8n/app/externalsecret.yaml).
+        LANGGRAPH_APPROVAL_SIGNING_KEY: "{{ .LANGGRAPH_APPROVAL_SIGNING_KEY }}"
   dataFrom:
     - extract:
         key: langgraph-agents

--- a/kubernetes/apps/ai/langgraph-agents/app/pvc.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/pvc.yaml
@@ -8,8 +8,9 @@
 # langgraph-vault-rw — output content written by langgraph-agents (drafts,
 #                      reports, per-agent activity logs). Mounted RW at /vault.
 #                      Owns inbox/, reports/, and agents/<id>/memory/ subdirs.
-#                      Sync-receiver does NOT touch this PVC — outputs flow
-#                      laptop-ward via separate (future) pull mechanism.
+#                      Also mounted read-only by sync-receiver at /vault-rw so
+#                      the laptop can rsync-pull drafts; sync-receiver never
+#                      writes here.
 #
 # The nested mount layout lets the application code stay path-agnostic: it
 # sees a single /vault tree, but writes to inbox/reports land on vault-rw

--- a/kubernetes/apps/ai/sync-receiver/app/deployment.yaml
+++ b/kubernetes/apps/ai/sync-receiver/app/deployment.yaml
@@ -54,6 +54,9 @@ spec:
           volumeMounts:
             - name: vault
               mountPath: /vault
+            - name: vault-rw
+              mountPath: /vault-rw
+              readOnly: true
             - name: authorized-keys
               mountPath: /run/secrets
               readOnly: true
@@ -70,6 +73,12 @@ spec:
             # RWX ceph-filesystem — both the agent pod (RO) and this pod (RW)
             # can mount concurrently.
             claimName: langgraph-vault
+        - name: vault-rw
+          persistentVolumeClaim:
+            # langgraph-vault-rw PVC — agent output (drafts, reports, activity
+            # logs). Mounted read-only here so the laptop can rsync-pull drafts
+            # without risking a clobber back into agent output state.
+            claimName: langgraph-vault-rw
         - name: authorized-keys
           secret:
             secretName: sync-receiver-secret

--- a/kubernetes/apps/ai/sync-receiver/app/deployment.yaml
+++ b/kubernetes/apps/ai/sync-receiver/app/deployment.yaml
@@ -42,7 +42,10 @@ spec:
             - name: PUBLIC_KEY_FILE
               value: /run/secrets/authorized_keys
             - name: USER_NAME
-              value: sync
+              # NOT "sync" — that collides with a stock user in the base image
+              # and halts s6-overlay init before sshd starts (silent: pod
+              # stays Running, TCP accepts, SSH handshake gets reset).
+              value: lgsync
             - name: PASSWORD_ACCESS
               value: "false"
             - name: SUDO_ACCESS

--- a/kubernetes/apps/home/n8n/app/externalsecret.yaml
+++ b/kubernetes/apps/home/n8n/app/externalsecret.yaml
@@ -27,8 +27,14 @@ spec:
         INIT_POSTGRES_USER: "{{ .POSTGRES_USER }}"
         INIT_POSTGRES_PASS: "{{ .POSTGRES_PASSWORD }}"
         INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
+        # HMAC key for langgraph-agents /approval requests. Same value as
+        # the langgraph-agents Deployment sees — sourced from the same
+        # 1Password item to make rotation a single op.
+        LANGGRAPH_APPROVAL_SIGNING_KEY: "{{ .LANGGRAPH_APPROVAL_SIGNING_KEY }}"
   dataFrom:
     - extract:
         key: cloudnative-pg
     - extract:
         key: n8n
+    - extract:
+        key: langgraph-agents


### PR DESCRIPTION
## Summary
- Adds the \`langgraph-vault-rw\` PVC as a second mount on the sync-receiver pod at \`/vault-rw\`, read-only.
- Closes the output loop so the laptop can \`rsync\`-pull drafts written by langgraph-agents into \`inbox/drafts/\`, \`reports/\`, and per-agent \`memory/\` directories — no \`kubectl exec\` workaround needed.
- The agent pod remains the sole writer of \`langgraph-vault-rw\`; sync-receiver's RO mount is defensive.

## Also fixed
- **USER_NAME=sync collision** that was silently breaking sshd startup. The linuxserver/openssh-server base image already has a \`sync\` user, so s6-overlay's init-adduser hung in \`sleep infinity\`; pod stayed Running but sshd never listened. Smoke test before fix: \`kex_exchange_identification: Connection closed by remote host\`. After fix (USER_NAME=lgsync): clean SSH.

## Note on commits
The middle commit (\`feat(ai,n8n): wire LANGGRAPH_APPROVAL_SIGNING_KEY into both apps\`) is identical to what already landed in main via #11398 — same hash, will dedupe at merge time.

## Test plan
- [ ] Flux reconciles \`ai-sync-receiver\` Kustomization
- [ ] \`kubectl exec -n ai deploy/sync-receiver -- ls -la /vault-rw\` shows agent-written content
- [ ] \`kubectl exec -n ai deploy/sync-receiver -- touch /vault-rw/__test\` fails with "Read-only file system"
- [ ] \`kubectl exec -n ai deploy/langgraph-agents -- touch /vault/inbox/__test\` still succeeds (agent write path unchanged)
- [ ] \`kubectl port-forward -n ai svc/sync-receiver 2222:2222 && ssh -p 2222 lgsync@localhost echo OK\` returns OK
- [ ] \`rsync\` push from laptop into \`/vault/agents/workspaces/\` succeeds
- [ ] \`rsync\` pull from laptop of \`/vault-rw/inbox/drafts/\` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)