### PR TITLE
feat(network-policy): selfhosted default-deny enforce (Phase 1)

### DIFF
--- a/kubernetes/apps/selfhosted/kustomization.yaml
+++ b/kubernetes/apps/selfhosted/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: selfhosted
 components:
   - ../../components/alerts
   - ../../components/network-policy/baseline
+  - ../../components/network-policy/default-deny
 resources:
   - ./namespace.yaml
   - ./webhook/ks.yaml

--- a/kubernetes/apps/selfhosted/webhook/app/cnp-allow-from-gateway.yaml
+++ b/kubernetes/apps/selfhosted/webhook/app/cnp-allow-from-gateway.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: webhook-allow-from-gateway
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: webhook
+  # Additive — the default-deny CNP from network-policy/default-deny
+  # is what triggers the lockdown; this rule punches a hole through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP

--- a/kubernetes/apps/selfhosted/webhook/app/kustomization.yaml
+++ b/kubernetes/apps/selfhosted/webhook/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow-from-gateway.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
 configMapGenerator:

--- a/kubernetes/components/network-policy/baseline/README.md
+++ b/kubernetes/components/network-policy/baseline/README.md
@@ -13,6 +13,7 @@ the first step of the NetworkPolicy rollout. See the full plan:
 | `allow-apiserver` | Egress to `reserved:kube-apiserver` entity, port 6443. **Entity selector, not CIDR** — Cilium 1.19 with `policy-cidr-match-mode=""` silently drops apiserver traffic from CIDR-only rules. |
 | `allow-intra-namespace` | Pods in the same namespace can talk to each other (ingress + egress). Covers the bjw-s init-container / sidecar / companion-deployment pattern without per-app rules. |
 | `allow-monitoring-scrape` | Ingress from the `observability` namespace's Prometheus pod (`app.kubernetes.io/name: prometheus`). |
+| `allow-host-probes` | Ingress from `reserved:host` + `reserved:remote-node` so kubelet liveness/readiness/startup probes work after default-deny lands. Without this, every pod under default-deny goes Unready and restarts in a loop. |
 
 All four ship with:
 

--- a/kubernetes/components/network-policy/baseline/allow-host-probes.yaml
+++ b/kubernetes/components/network-policy/baseline/allow-host-probes.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-host-probes
+  annotations:
+    # Audit mode: drops are logged as DROPPED-AUDITED but NOT enforced.
+    # Remove this annotation to flip the namespace into enforce mode.
+    # Lifecycle documented in this component's README.
+    policy.cilium.io/audit-mode: "enabled"
+spec:
+  endpointSelector: {}
+  # Additive-only.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # kubelet on the local node runs liveness/readiness/startup probes;
+    # without this allow, every pod under default-deny goes Unready and
+    # gets restarted. `remote-node` covers cross-node cilium-agent health
+    # checks and HA control-plane probes that occasionally cross nodes.
+    - fromEntities:
+        - host
+        - remote-node

