### PR TITLE
revert(network-policy): disable cluster audit mode + drop ai default-deny

### DIFF
--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -5,7 +5,6 @@ kind: Kustomization
 namespace: ai
 components:
   - ../../components/network-policy/baseline
-  - ../../components/network-policy/default-deny
 resources:
   - ./namespace.yaml
   - ./priority-class.yaml

--- a/kubernetes/apps/kube-system/cilium/app/values.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/values.yaml
@@ -91,14 +91,6 @@ hubble:
 pmtuDiscovery:
   enabled: true
 
-# TEMPORARY (Phase 2 of NetworkPolicy rollout, 2026-05-17): cluster-wide
-# audit mode so default-deny CNPs in `ai` (and any subsequent Phase 2
-# namespace) log drops as DROPPED-AUDITED instead of enforcing. Disable
-# this when ai's per-app overlays are finalized — selfhosted (the only
-# existing default-deny consumer) re-enforces automatically when this
-# flips back. See docs/src/networkpolicy_rollout_plan.md.
-policyAuditMode: true
-
 securityContext:
   capabilities:
     ciliumAgent:


### PR DESCRIPTION
## Summary

**Recovery PR.** Reverts the Phase 2 audit-mode setup which was found to silently disable policy enforcement (rather than log+pass as the chart docs suggested).

## Why

Investigation found that Cilium 1.19's `policyAuditMode: true` in cilium-config sets `policy_enabled: null` on every endpoint — policy enforcement is fully disabled, not audited. Evidence:

- `cilium-dbg endpoint get` on selfhosted webhook (EP 595) and ai langgraph-agents (EP 2739): both show `policy_enabled: null`
- `cilium-dbg monitor --type policy-verdict` across all 10 agents: 0 `action audit` events, only `action allow`
- `hubble observe --verdict AUDIT --since 30m`: 0 events cluster-wide
- `cilium_policy_verdict_total{reason=...}`: empty in Prometheus

**Net effect of the prior state was bad both ways:**

1. selfhosted's verified-working default-deny was NOT enforcing — regression from Phase 1
2. No audit data being captured for ai overlay design — we paid the cost without the benefit

## Changes

- `cilium/app/values.yaml` — remove `policyAuditMode: true` block (back to default behavior)
- `ai/kustomization.yaml` — remove `default-deny` component reference (ai goes back to baseline-only, additive)

## After merge (auto via Flux)

- Cilium daemonset rolls (brief CNI hiccup per node, ~2 min)
- selfhosted webhook's default-deny re-engages (Pattern A + baseline still cover what it needs)
- ai is back to additive baseline only — 5 CNPs, no enforcement

## Test plan

- [ ] Cilium daemonset rolls cleanly
- [ ] `kubectl get cm -n kube-system cilium-config -o yaml | grep policy-audit` shows the key is absent or `disabled`
- [ ] `kubectl get cnp -n selfhosted` still shows 7 CNPs (default-deny stays)
- [ ] `kubectl get cnp -n ai` shows 5 CNPs (default-deny removed)
- [ ] selfhosted webhook external reachability still works (HTTP 200 from external curl)
- [ ] `kubectl exec ds/cilium -- cilium-dbg endpoint get <webhook-ep>` shows `policy_enabled: true` again

## Next pass at ai

Two viable mechanisms not yet tried:
1. Per-pod `policy.cilium.io/audit-mode: enabled` annotation (the actually-documented per-endpoint mechanism)
2. Speculative overlay design from helmrelease/HTTPRoute survey + ship in enforce mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)