### PR TITLE
docs(readme): fix inaccuracies + add AI agent pipeline section

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,46 @@ A single `rwlove/langgraph-agents` FastAPI service runs the fleet. Each agent is
 
 `health-tracker` and `errand-runner` are pinned local-only — they never escalate, even if quality suffers, because the data class isn't suitable for off-site inference.
 
+#### Voice-to-action: dictate on Android, act in the cluster
+
+The most common way work enters the agent fleet: dictate a note on the phone, watch it become an actioned outcome.
+
+```mermaid
+flowchart LR
+    Phone[📱 Android Obsidian<br/>voice-to-text dictation] -->|markdown into /inbox| CouchDB[(obsidian-couchdb<br/>self-hosted Obsidian sync)]
+    CouchDB --> Laptop[💻 Laptop Obsidian<br/>same vault]
+    CouchDB -->|new note in /inbox| Hook[n8n: langgraph-inbox<br/>webhook]
+    Hook -->|POST /inbox| LG[langgraph-agents]
+    LG --> Triage[triager classifies]
+    Triage -->|capture only| Note[note-maker<br/>files to vault]
+    Triage -->|plan + act| Spec[specialist agent<br/>drafts action plan]
+    Spec -->|needs input| Zulip[💬 Zulip approval<br/>+ Pushover ping]
+    Zulip -->|reply| Receive[langgraph-approval-receive]
+    Receive --> Spec
+    Spec -->|executes via MCP| Done[outcome → vault<br/>→ reporter digest]
+    Note --> Done
+    Done --> CouchDB
+```
+
+1. **Dictate** — Open Obsidian on Android, drop a note into the inbox folder, tap the mic, talk. The phone's voice-to-text handles transcription; no cluster-side STT in this loop.
+2. **Sync** — Obsidian Self-hosted LiveSync replicates the new note through `obsidian-couchdb` in the cluster. Cloudflare rate-limits the auth endpoint to blunt credential stuffing.
+3. **Pick-up** — a new file in `/inbox/` triggers a POST to the `langgraph-inbox` n8n webhook with `{ source: "voice", user, content }`. n8n normalizes the payload and calls `langgraph-agents` `/inbox`.
+4. **Triage** — `triager` classifies: research question, household errand, homelab change, property task, or note-to-self. The classification picks the specialist agent.
+5. **Plan or just capture** —
+   - **Capture only** → `note-maker` files the note into the right vault folder. Pipeline ends.
+   - **Plan + act** → the specialist (`errand-runner`, `homelab-engineer`, `property-coordinator`, `smart-home-engineer`, etc.) drafts an action plan: goal, steps, tool calls, expected cost. Plan is persisted to Postgres + a draft in `/vault/outputs/`.
+6. **HITL — pause and ask** — the agent pauses and asks for input whenever:
+   - Intent is ambiguous (multiple plausible interpretations of the dictation)
+   - The plan needs a decision the agent can't make alone (which vendor, which date, which file)
+   - Estimated cost exceeds the per-task cap
+   - The action touches a flagged-irreversible system (anything in the operational pillars list)
+
+   `langgraph-approval-post` packages the plan into a signed Zulip message + Pushover ping. The operator replies in-thread on whatever device is closest. `langgraph-approval-receive` parses the reply back into structured input; `langgraph-awaiting-user-sweep` nudges anything that's been stuck too long. The signing key (rotated daily via the same machinery as the MCP gateway) prevents anyone else in the realm from impersonating an approval.
+7. **Execute** — agent resumes with the operator's input, runs tool calls through the MCP gateway, honors per-task and global cost caps.
+8. **Report back to the same surface** — outcome lands as a markdown file under `/vault/outputs/{drafts,finals}/` and syncs back through `obsidian-couchdb` — so the result reaches the phone in the same vault the dictation came from. The `reporter` agent rolls completed items into the daily Zulip digest.
+
+The loop closes locally and on a single surface: an idea spoken into the phone in a parking lot comes back as a finished draft, a completed errand, or an action plan awaiting confirmation — all inside the Obsidian vault that started it, with Zulip as the side-channel only when input is needed.
+
 #### Alert triage (production today)
 
 HolmesGPT is the one agent already running in production:

