### PR TITLE
chore(renovate): disable platformCommit to fix dashboard drain stall

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -35,7 +35,13 @@
   timezone: 'America/New_York',
   rebaseWhen: 'auto',
   commitBodyTable: true,
-  platformCommit: 'enabled',
+  // 'disabled' = plain git push. 'enabled' (Contents API) appears to
+  // interact badly with Renovate's "Repository has changed during
+  // renovation" abort: each successful platform-commit push immediately
+  // trips the check and Renovate bails before PR creation, leaving an
+  // orphan branch (see Dashboard #10329 stall on 2026-05-17). Trade-off
+  // is unsigned commits from the bot, which we accept.
+  platformCommit: 'disabled',
   flux: {
     managerFilePatterns: [
       '/kubernetes/.+\\.ya?ml$/',

--- a/kubernetes/apps/renovate/renovate-operator/jobs/home-ops.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/jobs/home-ops.yaml
@@ -18,7 +18,7 @@ spec:
     - name: RENOVATE_PLATFORM
       value: github
     - name: RENOVATE_PLATFORM_COMMIT
-      value: enabled
+      value: disabled  # See renovate.json5 — platformCommit trips Repository-has-changed abort.
     - name: DOCKERHUB_USERNAME
       valueFrom:
         secretKeyRef:


### PR DESCRIPTION
## Summary

Flips `platformCommit` from `enabled` to `disabled` in both `renovate.json5` and the operator's `RenovateJob` env (env wins over config file, so both have to flip).

## Why

After the workflows-permission grant earlier today, Renovate could finally push branches that touch `.github/workflows/*.yaml`. First run succeeded for exactly 1 entry (`renovate/actions-create-github-app-token-digest`), then every subsequent run aborted with:

```
Repository has changed during renovation - aborting
```

…immediately after its own successful push, before reaching the PR-creation step. Five back-to-back drain runs (manual + the 14:00 operator tick) produced 0 additional progress.

Inspecting both refs of the one successful entry showed the smoking gun:

| Ref | SHA |
|---|---|
| `refs/heads/renovate/actions-create-github-app-token-digest` | `0385e8ad8c…` |
| `refs/renovate/branches/renovate/actions-create-github-app-token-digest` | `538af34292…` |

`platformCommit: enabled` commits via the GitHub Contents API, then *also* does a `git push` to its internal `refs/renovate/branches/*` cache namespace. The two paths leave different SHAs, and the cache-ref push (or the resulting global repo-state shift) appears to be what trips Renovate's mid-run "Repository has changed" abort.

`platformCommit: disabled` uses plain `git push` for the actual branch and skips the Contents API entirely. Single code path, no two-SHA confusion.

## Trade-off

Bot commits become **unsigned**. Acceptable for this repo — no commit-signing policy on `main`, no protection rule requiring verified commits.

## Test plan

- [ ] After merge, wait for Flux to reconcile the `RenovateJob` and the operator to spawn a fresh job with the new env.
- [ ] Next Renovate run should push *and* PR each pending dashboard entry without aborting.
- [ ] Dashboard #10329 "Other Branches" count should drop from 9 → close to 0 within 1-2 hourly runs (trusted-actions auto-merge; node-major + peaceiris sit as PRs awaiting review or aging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)