### PR TITLE
feat(node-exporter): grant DAC_READ_SEARCH so RAPL collector works

### DIFF
--- a/kubernetes/apps/observability/exporters/node-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/exporters/node-exporter/app/helmrelease.yaml
@@ -22,6 +22,19 @@ spec:
       registry: quay.io
       repository: prometheus/node-exporter
 
+    # RAPL collector needs to read /sys/class/powercap/intel-rapl:*/energy_uj
+    # which on recent kernels is mode 400 root-only (Platypus side-channel
+    # mitigation). DAC_READ_SEARCH lets a non-root container bypass the
+    # file read permission check without escalating to full root. See
+    # https://github.com/prometheus/node_exporter/issues/2151
+    containerSecurityContext:
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop:
+          - ALL
+        add:
+          - DAC_READ_SEARCH
+
     prometheus:
       monitor:
         enabled: true


### PR DESCRIPTION
## Summary

The rapl collector was silently failing:

```
node_scrape_collector_success{collector="rapl"} 0
```

Verified the root cause: `/sys/class/powercap/intel-rapl:*/energy_uj` is mode `r--------` root-only on recent kernels (Platypus side-channel mitigation, 2020+). Node-exporter runs as nobody (uid 65534), so the rapl scrape hits EACCES on the energy counter.

`DAC_READ_SEARCH` lets a non-root container bypass file read permission checks. Narrower than `runAsUser: 0`, and the only privilege the collector needs.

## Expected after Flux reconcile

- `node_rapl_*_joules_total` metrics for every worker with a RAPL-capable CPU
- `rate(node_rapl_package_joules_total[1m])` = per-worker CPU package power in W
- Foundation for HA sensors per-worker → Energy Dashboard "Individual devices"

## Caveats

- RAPL covers CPU package only — ~60-70% of whole-system power on M910x-class workers. Better than nothing, not a full measurement.
- Talos workers (one pilot today) may not expose /sys/class/powercap depending on kernel build; will be visible per-node in metric presence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)