--- a/README.md
+++ b/README.md
@@ -396,45 +396,48 @@ A single `rwlove/langgraph-agents` FastAPI service runs the fleet. Each agent is
 
 `health-tracker` and `errand-runner` are pinned local-only — they never escalate, even if quality suffers, because the data class isn't suitable for off-site inference.
 
-#### Voice-to-action: dictate on Android, act in the cluster
+#### Voice-to-action: power button → HA Assist → agents → Obsidian
 
-The most common way work enters the agent fleet: dictate a note on the phone, watch it become an actioned outcome.
+The most common way work enters the fleet — hold the phone's power button, say "inbox &lt;whatever I'm thinking&gt;", and the cluster takes it from there.
 
 ```mermaid
 flowchart LR
-    Phone[📱 Android Obsidian<br/>voice-to-text dictation] -->|markdown into /inbox| CouchDB[(obsidian-couchdb<br/>self-hosted Obsidian sync)]
-    CouchDB --> Laptop[💻 Laptop Obsidian<br/>same vault]
-    CouchDB -->|new note in /inbox| Hook[n8n: langgraph-inbox<br/>webhook]
-    Hook -->|POST /inbox| LG[langgraph-agents]
+    Btn[📱 Hold power button<br/>Pixel: 'Hold for Assistant'] --> Assist[HA Companion app<br/>set as default assistant]
+    Assist -->|audio stream| HA[Home Assistant<br/>Assist pipeline]
+    HA --> Whisper[Whisper STT<br/>wyoming-services on P40]
+    Whisper --> Sentence[Sentence trigger:<br/>'inbox &#123;content&#125;']
+    Sentence --> Ollama[conversation.ollama_voice<br/>qwen3:8b]
+    Ollama --> Rest[HA rest_command<br/>POST + Authelia JWT]
+    Rest --> Hook[n8n: langgraph-inbox]
+    Hook --> LG[langgraph-agents /inbox]
     LG --> Triage[triager classifies]
-    Triage -->|capture only| Note[note-maker<br/>files to vault]
-    Triage -->|plan + act| Spec[specialist agent<br/>drafts action plan]
+    Triage -->|capture only| Note[note-maker]
+    Triage -->|plan + act| Spec[specialist agent<br/>drafts plan]
     Spec -->|needs input| Zulip[💬 Zulip approval<br/>+ Pushover ping]
-    Zulip -->|reply| Receive[langgraph-approval-receive]
+    Zulip -->|reply| Receive[approval-receive]
     Receive --> Spec
-    Spec -->|executes via MCP| Done[outcome → vault<br/>→ reporter digest]
-    Note --> Done
-    Done --> CouchDB
+    Spec --> Done[outcome to vault]
+    Note --> Inbox[/vault/inbox/YYYY-MM-DD-…md/]
+    Done --> Outputs[/vault/outputs/&#123;drafts,finals&#125;//]
+    Inbox --> Couch[(obsidian-couchdb)]
+    Outputs --> Couch
+    Couch -->|LiveSync| Phone[📱 Obsidian on phone<br/>same vault]
 ```
 
-1. **Dictate** — Open Obsidian on Android, drop a note into the inbox folder, tap the mic, talk. The phone's voice-to-text handles transcription; no cluster-side STT in this loop.
-2. **Sync** — Obsidian Self-hosted LiveSync replicates the new note through `obsidian-couchdb` in the cluster. Cloudflare rate-limits the auth endpoint to blunt credential stuffing.
-3. **Pick-up** — a new file in `/inbox/` triggers a POST to the `langgraph-inbox` n8n webhook with `{ source: "voice", user, content }`. n8n normalizes the payload and calls `langgraph-agents` `/inbox`.
-4. **Triage** — `triager` classifies: research question, household errand, homelab change, property task, or note-to-self. The classification picks the specialist agent.
-5. **Plan or just capture** —
-   - **Capture only** → `note-maker` files the note into the right vault folder. Pipeline ends.
-   - **Plan + act** → the specialist (`errand-runner`, `homelab-engineer`, `property-coordinator`, `smart-home-engineer`, etc.) drafts an action plan: goal, steps, tool calls, expected cost. Plan is persisted to Postgres + a draft in `/vault/outputs/`.
-6. **HITL — pause and ask** — the agent pauses and asks for input whenever:
-   - Intent is ambiguous (multiple plausible interpretations of the dictation)
-   - The plan needs a decision the agent can't make alone (which vendor, which date, which file)
-   - Estimated cost exceeds the per-task cap
-   - The action touches a flagged-irreversible system (anything in the operational pillars list)
+##### The path
 
