### PR TITLE
feat(grafana): add Power Overview dashboard

### DIFF
--- a/kubernetes/apps/observability/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/grafana/app/helmrelease.yaml
@@ -205,6 +205,10 @@ spec:
           # Ref: https://grafana.com/grafana/dashboards/7845
           gnetId: 13665
           revision: 4
+      power:
+        power_overview:
+          datasource: Prometheus
+          url: https://raw.githubusercontent.com/rwlove/home-ops/main/kubernetes/apps/observability/grafana/dashboards/power.json
     datasources:
       datasources.yaml:
         apiVersion: 1

--- a/kubernetes/apps/observability/grafana/dashboards/power.json
+++ b/kubernetes/apps/observability/grafana/dashboards/power.json
@@ -1,0 +1,423 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {"type": "datasource", "uid": "grafana"},
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "House-wide power monitoring: APC SmartConnect UPSes, beast iDRAC, and Refoss EM16 per-circuit.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "type": "row",
+      "id": 100,
+      "title": "Live power",
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 0},
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "stat",
+      "id": 1,
+      "title": "UPS 1500",
+      "gridPos": {"h": 6, "w": 6, "x": 0, "y": 1},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {"expr": "upsAdvOutputActivePower{target=\"apc-ups-1500\"}", "refId": "A", "legendFormat": ""}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "watt",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "orange", "value": 600},
+              {"color": "red", "value": 1200}
+            ]
+          }
+        }
+      },
+      "options": {
+        "graphMode": "area",
+        "colorMode": "value",
+        "justifyMode": "center",
+        "textMode": "value_and_name",
+        "reduceOptions": {"calcs": ["lastNotNull"]}
+      }
+    },
+    {
+      "type": "stat",
+      "id": 2,
+      "title": "UPS 3000",
+      "gridPos": {"h": 6, "w": 6, "x": 6, "y": 1},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {"expr": "upsAdvOutputActivePower{target=\"apc-ups-3000\"}", "refId": "A", "legendFormat": ""}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "watt",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "orange", "value": 1500},
+              {"color": "red", "value": 2400}
+            ]
+          }
+        }
+      },
+      "options": {
+        "graphMode": "area",
+        "colorMode": "value",
+        "justifyMode": "center",
+        "textMode": "value_and_name",
+        "reduceOptions": {"calcs": ["lastNotNull"]}
+      }
+    },
+    {
+      "type": "stat",
+      "id": 3,
+      "title": "Beast (R730xd)",
+      "gridPos": {"h": 6, "w": 6, "x": 12, "y": 1},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {"expr": "amperageProbeReading{job=\"snmp-exporter-dell-idrac\", amperageProbeIndex=\"3\"}", "refId": "A", "legendFormat": ""}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "watt",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "orange", "value": 500},
+              {"color": "red", "value": 800}
+            ]
+          }
+        }
+      },
+      "options": {
+        "graphMode": "area",
+        "colorMode": "value",
+        "justifyMode": "center",
+        "textMode": "value_and_name",
+        "reduceOptions": {"calcs": ["lastNotNull"]}
+      }
+    },
+    {
+      "type": "stat",
+      "id": 4,
+      "title": "Total (both UPSes)",
+      "gridPos": {"h": 6, "w": 6, "x": 18, "y": 1},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {"expr": "sum(upsAdvOutputActivePower)", "refId": "A", "legendFormat": ""}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "watt",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "orange", "value": 2000},
+              {"color": "red", "value": 3000}
+            ]
+          }
+        }
+      },
+      "options": {
+        "graphMode": "area",
+        "colorMode": "value",
+        "justifyMode": "center",
+        "textMode": "value_and_name",
+        "reduceOptions": {"calcs": ["lastNotNull"]}
+      }
+    },
+    {
+      "type": "row",
+      "id": 101,
+      "title": "UPS battery state",
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 7},
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "stat",
+      "id": 10,
+      "title": "Charge",
+      "gridPos": {"h": 4, "w": 4, "x": 0, "y": 8},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {"expr": "upsAdvBatteryCapacity{target=\"apc-ups-1500\"}", "refId": "A", "legendFormat": "UPS 1500"},
+        {"expr": "upsAdvBatteryCapacity{target=\"apc-ups-3000\"}", "refId": "B", "legendFormat": "UPS 3000"}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "red", "value": null},
+              {"color": "orange", "value": 50},
+              {"color": "green", "value": 90}
+            ]
+          }
+        }
+      },
+      "options": {
+        "graphMode": "none",
+        "colorMode": "value",
+        "justifyMode": "center",
+        "textMode": "value_and_name",
+        "reduceOptions": {"calcs": ["lastNotNull"]}
+      }
+    },
+    {
+      "type": "stat",
+      "id": 11,
+      "title": "Runtime",
+      "gridPos": {"h": 4, "w": 4, "x": 4, "y": 8},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {"expr": "upsAdvBatteryRunTimeRemaining{target=\"apc-ups-1500\"} / 6000", "refId": "A", "legendFormat": "UPS 1500"},
+        {"expr": "upsAdvBatteryRunTimeRemaining{target=\"apc-ups-3000\"} / 6000", "refId": "B", "legendFormat": "UPS 3000"}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "m",
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "red", "value": null},
+              {"color": "orange", "value": 10},
+              {"color": "green", "value": 30}
+            ]
+          }
+        }
+      },
+      "options": {
+        "graphMode": "none",
+        "colorMode": "value",
+        "justifyMode": "center",
+        "textMode": "value_and_name",
+        "reduceOptions": {"calcs": ["lastNotNull"]}
+      }
+    },
+    {
+      "type": "stat",
+      "id": 12,
+      "title": "Battery temp",
+      "gridPos": {"h": 4, "w": 4, "x": 8, "y": 8},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {"expr": "upsAdvBatteryTemperature{target=\"apc-ups-1500\"}", "refId": "A", "legendFormat": "UPS 1500"},
+        {"expr": "upsAdvBatteryTemperature{target=\"apc-ups-3000\"}", "refId": "B", "legendFormat": "UPS 3000"}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "celsius",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "orange", "value": 35},
+              {"color": "red", "value": 45}
+            ]
+          }
+        }
+      },
+      "options": {
+        "graphMode": "none",
+        "colorMode": "value",
+        "justifyMode": "center",
+        "textMode": "value_and_name",
+        "reduceOptions": {"calcs": ["lastNotNull"]}
+      }
+    },
+    {
+      "type": "stat",
+      "id": 13,
+      "title": "Status",
+      "gridPos": {"h": 4, "w": 12, "x": 12, "y": 8},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {"expr": "upsBasicOutputStatus{target=\"apc-ups-1500\"}", "refId": "A", "legendFormat": "UPS 1500"},
+        {"expr": "upsBasicOutputStatus{target=\"apc-ups-3000\"}", "refId": "B", "legendFormat": "UPS 3000"}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {"type": "value", "options": {
+              "1": {"text": "unknown", "color": "yellow"},
+              "2": {"text": "online", "color": "green"},
+              "3": {"text": "on battery", "color": "red"},
+              "4": {"text": "smart boost", "color": "orange"},
+              "5": {"text": "timed sleeping", "color": "orange"},
+              "6": {"text": "software bypass", "color": "orange"},
+              "7": {"text": "off", "color": "red"},
+              "8": {"text": "rebooting", "color": "orange"},
+              "9": {"text": "switched bypass", "color": "orange"},
+              "10": {"text": "hardware failure bypass", "color": "red"},
+              "11": {"text": "sleeping until power return", "color": "orange"},
+              "12": {"text": "smart trim", "color": "orange"}
+            }}
+          ],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]}
+        }
+      },
+      "options": {
+        "graphMode": "none",
+        "colorMode": "background",
+        "justifyMode": "center",
+        "textMode": "value_and_name",
+        "reduceOptions": {"calcs": ["lastNotNull"]}
+      }
+    },
+    {
+      "type": "row",
+      "id": 102,
+      "title": "Power over time",
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 12},
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "id": 20,
+      "title": "Output power",
+      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 13},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {"expr": "upsAdvOutputActivePower{target=\"apc-ups-1500\"}", "refId": "A", "legendFormat": "UPS 1500"},
+        {"expr": "upsAdvOutputActivePower{target=\"apc-ups-3000\"}", "refId": "B", "legendFormat": "UPS 3000"},
+        {"expr": "amperageProbeReading{job=\"snmp-exporter-dell-idrac\", amperageProbeIndex=\"3\"}", "refId": "C", "legendFormat": "Beast (of UPS 3000)"}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "watt",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "pointSize": 5,
+            "showPoints": "never",
+            "axisLabel": "Watts"
+          },
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]}
+        }
+      },
+      "options": {
+        "legend": {"displayMode": "table", "placement": "right", "calcs": ["mean", "max", "lastNotNull"]},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      }
+    },
+    {
+      "type": "row",
+      "id": 103,
+      "title": "Refoss EM16 — per-circuit",
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 21},
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "bargauge",
+      "id": 30,
+      "title": "Per-circuit power (now)",
+      "gridPos": {"h": 10, "w": 12, "x": 0, "y": 22},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {
+          "expr": "topk(16, hass_sensor_power_w{entity=~\"sensor.em16_.+_power\"})",
+          "refId": "A",
+          "legendFormat": "{{friendly_name}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "watt",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "orange", "value": 500},
+              {"color": "red", "value": 1500}
+            ]
+          }
+        }
+      },
+      "options": {
+        "orientation": "horizontal",
+        "displayMode": "gradient",
+        "showUnfilled": true,
+        "reduceOptions": {"calcs": ["lastNotNull"]}
+      }
+    },
+    {
+      "type": "timeseries",
+      "id": 31,
+      "title": "Heavy loads — over time",
+      "gridPos": {"h": 10, "w": 12, "x": 12, "y": 22},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {"expr": "hass_sensor_power_w{entity=\"sensor.heat_pump_power\"}", "refId": "A", "legendFormat": "Heat Pump"},
+        {"expr": "hass_sensor_power_w{entity=\"sensor.pool_equipment_power\"}", "refId": "B", "legendFormat": "Pool"},
+        {"expr": "hass_sensor_power_w{entity=\"sensor.water_heater_power\"}", "refId": "C", "legendFormat": "Water Heater"},
+        {"expr": "hass_sensor_power_w{entity=\"sensor.well_pump_power\"}", "refId": "D", "legendFormat": "Well Pump"}
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "watt",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "pointSize": 5,
+            "showPoints": "never"
+          },
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]}
+        }
+      },
+      "options": {
+        "legend": {"displayMode": "table", "placement": "right", "calcs": ["mean", "max", "lastNotNull"]},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      }
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["power", "ups", "energy"],
+  "templating": {"list": []},
+  "time": {"from": "now-6h", "to": "now"},
+  "timepicker": {},
+  "timezone": "America/New_York",
+  "title": "Power Overview",
+  "uid": "power-overview",
+  "version": 1,
+  "weekStart": ""
+}


### PR DESCRIPTION
## Summary

Lands in the previously-empty \`power\` Grafana folder. Pulls together the three power-monitoring data sources into one pane:

- \`snmp-exporter-apc-ups\` → UPS-1500 / UPS-3000 output power, battery charge / runtime / temperature / status
- \`snmp-exporter-dell-idrac\` → beast (R730xd) system board total
- HA Prometheus exporter (\`hass_sensor_power_w\`) → Refoss EM16 per-circuit + heavy-load aggregates (heat pump, pool, water heater, well pump)

## Panels

1. Live power — UPS-1500, UPS-3000, beast, total
2. UPS battery state — charge, runtime, temperature, status (text enum mapped from \`upsBasicOutputStatus\`)
3. Power over time — UPS + beast time series (6h default)
4. Refoss EM16 — per-circuit bar gauge + heavy-load time series

## Why

Closes the loop on the power-monitoring review (PRs #11431, #11433, #11437 in this repo; home-assistant-config #11, #12). Until now the data was scattered across Prom, Kromgo, and HA's Energy Dashboard with no single Grafana board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)