### PR TITLE
chore(renovate): major bumps always open a PR, never auto-merge

### DIFF
--- a/.github/renovate/packageRules.json5
+++ b/.github/renovate/packageRules.json5
@@ -2,6 +2,12 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "packageRules": [
     {
+      "description": "Major updates: always open a PR, never auto-merge — manual review",
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": false,
+      "automerge": false
+    },
+    {
       "matchDatasources": ["docker", "github-tags"],
       "matchPackageNames": ["ghcr.io/fluxcd/flux-manifests", "fluxcd/flux2"],
       "groupName": "fluxcd/flux2"


### PR DESCRIPTION
## Summary

Follow-up to #11428. Adds an explicit top-of-list packageRule for `matchUpdateTypes: ["major"]` that disables `dependencyDashboardApproval` and pins `automerge: false`.

Resolves the dangling node 22→24 case from Renovate Dashboard #10329 where the major bump was parked under "Other Branches" with a "force creation" affordance. After this lands:

- Major version bumps flow through as a normal PR automatically (no dashboard approval).
- Major version bumps never auto-merge — a human reviews and merges.

The two behaviors are coupled on purpose: the rule is the canonical place to land "major updates are different" if we ever need to add more nuance (e.g. labels, assignees, scheduling).

## Test plan

- [ ] Next Renovate run: the node 22→24 dashboard entry becomes an open PR labeled `type/major`.
- [ ] PR sits open awaiting manual merge (no auto-merge label, no Renovate auto-merge attempt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)