### PR TITLE
feat(network-policy): home baseline (Phase 2)

### DIFF
--- a/kubernetes/apps/home/kustomization.yaml
+++ b/kubernetes/apps/home/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 namespace: home
 components:
   - ../../components/alerts
+  - ../../components/network-policy/baseline
 resources:
   - ./namespace.yaml
   - ./priority-class.yaml


### PR DESCRIPTION
## Summary

Phase 2 baseline for `home` (smart-home namespace, 14 apps). 1-line diff; 5 additive CNPs land via the existing baseline component. `enableDefaultDeny: false` everywhere — zero enforcement risk.

## Test plan

- [ ] Flux reconciles `home` Kustomization cleanly
- [ ] `kubectl get cnp -n home` shows 5 baseline policies
- [ ] All 21 home pods stay Ready (home-assistant, frigate, emqx 3-node cluster, zigbee2mqtt, zwave-js-ui, matter-server, wyoming services, etc.)

## Sequence

Parallel with ai's audit-mode soak. home's default-deny + overlays will be the biggest Phase 2 follow-up given:
- Cross-VLAN egress to cameras (iot VLAN) via Frigate
- MQTT broker (EMQX) cross-app
- External SMTP relay
- n8n webhooks + OIDC auth
- ZigbeeMQTT / Z-Wave radios with USB attachments (host-network considerations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)