### PR TITLE
chore(workflows): switch create-github-app-token to client-id

### DIFF
--- a/.github/workflows/bulk-merge-prs.yaml
+++ b/.github/workflows/bulk-merge-prs.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
         id: app-token
         with:
-          app-id: "${{ secrets.LOVENET_RENOVATE_OPERATOR_APP_ID }}"
+          client-id: "${{ secrets.LOVENET_RENOVATE_OPERATOR_CLIENT_ID }}"
           private-key: "${{ secrets.LOVENET_RENOVATE_OPERATOR_PRIVATE_KEY }}"
 
       - name: Checkout

--- a/.github/workflows/flux-local.yaml
+++ b/.github/workflows/flux-local.yaml
@@ -116,7 +116,7 @@ jobs:
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.diff.outputs.diff != '' }}
         id: app-token
         with:
-          app-id: ${{ secrets.LOVENET_RENOVATE_OPERATOR_APP_ID }}
+          client-id: ${{ secrets.LOVENET_RENOVATE_OPERATOR_CLIENT_ID }}
           private-key: ${{ secrets.LOVENET_RENOVATE_OPERATOR_PRIVATE_KEY }}
 
       - if: ${{ steps.diff.outputs.diff != '' }}

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token
         with:
-          app-id: ${{ secrets.LOVENET_RENOVATE_OPERATOR_APP_ID }}
+          client-id: ${{ secrets.LOVENET_RENOVATE_OPERATOR_CLIENT_ID }}
           private-key: ${{ secrets.LOVENET_RENOVATE_OPERATOR_PRIVATE_KEY }}
 
       - name: Labeler

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
         id: app-token
         with:
-          app-id: "${{ secrets.LOVENET_RENOVATE_OPERATOR_APP_ID }}"
+          client-id: "${{ secrets.LOVENET_RENOVATE_OPERATOR_CLIENT_ID }}"
           private-key: "${{ secrets.LOVENET_RENOVATE_OPERATOR_PRIVATE_KEY }}"
 
       - name: Checkout


### PR DESCRIPTION
## Summary

`actions/create-github-app-token` v3 deprecated `app-id` in favor of `client-id` — the warning was firing on every workflow run that minted an App token (see e.g. run #803).

Replaces the input name and the secret reference across all four workflows that use the action:
- `bulk-merge-prs.yaml`
- `flux-local.yaml`
- `labeler.yaml`
- `renovate.yaml`

## Secret

- `LOVENET_RENOVATE_OPERATOR_CLIENT_ID` set on the repo (value `Iv23li1...`, retrieved via App-JWT against `/app`).
- `LOVENET_RENOVATE_OPERATOR_APP_ID` can be deleted after this merges and a clean run is observed — left in place for now in case rollback is needed.

`tibdex/github-app-token` in `lychee.yaml` and `docs.yaml` is a different action and not affected by this deprecation; left alone.

## Test plan

- [ ] Re-run `Bulk Merge PRs` after merge: annotations should show 0 warnings.
- [ ] Next `Flux Local` run on a PR: token generation still succeeds, sticky comment lands.
- [ ] Next scheduled `Renovate` run: token works, PRs continue to be created.
- [ ] Next `Labeler` run on a PR: tokens work, labels applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)