-   `langgraph-approval-post` packages the plan into a signed Zulip message + Pushover ping. The operator replies in-thread on whatever device is closest. `langgraph-approval-receive` parses the reply back into structured input; `langgraph-awaiting-user-sweep` nudges anything that's been stuck too long. The signing key (rotated daily via the same machinery as the MCP gateway) prevents anyone else in the realm from impersonating an approval.
-7. **Execute** — agent resumes with the operator's input, runs tool calls through the MCP gateway, honors per-task and global cost caps.
-8. **Report back to the same surface** — outcome lands as a markdown file under `/vault/outputs/{drafts,finals}/` and syncs back through `obsidian-couchdb` — so the result reaches the phone in the same vault the dictation came from. The `reporter` agent rolls completed items into the daily Zulip digest.
+1. **Hold power button.** Pixel's "Hold for Assistant" gesture is bound to the HA Companion app as the default digital assistant. The Assist UI opens with the mic hot.
+2. **Speak.** Audio streams to the cluster — no on-phone STT. The trigger phrase is `inbox <body>`; everything after `inbox` is the note.
+3. **STT in cluster.** The Assist pipeline routes the audio to **Whisper** (`wyoming-services`, GPU-accelerated on the P40).
+4. **Intent + LLM.** A sentence trigger matches `inbox {content}` and hands `{content}` to `conversation.ollama_voice` (qwen3:8b on Ollama, tool-calling enabled). The conversation agent's only job here is to confirm the intent and call the rest_command — it does not interpret the content.
+5. **Auth'd POST.** An HA `rest_command` POSTs to `https://langgraph-inbox.${SECRET_DOMAIN}/webhook` with `{ source:"voice", user:"rob", content:"<transcript>" }`. The request carries an **Authelia client_credentials JWT** issued to a dedicated `ha-voice-inbox` OIDC client — same daily-rotated signing-key machinery the MCP gateway already uses. Envoy's `SecurityPolicy` validates the JWT against Authelia's JWKS at the gateway.
+6. **n8n langgraph-inbox.** Normalizes the payload and POSTs to `/inbox` on `langgraph-agents`.
+7. **Triager classifies.** Research question, household errand, homelab change, property task, or note-to-self — and picks the specialist agent.
+8. **Capture path → note-maker writes the file** to `/vault/inbox/YYYY-MM-DD-HHMM-<slug>.md` on the `langgraph-vault-rw` PVC. Single writer, no race with the phone.
+9. **Plan-and-act path → specialist drafts a plan** into Postgres + a draft under `/vault/outputs/drafts/`. HITL approval via the existing Zulip + Pushover loop when needed (see triggers above).
+10. **Round-trip to the phone.** `obsidian-couchdb` watches the vault PVC and replicates new files through Self-hosted LiveSync — the note from step 8, plus any drafts/finals from step 9, appear in the Obsidian app on the phone within a sync cycle. Same surface the dictation started on.
 
