### PR TITLE
feat(network-policy): media baseline (Phase 2 — final ns)

### DIFF
--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 namespace: media
 components:
   - ../../components/alerts
+  - ../../components/network-policy/baseline
 resources:
   - ./namespace.yaml
   - ./priority-class.yaml


### PR DESCRIPTION
## Summary

Phase 2 baseline for `media` (30+ apps, 41 pods — biggest stateless ns). 1-line diff; 5 additive CNPs via the existing baseline component. `enableDefaultDeny: false` — zero enforcement risk.

**This is the last Phase 2 baseline PR.** With it merged, all 7 Phase 2 namespaces (ai, actions-runner-system, renovate, mcp-system, home, collab, media) have baselines in place.

## Test plan

- [ ] Flux reconciles `media` Kustomization cleanly
- [ ] `kubectl get cnp -n media` shows 5 baseline policies
- [ ] All 41 media pods stay Ready (*arr stack, jellyfin, immich, music-assistant, etc.)

## What's next (after merge)

- ai's 48h audit-mode soak continues. Once enough Hubble data accumulates, Phase 2 PR 3 = per-namespace default-deny + overlays + flip cluster `policyAuditMode` off. That re-enforces selfhosted simultaneously.
- Phases 3-6 (`auth`/`databases`/`vpn`/`downloads`, then storage, gateway/cert/secrets, observability/kuadrant/istio-system/cilium-secrets) follow per the rollout plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)