### PR TITLE
feat(network-policy): mcp-system baseline (Phase 2)

### DIFF
--- a/kubernetes/apps/mcp-system/kustomization.yaml
+++ b/kubernetes/apps/mcp-system/kustomization.yaml
@@ -3,6 +3,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: mcp-system
+components:
+  - ../../components/network-policy/baseline
 resources:
   - ./namespace.yaml
   - ./arr-mcp/ks.yaml


### PR DESCRIPTION
## Summary

Phase 2 baseline for `mcp-system`. 3-line diff (new `components:` block); 5 additive CNPs land in the namespace. `enableDefaultDeny: false` everywhere — zero enforcement risk.

mcp-system didn't have a `components:` field previously, so this adds the block (no other components were in scope).

## Test plan

- [ ] Flux reconciles `mcp-system` Kustomization cleanly
- [ ] `kubectl get cnp -n mcp-system` shows 5 baseline policies
- [ ] All 14 MCP server pods + mcp-gateway stay Ready

## Sequence

Parallel with ai's audit-mode soak. Default-deny + per-app overlays come after ai PR 3 (mcp-system overlays will be more complex than other namespaces given the cross-namespace fan-out of MCP backends).

🤖 Generated with [Claude Code](https://claude.com/claude-code)