### PR TITLE
feat(open-webui): add BGE cross-encoder reranker for RAG

### DIFF
--- a/kubernetes/apps/collab/open-webui/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/open-webui/app/helmrelease.yaml
@@ -41,6 +41,15 @@ spec:
               ENABLE_RAG_WEB_SEARCH: true
               RAG_EMBEDDING_ENGINE: ollama
               RAG_EMBEDDING_MODEL: nomic-embed-text
+              # Cross-encoder reranker — runs in-process via sentence-transformers
+              # on CPU. Adds ~2.5GiB to the pod's resident set (model weights);
+              # latency is ~hundreds of ms per batch which is fine for homelab
+              # RAG volume. v0.9.5 also supports external rerank (TEI etc.) via
+              # RAG_RERANKING_ENGINE=external + RAG_EXTERNAL_RERANKER_URL — but
+              # the P40 is Pascal (sm_61) so no prebuilt TEI image fits without
+              # a custom Pascal build. Revisit if Spark lands.
+              RAG_RERANKING_MODEL: BAAI/bge-reranker-v2-m3
+              RAG_TOP_K_RERANKER: "5"
               RAG_WEB_SEARCH_ENGINE: searxng
               QDRANT_URI: http://qdrant.databases.svc.cluster.local:6333
               SEARXNG_QUERY_URL: http://searxng.collab.svc.cluster.local:8080/search?q=<query>
@@ -93,9 +102,9 @@ spec:
             resources:
               requests:
                 cpu: 15m
-                memory: 3Gi
+                memory: 6Gi
               limits:
-                memory: 3Gi
+                memory: 6Gi
 
     service:
       app:


### PR DESCRIPTION
## Summary

- Adds `RAG_RERANKING_MODEL=BAAI/bge-reranker-v2-m3` (cross-encoder, in-process via sentence-transformers).
- `RAG_TOP_K_RERANKER=5` — slightly above the default 3 to give the LLM more context post-rerank.
- Memory limit `3Gi → 6Gi` to fit the ~2.5GiB model resident set + headroom.

Rerank engine stays default (in-process). External rerank via TEI / similar is supported in v0.9.5 (`RAG_RERANKING_ENGINE=external` + `RAG_EXTERNAL_RERANKER_URL`) but the P40 is Pascal (`sm_61`) and no upstream TEI image targets that architecture — revisit when Spark replaces P40 as the primary GPU.

## Test plan

- [ ] Open-webui pod restarts cleanly after the memory bump.
- [ ] First Knowledge Base query downloads `bge-reranker-v2-m3` from HF (visible in pod logs as `Loading model...`).
- [ ] Memory usage settles at ~5GiB after model load.
- [ ] Compare rerank-on vs rerank-off retrieval quality on a Paperless-backed Knowledge Base query — relevant docs should rank higher.
- [ ] Query latency is acceptable (~hundreds of ms for rerank stage on top-k = 50 or so).

🤖 Generated with [Claude Code](https://claude.com/claude-code)