### PR TITLE
feat(network-policy): downloads baseline (Phase 3 final)

### DIFF
--- a/kubernetes/apps/downloads/kustomization.yaml
+++ b/kubernetes/apps/downloads/kustomization.yaml
@@ -3,6 +3,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: downloads
+components:
+  - ../../components/network-policy/baseline
 resources:
   - ./namespace.yaml
   - ./jdownloader2/ks.yaml


### PR DESCRIPTION
## Summary

Phase 3, namespace 4 of 4 (downloads). 3-line diff; 5 additive CNPs via the baseline component. `enableDefaultDeny: false` — zero enforcement risk.

VPN-routed clients (jdownloader2, prowlarr, qbittorrent, sabnzbd, slskd) + oauth2-proxies. VXLAN tunnel flow to vpn/downloads-gateway-pod-gateway-main-0 unchanged (existing CNP preserved).

## Test plan

- [ ] Flux reconciles `downloads` Kustomization cleanly
- [ ] `kubectl get cnp -n downloads` shows 5 baseline + 1 existing pod-gateway CNP
- [ ] All downloads pods stay Ready, VPN-routed traffic flows fine

## Phase 3 complete after merge

12 namespaces with baselines in place after this:
- Phase 1: selfhosted (also has default-deny enforce)
- Phase 2: ai, actions-runner-system, renovate, mcp-system, home, collab, media
- Phase 3: auth, databases, vpn, downloads

Remaining: Phases 4-6 (storage, gateway/cert/secrets, observability cluster).

🤖 Generated with [Claude Code](https://claude.com/claude-code)