### PR TITLE
feat(network-policy): selfhosted baseline allow-policies (Phase 1)

### DIFF
--- a/kubernetes/apps/selfhosted/kustomization.yaml
+++ b/kubernetes/apps/selfhosted/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 namespace: selfhosted
 components:
   - ../../components/alerts
+  - ../../components/network-policy/baseline
 resources:
   - ./namespace.yaml
   - ./webhook/ks.yaml


### PR DESCRIPTION
## Summary

Phase 1, PR 1 of the [NetworkPolicy rollout](docs/src/networkpolicy_rollout_plan.md). Adds the four baseline allow-policies to the `selfhosted` namespace via the kustomize component shipped in Phase 0.

- 4 `CiliumNetworkPolicy` resources land in `selfhosted`: `allow-dns`, `allow-apiserver`, `allow-intra-namespace`, `allow-monitoring-scrape`
- All four have `enableDefaultDeny: false` → additive only
- All four have `policy.cilium.io/audit-mode: enabled` → drops would log as `DROPPED-AUDITED`, not enforce
- No `default-deny` in this PR; that's PR 3 after 24h soak

## Test plan

- [ ] Flux reconciles `selfhosted` Kustomization cleanly
- [ ] `kubectl get cnp -n selfhosted` shows all 4 policies present
- [ ] `kubectl get pods -n selfhosted` — webhook stays Ready
- [ ] `hubble observe --namespace selfhosted --verdict DROPPED-AUDITED --last 100` shows nothing surprising after 24h
- [ ] Prometheus `hubble_drop_total{namespace="selfhosted"}` stays flat

🤖 Generated with [Claude Code](https://claude.com/claude-code)