### PR TITLE
feat(observability): scrape node-exporter on security-storage

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/addons/scrapeconfigs/node-exporter.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/addons/scrapeconfigs/node-exporter.yaml
@@ -9,6 +9,7 @@ spec:
     - targets:
         - brain.${SECRET_DOMAIN}:9100
         - beast.${SECRET_DOMAIN}:9100
+        - security-storage.${SECRET_DOMAIN}:9100
   metricsPath: /metrics
   relabelings:
     - action: replace


### PR DESCRIPTION
Adds security-storage to the existing node-exporter ScrapeConfig.

- node_exporter 1.11.1 installed on security-storage 2026-05-17 (scp + systemd unit; github is blocked from the host's network)
- Core 2 Duo E6400, no RAPL — won't produce power data, but memory/disk/network/uptime metrics will flow
- Hardware-level power for this host needs a Zigbee plug (TODO already saved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)