### PR TITLE
fix(node-exporter): run as root so RAPL collector actually reads energy_uj

### DIFF
--- a/kubernetes/apps/observability/exporters/node-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/exporters/node-exporter/app/helmrelease.yaml
@@ -22,18 +22,22 @@ spec:
       registry: quay.io
       repository: prometheus/node-exporter
 
-    # RAPL collector needs to read /sys/class/powercap/intel-rapl:*/energy_uj
-    # which on recent kernels is mode 400 root-only (Platypus side-channel
-    # mitigation). DAC_READ_SEARCH lets a non-root container bypass the
-    # file read permission check without escalating to full root. See
-    # https://github.com/prometheus/node_exporter/issues/2151
+    # RAPL collector needs to read /sys/class/powercap/intel-rapl:*/energy_uj,
+    # mode 400 root-only on recent kernels (Platypus side-channel mitigation).
+    # CAP_DAC_READ_SEARCH alone is insufficient: on a non-root UID the cap
+    # lands in the bounding set but effective/permitted/ambient stay empty
+    # (Linux capability model — needs file caps on the binary or the kernel
+    # ambient set, neither of which the chart provides). Simplest fix is
+    # runAsUser: 0. node-exporter mounts /proc, /sys, /root read-only so
+    # root inside the container isn't a meaningful trust escalation.
+    securityContext:
+      runAsUser: 0
+      runAsNonRoot: false
     containerSecurityContext:
       readOnlyRootFilesystem: true
       capabilities:
         drop:
           - ALL
-        add:
-          - DAC_READ_SEARCH
 
     prometheus:
       monitor:


### PR DESCRIPTION
## Summary

Follow-up to #11454. Verified post-merge:

```
CapBnd: 0000000000000004   ← bounding has DAC_READ_SEARCH ✓
CapEff: 0000000000000000   ← effective is empty (uid 65534)
```

The cap lands in the bounding set but effective/permitted stay empty for the non-root UID. Linux capability model requires either file caps on the binary or the kernel ambient set to elevate to effective — neither is provided by the prometheus-community chart and neither is trivially addable. Collector says success but emits zero metrics because every `energy_uj` read returns EACCES.

Switch to `runAsUser: 0`, drop the now-redundant cap.

## Why this is acceptable

node-exporter only mounts /proc, /sys, /root **read-only**. Root inside the container isn't a meaningful trust escalation vs. the cap path that this PR replaces — it just gets the actual privilege node-exporter needs to do its job.

## Coverage

4 of 10 nodes have `/sys/class/powercap` exposed at all:

| Has RAPL | No RAPL |
|---|---|
| master1, worker2, worker3, worker4 (physical M910x) | master2, master3, worker5, worker6, worker7, worker8 (KVM on beast — covered by beast iDRAC) |

So the partial coverage is expected, not a bug. Total RAPL data after this lands: 4 nodes × CPU-package power ≈ ~20-60W of additional visibility, complementing beast's per-system iDRAC reading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)