### PR TITLE
feat(network-policy): collab baseline (Phase 2)

### DIFF
--- a/kubernetes/apps/collab/kustomization.yaml
+++ b/kubernetes/apps/collab/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 namespace: collab
 components:
   - ../../components/alerts
+  - ../../components/network-policy/baseline
 resources:
   - ./namespace.yaml
   - ./atuin/ks.yaml


### PR DESCRIPTION
## Summary

Phase 2 baseline for `collab`. 1-line diff; 5 additive CNPs via the existing baseline component. `enableDefaultDeny: false` — zero enforcement risk.

## Test plan

- [ ] Flux reconciles `collab` Kustomization cleanly
- [ ] `kubectl get cnp -n collab` shows 5 baseline policies
- [ ] All collab pods stay Ready (atuin, glance, paperless, zulip, open-webui, etc.)

## Sequence

Parallel with ai's audit-mode soak. collab's default-deny + overlays will be a meaty follow-up — 17+ apps with heavy OIDC fan-out (every glance/paperless/etc. behind oauth2-proxy → Authelia in `auth` ns) and cross-ns DB egress (CNPG clusters in `databases`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)