### PR TITLE
chore(renovate): ignore .archive/** and migrate off matchPackagePrefixes

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -22,6 +22,12 @@
     'helpers:pinGitHubActionDigests',
   ],
   dependencyDashboardTitle: 'Renovate Dashboard 🤖',
+  // .archive/** holds historical app configs no longer deployed — don't
+  // scan them. Keeps the Detected Dependencies section of the dashboard
+  // (#10329) focused on live workloads.
+  ignorePaths: [
+    '.archive/**',
+  ],
   suppressNotifications: [
     'prIgnoreNotification',
     'prEditedNotification',

--- a/.github/renovate/autoMerge.json5
+++ b/.github/renovate/autoMerge.json5
@@ -14,11 +14,11 @@
       automerge: true,
       automergeType: "pr",
       matchUpdateTypes: ["digest"],
-      matchPackagePrefixes: [
-        "ghcr.io/home-operations",
-        "ghcr.io/onedr0p",
-        "ghcr.io/bjw-s",
-        "ghcr.io/bjw-s-labs",
+      matchPackageNames: [
+        "ghcr.io/home-operations/**",
+        "ghcr.io/onedr0p/**",
+        "ghcr.io/bjw-s/**",
+        "ghcr.io/bjw-s-labs/**",
       ],
       ignoreTests: false,
     },


### PR DESCRIPTION
## Summary

Two cleanups picked up while sweeping the Renovate config:

- **`ignorePaths: ['.archive/**']`** at the top of `renovate.json5`. The `.archive/` tree (~191 YAMLs of retired app configs) was still being scanned and feeding the Detected Dependencies section of #10329 with stale entries that haven't deployed in months.
- **`matchPackagePrefixes` → `matchPackageNames` with `**` globs** in `autoMerge.json5`. Renovate v38 deprecated `matchPackagePrefixes`; functionally identical replacement, suppresses warnings on every run.

## Test plan

- [ ] Next Renovate run: no more `.archive/**` entries in Detected Dependencies.
- [ ] No deprecation warnings on `matchPackagePrefixes` in the run log.
- [ ] Container-digest auto-merge still applies to `ghcr.io/home-operations/*`, `ghcr.io/onedr0p/*`, `ghcr.io/bjw-s/*`, `ghcr.io/bjw-s-labs/*` (look for a digest PR from one of these prefixes auto-merging in the next 24 hours).

🤖 Generated with [Claude Code](https://claude.com/claude-code)