### PR TITLE
feat(snmp-exporter): port NUT alerts to APC UPS SNMP PrometheusRule

### DIFF
--- a/kubernetes/apps/observability/exporters/snmp-exporter/app/apc-ups/prometheusrule.yaml
+++ b/kubernetes/apps/observability/exporters/snmp-exporter/app/apc-ups/prometheusrule.yaml
@@ -8,16 +8,45 @@ spec:
   groups:
     - name: snmp-exporter-apc-ups.rules
       rules:
+        - alert: SnmpExporterApcUpsAbsent
+          annotations:
+            description: APC UPS SNMP exporter has disappeared from Prometheus target discovery.
+            summary: APC UPS SNMP exporter is down.
+          expr: absent(up{job=~".*snmp-exporter-apc-ups.*"} == 1)
+          for: 5m
+          labels:
+            severity: critical
         - alert: UPSOnBattery
           annotations:
-            summary: ZPM {{$labels.instance}} is running on batteries
-              and has less than 20 minutes of battery left
-          expr: |
-            (
-              upsAdvBatteryRunTimeRemaining/60/100 <= 20
-            and
-              upsBasicBatteryTimeOnBattery > 0
-            )
+            description: UPS {{ $labels.target }} has lost power and is running on battery.
+            summary: UPS is running on battery.
+          # upsBasicOutputStatus: 2=onLine, 3=onBattery
+          expr: upsBasicOutputStatus == 3
+          for: 10s
+          labels:
+            severity: critical
+        - alert: UPSLowRuntime
+          annotations:
+            description: UPS {{ $labels.target }} is on battery and has less than 10 minutes of runtime remaining.
+            summary: UPS battery runtime is low.
+          # upsAdvBatteryRunTimeRemaining is in TimeTicks (1/100s); 60000 = 10 min.
+          expr: (upsBasicOutputStatus == 3) and (upsAdvBatteryRunTimeRemaining < 60000)
           for: 1m
+          labels:
+            severity: critical
+        - alert: UPSLowBattery
+          annotations:
+            description: UPS {{ $labels.target }} battery charge is {{ $value }}%, below 50%.
+            summary: UPS battery charge low.
+          expr: upsAdvBatteryCapacity < 50
+          labels:
+            severity: warning
+        - alert: UPSBatteryReplace
+          annotations:
+            description: UPS {{ $labels.target }} battery needs to be replaced.
+            summary: Replace UPS battery.
+          # upsAdvBatteryReplaceIndicator: 1=noBatteryNeedsReplacing, 2=batteryNeedsReplacing
+          expr: upsAdvBatteryReplaceIndicator == 2
+          for: 10s
           labels:
             severity: critical


### PR DESCRIPTION
## Summary

Step 1 of the NUT-to-SNMP consolidation. Adds SNMP-side equivalents of the alerts currently served by \`prometheus-nut-exporter\`, and rewrites the existing UPSOnBattery rule to be cleaner.

- Adds **\`SnmpExporterApcUpsAbsent\`** — alert if the SNMP exporter falls off Prometheus target discovery
- Adds **\`UPSLowRuntime\`** — on battery + <10min runtime remaining (TimeTicks unit, 60000 = 10 min)
- Adds **\`UPSLowBattery\`** — \`upsAdvBatteryCapacity < 50\`
- Adds **\`UPSBatteryReplace\`** — \`upsAdvBatteryReplaceIndicator == 2\`
- Rewrites **\`UPSOnBattery\`** to use \`upsBasicOutputStatus == 3\` (the previous expression worked but the description had a "ZPM" typo and labels used \`instance\` (the IP) rather than \`target\` (the friendly UPS name))

## Why

The NUT path (apcupsd USB → NUT → exporter) can't distinguish the two physical UPSes — apcupsd's USB HID driver collapses both onto the 1500VA's serial, regardless of the \`DEVICE\` config. The \`snmp-exporter\` already scrapes the SmartConnect cards directly with correct per-UPS data. This PR moves the alerting surface onto SNMP so NUT can be retired cleanly in a later step after a soak window.

## Verification

Each PromQL expression was evaluated against live Prometheus before commit:

\`\`\`
absent(up{job=~".*snmp-exporter-apc-ups.*"} == 1)          → []  (exporter up ✓)
upsBasicOutputStatus == 3                                  → []  (both onLine ✓)
(upsBasicOutputStatus == 3) and (upsAdvBatteryRunTimeRemaining < 60000)  → []
upsAdvBatteryCapacity < 50                                 → []  (both 100% ✓)
upsAdvBatteryReplaceIndicator == 2                         → []  (neither needs replace ✓)
\`\`\`

No false positives at baseline. NUT-side \`PrometheusRule\` is unchanged in this PR — both rule sets run side-by-side during the soak window. NUT-side rules will be removed in a follow-up after Steps 3-4 retire the NUT pod itself.

## Test plan

- [ ] PR merges → Flux reconciles
- [ ] \`kubectl -n observability get prometheusrule snmp-exporter-apc-ups-rules -o yaml\` shows the new rules
- [ ] Alertmanager UI shows all 5 rules registered, none firing
- [ ] After 24-48h soak with no spurious firings, proceed to Step 2 of the plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)