-The loop closes locally and on a single surface: an idea spoken into the phone in a parking lot comes back as a finished draft, a completed errand, or an action plan awaiting confirmation — all inside the Obsidian vault that started it, with Zulip as the side-channel only when input is needed.
+The loop closes locally and on one surface: power-button → speak → outcome appears in the vault. Whisper, Ollama, n8n, and the agents all run in the cluster; the only off-site dependency is `claude.com` if the local fleet escalates a task.
 
 #### Alert triage (production today)
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Storage tiers are picked deliberately per workload — see [`storage-class.instr
 | 💪   | worker7   | VM on **beast**     | 10  | 30 GB | CentOS 9   | NVMe (Longhorn + Ceph OSD)   |                                       |
 | 🎮   | worker8   | VM on **beast**     | 10  | 55 GB | CentOS 9   | NVMe (Longhorn + Ceph OSD)   | NVIDIA **P40** (24 GB VRAM)           |
 
-**Off-cluster infrastructure**
+### Off-cluster infrastructure
 
 | Host    | Role                                                                                          |
 |---------|-----------------------------------------------------------------------------------------------|
@@ -357,7 +357,7 @@ flowchart TB
     LG --> DB
 ```
 
-#### Agent fleet (LangGraph)
+### Agent fleet (LangGraph)
 
 A single `rwlove/langgraph-agents` FastAPI service runs the fleet. Each agent is a LangGraph graph with its own persona, tool set, and cost cap. Postgres-checkpointed state lets long-running plans survive restarts.
 
@@ -377,7 +377,7 @@ A single `rwlove/langgraph-agents` FastAPI service runs the fleet. Each agent is
 | `property-coordinator` | 3532 Foxhall workstreams (contractors, deck, pool)         |
 | `health-tracker`       | Local-only — never escalated to Claude API                 |
 
-#### Pipeline stages
+### Pipeline stages
 
 1. **Inbox** — `langgraph-inbox.json` workflow ingests requests from chat, AlertManager, or scheduled triggers.
 2. **Triage** — `triager` classifies and assigns to a specialist agent.
@@ -386,7 +386,7 @@ A single `rwlove/langgraph-agents` FastAPI service runs the fleet. Each agent is
 5. **Execute** — agent runs tool calls through the MCP gateway. Cost caps enforced by `langgraph-cost-cap-watcher` ($5/task, $10/agent/day, $30/global/day).
 6. **Report** — output written to `langgraph-vault` (drafts / finals), summarized into the `reporter` agent's daily Zulip digest (`langgraph-daily-digest`).
 
-#### Local-first by design
+### Local-first by design
 
 | Tier | Backend                       | When used                                                  |
 |------|-------------------------------|------------------------------------------------------------|
@@ -396,7 +396,7 @@ A single `rwlove/langgraph-agents` FastAPI service runs the fleet. Each agent is
 
 `health-tracker` and `errand-runner` are pinned local-only — they never escalate, even if quality suffers, because the data class isn't suitable for off-site inference.
 
-#### Voice-to-action: power button → HA Assist → agents → Obsidian
+### Voice-to-action: power button → HA Assist → agents → Obsidian
 
 The most common way work enters the fleet — hold the phone's power button, say "inbox &lt;whatever I'm thinking&gt;", and the cluster takes it from there.
 
@@ -424,7 +424,7 @@ flowchart LR
     Couch -->|LiveSync| Phone[📱 Obsidian on phone<br/>same vault]
 ```
 
-##### The path
+#### The path
 
 1. **Hold power button.** Pixel's "Hold for Assistant" gesture is bound to the HA Companion app as the default digital assistant. The Assist UI opens with the mic hot.
 2. **Speak.** Audio streams to the cluster — no on-phone STT. The trigger phrase is `inbox <body>`; everything after `inbox` is the note.
@@ -439,7 +439,7 @@ flowchart LR
 
 The loop closes locally and on one surface: power-button → speak → outcome appears in the vault. Whisper, Ollama, n8n, and the agents all run in the cluster; the only off-site dependency is `claude.com` if the local fleet escalates a task.
 
-#### Alert triage (production today)
+### Alert triage (production today)
 
 HolmesGPT is the one agent already running in production:
 
@@ -447,7 +447,7 @@ HolmesGPT is the one agent already running in production:
 - HolmesGPT queries Prometheus, Loki, and the cluster directly to build a root-cause hypothesis
 - Result posted back as a Pushover message + Zulip thread; n8n sanitizes raw tool-call descriptors out of the agent text before delivery
 
-#### Current state (2026-05-16)
+### Current state (2026-05-16)
 
 - **HolmesGPT** — live, handling cluster alerts daily.
 - **LangGraph fleet** — plumbed but cold (`ENABLE_CLAUDE_API: false`, no production triggers). Gated on NVIDIA Spark / Ascent GX10 arrival (~2026-05-20), which becomes the primary Ollama backend before the fleet goes hot.
@@ -472,25 +472,32 @@ HolmesGPT is the one agent already running in production:
 
 ## 🛡️ Operational pillars
 
-#### 💾 Tiered storage durability
+### 💾 Tiered storage durability
+
 Four tiers, picked by what the data has to survive — node loss, Ceph loss, cluster loss, or full site loss. Databases get `ceph-block` + Barman→Garage; irreplaceable state goes to Longhorn with NFS-shipped weekly + monthly backups; S3-shaped workloads use Garage; bulk media rides direct NFS. Full decision tree: [`.agents/instructions/storage-class.instructions.md`](.agents/instructions/storage-class.instructions.md).
 
-#### 🔐 Secrets — zero plain-text in Git
+### 🔐 Secrets — zero plain-text in Git
+
 All 109 ExternalSecrets resolve through External Secrets Operator from 1Password. Application credentials are templated into `ExternalSecret` resources and never live in YAML. Cross-namespace mirrors use the reflector pattern when consumer charts hard-code secret names.
 
-#### 🪪 Authentication — single sign-on everywhere
+### 🪪 Authentication — single sign-on everywhere
+
 Authelia (with LLDAP) is the OIDC identity provider; per-app oauth2-proxy instances enforce auth at Envoy Gateway. 24 apps sit behind SSO today. The mcp-gateway validates Authelia-issued JWTs with a daily-rotated signing key for MCP tooling.
 
-#### 🔭 Observability — metrics, logs, AI triage
+### 🔭 Observability — metrics, logs, AI triage
+
 kube-prometheus-stack scrapes everything; Loki ingests pod logs; Grafana stitches the dashboards. AlertManager fans alerts to Pushover and to **HolmesGPT**, which runs LLM-driven root-cause investigation against the cluster and posts findings back via n8n.
 
-#### 🎮 GPU workloads
+### 🎮 GPU workloads
+
 A single NVIDIA P40 (24 GB VRAM) on worker8 drives Ollama (local LLM), ComfyUI (image gen), Whisper STT, Immich's CLIP face/pet recognition, and the immich-pet-tagger fork pinned to a P40-compatible PyTorch build. Driver lifecycle is handled by the NVIDIA GPU Operator.
 
-#### 🛟 Disaster recovery
+### 🛟 Disaster recovery
+
 Per-app rclone CronJobs ship Immich originals and Paperless documents — plus their Garage-stored Postgres backups — to encrypted AWS S3 with a 1-day Glacier Deep Archive transition. Recovery procedure is documented at [`docs/src/offsite_recovery.md`](docs/src/offsite_recovery.md) and was last validated 2026-05-05.
 
-#### 🌪️ Strict GitOps
+### 🌪️ Strict GitOps
+
 Every change reaches the cluster through Git. Flux suspends are a deliberate manual signal — paused Kustomizations are not "broken," they're intentional pauses for in-flight maintenance and are documented in conventions, not reverted on sight.
 
 ---

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Storage tiers are picked deliberately per workload — see [`storage-class.instr
 | **Automation**   | Renovate + GitHub Actions           | Dependency PRs, link checks, self-hosted runners     |
 | **CNI**          | Cilium (eBPF)                       | Networking, BGP peering, LoadBalancer pool            |
 | **Ingress**      | Envoy Gateway                       | L7 gateway / HTTPRoute                                |
+| **Service mesh** | Istio + Kiali                       | mTLS + traffic mgmt for mcp-system; Kiali UI for topology |
 | **DNS**          | external-dns                        | Cloudflare + bind9 split-horizon                      |
 | **TLS**          | cert-manager                        | Let's Encrypt + internal CA                           |
 | **Tunnel**       | cloudflared                         | Public ingress without exposing home WAN              |
@@ -178,15 +179,14 @@ Worker nodes attach to **iot** and **sec** VLANs via Multus for direct camera an
 
 | App | Purpose |
 |-----|---------|
-| **Ollama** | Local LLM serving on the P40 (Qwen, DeepSeek-R1, etc.) |
+| **Ollama** | Local LLM serving on the P40 (Qwen 2.5 7b/14b, DeepSeek-R1, etc.) |
 | **ComfyUI** | Image generation workflows |
 | **Khoj** | Personal AI assistant over notes + docs |
-| **LangGraph Agents** | Custom multi-agent framework (errand_runner et al.) |
-| **KubeClaw** | Multi-agent platform (in development) |
-| **MCP Inspector** | Model Context Protocol debugger |
-| **HolmesGPT** | AI-driven alert triage (AlertManager webhook → root cause) |
+| **LangGraph Agents** | Custom multi-agent runtime (`rwlove/langgraph-agents`); Postgres-checkpointed; MCP-gateway client. See **AI agent pipeline** section below. |
+| **KubeClaw** | Workflow agent platform w/ browser automation (upstream chart); being phased out in favor of LangGraph |
+| **MCP Inspector** | Model Context Protocol debugger UI |
 | **Paperless-AI** | Auto-tagging for paperless-ngx |
-| **sync-receiver** | Cross-host AI state sync |
+| **sync-receiver** | Cross-host AI state sync endpoint |
 
 </details>
 
@@ -233,7 +233,8 @@ Worker nodes attach to **iot** and **sec** VLANs via Multus for direct camera an
 | **cert-manager** | TLS certificate lifecycle |
 | **external-dns** | Cloudflare + bind9 record sync |
 | **cloudflared** | Public tunnel without exposed WAN |
-| **Authelia** | OIDC identity provider (LLDAP backend) |
+| **Authelia** | OIDC identity provider |
+| **LLDAP** | Lightweight LDAP directory backing Authelia |
 | **oauth2-proxy** | 24 instances gating per-app SSO |
 | **wg-easy** | Primary OOB WireGuard access |
 | **External Secrets Operator** | 1Password-backed secret materialization |
@@ -246,16 +247,168 @@ Worker nodes attach to **iot** and **sec** VLANs via Multus for direct camera an
 </details>
 
 <details>
-<summary>🗂️ <b>Documents & Collaboration</b> — Personal knowledge stack</summary>
+<summary>🗂️ <b>Documents & Collaboration</b> — Personal knowledge stack + self-hosted tools</summary>
 
 | App | Purpose |
 |-----|---------|
 | **Paperless-ngx** | Document scanning, OCR, tagging (CNPG-backed, offsite-backed) |
 | **Obsidian** + **obsidian-couchdb** | Notes sync (CouchDB w/ Cloudflare rate-limiting) |
-| **Zulip** | Self-hosted team chat |
-| **Mealie** | Recipe management |
+| **Zulip** | Self-hosted team chat (also wired into agent pipeline approvals) |
+| **Kitchenowl** | Shopping lists + recipe / meal management |
+| **Open WebUI** | Self-hosted LLM frontend (Ollama + MCP servers as tool servers) |
+| **SearXNG** | Privacy-respecting metasearch engine |
+| **Glance** | Personal dashboard / start page |
+| **Atuin** | Encrypted shell-history sync across machines |
+| **IT-Tools** | Self-hosted developer toolbox |
+| **MediKeep** | Personal medical records |
+| **Nametag** | Name tag / badge generator |
+| **Pump** + **Pump-cv** | Custom personal apps (`rwlove`-built) |
 
 </details>
+
+<details>
+<summary>🔌 <b>MCP Servers</b> — 14 Model Context Protocol servers behind an Authelia-gated gateway</summary>
+
+| Server | Exposes |
+|--------|---------|
+| **mcp-gateway** | Aggregating gateway; Envoy SecurityPolicy validates Authelia-issued JWTs (daily-rotated key) |
+| **ha-mcp** | Home Assistant entities + service calls |
+| **immich-mcp** | Immich library search + asset metadata |
+| **kubectl-mcp** | Cluster introspection + safe `kubectl` ops |
+| **grafana-mcp** | Grafana dashboards + Loki/Prom queries |
+| **prometheus-mcp** | Direct PromQL access |
+| **paperless-mcp** | Paperless-ngx document search |
+| **netbox-mcp** | NetBox IPAM / DCIM |
+| **github-mcp** | GitHub repo + PR ops |
+| **n8n-mcp** | n8n workflow control |
+| **omada-mcp** | TP-Link Omada controller |
+| **searxng-mcp** | Privacy search through SearXNG |
+| **arr-mcp** | Library-search interface to *arr apps |
+| **time-mcp** | Time / timezone utilities (`rwlove/time-mcp` native-SHTTP build) |
+
+</details>
+
+---
+
+## 🧠 AI agent pipeline
+
+How local AI agents run, get work, ask for human approval, and produce reports — all without putting data in someone else's cloud unless a task genuinely needs it.
+
+```mermaid
+flowchart TB
+    subgraph Inputs[Inputs]
+        AM[AlertManager alerts]
+        Op[Operator chat / voice]
+        Cron[n8n cron + webhooks]
+    end
+
+    subgraph Frontends[Frontends]
+        OWUI[Open WebUI]
+        HA[Home Assistant<br/>voice + conversation]
+        N8N[n8n workflows]
+    end
+
+    subgraph Orchestration[Orchestration]
+        Holmes[HolmesGPT<br/>alert RCA]
+        LG[LangGraph Agents<br/>agent fleet]
+        KC[KubeClaw<br/>retiring]
+    end
+
+    subgraph Inference[Inference]
+        Ollama[Ollama on P40<br/>qwen2.5:7b/14b]
+        Claude[Claude API<br/>escalation only]
+    end
+
+    subgraph Tools[Tools]
+        Gw[MCP Gateway<br/>Authelia-gated JWT]
+        Servers[14× MCP servers<br/>HA · Immich · k8s · Grafana · …]
+    end
+
+    subgraph Outputs[Outputs]
+        Z[Zulip<br/>approvals + chat]
+        P[Pushover<br/>high-priority alerts]
+        V[(langgraph-vault<br/>drafts + reports)]
+        DB[(Postgres CNPG<br/>checkpoints + memory)]
+    end
+
+    AM --> Holmes
+    Op --> OWUI
+    Op --> HA
+    Cron --> N8N
+
+    OWUI --> Ollama
+    HA --> Ollama
+    N8N --> LG
+
+    Holmes --> Ollama
+    LG --> Ollama
+    LG -.-> Claude
+    KC --> Ollama
+
+    Holmes --> N8N
+    LG --> Gw
+    KC --> Gw
+    OWUI --> Gw
+    Gw --> Servers
+
+    N8N --> Z
+    N8N --> P
+    LG --> V
+    LG --> DB
+```
+
+#### Agent fleet (LangGraph)
+
+A single `rwlove/langgraph-agents` FastAPI service runs the fleet. Each agent is a LangGraph graph with its own persona, tool set, and cost cap. Postgres-checkpointed state lets long-running plans survive restarts.
+
+| Agent                  | Role                                                       |
+|------------------------|------------------------------------------------------------|
+| `supervisor`           | Routes work to specialist agents; opens approvals         |
+| `researcher`           | Web + repo + vault research                                |
+| `coder`                | Code reading, drafting, PR descriptions                    |
+| `reviewer`             | Reviews drafts before they reach the operator              |
+| `triager`              | Classifies inbound items, assigns owner agent              |
+| `reporter`             | Daily digests, summaries, status rollups                   |
+| `note-maker`           | Captures decisions + facts back into the vault             |
+| `homelab-engineer`     | Cluster ops, HelmRelease drafting, PR-shaped output        |
+| `smart-home-engineer`  | Home Assistant entities, automations, ESPHome configs      |
+| `ml-tuner`             | Frigate, Immich CLIP, model tuning                         |
+| `errand-runner`        | One-shot real-world tasks (purchases, lookups, scheduling) |
+| `property-coordinator` | 3532 Foxhall workstreams (contractors, deck, pool)         |
+| `health-tracker`       | Local-only — never escalated to Claude API                 |
+
+#### Pipeline stages
+
+1. **Inbox** — `langgraph-inbox.json` workflow ingests requests from chat, AlertManager, or scheduled triggers.
+2. **Triage** — `triager` classifies and assigns to a specialist agent.
+3. **Plan** — agent drafts an action plan (goals, steps, tool calls, expected cost) into Postgres state.
+4. **Approval (HITL)** — for anything non-trivial, `langgraph-approval-post` sends a signed Zulip message + Pushover ping with the plan summary; `langgraph-approval-receive` waits on the reply; `langgraph-awaiting-user-sweep` chases stuck tasks.
+5. **Execute** — agent runs tool calls through the MCP gateway. Cost caps enforced by `langgraph-cost-cap-watcher` ($5/task, $10/agent/day, $30/global/day).
+6. **Report** — output written to `langgraph-vault` (drafts / finals), summarized into the `reporter` agent's daily Zulip digest (`langgraph-daily-digest`).
+
+#### Local-first by design
+
+| Tier | Backend                       | When used                                                  |
+|------|-------------------------------|------------------------------------------------------------|
+| 1    | `qwen2.5:7b` on Ollama (P40)  | Fast / simple agents (`triager`, `note-maker` drafts)      |
+| 2    | `qwen2.5:14b` on Ollama (P40) | Default for everything else                                |
+| 3    | Claude API (escalation)       | Only on explicit uncertainty markers, repeated local-retry failure, novel/long-context work, or `requires_cloud` tag |
+
+`health-tracker` and `errand-runner` are pinned local-only — they never escalate, even if quality suffers, because the data class isn't suitable for off-site inference.
+
+#### Alert triage (production today)
+
+HolmesGPT is the one agent already running in production:
+
+- **AlertManager → HolmesGPT** webhook (via `alertmanager-holmesgpt-pushover.json`) on every firing alert
+- HolmesGPT queries Prometheus, Loki, and the cluster directly to build a root-cause hypothesis
+- Result posted back as a Pushover message + Zulip thread; n8n sanitizes raw tool-call descriptors out of the agent text before delivery
+
+#### Current state (2026-05-16)
+
+- **HolmesGPT** — live, handling cluster alerts daily.
+- **LangGraph fleet** — plumbed but cold (`ENABLE_CLAUDE_API: false`, no production triggers). Gated on NVIDIA Spark / Ascent GX10 arrival (~2026-05-20), which becomes the primary Ollama backend before the fleet goes hot.
+- **KubeClaw** — running in parallel during the LangGraph transition; scheduled for retirement once LangGraph is validated.
 
 ---
 


### PR DESCRIPTION
## Summary

Follow-up to #11415. Fixes README inaccuracies found by checking against live cluster state, and adds a new section on local AI agent usage.

### Corrections

- **Mealie → Kitchenowl** — Mealie was retired in `9816c2ebfd`; cluster runs Kitchenowl in `collab/`
- **Istio + Kiali** added to stack-at-a-glance (was missing entirely — live in \`istio-system/\` and used for mcp-system traffic mgmt)
- **HolmesGPT duplicate removed** from AI section (lives in \`observability/\`, kept there)
- **KubeClaw / LangGraph** wording clarified — KubeClaw is being phased out in favor of LangGraph, not coexisting indefinitely
- **LLDAP** row added next to Authelia (directory backing OIDC)

### Additions

- New collapsible **MCP Servers** section listing all 14 servers behind the Authelia-gated mcp-gateway
- **Documents & Collaboration** expanded to cover the rest of the \`collab/\` namespace: Open WebUI, SearXNG, Glance, Atuin, IT-Tools, MediKeep, Nametag, Pump, Pump-cv
- New **🧠 AI agent pipeline** section:
  - Mermaid diagram of inputs → orchestration → inference → tools → outputs
  - Agent fleet roster (13 LangGraph agents — supervisor, researcher, coder, reviewer, triager, reporter, note-maker, homelab-engineer, smart-home-engineer, ml-tuner, errand-runner, property-coordinator, health-tracker)
  - Pipeline stages: inbox → triage → plan → approval (HITL via Zulip+Pushover) → execute → report
  - Local-first tiering table (qwen2.5:7b / qwen2.5:14b / Claude API escalation)
  - HolmesGPT alert triage flow (the one agent live in production today)
  - Current activation state — HolmesGPT live, LangGraph fleet plumbed but cold pending Spark arrival

## Test plan

- [x] Mealie/Kitchenowl: verified against \`git log\` (Mealie retired) and \`kubectl get pods -n collab\` (kitchenowl-0 running)
- [x] Istio: \`kubectl get pods -n istio-system\` confirms istiod + kiali running
- [x] KubeClaw + LangGraph both running today; phrasing reflects staged retirement
- [x] All 14 MCP servers confirmed in \`kubernetes/apps/mcp-system/\`
- [x] Agent roster cross-checked against \`feedback_local_first_agent_design\` memory
- [x] Pipeline stages match the 7 \`langgraph-*.json\` n8n workflows
- [ ] Mermaid renders correctly on GitHub PR preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)