### PR TITLE
feat(gpu,ai): Phase 0 Spark prep — per-node gpu-operator split + ollama-spark scaffold

### DIFF
--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
   - ./langgraph-agents/ks.yaml
   - ./mcp-inspector/ks.yaml
   - ./ollama/ks.yaml
+  - ./ollama-spark/ks.yaml
   - ./paperless-ai/ks.yaml
   - ./sync-receiver/ks.yaml
   - ./khoj/ks.yaml

--- a/kubernetes/apps/ai/ollama-spark/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/ollama-spark/app/helmrelease.yaml
@@ -1,0 +1,125 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: ollama-spark
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 30m
+  values:
+    controllers:
+      backend:
+        pod:
+          # Hard-pin to Spark. The existing `ollama` Deployment serves
+          # smaller models on the P40 (worker8); this instance hosts the
+          # larger Spark-tier models. Both Deployments coexist.
+          #
+          # Update the nodeSelector hostname value when Spark joins
+          # with its final hostname (spark.${SECRET_DOMAIN} assumed).
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: kubernetes.io/hostname
+                        operator: In
+                        values:
+                          - "spark.thesteamedcrab.com"
+
+          nodeSelector:
+            kubernetes.io/hostname: "spark.thesteamedcrab.com"
+            nvidia.com/gpu.present: "true"
+
+          priorityClassName: ai-gpu-critical
+
+        annotations:
+          reloader.stakater.com/auto: "true"
+
+        type: statefulset
+
+        containers:
+          main:
+            image:
+              repository: docker.io/ollama/ollama
+              tag: 0.24.0@sha256:a6149234667efc71d37766d61c1a16f24c33e4cd7a0bf4125c44a7e47e2419c4
+
+            env:
+              OLLAMA_HOST: 0.0.0.0
+              OLLAMA_ORIGINS: "*"
+              OLLAMA_LOG_LEVEL: info
+              OLLAMA_MODELS: &pvc /models
+              OLLAMA_LOAD_TIMEOUT: 10m
+              OLLAMA_KV_CACHE_TYPE: q8_0
+              OLLAMA_FLASH_ATTENTION: 1
+              # Spark has ~128 GB unified memory; can carry larger
+              # context windows and multiple concurrent loaded models
+              # without the P40's constrained budget.
+              OLLAMA_CONTEXT_LENGTH: 32768
+              OLLAMA_NUM_PARALLEL: 4
+              # Drop the P40 single-model cap. Spark can hold the agent
+              # fleet's working set (primary 14b/30b + embedding +
+              # alternate) resident concurrently.
+              OLLAMA_MAX_LOADED_MODELS: 3
+
+            resources:
+              requests:
+                # Tune post-arrival once we see real Spark CPU/memory
+                # baselines under the agent fleet's load. Starting
+                # values are conservative for a Blackwell-class node.
+                memory: 16G
+                cpu: 4000m
+                nvidia.com/gpu: 1
+              limits:
+                memory: 16G
+                nvidia.com/gpu: 1
+
+            securityContext:
+              privileged: true
+
+    service:
+      backend:
+        controller: backend
+        ports:
+          http:
+            port: &httpPort 11434
+
+    route:
+      main:
+        hostnames:
+          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: backend
+                port: *httpPort
+
+    persistence:
+      data:
+        existingClaim: ollama-spark-data-pvc
+        advancedMounts:
+          backend:
+            main:
+              - path: /.ollama
+
+      # Models live on a Longhorn volume pinned strict-local to Spark
+      # (single replica + nodeSelector affinity above). Avoids cross-
+      # node IO during model loads. Same pattern as the P40 ollama PVC.
+      models:
+        existingClaim: ollama-spark-models-pvc
+        advancedMounts:
+          backend:
+            main:
+              - path: *pvc
+
+      tmp:
+        type: emptyDir
+        enabled: true
+        medium: Memory
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/ai/ollama-spark/app/kustomization.yaml
+++ b/kubernetes/apps/ai/ollama-spark/app/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../components/repos/app-template
+
+resources:
+  - ./helmrelease.yaml
+  - ./longhorn-pvc.yaml

--- a/kubernetes/apps/ai/ollama-spark/app/longhorn-pvc.yaml
+++ b/kubernetes/apps/ai/ollama-spark/app/longhorn-pvc.yaml
@@ -1,0 +1,91 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ollama-spark-data-pvc
+  labels:
+    type: longhorn
+spec:
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: 2Gi
+  volumeName: ollama-spark-data-pv
+  storageClassName: ollama-spark-data-storage-class
+
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: ollama-spark-data-pv
+  labels:
+    type: longhorn
+    recurring-job-group.longhorn.io/weekly-backup: enabled
+    recurring-job-group.longhorn.io/daily-snapshot: enabled
+spec:
+  capacity:
+    storage: 2Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ollama-spark-data-storage-class
+  csi:
+    driver: driver.longhorn.io
+    fsType: xfs
+    volumeAttributes:
+      numberOfReplicas: "2"
+      staleReplicaTimeout: "2880"
+    volumeHandle: ollama-spark-data-xfs
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ollama-spark-models-pvc
+  labels:
+    type: longhorn
+spec:
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Filesystem
+  resources:
+    requests:
+      # Spark hosts larger models — qwen2.5:14b is ~9 GB, qwen3:30b would
+      # be ~18 GB, plus alternates + embeddings. 200Gi gives room for a
+      # working set of 5–10 models with a buffer.
+      storage: 200Gi
+  volumeName: ollama-spark-models-pv
+  storageClassName: ollama-spark-models-storage-class
+
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: ollama-spark-models-pv
+  labels:
+    type: longhorn
+    recurring-job-group.longhorn.io/monthly-backup: enabled
+    recurring-job-group.longhorn.io/weekly-snapshot: enabled
+spec:
+  capacity:
+    storage: 200Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ollama-spark-models-storage-class
+  csi:
+    driver: driver.longhorn.io
+    fsType: xfs
+    volumeAttributes:
+      # Strict-local with 1 replica — model loads need fast local IO.
+      # Same rationale as the P40 ollama PVC. Spark must be in the
+      # cluster (post-Phase-2 of the day-of checklist) before this
+      # PVC will bind.
+      numberOfReplicas: "1"
+      staleReplicaTimeout: "2880"
+    volumeHandle: ollama-spark-models-xfs

