### PR TITLE
feat(network-policy): actions-runner-system baseline (Phase 2)

### DIFF
--- a/kubernetes/apps/actions-runner-system/kustomization.yaml
+++ b/kubernetes/apps/actions-runner-system/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 namespace: actions-runner-system
 components:
   - ../../components/alerts
+  - ../../components/network-policy/baseline
 resources:
   - ./namespace.yaml
   - ./actions-runner-controller/ks.yaml


### PR DESCRIPTION
## Summary

Phase 2, baseline-only PR for `actions-runner-system`. Same risk-free pattern as `ai` PR 1 — additive policies, no enforcement.

5 CiliumNetworkPolicy resources land in `actions-runner-system` via the existing baseline component. All ship with `enableDefaultDeny: false` so nothing is restricted.

## Why now

Running in parallel with `ai`'s 48h audit-mode soak. No conflict — baseline addition to an unrelated namespace has zero interaction with the cluster-wide audit mode flag or `ai`'s default-deny.

## Test plan

- [ ] Flux reconciles `actions-runner-system` Kustomization cleanly
- [ ] `kubectl get cnp -n actions-runner-system` shows 5 baseline policies
- [ ] All actions-runner-system pods stay Ready (controller, listener, runners)
- [ ] No new `DROPPED-AUDITED` flows attributed to this namespace (baseline is additive)

## Sequence to default-deny

This is step 1 of 2 for actions-runner-system. Step 2 (default-deny + per-app overlays) waits until `ai` PR 3 ships and the cluster audit-mode flag is back off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)