### PR TITLE
chore(grafana): de-literal HA datasource cred; drop dead UPS dashboard

### DIFF
--- a/kubernetes/apps/observability/grafana/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/grafana/app/externalsecret.yaml
@@ -16,6 +16,8 @@ spec:
       data:
         POSTGRES_USER: "{{ .POSTGRES_SUPER_USER }}"
         POSTGRES_PASS: "{{ .POSTGRES_SUPER_PASS }}"
+        HA_DB_USER: "{{ .HA_DB_USER }}"
+        HA_DB_PASS: "{{ .HA_DB_PASS }}"
   dataFrom:
     - extract:
         key: cloudnative-pg

--- a/kubernetes/apps/observability/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/grafana/app/helmrelease.yaml
@@ -205,11 +205,6 @@ spec:
           # Ref: https://grafana.com/grafana/dashboards/7845
           gnetId: 13665
           revision: 4
-      power:
-        ups:
-          datasource: Prometheus
-          gnetId: 12340
-          revision: 1
     datasources:
       datasources.yaml:
         apiVersion: 1
@@ -242,10 +237,10 @@ spec:
               sslmode: disable
             name: home_assistant
             secureJsonData:
-              password: "home-assistant"
+              password: $__env{HA_DB_PASS}
             type: postgres
             url: postgres-home-assistant-ro.databases.svc.cluster.local:5432
-            user: "home-assistant"
+            user: $__env{HA_DB_USER}
             version: 1
 
             withCredentials: false

--- a/tools/git-hooks/pre-commit
+++ b/tools/git-hooks/pre-commit
@@ -44,8 +44,8 @@ for f in $files; do
     fail=1
   fi
 
-  # YAML field: 'password: literal' (allow {ENV} templates)
-  m=$(grep -nE "^[[:space:]]*password:[[:space:]]*['\"]?[^[:space:]'\"{]" "$f" || true)
+  # YAML field: 'password: literal' (allow {ENV} or $__env{ENV} / ${ENV} templates)
+  m=$(grep -nE "^[[:space:]]*password:[[:space:]]*['\"]?[^[:space:]'\"{\$]" "$f" || true)
   if [ -n "$m" ]; then
     printf '%s\n' "ERROR: literal credential in YAML field form: $f" >&2
     printf '%s\n' "$m" >&2


### PR DESCRIPTION
## Summary

Three coupled cleanups in one PR — all touching the grafana HelmRelease, plus a related tweak to the pre-commit hook so this PR can land.

1. **De-literal the HA Postgres datasource password.** Extend the existing \`grafana\` ExternalSecret template with \`HA_DB_USER\` and \`HA_DB_PASS\` (pulled from the same \`cloudnative-pg\` 1Password item already in use). The datasource then references them via \`\$__env{HA_DB_USER}\` / \`\$__env{HA_DB_PASS}\` substitution. Same Grafana \`envFromSecrets\` plumbing as today; no new pod env wiring needed.

2. **Drop the \`gnetId: 12340\` ("UPS NUT Dashboard") import.** After home-ops #11433 retired prometheus-nut-exporter, that dashboard's \`network_ups_tools_*\` queries return no data. Replacement coverage lives in the \`snmp-exporter-apc-ups\` PrometheusRule + the per-UPS HA SNMP sensors landed in home-assistant-config #11. The \`power\` provider/mount stays as the home for a future SNMP-based dashboard.

3. **Pre-commit hook**: add \`\$\` to the allowed prefix set for the \`password: literal\` regex. Grafana uses \`\$__env{VAR}\` and shell-style \`\${VAR}\` substitution; both should be recognized as templates alongside the existing Frigate-style \`{VAR}\`.

## 1Password side

The \`cloudnative-pg\` item in the Kubernetes vault now has two new STRING fields:
- \`HA_DB_USER\` = \`home-assistant\` (matches the actual PG role name; hyphenated, not underscored)
- \`HA_DB_PASS\` = \`home-assistant\` (current literal value, preserved per memory: don't push rotation for home-lab internal creds)

## Test plan

- [ ] CI passes (yamllint, flux-local diff)
- [ ] After merge + reconcile: Grafana → Datasources → home_assistant → "Save & Test" returns success
- [ ] Home Assistant Grafana dashboard at \`/d/.../home_assistant\` continues to render

🤖 Generated with [Claude Code](https://claude.com/claude-code)