### PR TITLE
chore(renovate): always open a PR — fix group regex + drop branch automerge

### DIFF
--- a/.github/renovate/autoMerge.json5
+++ b/.github/renovate/autoMerge.json5
@@ -57,6 +57,8 @@
       matchManagers: ["github-actions"],
       matchPackageNames: [
         "/^actions\//",
+        "/^anthropics\//",
+        "/^github\//",
         "/^renovatebot\//",
       ],
       automerge: true,

--- a/.github/renovate/autoMerge.json5
+++ b/.github/renovate/autoMerge.json5
@@ -1,8 +1,10 @@
 // Convention:
 //   matchPackageNames entries are regex when wrapped in /.../ slashes,
 //   exact matches otherwise. Keep similar entries in the same form.
-//   Trusted-upstream + automergeType=branch rules use ignoreTests=true;
-//   everything else keeps tests as a gate (ignoreTests=false).
+//   Trusted-upstream rules use ignoreTests=true; everything else keeps
+//   tests as a gate (ignoreTests=false).
+//   automergeType=pr everywhere — we always want a PR (no silent
+//   branch fast-forwards that hide on the dependency dashboard).
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   packageRules: [
@@ -36,7 +38,7 @@
       description: "Auto-merge GitHub Actions",
       matchManagers: ["github-actions"],
       automerge: true,
-      automergeType: "branch",
+      automergeType: "pr",
       matchUpdateTypes: ["minor", "patch", "digest"],
       minimumReleaseAge: "3 days",
       ignoreTests: true,
@@ -62,7 +64,7 @@
         "/^renovatebot\//",
       ],
       automerge: true,
-      automergeType: "branch",
+      automergeType: "pr",
       matchUpdateTypes: ["minor", "patch", "digest"],
       minimumReleaseAge: "1 minute",
       ignoreTests: true,
@@ -71,16 +73,16 @@
       description: "Auto-merge GitHub Releases",
       matchDatasources: ["github-releases"],
       automerge: true,
-      automergeType: "branch",
+      automergeType: "pr",
       matchUpdateTypes: ["minor", "patch"],
       matchPackageNames: ["/external-dns/", "/gateway-api/", "/prometheus-operator/"],
       ignoreTests: true,
     },
     {
-      description: "Auto-merge rwlove personal container images (branch + PR)",
+      description: "Auto-merge rwlove personal container images",
       matchDatasources: ["docker"],
       automerge: true,
-      automergeType: "branch",
+      automergeType: "pr",
       matchPackageNames: [
         "/^ghcr\\.io\\/rwlove\\//",
       ],

--- a/.github/renovate/groups.json5
+++ b/.github/renovate/groups.json5
@@ -38,12 +38,15 @@
       description: "Kubernetes Group",
       groupName: "Kubernetes",
       matchDatasources: ["docker"],
+      // Anchored to the upstream registry path so unrelated images that happen
+      // to contain "kubelet" (e.g. ghcr.io/postfinance/charts/kubelet-csr-approver)
+      // don't get grouped here and held by minimumGroupSize.
       matchPackageNames: [
-        "/kube-apiserver/",
-        "/kube-controller-manager/",
-        "/kube-proxy/",
-        "/kube-scheduler/",
-        "/kubelet/",
+        "registry.k8s.io/kube-apiserver",
+        "registry.k8s.io/kube-controller-manager",
+        "registry.k8s.io/kube-proxy",
+        "registry.k8s.io/kube-scheduler",
+        "registry.k8s.io/kubelet",
       ],
       group: {
         commitMessageTopic: "{{{groupName}}} group",

--- a/.github/renovate/groups.json5
+++ b/.github/renovate/groups.json5
@@ -1,3 +1,8 @@
+// Groups still bundle co-released sibling updates into a single PR,
+// but minimumGroupSize is intentionally omitted: never hold a group
+// off the PR queue waiting for siblings — open the PR with whatever
+// updates are ready right now. The user wants PRs, not dashboard
+// "force creation" entries.
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   packageRules: [
@@ -9,7 +14,6 @@
       group: {
         commitMessageTopic: "{{{groupName}}} group",
       },
-      minimumGroupSize: 2,
     },
     {
       description: "Actions Runner Controller Group",
@@ -22,7 +26,6 @@
       group: {
         commitMessageTopic: "{{{groupName}}} group",
       },
-      minimumGroupSize: 2,
     },
     {
       description: "Flux Operator Group",
@@ -32,7 +35,6 @@
       group: {
         commitMessageTopic: "{{{groupName}}} group",
       },
-      minimumGroupSize: 3,
     },
     {
       description: "Kubernetes Group",
@@ -40,7 +42,7 @@
       matchDatasources: ["docker"],
       // Anchored to the upstream registry path so unrelated images that happen
       // to contain "kubelet" (e.g. ghcr.io/postfinance/charts/kubelet-csr-approver)
-      // don't get grouped here and held by minimumGroupSize.
+      // don't get grouped here.
       matchPackageNames: [
         "registry.k8s.io/kube-apiserver",
         "registry.k8s.io/kube-controller-manager",
@@ -51,7 +53,6 @@
       group: {
         commitMessageTopic: "{{{groupName}}} group",
       },
-      minimumGroupSize: 5,
     },
     {
       description: "Rook-Ceph Group",
@@ -61,7 +62,6 @@
       group: {
         commitMessageTopic: "{{{groupName}}} group",
       },
-      minimumGroupSize: 2,
     },
   ],
 }


### PR DESCRIPTION
## Summary

Two-pass cleanup of the Renovate Dashboard so updates flow through as visible PRs instead of "force creation" entries.

**Pass 1 — fix accidental grouping + expand trusted actions:**
- `groups.json5`: Kubernetes-group `matchPackageNames` regex was `/kubelet/`, which silently matched `ghcr.io/postfinance/charts/kubelet-csr-approver` and held it under `minimumGroupSize: 5`. Anchored to exact `registry.k8s.io/*` paths.
- `autoMerge.json5`: trusted GitHub Actions list (1-minute `minimumReleaseAge`) only included `actions/*` and `renovatebot/*`. Added `anthropics/*` (claude-code-action, used by `renovate-review.yaml`) and `github/*` (codeql-action).

**Pass 2 — always open a PR:**
- `autoMerge.json5`: every `automergeType: "branch"` → `"pr"` (4 rules). Branch-type automerge silently fast-forwards into main and parks anything that can't merge cleanly on the dashboard with no PR to look at. PR-type still auto-merges when the rule allows; the PR just exists while it happens.
- `groups.json5`: dropped `minimumGroupSize` from all 5 groups. Grouping is retained (co-released siblings still collapse into one PR), but the group no longer holds back the PR when only a subset is ready.

## Non-changes

- Branch protection on `main` is off, so `automergeType: branch` is not blocked by GitHub. The original "Other Branches" stuck-state was Renovate's own dashboard surfacing of branch-only updates that hadn't reached merge criteria.
- `minimumReleaseAge` retained (3-day general, 1-minute trusted) — safety against unstable releases, not a confirmation gate.
- Node 22→24 (major) still requires dashboard confirmation — no auto-merge rule matches major bumps. Out of scope for this PR.

## Test plan

- [ ] Dashboard #10329 next refresh: "Minimum group size" and "Other Branches" buckets shrink. Trusted actions appear as PRs (auto-merging within minutes).
- [ ] kubelet-csr-approver opens its own PR instead of waiting for 4 sibling Kubernetes updates.
- [ ] Verify no surprise auto-merges land. PR-type automerge respects `ignoreTests` the same way branch-type did, so behavior at merge time should be equivalent — just visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)