--- a/kubernetes/apps/ai/ollama-spark/ks.yaml
+++ b/kubernetes/apps/ai/ollama-spark/ks.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app ollama-spark
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: ai
+  path: "./kubernetes/apps/ai/ollama-spark/app"
+  interval: 30m
+  timeout: 3m
+  prune: true
+  wait: true
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: onepassword-connect
+      namespace: external-secrets
+    - name: gpu-operator
+      namespace: kube-system
+    - name: longhorn
+      namespace: longhorn-system

--- a/kubernetes/apps/kube-system/gpu-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/gpu-operator/app/helmrelease.yaml
@@ -23,8 +23,30 @@ spec:
     operator:
       cleanupCRD: false
       upgradeCRD: true
+    # Per-node driver split. The operator deploys the driver daemonset
+    # to any GPU node that does NOT carry the label
+    # `nvidia.com/gpu.deploy.driver=false`. Two GPU nodes with different
+    # needs as of 2026-05-17:
+    #
+    #   worker8  — Tesla P40 (Pascal, sm_61) on CentOS Stream 9. NVIDIA
+    #              does not ship a precompiled driver container for
+    #              Stream 9, so the driver stays manually installed and
+    #              worker8 is opted out via the label above. Apply the
+    #              opt-out BEFORE this change reconciles, or the operator
+    #              will try and fail on worker8:
+    #
+    #                kubectl label node worker8.${SECRET_DOMAIN} \
+    #                  nvidia.com/gpu.deploy.driver=false --overwrite
+    #
+    #   Spark    — Blackwell GB10 on Ubuntu/DGX OS. Joins with no opt-out
+    #              label; operator manages its driver via open kernel
+    #              modules. `useOpenKernelModules: true` is for Spark;
+    #              the setting is a no-op on worker8 (which is opted out).
+    #
+    # See: docs/src/p40.md, project_todo_worker8_os_rebuild memory.
     driver:
-      enabled: false
+      enabled: true
+      useOpenKernelModules: true
     toolkit:
       enabled: true
       installDir: /usr/local/nvidia


### PR DESCRIPTION
**DRAFT — do not merge until Spark hardware physically joins (~2026-05-20).** Full activation sequence in \`~/vaults/claude/agents/workspaces/ml-tuner/spark-day-of.md\`.

## What this PR does

1. **Flips \`driver.enabled: true\` in the gpu-operator HelmRelease** with per-node opt-out for worker8 via the \`nvidia.com/gpu.deploy.driver=false\` label. Decision 2026-05-17: P40 stays after Spark, worker8 stays on CentOS Stream 9 + manual driver indefinitely.
   - Spark (Blackwell, joins on Ubuntu/DGX OS) gets operator-managed driver via open kernel modules.
   - worker8 (Pascal P40, Stream 9) opts out and keeps the manually-installed proprietary driver.

2. **New \`ollama-spark\` HelmRelease** in the \`ai\` namespace, pinned to the Spark node via \`nodeSelector\`. Hosts larger Spark-tier models (qwen2.5:14b, qwen3:14b/30b, etc.). The existing \`ai/ollama\` Deployment continues to serve smaller P40-friendly models (qwen2.5:7b for HolmesGPT, embeddings). Same strict-local Longhorn PVC pattern as the P40 ollama; 200Gi for the larger model working set.

## Pre-merge requirements

Before merging this PR:

1. Spark physically joined as a k8s node (assumed hostname \`spark.thesteamedcrab.com\`; update the nodeSelector if different).
2. Worker8 labeled with the driver opt-out:

   \`\`\`sh
   kubectl label node worker8.thesteamedcrab.com \\
     nvidia.com/gpu.deploy.driver=false --overwrite
   \`\`\`

   The label must exist BEFORE the gpu-operator HelmRelease reconciles with \`driver.enabled: true\`, or the operator will try and fail to install a driver on Stream 9.

3. The \`ollama-spark\` HelmRelease will not progress past install until Spark is in the cluster (nodeSelector pins to \`spark.thesteamedcrab.com\`). Update the hostname in the nodeSelector if Spark joins under a different name.

## Connected work

- \`~/vaults/claude/agents/workspaces/ml-tuner/spark-day-of.md\` — full mechanical sequence post-merge.
- Memory entries already updated for "P40 stays" decision: \`project_immich_pet_tagger_p40_fork\`, \`project_todo_worker8_os_rebuild\` (closed), \`reference_gpu_resource_matrix\` (post-Spark section added).

## Test plan

- [ ] flux-local diff / test passes in CI
- [ ] Spark physically joins
- [ ] worker8 opt-out label applied
- [ ] Merge → driver daemonset appears on Spark only, worker8 unchanged
- [ ] Pull qwen2.5:14b on ollama-spark, verify Service responds

🤖 Generated with [Claude Code](https://claude.com/claude-code)