--- a/kubernetes/components/network-policy/default-deny/README.md
+++ b/kubernetes/components/network-policy/default-deny/README.md
@@ -1,0 +1,78 @@
+# network-policy/default-deny
+
+Reusable kustomize Component providing the namespace-wide
+`default-deny` `CiliumNetworkPolicy`. **This component locks down
+the namespace.** Pair it with `network-policy/baseline` + per-app
+allow overlays; without those, every pod loses all ingress and
+egress.
+
+## What this provides
+
+One CNP, `default-deny`, with `endpointSelector: {}` and
+`ingressDeny: [{}]` + `egressDeny: [{}]`. Cilium 1.14+ explicit
+deny primitive; relies on `enable-non-default-deny-policies=true`
+(set cluster-wide in `cilium-config`).
+
+## How a namespace includes it
+
+In the namespace's `kustomization.yaml`, alongside the baseline
+component:
+
+```yaml
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: <ns>
+components:
+  - ../../components/network-policy/baseline
+  - ../../components/network-policy/default-deny
+resources:
+  - ./namespace.yaml
+  # ...
+```
+
+Adjust the relative path to match the namespace's actual depth.
+
+## Pre-flight before adding to a new namespace
+
+The baseline + per-app overlays must cover every legitimate flow
+in the namespace, or those flows will be denied the moment this
+component lands. Minimum coverage:
+
+- `allow-dns` (baseline) — pods can resolve names
+- `allow-apiserver` (baseline) — pods using kube-clients work
+- `allow-intra-namespace` (baseline) — sidecar/init/companion deploys talk
+- `allow-monitoring-scrape` (baseline) — Prometheus can scrape `/metrics`
+- `allow-host-probes` (baseline) — kubelet liveness/readiness/startup probes work
+- Pattern A overlay (per-app) — Envoy Gateway → ingress-served apps
+- Pattern B/C/etc. overlays per the rollout plan for DB / S3 / external API needs
+
+See `docs/src/networkpolicy_rollout_plan.md` for the full pattern
+catalog and which overlays each app needs.
+
+## Audit-mode → enforce-mode
+
+This component intentionally has **no** `policy.cilium.io/audit-mode`
+annotation. Adding it lands the namespace in enforce mode immediately.
+
+For the audit-mode-first rollout pattern (per
+`networkpolicy_rollout_plan.md` Decision #3), either:
+
+1. **Per-pod audit (canary):** annotate one pod with
+   `policy.cilium.io/audit-mode: enabled` *before* this component
+   ships, watch Hubble for 48h, then remove the annotation.
+2. **Per-namespace patch:** add a `patches:` block in the namespace's
+   kustomization that adds the annotation to this CNP, then remove
+   the patch when the audit window passes clean.
+
+The canary path is what the rollout plan codifies. The patch path
+is the escape valve.
+
+## What this is NOT
+
+- Not for `kube-system` or `flux-system` — explicitly out of scope.
+- Not safe to add without the baseline + per-app overlays. Adding
+  this component alone breaks every pod in the namespace.
+- Not reversible by Cilium's policy ordering — this CNP composes
+  with allows via OR semantics, but if no allow matches a flow,
+  the flow is dropped.

--- a/kubernetes/components/network-policy/default-deny/default-deny.yaml
+++ b/kubernetes/components/network-policy/default-deny/default-deny.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: default-deny
+spec:
+  # All pods in this namespace.
+  endpointSelector: {}
+  # Cilium 1.14+ explicit deny primitive. With `enable-non-default-deny-policies=true`
+  # (set cluster-wide in cilium-config), this triggers default-deny for matched
+  # endpoints without the empty-allow trick. Companion `allow-*` CNPs in the
+  # baseline + per-app overlays are what punch holes through this.
+  ingressDeny:
+    - {}
+  egressDeny:
+    - {}

--- a/kubernetes/components/network-policy/default-deny/kustomization.yaml
+++ b/kubernetes/components/network-policy/default-deny/kustomization.yaml
@@ -3,8 +3,4 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 resources:
-  - ./allow-apiserver.yaml
-  - ./allow-dns.yaml
-  - ./allow-host-probes.yaml
-  - ./allow-intra-namespace.yaml
-  - ./allow-monitoring-scrape.yaml
+  - ./default-deny.yaml


### PR DESCRIPTION
## Summary

Phase 1, PR 2 of the [NetworkPolicy rollout](docs/src/networkpolicy_rollout_plan.md). Collapses the original plan's PR 2 + PR 3 + PR 4 into one — selfhosted has a single idle app (`webhook`), and you authorized direct-to-enforce (no audit-mode soak).

**Reusable new pieces (other namespaces will use these):**

- `components/network-policy/default-deny/` — new component. `ingressDeny: [{}]` + `egressDeny: [{}]`, no audit-mode annotation, enforces on apply.
- `components/network-policy/baseline/allow-host-probes.yaml` — kubelet probes ingress allow (`reserved:host` + `reserved:remote-node`). Without this, default-deny breaks every pod's readiness/liveness.

**selfhosted-specific:**

- `apps/selfhosted/webhook/app/cnp-allow-from-gateway.yaml` — Pattern A: ingress from `network/envoy` pods on port 8080.
- `apps/selfhosted/kustomization.yaml` — adds `default-deny` component reference.

## Test plan

- [ ] Flux reconciles cleanly (`flux get kustomization -A | grep selfhosted`)
- [ ] `kubectl get cnp -n selfhosted` shows 6 CNPs (allow-apiserver, allow-dns, allow-host-probes, allow-intra-namespace, allow-monitoring-scrape, default-deny) + `webhook-allow-from-gateway`
- [ ] `kubectl get pods -n selfhosted` — webhook stays Ready, no restart count bump
- [ ] `curl https://renovate-webhook.${SECRET_DOMAIN}` returns webhook's normal response (not a 5xx from envoy timing out on a denied connection)
- [ ] `hubble observe --namespace selfhosted --verdict DROPPED --last 100` shows nothing critical (some noise possible from unrelated probes; verify nothing app-functional)

## Rollback

- Fast: `flux suspend kustomization -n flux-system cluster-apps && kubectl delete cnp -n selfhosted default-deny`
- Full: revert this PR, Flux reconciles back

🤖 Generated with [Claude Code](https://claude.com/claude-code)