### PR TITLE
feat(network-policy): vpn baseline (Phase 3)

### DIFF
--- a/kubernetes/apps/vpn/kustomization.yaml
+++ b/kubernetes/apps/vpn/kustomization.yaml
@@ -3,6 +3,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: vpn
+components:
+  - ../../components/network-policy/baseline
 resources:
   - ./namespace.yaml
   - ./downloads-gateway/ks.yaml


### PR DESCRIPTION
## Summary

Phase 3, namespace 3 of 4 (vpn). 3-line diff; 5 additive CNPs via the baseline component. `enableDefaultDeny: false` — zero enforcement risk.

vpn runs the pod-gateway main pod (WireGuard egress) + webhook controller. The existing `downloads-gateway-pod-gateway` CNP is unchanged.

## Test plan

- [ ] Flux reconciles `vpn` Kustomization cleanly
- [ ] `kubectl get cnp -n vpn` shows 5 baseline + 1 existing pod-gateway CNP (6 total)
- [ ] downloads-gateway-pod-gateway-main-0 + webhook pod stay Ready
- [ ] downloads namespace VPN-routed clients keep working (qbittorrent, sabnzbd, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)