### PR TITLE
feat(network-policy): ai default-deny in cluster-wide audit mode (Phase 2)

### DIFF
--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 namespace: ai
 components:
   - ../../components/network-policy/baseline
+  - ../../components/network-policy/default-deny
 resources:
   - ./namespace.yaml
   - ./priority-class.yaml

--- a/kubernetes/apps/kube-system/cilium/app/values.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/values.yaml
@@ -91,6 +91,14 @@ hubble:
 pmtuDiscovery:
   enabled: true
 
+# TEMPORARY (Phase 2 of NetworkPolicy rollout, 2026-05-17): cluster-wide
+# audit mode so default-deny CNPs in `ai` (and any subsequent Phase 2
+# namespace) log drops as DROPPED-AUDITED instead of enforcing. Disable
+# this when ai's per-app overlays are finalized — selfhosted (the only
+# existing default-deny consumer) re-enforces automatically when this
+# flips back. See docs/src/networkpolicy_rollout_plan.md.
+policyAuditMode: true
+
 securityContext:
   capabilities:
     ciliumAgent:


### PR DESCRIPTION
## Summary

Phase 2 PR 2 for `ai`. Two changes paired:

1. **`cilium/app/values.yaml`** — enable `policyAuditMode: true` cluster-wide. Marked TEMPORARY in a comment; this comes off in PR 3 when ai's overlays are finalized.
2. **`apps/ai/kustomization.yaml`** — add `default-deny` component reference. With the cluster-wide flag, default-deny logs `DROPPED-AUDITED` flows instead of enforcing.

## Why this path

`policy.cilium.io/audit-mode` annotation on individual CNPs is a no-op in Cilium 1.19 without the cluster-wide `policy-audit-mode` flag set. The annotation Phase 0 stamped on baseline allows didn't do anything (didn't matter — they're additive). For ai's default-deny to be observable-without-enforcing, the cluster-wide flag is the supported mechanism.

## Tradeoffs to know

- **selfhosted's enforcement temporarily becomes audit.** The webhook keeps working (audit = permissive). When PR 3 flips the flag off, selfhosted re-enforces automatically. ~48h enforcement gap.
- **Cilium agent rolling restart** when the helm value applies. Brief CNI hiccup possible per node (typically <30s).
- **No other namespace currently has default-deny**, so audit-mode flag has no observable effect on them.

## Test plan

- [ ] Flux reconciles cilium HelmRelease, daemonset rollout completes
- [ ] `kubectl get cm -n kube-system cilium-config -o yaml | grep policy-audit-mode` shows `enabled`
- [ ] `kubectl get cnp -n ai` shows 6 policies present (5 baseline + default-deny)
- [ ] All ai pods stay Ready (selfhosted webhook too)
- [ ] Wait 30 min, then `hubble observe --namespace ai --verdict DROPPED-AUDITED --since 30m` shows actual flows that *would* be denied

## After 48h soak

PR 3 = write Pattern overlays based on observed `DROPPED-AUDITED` flows + flip `policyAuditMode: false`. Selfhosted re-enforces; ai enforces for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)