### PR TITLE
fix(ai): sync-receiver authorized_keys mount collision with serviceaccount

### DIFF
--- a/kubernetes/apps/ai/sync-receiver/app/deployment.yaml
+++ b/kubernetes/apps/ai/sync-receiver/app/deployment.yaml
@@ -42,7 +42,11 @@ spec:
             - name: TZ
               value: America/New_York
             - name: PUBLIC_KEY_FILE
-              value: /run/secrets/authorized_keys
+              # Avoid /run/secrets — Kubernetes auto-mounts the service
+              # account token tree at /run/secrets/kubernetes.io/..., which
+              # shadows a Secret volume mounted at /run/secrets so its files
+              # are invisible to the application. /etc/lgsync avoids that.
+              value: /etc/lgsync/authorized_keys
             - name: USER_NAME
               # NOT "sync" — that collides with a stock user in the base image
               # and halts s6-overlay init before sshd starts (silent: pod
@@ -63,7 +67,7 @@ spec:
               mountPath: /vault-rw
               readOnly: true
             - name: authorized-keys
-              mountPath: /run/secrets
+              mountPath: /etc/lgsync
               readOnly: true
             # linuxserver/openssh-server writes its host keys, sshd_config
             # template, and the in-container user's ~/.ssh into /config.


### PR DESCRIPTION
## Summary
- Moves the \`authorized_keys\` Secret mount from \`/run/secrets\` to \`/etc/lgsync\` to avoid Kubernetes's automatic serviceaccount token mount at \`/run/secrets/kubernetes.io/\`.
- Updates \`PUBLIC_KEY_FILE\` env to match the new path.

## Why this is a follow-up to #11400
PR #11400 got sshd actually started — the test plan from #11397 partially passed (sshd listens on 2222, handshake completes). But ssh auth still rejected the laptop key with "Permission denied (publickey)" because PUBLIC_KEY_FILE pointed at \`/run/secrets/authorized_keys\` which the serviceaccount auto-mount had hidden. \`ls /run/secrets/\` inside the pod shows only \`kubernetes.io/\` — the Secret's authorized_keys file is mounted but invisible at that path.

## Test plan
- [x] After Flux reconcile, sync-receiver pod log shows "sshd is listening on port 2222"
- [x] \`kubectl exec ... -- ls /etc/lgsync/\` shows authorized_keys
- [ ] \`ssh -p 2222 lgsync@localhost echo OK\` succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)