### PR TITLE
feat(network-policy): renovate baseline (Phase 2)

### DIFF
--- a/kubernetes/apps/renovate/kustomization.yaml
+++ b/kubernetes/apps/renovate/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 namespace: renovate
 components:
   - ../../components/alerts
+  - ../../components/network-policy/baseline
 resources:
   - ./namespace.yaml
   - ./renovate-operator/ks.yaml


### PR DESCRIPTION
## Summary

Phase 2 baseline for `renovate`. 1-line diff; 5 additive CNPs land in the namespace via the existing baseline component. `enableDefaultDeny: false` everywhere — zero enforcement risk.

## Test plan

- [ ] Flux reconciles `renovate` Kustomization cleanly
- [ ] `kubectl get cnp -n renovate` shows 5 baseline policies
- [ ] renovate-operator + active CronJob pods stay Ready

## Sequence

Parallel with ai's audit-mode soak. Default-deny + overlays come after the ai PR 3 ships and cluster audit-mode flips back off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)