### PR TITLE
feat(observability): power:workers_cpu:watts recording rule

### DIFF
--- a/kubernetes/apps/observability/exporters/snmp-exporter/app/apc-ups/prometheusrule.yaml
+++ b/kubernetes/apps/observability/exporters/snmp-exporter/app/apc-ups/prometheusrule.yaml
@@ -75,6 +75,14 @@ spec:
         # PoE delivered per Omada switch
         - record: power:omada_poe:watts
           expr: sum by (device_name) (omada_port_power_watts)
+        # CPU package power across the 4 physical workers (master1, worker2,
+        # worker3, worker4). The other 6 cluster nodes are KVM guests on
+        # beast and have no /sys/class/powercap exposed — beast's iDRAC
+        # already accounts for their power. RAPL captures ~60-70% of true
+        # system power on M910x (CPU package only; RAM, NIC, disk, board
+        # not measured).
+        - record: power:workers_cpu:watts
+          expr: sum(rate(node_rapl_package_joules_total[2m]))
     # Anomaly alerts on the recording rules above.
     - name: power.alerts
       rules:


### PR DESCRIPTION
Now that #11460 unblocked RAPL, aggregate the 4 physical workers' CPU package power into a single recording rule for cleaner consumption by HA + Grafana.

```
power:workers_cpu:watts = sum(rate(node_rapl_package_joules_total[2m]))
```

Currently ~65W combined across master1, worker2, worker3, worker4. The other 6 nodes are KVM on beast (covered by iDRAC).

Next PR (HA side): REST sensor pulls this metric → Riemann integration to kWh → Energy Dashboard Individual Device under UPS 3000.

🤖 Generated with [Claude Code](https://claude.com/claude-code)