### PR TITLE
chore(deps): update actions/create-github-app-token digest to bcd2ba4

### DIFF
--- a/.github/workflows/bulk-merge-prs.yaml
+++ b/.github/workflows/bulk-merge-prs.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Generate Token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         id: app-token
         with:
           client-id: "${{ secrets.LOVENET_RENOVATE_OPERATOR_CLIENT_ID }}"

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -25,7 +25,7 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
       - name: Generate Token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         id: app-token
         with:
           client-id: "${{ secrets.LOVENET_RENOVATE_OPERATOR_CLIENT_ID }}"

--- a/.github/workflows/lychee.yaml
+++ b/.github/workflows/lychee.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Generate Token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         id: generate-token
         with:
           client-id: "${{ secrets.LOVENET_RENOVATE_OPERATOR_CLIENT_ID }}"

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Generate Token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         id: app-token
         with:
           client-id: "${{ secrets.LOVENET_RENOVATE_OPERATOR_CLIENT_ID }}"


### PR DESCRIPTION
Auto-created from Renovate branch that succeeded its push but never got its PR (Renovate run kept aborting with "Repository has changed during renovation" before reaching PR-creation).

Bumps `actions/create-github-app-token` digest from `1b10c78c` → `bcd2ba49` across the four workflows that use it.

🤖 Restored by Claude