### PR TITLE
docs(lint): fix markdownlint failures in two runbooks

### DIFF
--- a/docs/src/master1_etcd_disk_swap.md
+++ b/docs/src/master1_etcd_disk_swap.md
@@ -34,6 +34,7 @@ own schedule.
 **Micron 7450 PRO 480 GB M.2 2280** (MTFDKBA480TFR-1BC1ZABYYR), ~$200 USD.
 
 Why this one:
+
 - M.2 2280 fits the most common slot (verify before ordering).
 - 480 GB is plenty for `/` + etcd (etcd DB is ~340 MB).
 - 1 DWPD, 800 TBW endurance — etcd will not wear it out.
@@ -41,6 +42,7 @@ Why this one:
 - Gen4×4, negotiates down to Gen3.
 
 Alternatives if master1 has an M.2 22110 slot (longer 110 mm form factor):
+
 - Samsung PM9A3 960 GB M.2 22110 (~$230–280)
 - Micron 7450 PRO 960 GB M.2 22110 (~$270–370)
 
@@ -51,20 +53,24 @@ See conversation history for retailer links; pricing as of 2026-05-04.
 1. **Confirm M.2 slot length on master1**: SSH and run `lspci -vv`,
    or look at the board. 2280 vs 22110 changes the buy.
 2. **Confirm where `cs_master1-root` LVM actually sits**:
+
    ```sh
    pvs && vgs && lvs && lsblk
    ```
+
    This is to verify the hypothesis that `/var/lib/etcd` is on
    `nvme1n1`. If it turns out to be on `nvme0n1` (the WD Blue), the
    diagnosis changes — the issue would be NVMe contention with
    Longhorn/Ceph rather than a slow drive. The fix would then be
    different (move workloads, not the drive).
 3. **Identify what was on `/dev/sdb`**:
+
    ```sh
    cat /etc/fstab | grep sdb
    blkid /dev/sdb              # may return nothing if device gone
    dmesg -T | grep -E 'sd[ab]|ata|sata'
    ```
+
    This is independent of the etcd fix but should be cleaned up
    eventually.
 

--- a/docs/src/per-route-cert-migration.md
+++ b/docs/src/per-route-cert-migration.md
@@ -294,6 +294,7 @@ spec:
 
 This is the non-zero operational cost. Export the CA cert and import
 it into:
+
 - Each laptop / desktop browser (or system trust store)
 - Each phone / tablet
 - Any in-cluster client that calls internal hostnames over TLS
@@ -405,13 +406,16 @@ For each batch of 5:
 3. Commit + push. One PR per wave. Title: `feat(network): per-app TLS
    migration wave N (X/Y)`.
 4. Watch issuance:
+
    ```sh
    kubectl get certificate -A -w
    ```
+
    All 5 should reach Ready within ~2 min. Anything stuck → check
    `kubectl describe certificate <name> -n network` and the Order /
    Challenge resources.
 5. Soak ~12h between waves. Watch the issuer for rate-limit warnings:
+
    ```sh
    kubectl describe clusterissuer letsencrypt-production
    kubectl get challenge -A
@@ -440,6 +444,7 @@ kubectl describe order -n network <order>
 ```
 
 If hit:
+
 - **Stop the next wave immediately.**
 - **Don't delete failing Certificates** — that doesn't reset the
   counter and can cause cert-manager to retry, eating more budget.
@@ -491,15 +496,15 @@ For each istio HTTPRoute (`<app>` = e.g. `kiali`):
 
 After all istio HTTPRoutes are migrated:
 
-5. Remove the wildcard listener from the istio Gateway.
+1. Remove the wildcard listener from the istio Gateway.
 
-6. Remove `istio-system` from the wildcard Certificate's
+2. Remove `istio-system` from the wildcard Certificate's
    `reflector...reflection-allowed-namespaces` annotation list (in
    `kubernetes/apps/network/envoy-gateway/config/certificate.yaml`).
    This stops new mirroring; existing Secret in istio-system can be
    deleted manually if desired (no consumers).
 
-7. Now the istio Gateway has no reflector-mirrored Secret. Add the
+3. Now the istio Gateway has no reflector-mirrored Secret. Add the
    `cert-manager.io/cluster-issuer` annotations from Phase 0. The
    shim is now safe — every listener's referenced Secret is owned by
    an in-namespace manual Certificate. (Optionally, delete the manual


### PR DESCRIPTION
## Summary

PR #11421 was merged but CI markdownlint actually fails on this — it runs against every changed \`.md\` file, not just \`README.md\`. Two of the touched runbooks had pre-existing fence/list spacing issues that I missed.

Surgical fixes:

- \`master1_etcd_disk_swap.md\` — blank lines around 2 lists (Why this one / Alternatives) + 2 fenced code blocks (Preflight steps 2 and 3)
- \`per-route-cert-migration.md\` — blank lines around 1 list (CA distribution) + 2 fenced code blocks (Watch issuance / Soak commands) + 1 list (\"If hit:\"); renumbered the istio Gateway post-migration steps 5/6/7 → 1/2/3 because MD029 wants restart-at-1 after a heading break

No content changed.

## Test plan

- [x] \`markdownlint-cli2 docs/src/master1_etcd_disk_swap.md docs/src/per-route-cert-migration.md\` → 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)