### PR TITLE
feat(network-policy): ai baseline allow-policies (Phase 2 PR 1)

### DIFF
--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -3,6 +3,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: ai
+components:
+  - ../../components/network-policy/baseline
 resources:
   - ./namespace.yaml
   - ./priority-class.yaml


### PR DESCRIPTION
## Summary

Phase 2, PR 1 for the `ai` namespace. Additive baseline only — no enforcement, no risk. Adds the `network-policy/baseline` component reference; 5 allow-policies land in `ai`.

## Why baseline-only here

`ai` has 10 apps (ollama, langgraph-agents, paperless-ai, khoj + oauth2-proxy, kubeclaw + chromium/qmd, comfyui, mcp-inspector, sync-receiver) with 7 HTTPRoutes and several cross-namespace deps. Direct-to-enforce (selfhosted's pattern) is too risky here. Sequence:

1. **This PR** — baseline only (additive). Soak 24h.
2. PR 2 — per-app Pattern A/B/C overlays (ingress allows, cross-ns DB egress, external FQDNs).
3. PR 3 — `default-deny` with audit-mode for 48h. Analyze `DROPPED-AUDITED` flows, add allow rules for anything legitimate.
4. PR 4 — flip audit annotation off, namespace is locked.

## Test plan

- [ ] Flux reconciles `ai` Kustomization cleanly
- [ ] `kubectl get cnp -n ai` shows 5 baseline policies present
- [ ] All ai pods stay Ready, no restart bump
- [ ] `hubble observe --namespace ai --verdict DROPPED-AUDITED --since 1h` stays empty for 24h (baseline allows are additive; no drops expected)

## Note (out of scope)

`ai/kustomization.yaml`'s existing `resources:` list isn't alphabetically sorted per `kustomize.config.sorting.instructions.md` (khoj entries are at the bottom, not in their sort position). Long-standing drift; left untouched in this PR. Worth a separate sort-only PR if you want it tidied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)