### PR TITLE
docs(readme): add doc-writer (Scribner) to agent fleet roster

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,7 @@ A single `rwlove/langgraph-agents` FastAPI service runs the fleet. Each agent is
 | `errand-runner`        | One-shot real-world tasks (purchases, lookups, scheduling) |
 | `property-coordinator` | 3532 Foxhall workstreams (contractors, deck, pool)         |
 | `health-tracker`       | Local-only — never escalated to Claude API                 |
+| `doc-writer` (Scribner) | Sweeps repos for stale docs; drafts README + `docs/` patches as diffs when commits land |
 
 ### Pipeline stages
 


### PR DESCRIPTION
## Summary

One-line addition to the agent fleet table — `doc-writer` (Scribner, 📖) was added in \`langgraph-agents\` v0.2.0 and was missed when the AI agent pipeline section was originally drafted.

The agent's existing \`AGENTS.md\` in \`~/vaults/claude/agents/workspaces/doc-writer/\` already encodes the contract: it sweeps repos for commits-since-last-doc-update and produces README/\`docs/\` patches as diffs. No agent-config change needed; just surfacing it in the README.

Network agent is WIP and intentionally left out until it ships.

## Test plan

- [x] \`markdownlint-cli2 README.md\` → 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)