### PR TITLE
docs(p40): refresh for GPU Operator + Pascal-era cluster state

### DIFF
--- a/docs/src/p40.md
+++ b/docs/src/p40.md
@@ -1,110 +1,171 @@
-# nVIDIA Tesla P40
+# NVIDIA Tesla P40
 
-nVIDIA GPU ignored on Host (Dell R730xd, CentOS 9), PCI Passthrough to KVM VM, running CentOS 9 as a K8S node running nVIDIA Container Toolkit pods.
+24 GiB Pascal (sm_61) accelerator passed through to one Kubernetes node, time-sliced across multiple AI workloads.
 
-## Host
+## Overview
 
-### Ignore PCI device
+A single Tesla P40 lives in slot 6 of [`beast`][beast] (a Dell R730 hypervisor, not itself a k8s node), passed through via VFIO to the `worker8` VM. `worker8` joins the cluster as a normal worker node; the P40 is exposed to pods as `nvidia.com/gpu` resources, time-sliced 8 ways by the NVIDIA GPU Operator.
 
-1. Apend to GRUB_CMDLINE_LINUX in /etc/default/grub
+[beast]: https://github.com/rwlove/home-ops/blob/main/README.md#-hardware
 
-`intel_iommu=on pci-stub.ids=10de:1b38`
+## Hardware
 
-2. Update Grub
+| Field | Value |
+| --- | --- |
+| Card | NVIDIA Tesla P40 |
+| Architecture | Pascal (`sm_61`) |
+| VRAM | 24,576 MiB |
+| Host | `beast` (Dell R730, slot 6, PCIe 3.0 x16) |
+| Consumer VM | `worker8` (CentOS Stream 9) |
+| PCI passthrough | VFIO via `vfio-pci.ids=10de:1b38` |
+| Cluster resource | `nvidia.com/gpu` (8× time-sliced replicas) |
 
-`grubby --add-kernel $(grubby --default-kernel) --copy-default --args=vfio_pci.ids=10de:1b38 --title "Default kernel with vfio_pci" --make-default`
+## Host (beast) — PCI passthrough
 
