### PR TITLE
fix(n8n): guard Pushover against HolmesGPT tool-call-as-text leakage

### DIFF
--- a/kubernetes/apps/home/n8n/workflows/alertmanager-holmesgpt-pushover.json
+++ b/kubernetes/apps/home/n8n/workflows/alertmanager-holmesgpt-pushover.json
@@ -83,7 +83,7 @@
       ],
       "parameters": {
         "language": "javaScript",
-        "jsCode": "const src = $input.first().json;\nconst raw = String(src.analysis || src.response || '').trim();\nlet message;\nif (!raw) {\n  message = '⚠️ HolmesGPT returned no analysis. Check the n8n execution.';\n} else if (raw.length <= 1000) {\n  message = raw;\n} else {\n  const cut = raw.slice(0, 997);\n  const m = cut.match(/^[\\s\\S]*[.!?\\n](?=[^.!?\\n]*$)/);\n  message = ((m && m[0].length > 600) ? m[0] : cut).trimEnd() + '…';\n}\nreturn [{ json: { message } }];"
+        "jsCode": "const src = $input.first().json;\nconst raw = String(src.analysis || src.response || '').trim();\nlet message;\nif (!raw) {\n  message = '⚠️ HolmesGPT returned no analysis. Check the n8n execution.';\n} else if (/^[:\\s]*\\{/.test(raw) && /\"(suggested_prefixes|tool_call_id|function)\"\\s*:/.test(raw.slice(0, 200))) {\n  message = `⚠️ HolmesGPT model returned a tool-call instead of a summary. Check execution ${$execution.id}.`;\n} else if (raw.length <= 1000) {\n  message = raw;\n} else {\n  const cut = raw.slice(0, 997);\n  const m = cut.match(/^[\\s\\S]*[.!?\\n](?=[^.!?\\n]*$)/);\n  message = ((m && m[0].length > 600) ? m[0] : cut).trimEnd() + '…';\n}\nreturn [{ json: { message } }];"
       }
     },
     {


### PR DESCRIPTION
## Summary

- Detect raw OpenAI tool-call JSON in HolmesGPT's `analysis` field and replace it with a short pointer to the n8n execution instead of forwarding garbage to Pushover.
- `qwen2.5:7b` on the P40 occasionally emits a `{"id":"call_...","type":"function","function":{"name":"...","arguments":{...}}}` payload as the final assistant turn instead of a synthesized summary; the previous `Format Message` node passed it through verbatim.
- No-op against well-behaved models. Keep permanently as a regression guard.

Detector fires on payload that matches `/^[:\s]*\{/` AND has `"function":` / `"tool_call_id"` / `"suggested_prefixes"` in the first 200 chars.

DB rows (`workflow_entity` + active `workflow_history`) were patched + n8n restarted in-cluster at deploy time; this commit is the canonical git source of truth.

## Test plan

- [x] Local JSON validates (`jq` parses)
- [x] Detector branch present in DB after manual patch (verified via `~ 'tool_call_id'` SELECT)
- [x] n8n Deployment restarted to flush in-memory workflow cache
- [ ] Next OOMKilled / similar alert fires the workflow; verify Pushover body is either a clean summary or the new `⚠️ HolmesGPT model returned a tool-call instead of a summary` pointer (not raw JSON)

🤖 Generated with [Claude Code](https://claude.com/claude-code)