### PR TITLE
chore(workflows): migrate tibdex/github-app-token to actions/create-github-app-token

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -25,11 +25,11 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
       - name: Generate Token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
         id: app-token
         with:
-          app_id: "${{ secrets.LOVENET_RENOVATE_OPERATOR_APP_ID }}"
-          private_key: "${{ secrets.LOVENET_RENOVATE_OPERATOR_PRIVATE_KEY }}"
+          client-id: "${{ secrets.LOVENET_RENOVATE_OPERATOR_CLIENT_ID }}"
+          private-key: "${{ secrets.LOVENET_RENOVATE_OPERATOR_PRIVATE_KEY }}"
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/lychee.yaml
+++ b/.github/workflows/lychee.yaml
@@ -16,11 +16,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Generate Token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
         id: generate-token
         with:
-          app_id: "${{ secrets.LOVENET_RENOVATE_OPERATOR_APP_ID }}"
-          private_key: "${{ secrets.LOVENET_RENOVATE_OPERATOR_PRIVATE_KEY }}"
+          client-id: "${{ secrets.LOVENET_RENOVATE_OPERATOR_CLIENT_ID }}"
+          private-key: "${{ secrets.LOVENET_RENOVATE_OPERATOR_PRIVATE_KEY }}"
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary

The last two workflows still on `tibdex/github-app-token` (unmaintained since v2.1.0 / 2024-01) — `docs.yaml` and `lychee.yaml` — switched to `actions/create-github-app-token` with `client-id`, matching the convention established by #11432 for the other four workflows.

After this merges, `LOVENET_RENOVATE_OPERATOR_APP_ID` can be deleted again — only `CLIENT_ID` + `PRIVATE_KEY` are referenced anywhere in the repo.

## Background

I deleted `APP_ID` immediately after #11432 merged without checking these two holdouts. Docs workflow run [#3711](https://github.com/rwlove/home-ops/actions/runs/25990796010) failed with `Error: Input required and not supplied: app_id`. The secret has been temporarily restored to unblock; this PR cleans up properly.

## Test plan

- [ ] Re-run `Docs: Publish to Github Pages` after merge — succeeds with the new action.
- [ ] Next `Link Checker` run on schedule — token generation works, sticky issue still gets updated.
- [ ] After both green, delete `LOVENET_RENOVATE_OPERATOR_APP_ID` (final cleanup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)