-[IBM through-pci](https://www.ibm.com/docs/en/linux-on-systems?topic=through-pci)
+1. Append to `GRUB_CMDLINE_LINUX` in `/etc/default/grub`:
 
-3. reboot
+   ```text
+   intel_iommu=on pci-stub.ids=10de:1b38
+   ```
 
-### PCI Passthrough to VM (via virt-manager)
+2. Register the VFIO driver for the device:
 
-1. Add Hardware -> PCI Host Device
+   ```sh
+   grubby --add-kernel "$(grubby --default-kernel)" \
+     --copy-default \
+     --args=vfio_pci.ids=10de:1b38 \
+     --title "Default kernel with vfio_pci" \
+     --make-default
+   ```
 
-## In the VM
+3. Reboot.
 
-### Blacklist nouveau in VM
+4. In `virt-manager` for the `worker8` VM: **Add Hardware → PCI Host Device** → select the P40.
 
-1. echo "blacklist nouveau" > /etc/modprobe.d/blacklist-nouveau.conf 
+Reference: [IBM PCI passthrough docs](https://www.ibm.com/docs/en/linux-on-systems?topic=through-pci).
 
-2. Comment out the following block in /etc/X11/xorg.conf.d/10-nvidia.conf
+## VM (worker8) — driver installation
 
+Driver install on `worker8` is **manual** today, not operator-managed. The NVIDIA GPU Operator does not ship precompiled driver containers for CentOS Stream 9, and source-build mode needs entitled `kernel-devel` packages. Driver installation will flip to operator-managed when `worker8` is rebuilt onto a supported OS (deferred until a second GPU node arrives).
+
+### Blacklist `nouveau`
+
+```sh
+echo "blacklist nouveau" > /etc/modprobe.d/blacklist-nouveau.conf
 ```
-#Section "OutputClass"
-#    Identifier "nvidia"
-#    MatchDriver "nvidia-drm"
-#    Driver "nvidia"
-#    Option "AllowEmptyInitialConfiguration"
-#    Option "PrimaryGPU" "no"
-#    Option "SLI" "Auto"
-#    Option "BaseMosaic" "on"
-#EndSection
+
+Comment out the `nvidia` `OutputClass` section in `/etc/X11/xorg.conf.d/10-nvidia.conf`, then reboot.
+
+### Install the proprietary driver
+
+The P40 is Pascal — it **requires the proprietary closed driver**. Open kernel modules don't support sm_61.
+
+```sh
+dnf config-manager --add-repo \
+  "http://developer.download.nvidia.com/compute/cuda/repos/rhel9/$(uname -i)/cuda-rhel9.repo"
+
+dnf module install nvidia-driver:580-dkms
 ```
 
-3. reboot
+(`580` is the current branch; bump as newer LTS branches land.)
 
-### Install nVIDIA Driver
+Verify with `nvidia-smi`. The GPU should report 24 GiB and `sm_61`.
 
-`dnf config-manager --add-repo http://developer.download.nvidia.com/compute/cuda/repos/rhel9/$\(uname -i)/cuda-rhel9.repo`
+## Cluster integration — NVIDIA GPU Operator
 
-`dnf module install nvidia-driver:565-dkms`
+Everything above the kernel driver is managed declaratively by the GPU Operator HelmRelease at [`kubernetes/apps/kube-system/gpu-operator/app/helmrelease.yaml`](https://github.com/rwlove/home-ops/blob/main/kubernetes/apps/kube-system/gpu-operator/app/helmrelease.yaml).
 
-#### Install nVIDIA Container Toolkit
+| Component | State | Notes |
+| --- | --- | --- |
+| `driver.enabled` | **false** | Manual driver retained on worker8 until OS rebuild |
+| `toolkit.enabled` | true | Operator installs `nvidia-container-toolkit` into `/usr/local/nvidia` |
+| `devicePlugin.enabled` | true | Operator manages the device plugin (replaces the standalone HelmRelease that previously lived here) |
+| `dcgmExporter.enabled` | true | Prometheus scrape via `ServiceMonitor` |
+| `gfd.enabled` | true | GPU Feature Discovery labels worker8 with `nvidia.com/gpu.*` |
+| `nodeStatusExporter` | true | Surfaces operator state |
+| `mig.strategy` | `none` | MIG is a Hopper/Ampere feature; not applicable to Pascal |
+| `migManager.enabled` | false | Same |
 
-`curl -s -L https://nvidia.github.io/libnvidia-container/stable/rpm/nvidia-container-toolkit.repo | sudo tee /etc/yum.repos.d/nvidia-container-toolkit.repo`
+### Time-slicing
 
-`dnf install nvidia-container-toolkit`
+The single P40 is exposed to the scheduler as **8 replicas** of `nvidia.com/gpu` via the `gpu-operator-time-slicing-config` ConfigMap at [`timeslicing-config.yaml`](https://github.com/rwlove/home-ops/blob/main/kubernetes/apps/kube-system/gpu-operator/app/timeslicing-config.yaml):
 
-`nvidia-ctk runtime configure --runtime=crio`
+```yaml
+sharing:
+  timeSlicing:
+    renameByDefault: false
+    failRequestsGreaterThanOne: false
+    resources:
+      - name: nvidia.com/gpu
+        replicas: 8
+```
 
-#### Configure the runtime
+Time-slicing multiplexes **compute**, not memory. The 24 GiB VRAM is one shared pool — pods don't get a memory partition. Sizing your VRAM budget across resident workloads matters more than the replica count.
 
-`nvidia-ctk runtime configure --runtime=crio`
+### Workload-side request
 
-#### Results
+Workloads request a GPU via the standard resource pattern:
 
-[/etc/crio/crio.conf](https://raw.githubusercontent.com/rwlove/home-ops/refs/heads/main/docs/assets/crio.conf)
+```yaml
+resources:
+  limits:
+    nvidia.com/gpu: 1
+```
 
-[/etc/nvidia-container-runtime/config.toml](https://raw.githubusercontent.com/rwlove/home-ops/refs/heads/main/docs/assets/config.toml)
+`failRequestsGreaterThanOne: false` means asking for more than 1 is allowed but the time-slicing config caps the effective concurrency at 8.
 
+## Pascal (sm_61) constraints
 
-## Kubernetes
+The P40 is on the wrong side of two recent NVIDIA upstream breaks:
 
-### Install nVIDIA Device Plugin
+1. **PyTorch ≥ 2.7 + cu128 dropped sm_61.** Anything pinned to a torch 2.7+ wheel won't run on the P40. immich-pet-tagger is the canonical example: the cluster pulls the [`rwlove/immich-pet-tagger:v1.2.0-p40` fork](https://github.com/rwlove/immich-pet-tagger) which is pinned to torch 2.6.0+cu124. Drop this fork the day a non-Pascal GPU joins the cluster.
+2. **Open kernel modules are Volta-or-newer.** `useOpenKernelModules: true` will silently fail on Pascal. Keep the proprietary driver.
 
-[Helm Chart](https://raw.githubusercontent.com/rwlove/home-ops/main/kubernetes/apps/kube-system/nvidia-device-plugin/app/helmrelease.yaml)
+When `worker8` is rebuilt onto Ubuntu 24.04 LTS (DGX-aligned), `driver.enabled` flips to `true` for that node only — Spark (Blackwell) and any future cards can use the open module variant via `nodeSelector`-scoped operator config.
 
-## Configuration with NFD / LocalAI / Ollama / etc
+## Workloads currently using the P40
 
-### LocalAI
+Steady-state VRAM ~14.5 GiB used out of 24 GiB. Most consumers are resident; ComfyUI and AV1 transcodes spike on demand.
 
-1. make sure runtime is set correctly
-2. confirm that localai is running on the `nvidia-container-runtime`
+| Workload | Behavior | Approx VRAM |
+| --- | --- | --- |
+| Ollama (Qwen 2.5 7B/14B, embeddings) | Resident; idles down on keep-alive timeout | 5–9 GiB |
+| Immich machine-learning (CLIP + face recognition) | Resident | ~4 GiB |
+| Whisper STT (`wyoming-services`, `large-v3-turbo` preloaded) | Resident | ~1.6 GiB |
+| ComfyUI (SD checkpoints / Flux fp8) | On-demand | 2–16 GiB |
+| Frigate GenAI captions (`gemma3:4b` via Ollama) | On-demand | ~3 GiB |
+| `immich-pet-tagger` (Pascal fork) | On-demand | varies |
+| `pump-cv` (yolov8m-pose, cuda:0) | Resident | ~1.5 GiB |
+| `av1corrector` (NVENC) | On-demand during transcode | ~0.2 GiB |
 
-### stable-diffusion
+## Monitoring
 
-## On node install TCMalloc
+DCGM-exporter ships GPU metrics into Prometheus. The standard NVIDIA GPU dashboards (DCGM `0_0_1`) work in Grafana once the data source is wired up. Watch:
 
-dnf install -y gperftools gperftools-deve
+- `DCGM_FI_DEV_GPU_UTIL` — compute utilization
+- `DCGM_FI_DEV_FB_USED` — VRAM in use (the steady-state ceiling matters more than utilization)
+- `DCGM_FI_DEV_GPU_TEMP` — important for fan control discussion below
 
-## Other
+Alerts are defined in [`monitoring/alerts.yaml`](https://github.com/rwlove/home-ops/blob/main/kubernetes/apps/kube-system/gpu-operator/app/monitoring/alerts.yaml).
 
-### nVidia HTOP
+## Tools
 
-Improved `nvidia-smi` command.
+- [`nvidia-htop`](https://github.com/peci1/nvidia-htop) — improved `nvidia-smi` with per-process detail.
+- `nvidia-smi --query-gpu=memory.used --format=csv -l 5` — quick VRAM watch.
+- `dcgmi diag -r 1` — quick self-test via DCGM (requires running on the host with the driver).
 
-[nVidia HTOP](https://github.com/peci1/nvidia-htop)
+## Fan control
 
+The R730xd doesn't natively recognize the P40, so its default fan curve is incorrect under sustained GPU load. Below are workarounds — **none of them implemented in this cluster yet**:
 
-### Fan Control Methods
+- [IPMI Fan Control (DrSpeedy)](https://github.com/DrSpeedy/ipmi_fancontrol-ng)
+- [Fan control script (fragtion)](https://gist.github.com/fragtion/92ab3b33cfbaccb8e70037fb4f1b6c42)
+- [iDRAC7 fan control (brezlord)](https://github.com/brezlord/iDRAC7_fan_control)
 
-The R730XD doesn't officially support the P40 so it doesn't natively adjust the fan. Below are some workarounds that I have not implemented yet.
+Today the GPU is well within thermal envelope on the cluster's typical workloads; fan control becomes interesting when sustained Flux / fine-tuning workloads are added.
 
-[IPMI Fan Control](https://github.com/DrSpeedy/ipmi_fancontrol-ng)
+## Roadmap
 
-[Fan Control Script 1](https://gist.github.com/fragtion/92ab3b33cfbaccb8e70037fb4f1b6c42)
-
-[Fan Control Script 2](https://github.com/brezlord/iDRAC7_fan_control)
-
-
+- **Second GPU node (Spark / NVIDIA Ascent GX10)** is the trigger for re-evaluating worker8's OS and driver path. See the GPU upgrade decision in memory.
+- **worker8 OS rebuild** to Ubuntu 24.04 LTS will flip `driver.enabled` to `true` for that node and let the operator manage the entire stack end-to-end. Deferred until two GPU nodes makes standardization worth the rebuild churn.
+- **Drop the `immich-pet-tagger` Pascal fork** the day a non-Pascal GPU joins the cluster.


### PR DESCRIPTION
## Summary

The current \`docs/src/p40.md\` describes the pre-migration setup (manual \`nvidia-device-plugin\` HelmRelease, manual \`nvidia-ctk runtime configure\`). That HelmRelease was removed when the GPU Operator migration landed on 2026-05-07, which is also what's failing the lychee link checker:

> \`[404] https://raw.githubusercontent.com/rwlove/home-ops/main/kubernetes/apps/kube-system/nvidia-device-plugin/app/helmrelease.yaml\`

This rewrites the doc to match what's actually running.

## What changed

- **GPU Operator section added** — points at the live HelmRelease and explains why \`driver.enabled: false\` is the deliberate choice on worker8 (no precompiled driver for CentOS Stream 9, deferred until the OS rebuild that's gated on a second GPU node).
- **Time-slicing documented** — the 8-replica \`gpu-operator-time-slicing-config\` ConfigMap, with the explicit "compute is sliced, memory isn't" caveat.
- **Pascal constraints called out** — \`sm_61\` requires proprietary driver, PyTorch ≥ 2.7 + cu128 dropped sm_61, hence the \`rwlove/immich-pet-tagger:v1.2.0-p40\` fork.
- **Workloads table** — Ollama, ComfyUI, Whisper, Immich ML, Frigate GenAI, immich-pet-tagger, pump-cv, av1corrector with steady-state VRAM (~14.5 GiB / 24 GiB).
- **DCGM monitoring** — link to \`alerts.yaml\` and the key metrics to watch.
- **Roadmap** — second GPU node → worker8 OS rebuild → operator-managed driver → drop Pascal fork.

## Dropped

- LocalAI section (cluster uses Ollama, not LocalAI)
- Orphaned TCMalloc one-liner that lost its surrounding context
- Standalone \`nvidia-device-plugin\` link — the 404 that was failing lychee

## Test plan

- [x] \`markdownlint-cli2 docs/src/p40.md\` → 0 errors
- [x] All 3 in-repo GitHub blob URLs resolve to existing files
- [ ] lychee on the next CI run

🤖 Generated with [Claude Code](https://claude.com/claude-code)