### PR TITLE
feat(network-policy): databases baseline (Phase 3)

### DIFF
--- a/kubernetes/apps/databases/kustomization.yaml
+++ b/kubernetes/apps/databases/kustomization.yaml
@@ -3,6 +3,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: databases
+components:
+  - ../../components/network-policy/baseline
 resources:
   - ./namespace.yaml
   - ./priority-class.yaml


### PR DESCRIPTION
## Summary

Phase 3, namespace 2 of 4 (databases). 3-line diff; 5 additive CNPs via the baseline component. `enableDefaultDeny: false` — zero enforcement risk.

## Test plan

- [ ] Flux reconciles `databases` Kustomization cleanly
- [ ] `kubectl get cnp -n databases` shows 5 baseline policies
- [ ] All 80+ databases pods stay Ready (cloudnative-pg, dragonfly, pgadmin, qdrant, all CNPG clusters)

🤖 Generated with [Claude Code](https://claude.com/claude-code)