### PR TITLE
docs: comprehensive doc sweep — CLAUDE.md, missing READMEs, longhorn polish

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -12,11 +12,14 @@ context window space on every turn.
 
 | File | What it does |
 |------|--------------|
+| `configmap.resources.instructions.md` | ConfigMap source files live under `app/resources/`; file names match the in-container basename. |
 | `flux.sorting.instructions.md` | Field ordering for Flux-managed YAML (Kustomization, dependsOn, sourceRef). |
 | `helmfile.sorting.instructions.md` | Field ordering for HelmRelease YAML, especially app-template-based releases. |
+| `helmrelease.security.md` | Pod-securityContext defaults (runAsNonRoot, readOnlyRootFilesystem, etc.) for new HelmReleases. |
 | `kustomize.config.sorting.instructions.md` | Field ordering for kustomize `kustomization.yaml` files. |
+| `persona.md` | Repo-specific persona — role framing, tone, decision bias. |
 | `schema.correction.md` | apiVersion + kind → `# yaml-language-server: $schema=…` mappings used in this repo. |
-| `storage-class.instructions.md` | When to pick Rook/Ceph vs Longhorn vs Garage for new PVCs. |
+| `storage-class.instructions.md` | When to pick Rook/Ceph vs Longhorn vs Garage vs direct NFS. |
 
 When you add a new instructions file, also add an `@`-import line at
 the top of `CLAUDE.md` so it gets loaded.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ This is a **Home Kubernetes cluster monorepo** managed with GitOps (Flux, Renova
 
 ## Repository Structure
 
-```
+```text
 home-ops/
 ├── kubernetes/          # Kubernetes configurations (Flux-managed)
 │   ├── apps/            # Application configs
@@ -21,26 +21,31 @@ home-ops/
 │   └── flux/            # Flux cluster definitions
 ├── bootstrap/           # Bootstrap templates (helmfile.d, templates)
 ├── docs/                # mdBook documentation
-├── init/		 # Cluster initialization scripts
-└── tools/		 # Helper scripts
+├── init/                # Cluster initialization scripts
+└── tools/                # Helper scripts
 ```
 
 ## Key Technologies
 
-| Category   | Tool                         | Purpose                           |
-|------------|------------------------------|-----------------------------------|
-| GitOps     | Flux                         | Deploys configs from Git to k8s   |
-| CI         | Renovate + GitHub Actions    | Dependency updates, automation    |
-| Networking | cilium (eBPF)                | CNI, BGP, service mesh            |
-| Ingress    | Envoy Gateway                | L7 proxy, ingress controller      |
-| DNS        | external-dns                 | Syncs ingress to Cloudflare/bind  |
-| Secrets    | external-secrets + 1Password | Secret management                 |
-| Storage    | Rook/Ceph, Longhorn, Garage  | Distributed storage + backups     |
-| Images     | ZOT                          | Local container cache             |
+| Category      | Tool                         | Purpose                                          |
+|---------------|------------------------------|--------------------------------------------------|
+| GitOps        | Flux                         | Deploys configs from Git to k8s                  |
+| CI            | Renovate + GitHub Actions    | Dependency updates, automation                   |
+| Networking    | Cilium (eBPF)                | CNI, BGP peering, LoadBalancer pool              |
+| Ingress       | Envoy Gateway                | L7 gateway / HTTPRoute                           |
+| Service mesh  | Istio + Kiali                | mTLS + traffic mgmt for mcp-system               |
+| DNS           | external-dns                 | Cloudflare + bind9 split-horizon                 |
+| Tunnel        | cloudflared                  | Public ingress without exposing home WAN         |
+| AuthN/Z       | Authelia + oauth2-proxy      | OIDC SSO; ~24 oauth2-proxy instances             |
+| Secrets       | external-secrets + 1Password | Secret management (109 ExternalSecrets)          |
+| Storage       | Rook/Ceph, Longhorn, Garage  | Tiered durable storage; see `storage-class` instr |
+| Databases     | CloudNative-PG               | 24+ Postgres clusters with Garage Barman backup  |
+| Observability | kube-prometheus-stack, Loki, Grafana, HolmesGPT | Metrics, logs, AI alert triage |
+| Images        | ZOT                          | Pull-through registry cache                      |
 
 ## GitOps Flow
 
-```
+```text
 Git push → Flux source sync → Kustomization → HelmRelease → k8s resources
 ```
 
@@ -48,7 +53,7 @@ Flux recursively searches `kubernetes/apps/` for `kustomization.yaml` files. Eac
 
 ## Conventions
 
-- Component READMEs stay with components (e.g., `kubernetes/apps/base/cilium/README.md`)
+- Component READMEs stay with components (e.g., `kubernetes/components/network-policy/baseline/README.md`)
 - Secrets stored in 1Password, referenced via `external-secrets`
 - Apps use `HelmRelease` via Flux, rarely raw manifests
 - Clusters are mostly identical except for app selections and sizing
@@ -74,22 +79,27 @@ True` status shows up unexpectedly, ask before touching it.
 
 ## Documentation
 
-- Main docs: `/docs/src/` (mdBook)
+- Main docs: `/docs/src/` (mdBook, rendered at <https://rwlove.github.io/home-ops/>)
+- Repo-wide README: `/README.md` (the home-ops landing page)
 - Component docs: README files co-located with components
-#- Personal notes: `/docs/src/notes/`
+- Agent-loaded conventions: `/.agents/instructions/` (auto-imported via this CLAUDE.md)
+- Agent skills: `/.agents/skills/` (invoked on demand)
 
 ## Adding Documentation
 
 When adding architecture or operational docs, consider:
-1. Put user-facing docs in `/docs/src/`
-2. Keep component-specific docs with the component
-3. Personal notes go in `/docs/src/notes/`
+
+1. **Operator runbooks** → `/docs/src/` (mdBook chapters listed in `SUMMARY.md`)
+2. **Component-specific** → README next to the component (e.g. `kubernetes/components/network-policy/baseline/README.md`)
+3. **Conventions every AI session should auto-load** → `/.agents/instructions/` plus an `@`-import line in this file
+4. **One-shot agent workflows** → `/.agents/skills/` (not auto-loaded; invoked explicitly)
 
 ## PR Review Standards
 
 When reviewing Renovate PRs, enforce these criteria:
 
 ### HelmRelease Requirements
+
 - All applications MUST use `HelmRelease` via Flux, not raw manifests
 - Must include `spec.chart.spec.version` for pinned chart versions outside of `app-template`
 - Must include `spec.interval` for reconciliation frequency
@@ -97,11 +107,13 @@ When reviewing Renovate PRs, enforce these criteria:
 - `valuesFrom` should reference ConfigMaps/Secrets, not inline values
 
 ### Secret Management Rules
+
 - **NEVER** commit plain-text secrets or credentials in Git
 - All secrets MUST use `external-secrets` with 1Password backend
 - If a PR introduces a new secret, verify it's external-secrets backed
 
 ### Image & Digest Policy
+
 - Prefer `@sha256:` digests over version tags for reproducibility
 - For tag-only updates, verify OCI metadata (revision/source/created)
 - If revision changes between digests, ensure it's intentional
@@ -110,10 +122,13 @@ When reviewing Renovate PRs, enforce these criteria:
 - Avoid Docker Hub for critical infrastructure components
 
 ### Cluster-Specific Policies
+
 - Strict validation - all standards must be met
 
 ### Breaking Change Detection
+
 Always `request_changes` if:
+
 - API version changes (e.g., `apiVersion: apps/v1beta1` → `apps/v1`)
 - Deprecated field usage introduced
 - Major version bumps without justification
@@ -121,7 +136,9 @@ Always `request_changes` if:
 - Network policy or security context relaxations
 
 ### Required Evidence for Approval
+
 Before approving, verify:
+
 1. Release notes/changelog mention the upgrade
 2. GitHub compare shows expected changes
 3. Version aligns with what Renovate reported

--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -1,0 +1,87 @@
+# bootstrap/
+
+One-shot resources applied from the laptop before Flux can take over. Runs once per cluster bootstrap; nothing here is reconciled or re-applied later.
+
+The full cluster-bring-up workflow lives in [`docs/src/init_teardown.md`](../docs/src/init_teardown.md) and [`docs/src/cluster_rebuild.md`](../docs/src/cluster_rebuild.md). This README documents what each file in `bootstrap/` does and how they fit together.
+
+## Layout
+
+```text
+bootstrap/
+├── helmfile.d/
+│   ├── 00-crds.yaml       # CRDs that must exist before any HelmRelease lands
+│   ├── 01-apps.yaml       # Bootstrap apps: Cilium, CoreDNS, cert-manager,
+│   │                      # external-secrets + 1Password Connect, Flux operator + instance
+│   └── templates/         # Shared helmfile partials
+├── mod.just               # `just` recipes: render resources, helm bootstrap
+└── resources.yaml.j2      # 1Password-templated Secrets applied before Flux comes up
+```
+
+## Files
+
+### `resources.yaml.j2`
+
+Jinja-style template rendered by `op inject` (1Password CLI). Produces the two pre-Flux Secrets that everything else depends on:
+
+- `external-secrets/onepassword-connect-secret` — 1Password Connect credentials + token. Without this, no `ExternalSecret` in the cluster can resolve.
+- `flux-system/cluster-secrets` — cluster-wide variables (`SECRET_DOMAIN`, `EMAIL`, `NFS_HOST_*`) consumed by Flux Kustomization `postBuild.substituteFrom`.
+
+`op://` URIs reference items in the `kubernetes` 1Password vault. The render command (`just -f bootstrap/mod.just resources`) requires `op` to be signed in.
+
+### `helmfile.d/00-crds.yaml`
+
+CRDs that must exist *before* any HelmRelease can be parsed. Applied first because helmfile installing an operator that owns a CRD doesn't help an `ExternalSecret` manifest already in Git fail validation if the CRD isn't registered yet. Includes: external-secrets, cert-manager, gateway-api, kustomize-mutating-webhook CRDs.
+
+### `helmfile.d/01-apps.yaml`
+
+The minimal set of cluster apps that need to run before Flux can take over. Order matters:
+
+1. Cilium — the cluster has no networking without it; Pods can't even talk to apiserver
+2. CoreDNS — Pods can't resolve service names without it
+3. cert-manager + the Cloudflare ClusterIssuer — required by anything with a hostname
+4. external-secrets + 1Password Connect — required by anything with a Secret
+5. Flux operator + Flux instance — from this point on, everything else flows from Git
+
+After `01-apps.yaml` finishes, Flux pulls the `home-ops-kubernetes` GitRepository and reconciles the rest of `kubernetes/`.
+
+### `mod.just`
+
+Recipes invoked from the repo-root `justfile`:
+
+| Recipe | What it does |
+|---|---|
+| `just bootstrap resources` | Render `resources.yaml.j2` with `op inject`, then `kubectl apply --server-side` |
+| `just bootstrap helm-crds` | `helmfile sync --file bootstrap/helmfile.d/00-crds.yaml` |
+| `just bootstrap helm-apps` | `helmfile sync --file bootstrap/helmfile.d/01-apps.yaml` |
+
+The end-to-end `./init/initialize-cluster.sh` script runs these in the right order; you rarely invoke them individually.
+
+## Prerequisites
+
+Operator-side (laptop):
+
+- `kubectl`
+- `helmfile`
+- `helm` (helmfile shells out to it)
+- `op` (1Password CLI, signed in to a session that can access the `kubernetes` vault)
+- `just`
+
+Cluster-side (`master1`):
+
+- A kubeadm-joined control plane reachable via the VIP at `192.168.6.1`
+- A kubeconfig the laptop can read (typically pulled by `init/initialize-cluster.sh`)
+
+## When bootstrap re-runs
+
+Almost never. Bootstrap is one-shot per cluster lifetime. After `01-apps.yaml` lands, Flux owns Cilium / CoreDNS / cert-manager / external-secrets / 1Password Connect — bootstrap's job ends there.
+
+The exceptions are:
+
+- **Cluster rebuild** ([`cluster_rebuild.md`](../docs/src/cluster_rebuild.md)): teardown + bootstrap + Flux take-over again.
+- **Adding a new cluster-secret variable** (e.g. a new `NFS_HOST_X`): edit `resources.yaml.j2`, run `just bootstrap resources` to update the `cluster-secrets` Secret. The change does not flow through Git because the rendered output never lands in Git.
+
+## Related
+
+- [`init/`](../init/) — the shell scripts that orchestrate bootstrap (create-cluster, initialize-cluster, destroy-cluster, kube-vip).
+- [`docs/src/init_teardown.md`](../docs/src/init_teardown.md) — minimal bring-up procedure.
+- [`docs/src/cluster_rebuild.md`](../docs/src/cluster_rebuild.md) — full bootstrap + recovery walkthrough.

--- a/init/README.md
+++ b/init/README.md
@@ -1,0 +1,59 @@
+# init/
+
+Shell scripts that orchestrate cluster bootstrap and teardown. Each script is meant to be run once at a specific phase of the cluster lifecycle. Nothing here is reconciled — these are one-shot operator tools.
+
+Full end-to-end procedures live in [`docs/src/init_teardown.md`](../docs/src/init_teardown.md) and [`docs/src/cluster_rebuild.md`](../docs/src/cluster_rebuild.md). This README documents the individual scripts and the order they run in.
+
+## Scripts
+
+| Script | Run from | When | What it does |
+|---|---|---|---|
+| `kube-vip.sh` | `master1` (root) | Once, before `kubeadm init` | Renders the `kube-vip` static-pod manifest into `/etc/kubernetes/manifests/`. The VIP (`192.168.6.1`) is what `kubeadm init` will use as the control-plane endpoint. Interface defaults to `enp0s31f6`. |
+| `clusterconfiguration.yaml` | `master1` (read by `create-cluster.sh`) | n/a (manifest) | The `ClusterConfiguration` + `InitConfiguration` `kubeadm` ingests. Sets the control-plane endpoint to the VIP, cri-socket to cri-o, and the bootstrap token. |
+| `create-cluster.sh` | `master1` (root) | Once, after `kube-vip.sh` | `kubeadm init` with `clusterconfiguration.yaml`, joins masters 2/3 + every worker, labels Longhorn-eligible nodes, makes `master1` schedulable. Requires `SECRET_DOMAIN` env. |
+| `initialize-cluster.sh` | Laptop | After `create-cluster.sh` finishes | Pulls kubeconfig from `master1`, runs `bootstrap/mod.just` recipes (1Password-templated Secrets → CRDs → bootstrap apps via helmfile). Ends when Flux is reconciling. |
+| `approve-csrs.sh` | Laptop | Ad-hoc fallback | Approves pending node CSRs in bulk. Normally `kubelet-csr-approver` handles this automatically; this script is for the case where the auto-approver isn't up yet. |
+| `destroy-cluster.sh` | Laptop | Tearing down to rebuild | Suspends Rook/Ceph + Longhorn HelmReleases, drains every node, runs `kubeadm reset`, wipes Ceph OSD devices, clears `/var/lib/{etcd,kubelet,longhorn,rook}`. **Destructive — only reuses the same hardware.** |
+
+## Order
+
+### First bring-up (or rebuild)
+
+1. (`master1` only) Edit `init/kube-vip.sh` if the network interface or VIP differs from `enp0s31f6` / `192.168.6.1`.
+2. On `master1`: `./init/kube-vip.sh`
+3. On `master1`: `export SECRET_DOMAIN=...; ./init/create-cluster.sh`
+4. On the laptop: `./init/initialize-cluster.sh`
+5. On the laptop: `ssh root@master1 rm /etc/kubernetes/manifests/kube-vip.yaml` (the static pod is now redundant; Flux brings up the in-cluster kube-vip DaemonSet)
+
+### Teardown (only if reusing the same hardware)
+
+1. On the laptop: `./init/destroy-cluster.sh` — drains, resets, wipes
+2. Verify NFS-backed bits (Garage substrate on `${NFS_HOST_0}`, Longhorn backup target on `beast`) are intact *before* running this. Lose those and CNPG recovery has no source. See [`docs/src/cluster_rebuild.md`](../docs/src/cluster_rebuild.md) → "Preflight".
+
+## Prerequisites
+
+Laptop:
+
+- `kubectl`, `helmfile`, `helm`, `just`
+- `op` (1Password CLI, signed in)
+- SSH access to all cluster nodes as `root`
+
+`master1`:
+
+- A `kubeadm`-installed control plane (`kubeadm`, `kubelet`, `kubectl`, `cri-o`, `crun`)
+- `podman` (used by `kube-vip.sh` to render the static-pod manifest)
+
+## What lives here vs `bootstrap/`
+
+- **`init/`** = shell scripts that *orchestrate* the bootstrap procedure (run kubeadm, scp kubeconfigs, etc.).
+- **[`bootstrap/`](../bootstrap/)** = the resources that get *applied* during bootstrap (1Password-templated Secrets, CRDs, the bootstrap helmfile).
+
+`initialize-cluster.sh` is the seam — it pulls kubeconfig and then drives the `bootstrap/mod.just` recipes.
+
+## Related
+
+- [`bootstrap/README.md`](../bootstrap/README.md) — what gets applied during bootstrap.
+- [`docs/src/init_teardown.md`](../docs/src/init_teardown.md) — minimal procedure.
+- [`docs/src/cluster_rebuild.md`](../docs/src/cluster_rebuild.md) — full bootstrap + CNPG recovery walkthrough.
+- [`docs/src/promote_worker_to_control_plane.md`](../docs/src/promote_worker_to_control_plane.md) — for the case where you're swapping a control-plane node, not full bring-up.
+- [`docs/src/power-outage.md`](../docs/src/power-outage.md) — for the case where the cluster cold-started and `kube-vip` is racing the apiserver.

--- a/kubernetes/apps/longhorn-system/longhorn/README.md
+++ b/kubernetes/apps/longhorn-system/longhorn/README.md
@@ -1,13 +1,73 @@
-### To Fix permission deinied errors
+# Longhorn — operational notes
 
-1. Scale Down the service in K8s (kubectl scale --replicas=0 deploy/<serviceName>)
-2. Go into the Longhorn UI, click on Volume, and find the PV. It should be in a "Detached" state. Click on the "Name" field.
-3. In the Volume details screen, click the --- in the upper right and select "Attach"
-4. Pick any of your nodes to attach the PV to, do not select the Maintenance Mode checkbox.
-5. Take note of the 'Attached Node & Endpoint' in the 'Volume Details' screen, this should be the name of the server that you told it to attach to plus the path on that server that the block device is available (/dev/longhorn/<pv-name> )
-6. SSH into the server you mounted the block device on, create a temporary mountpoint for the block device to mount to (sudo mkdir /mnt/tmp
-7. Mount the block device to the temporary mount point (sudo mount /dev/longhorn<pv-name> /mnt/tmp)
-8. Chown the folders to use the UID/GID that the container is operating under. In the case of the kah images, that's 568:568. (sudo chown -R 568:568 /mnt/tmp/)
-9. Umount the mountpoint (sudo umount /mnt/tmp)
-10. Go back into the Longhorn UI and click the same --- in the upper right and select "Detach", click OK in the menu that pops up.
-11. Scale back up the service in kubernetes (kubectl scale --replicas=1 deploy/<serviceName>)
+The HelmRelease + StorageClasses live next to this file; tier-selection
+guidance is in [`.agents/instructions/storage-class.instructions.md`](../../../../.agents/instructions/storage-class.instructions.md).
+This README captures one runbook that pops up periodically.
+
+## Fix `EACCES` / permission-denied errors on a Longhorn PVC
+
+When you see something like `permission denied` on a directory the pod
+expects to own — or the pod crashes during `chown` / startup — the
+usual cause is one of:
+
+- **UID drift.** The image's `USER` directive changed (often after a major bump), but the existing volume's files are owned by the prior UID.
+- **`fsGroup` mismatch.** The HelmRelease specifies a `fsGroup` that doesn't include the directory mode/owner the app expects.
+- **ext4 `lost+found` quirk.** Fresh ext4 Longhorn PVCs ship with `lost+found` owned `root:root` mode-700; non-root containers enumerating the volume's root directory hit `EACCES`. The fix for that specific symptom is `chmod 755 lost+found` once; see `project_ext4_lostfound_nonroot` memory.
+
+The procedure below is for the UID-drift case — when the existing files need to be re-owned to match what the new pod expects. The image's running UID/GID is typically baked in (`568:568` for linuxserver.io images, `1000:1000` for bjw-s defaults, app-specific otherwise — check the container's `id` output before chowning).
+
+### Procedure
+
+1. **Scale the workload down**:
+
+   ```sh
+   kubectl scale -n <ns> --replicas=0 deploy/<name>
+   # (or statefulset/<name>)
+   ```
+
+2. **Find the volume in the Longhorn UI.** Open Longhorn (port-forward `longhorn-frontend` in `longhorn-system` if you don't have ingress wired up), navigate to **Volume**, find the PV by name. It should be **Detached**.
+
+3. **Attach to a node manually.** Click the volume name → top-right `⋮` → **Attach**. Pick any worker. Do **not** check the "Maintenance Mode" box.
+
+4. **Note the device path.** The Volume Details screen shows `Attached Node` and an `Endpoint` like `/dev/longhorn/<pv-name>`.
+
+5. **SSH to the attached node** and mount the block device to a temp mountpoint:
+
+   ```sh
+   ssh root@<node>
+   mkdir -p /mnt/tmp
+   mount /dev/longhorn/<pv-name> /mnt/tmp
+   ```
+
+6. **chown to the right UID/GID.** Confirm the target IDs from the image (e.g. `kubectl exec` into a running pod of the same image and `id`). Then:
+
+   ```sh
+   chown -R 568:568 /mnt/tmp/     # linuxserver.io default
+   # or 1000:1000 for bjw-s default, or whatever `id` reported
+   ```
+
+7. **Unmount and detach.**
+
+   ```sh
+   umount /mnt/tmp
+   ```
+
+   Back in the Longhorn UI, top-right `⋮` → **Detach** → confirm.
+
+8. **Scale the workload back up**:
+
+   ```sh
+   kubectl scale -n <ns> --replicas=1 deploy/<name>
+   ```
+
+### When NOT to use this
+
+- **Newly-provisioned PVC with `lost+found` issue** — that's a one-time `chmod 755 lost+found`, not a full chown sweep. See the memory.
+- **Symptom looks like "fresh PVC won't bind"** — that's usually a StorageClass / `volumeName` / capacity mismatch, not a permission issue. Check `kubectl describe pvc` first.
+- **App documented as needing root** (some images, e.g. older slskd builds) — running the procedure won't help; the app needs `runAsUser: 0` and the security defaults in `helmrelease.security.md` overridden. See the `project_slskd_readonly_rootfs` memory for that pattern.
+
+## Related
+
+- [`.agents/instructions/helmrelease.security.md`](../../../../.agents/instructions/helmrelease.security.md) — securityContext defaults and the read-only-rootfs deviations.
+- [`.agents/instructions/storage-class.instructions.md`](../../../../.agents/instructions/storage-class.instructions.md) — when Longhorn vs ceph-block vs Garage vs NFS.
+- [Longhorn HelmRelease values](app/helmrelease.yaml) — backupTarget, recurring jobs, replica counts.

--- a/tools/README.md
+++ b/tools/README.md
@@ -70,10 +70,17 @@ flow — they're for ad-hoc operator work.
 | `restart-k8s-service.sh` | Scale a Deployment to 0, wait, scale back up. |
 | `enable-disable-hr.sh` | Pause/unpause a HelmRelease via the `disable-<app>` commit pattern. |
 
-## Miscellaneous
+## Auth + registry helpers
+
+| Script | Purpose |
+|---|---|
+| `gen-oauth-client-secret.sh` | Generate an Authelia OAuth2 client secret + matching argon2 hash (paste both into `clients.yaml` / 1Password). |
+| `check-image-registry.sh` | Verify image registries used in the repo against the allowlist (renovate / PR-review aid). |
+
+## App-specific
 
 | Script | Purpose |
 |---|---|
 | `frigate_copy_speed.sh` | Tail Frigate logs and print recording copy throughput. |
 | `ollama-pull-models.sh` | Pull a predefined set of models into the Ollama instance. |
-| `start-fullykiosk.sh` | adb-trigger Fully Kiosk on the `frameo` display. |
+| `romm-apply-tags.sh` | Apply per-ROM tags in the RomM database after a scan. |


### PR DESCRIPTION
Audit + improvement pass across the doc surface outside \`docs/src/\` and \`.agents/instructions/\` (both already swept).

## Drift fixes

### \`CLAUDE.md\` (auto-loaded into every Claude session — highest leverage)

- **Bad path references:** \`kubernetes/apps/base/cilium/README.md\` and \`/docs/src/notes/\` — neither exists in the repo. Updated to point at real component-README locations and removed the dead \`notes/\` references.
- **Key Technologies row drift:** Cilium was labeled "service mesh" — the cluster's service mesh is Istio. Added Istio, Authelia, cloudflared, Databases, Observability rows so the table reflects what the cluster actually runs.
- **Documentation section reorganized** to enumerate the four doc-surface locations + an "Adding Documentation" decision tree.
- **Pre-existing markdownlint failures** in the PR Review Standards section fixed (MD022 / MD032 / MD040 / MD010 — blank lines around headings/lists, fenced code language, hard tabs in the structure tree).

### \`.agents/README.md\`

Instructions table listed 5 files; reality is 8. Added \`configmap.resources.instructions\`, \`helmrelease.security\`, \`persona\`.

### \`tools/README.md\`

- Removed \`start-fullykiosk.sh\` (no longer in \`tools/\`).
- Added missing entries for \`check-image-registry.sh\`, \`gen-oauth-client-secret.sh\`, \`romm-apply-tags.sh\`.

## New READMEs (entry points referenced by other docs but never written)

### \`bootstrap/README.md\`

Explains \`helmfile.d/{00-crds,01-apps}.yaml\`, \`mod.just\`, \`resources.yaml.j2\` — what each does, the order they apply in, prerequisites, when bootstrap re-runs (and when it doesn't). Cross-linked from \`init/\` and \`docs/src/{init_teardown,cluster_rebuild}.md\`.

### \`init/README.md\`

Per-script table for \`kube-vip.sh\` / \`clusterconfiguration.yaml\` / \`create-cluster.sh\` / \`initialize-cluster.sh\` / \`approve-csrs.sh\` / \`destroy-cluster.sh\`. Run order for bring-up + teardown. Documents the seam between \`init/\` (orchestration) and \`bootstrap/\` (applied resources).

## Polish

### \`kubernetes/apps/longhorn-system/longhorn/README.md\`

Was a 13-line bare procedure. Expanded to:

- Three different "permission denied" symptom patterns (UID drift, \`fsGroup\` mismatch, ext4 \`lost+found\` quirk) — different problems need different fixes.
- Concrete UID/GID examples (linuxserver \`568\`, bjw-s default \`1000\`) instead of leaving the reader to guess.
- "When NOT to use this" section pointing at the relevant memory entries.

## Doc surface left untouched (already current)

- \`.agents/skills/*\` (7 skill files) — all recently written, frontmatter clean, content current
- \`.claude/output-styles/*\` (architect / debugger / optimizer) — recent, internally consistent
- \`kubernetes/apps/home/n8n/workflows/README.md\` — recently rewritten for the LangGraph workflows
- \`kubernetes/apps/home/node-red/README.md\` — 3 lines, useful, accurate
- \`kubernetes/components/network-policy/{baseline,default-deny}/README.md\` — recent, very current

## Test plan

- [x] \`markdownlint-cli2\` clean on all 6 touched files
- [x] All cross-doc links point at real files
- [x] CLAUDE.md still auto-loads the same 8 \`.agents/instructions/\` files
- [ ] CI lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)