### PR TITLE
feat(network-policy): auth baseline (Phase 3)

### DIFF
--- a/kubernetes/apps/auth/kustomization.yaml
+++ b/kubernetes/apps/auth/kustomization.yaml
@@ -3,6 +3,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: auth
+components:
+  - ../../components/network-policy/baseline
 resources:
   - ./namespace.yaml
   - ./authelia/ks.yaml


### PR DESCRIPTION
## Summary

Phase 3, namespace 1 of 4 (auth). 3-line diff (new `components:` block); 5 additive CNPs land in `auth` via the baseline component. `enableDefaultDeny: false` — zero enforcement risk.

## Test plan

- [ ] Flux reconciles `auth` Kustomization cleanly
- [ ] `kubectl get cnp -n auth` shows 5 baseline policies
- [ ] Authelia + LLDAP pods stay Ready, OIDC sign-in flows untouched

## Sequence

Phase 3 baselines for auth → databases → vpn → downloads. Then ai overlay design (the substantial work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)