### PR TITLE
feat(observability): GPU power rule + BGE/GPU anomaly alerts (A+E)

### DIFF
--- a/kubernetes/apps/ai/comfyui/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/comfyui/app/cnp-allow.yaml
@@ -1,0 +1,48 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: comfyui-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: comfyui
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal gateway → comfyui:8188
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "8188"
+              protocol: TCP
+  egress:
+    # Provisioning script fetches model weights + custom nodes from the
+    # ai-dock provisioning URL on first start and on AUTO_UPDATE runs.
+    # ai-dock/comfyui pulls from raw.githubusercontent.com, HuggingFace,
+    # CivitAI, and PyPI mirrors. Allow HTTPS to those plus the broader
+    # GitHub release surface.
+    - toFQDNs:
+        - matchName: "raw.githubusercontent.com"
+        - matchName: "github.com"
+        - matchName: "codeload.github.com"
+        - matchPattern: "*.githubusercontent.com"
+        - matchName: "huggingface.co"
+        - matchPattern: "*.huggingface.co"
+        - matchName: "cdn-lfs.huggingface.co"
+        - matchPattern: "*.hf.co"
+        - matchName: "civitai.com"
+        - matchPattern: "*.civitai.com"
+        - matchName: "pypi.org"
+        - matchName: "files.pythonhosted.org"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/ai/comfyui/app/kustomization.yaml
+++ b/kubernetes/apps/ai/comfyui/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./helmrelease.yaml
   - ./longhorn-pvc.yaml
   - ./nfs-pvc.yaml

--- a/kubernetes/apps/ai/khoj-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/khoj-oauth2-proxy/app/cnp-allow.yaml
@@ -1,0 +1,37 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: khoj-oauth2-proxy-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: khoj-oauth2-proxy
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal gateway → khoj-oauth2-proxy:4180
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "4180"
+              protocol: TCP
+  egress:
+    # OIDC discovery + token exchange against Authelia. auth.SECRET_DOMAIN
+    # resolves to the internal Envoy gateway VIP, which then routes to
+    # the auth namespace. toFQDNs is the cleanest expression.
+    # Upstream → khoj.ai.svc.cluster.local:42110. Same-ns; the baseline
+    # allow-intra-namespace already covers that path.
+    - toFQDNs:
+        - matchName: "auth.thesteamedcrab.com"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/ai/khoj-oauth2-proxy/app/kustomization.yaml
+++ b/kubernetes/apps/ai/khoj-oauth2-proxy/app/kustomization.yaml
@@ -5,5 +5,6 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/ai/khoj/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/khoj/app/cnp-allow.yaml
@@ -1,0 +1,48 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: khoj-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: khoj
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  # No ingress rules needed: khoj-oauth2-proxy is the only door, and the
+  # baseline allow-intra-namespace already permits oauth2-proxy → khoj.
+  # No external clients hit khoj directly.
+  egress:
+    # CNPG cluster `postgres-khoj` in databases ns (Pattern B).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
+            cnpg.io/cluster: postgres-khoj
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+    # Searxng in collab ns (KHOJ_SEARXNG_URL).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: collab
+            app.kubernetes.io/name: searxng
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+    # HuggingFace model downloads (embedding/search models cached to
+    # khoj-models PVC on first run + on model config changes).
+    - toFQDNs:
+        - matchName: "huggingface.co"
+        - matchPattern: "*.huggingface.co"
+        - matchName: "cdn-lfs.huggingface.co"
+        - matchPattern: "*.hf.co"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/ai/khoj/app/kustomization.yaml
+++ b/kubernetes/apps/ai/khoj/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./config-pvc.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/ai/kubeclaw/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/kubeclaw/app/cnp-allow.yaml
@@ -1,0 +1,68 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: kubeclaw-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: kubeclaw
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it. Selector covers all 4 kubeclaw components
+  # (gateway, chromium, qmd-embed Job, qmd-update Job).
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal gateway → kubeclaw-gateway:18789. Chromium /
+    # CronJob pods don't have HTTPRoutes; the gateway is the public face.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "18789"
+              protocol: TCP
+  egress:
+    # Ollama in same ns (intra-namespace baseline already permits this,
+    # but explicit here for grep-ability when reading kubeclaw config).
+    # The kubeclaw `models.providers.ollama.baseUrl` resolves to
+    # ollama.ai.svc.cluster.local:11434.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: ai
+            app.kubernetes.io/name: ollama
+      toPorts:
+        - ports:
+            - port: "11434"
+              protocol: TCP
+    # mcporter skill talks to MCP servers via mcp-gateway. kubeclaw
+    # config references this implicitly through the bundled mcporter
+    # entrypoint; allow egress to the gateway pods in mcp-system.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: mcp-system
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+            - port: "50051"
+              protocol: TCP
+    # qmd-embed CronJob downloads embedding models from HuggingFace on
+    # first run and on model rotation. qmd-update may also reach GitHub
+    # for skill repo updates.
+    - toFQDNs:
+        - matchName: "huggingface.co"
+        - matchPattern: "*.huggingface.co"
+        - matchName: "cdn-lfs.huggingface.co"
+        - matchPattern: "*.hf.co"
+        - matchName: "github.com"
+        - matchName: "codeload.github.com"
+        - matchName: "raw.githubusercontent.com"
+        - matchPattern: "*.githubusercontent.com"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/ai/kubeclaw/app/kustomization.yaml
+++ b/kubernetes/apps/ai/kubeclaw/app/kustomization.yaml
@@ -3,6 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./httproute.yaml

--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 namespace: ai
 components:
   - ../../components/network-policy/baseline
+  - ../../components/network-policy/default-deny
 resources:
   - ./namespace.yaml
   - ./priority-class.yaml

--- a/kubernetes/apps/ai/langgraph-agents/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/cnp-allow.yaml
@@ -1,0 +1,87 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: langgraph-agents-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: langgraph-agents
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal gateway → langgraph-agents:8765
+    # (agents.${SECRET_DOMAIN}). n8n's approval-receive workflow also
+    # POSTs here, but that traffic still arrives via the internal
+    # Envoy gateway (n8n → HTTPRoute → envoy → langgraph-agents).
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "8765"
+              protocol: TCP
+  egress:
+    # Two CNPG clusters in databases ns: checkpoints + memory (Pattern B).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
+            cnpg.io/cluster: postgres-langgraph-checkpoints
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
+            cnpg.io/cluster: postgres-langgraph-memory
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+    # Ollama in same ns (baseline allow-intra-namespace covers this,
+    # but explicit for grep-ability — OLLAMA_BASE_URL is the agents'
+    # primary model backend).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: ai
+            app.kubernetes.io/name: ollama
+      toPorts:
+        - ports:
+            - port: "11434"
+              protocol: TCP
+    # MCP gateway (mcp-system ns). The agent fleet talks to every MCP
+    # tool via this gateway; per project_mcp_gateway_auth_done the
+    # gateway is the only ingress point. Use the istio-managed gateway
+    # service which langgraph-agents addresses by name.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: mcp-system
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+    # Zulip in collab ns — the agent fleet posts updates / receives
+    # commands via the Zulip bot API.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: collab
+            app.kubernetes.io/name: zulip
+      toPorts:
+        - ports:
+            - port: "80"
+              protocol: TCP
+    # External APIs:
+    #   - api.pushover.net    — Tier-1 alert escalations
+    #   - api.anthropic.com   — Claude API (gated on ENABLE_CLAUDE_API)
+    # Langfuse: user intends self-hosted in-cluster. LANGFUSE_HOST is
+    # currently empty so the client doesn't instantiate. When the
+    # in-cluster Langfuse lands, add a toEndpoints rule here for the
+    # langfuse ns + app label.
+    - toFQDNs:
+        - matchName: "api.pushover.net"
+        - matchName: "api.anthropic.com"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/ai/langgraph-agents/app/kustomization.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
-  - ./pvc.yaml
   - ./helmrelease.yaml
+  - ./pvc.yaml

--- a/kubernetes/apps/ai/ollama/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/ollama/app/cnp-allow.yaml
@@ -1,0 +1,65 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: ollama-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: ollama
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal gateway → ollama:11434 (ollama.${SECRET_DOMAIN}
+    # for direct user access).
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "11434"
+              protocol: TCP
+    # Cross-ns callers observed via Hubble + helmrelease survey:
+    #   home/home-assistant   — voice assist / conversation agent
+    #   media/suggestarr      — LLM-driven recommendation enrichment
+    #   collab/* (paperless-ai indirect via ai/paperless-ai; not direct)
+    #   mcp-system/*          — some MCP servers may proxy ollama calls
+    # Intra-ns callers (kubeclaw-gateway, langgraph-agents, khoj,
+    # comfyui prompt eval) are covered by baseline allow-intra-namespace.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: home
+            app.kubernetes.io/name: home-assistant
+        - matchLabels:
+            io.kubernetes.pod.namespace: media
+            app.kubernetes.io/name: suggestarr
+        - matchLabels:
+            io.kubernetes.pod.namespace: mcp-system
+      toPorts:
+        - ports:
+            - port: "11434"
+              protocol: TCP
+  egress:
+    # Model registry — ollama pulls model blobs on first invocation
+    # (`ollama pull <model>`) and on Modelfile changes. Targets registry
+    # are ollama.com (OCI-style manifests) and the GCS-backed blob host
+    # `dd20bb891979d25aebc8bec07b2b3bbc.r2.cloudflarestorage.com` (which
+    # rotates; broaden to all of cloudflarestorage.com to absorb that).
+    # HuggingFace also serves some community model GGUFs.
+    - toFQDNs:
+        - matchName: "ollama.com"
+        - matchName: "registry.ollama.ai"
+        - matchPattern: "*.ollama.ai"
+        - matchPattern: "*.cloudflarestorage.com"
+        - matchName: "huggingface.co"
+        - matchPattern: "*.huggingface.co"
+        - matchName: "cdn-lfs.huggingface.co"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/ai/ollama/app/kustomization.yaml
+++ b/kubernetes/apps/ai/ollama/app/kustomization.yaml
@@ -7,5 +7,6 @@ components:
   - ../../../../components/repos/app-template
 
 resources:
+  - ./cnp-allow.yaml
   - ./helmrelease.yaml
   - ./longhorn-pvc.yaml

--- a/kubernetes/apps/ai/paperless-ai/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/paperless-ai/app/cnp-allow.yaml
@@ -1,0 +1,52 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: paperless-ai-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: paperless-ai
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal gateway → paperless-ai:3000
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "3000"
+              protocol: TCP
+  egress:
+    # paperless-ai's whole purpose is enriching documents in paperless
+    # via the paperless REST API. Paperless lives in collab ns.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: collab
+            app.kubernetes.io/name: paperless
+      toPorts:
+        - ports:
+            - port: "8000"
+              protocol: TCP
+    # Ollama in same ns — paperless-ai defaults to ollama for local
+    # tagging unless the user configures OpenAI/Anthropic/etc in its
+    # web UI. Baseline allow-intra-namespace already covers; explicit
+    # here for grep-ability.
+    #
+    # External LLM providers — paperless-ai's UI lets the user pick
+    # OpenAI, Mistral, Anthropic, etc. as the tagging backend. Today
+    # it's ollama only; add toFQDNs egress here when config changes.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: ai
+            app.kubernetes.io/name: ollama
+      toPorts:
+        - ports:
+            - port: "11434"
+              protocol: TCP

--- a/kubernetes/apps/ai/paperless-ai/app/kustomization.yaml
+++ b/kubernetes/apps/ai/paperless-ai/app/kustomization.yaml
@@ -5,5 +5,6 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./helmrelease.yaml
   - ./longhorn-pvc.yaml

--- a/kubernetes/apps/observability/exporters/snmp-exporter/app/apc-ups/prometheusrule.yaml
+++ b/kubernetes/apps/observability/exporters/snmp-exporter/app/apc-ups/prometheusrule.yaml
@@ -91,6 +91,11 @@ spec:
         # repo systemd/ dir.
         - record: power:brain_cpu:watts
           expr: rate(node_rapl_package_joules_total{instance="brain.thesteamedcrab.com:9100"}[2m])
+        # GPU power (NVIDIA P40, passed through to worker8 VM on beast).
+        # Captured by dcgm-exporter. Total across all GPUs in the cluster
+        # in case more are added later.
+        - record: power:gpu:watts
+          expr: sum(DCGM_FI_DEV_POWER_USAGE)
     # Anomaly alerts on the recording rules above.
     - name: power.alerts
       rules:
@@ -125,3 +130,37 @@ spec:
           for: 10m
           labels:
             severity: warning
+        # BGE bill forecast tripped >20% above typical month.
+        # hass_sensor_monetary_usd is the HA prometheus exporter's
+        # form of sensor.elec_account_*_*_cost.
+        - alert: BGEForecastOverTypical
+          annotations:
+            summary: BGE forecast bill is {{ $value | humanizePercentage }} of typical
+            description: |
+              This billing cycle is on track above your typical month.
+              Forecast/typical ratio: {{ $value | humanize }}.
+              Check the Power Overview Grafana dashboard for which loads
+              are running heavier than usual.
+          expr: |
+            (
+              hass_sensor_monetary_usd{entity="sensor.elec_account_4632757682_current_bill_electric_forecasted_cost"}
+              /
+              hass_sensor_monetary_usd{entity="sensor.elec_account_4632757682_typical_monthly_electric_cost"}
+            ) > 1.20
+          for: 6h
+          labels:
+            severity: warning
+        # GPU power sustained high — runaway ollama / immich-pet-tagger /
+        # other GPU workload. P40 max TDP is 250W; 200W sustained is
+        # heavy active load.
+        - alert: GPUPowerSustainedHigh
+          annotations:
+            summary: GPU power sustained above 200W
+            description: |
+              GPU (P40) has been pulling {{ $value }}W for 30+ minutes.
+              Likely an active ollama inference or immich-pet-tagger run.
+              If unexpected, check workloads on worker8.
+          expr: power:gpu:watts > 200
+          for: 30m
+          labels:
+            severity: info


### PR DESCRIPTION
Steps A and E of the no-hw power-monitoring improvements.

## A — GPU power recording rule

```
power:gpu:watts = sum(DCGM_FI_DEV_POWER_USAGE)
```

P40 currently passed through to worker8 (KVM on beast). Single number rolls up paperless-ai, immich-pet-tagger, and any other ollama consumer.

## E — Anomaly alerts

- **BGEForecastOverTypical** — Opower forecast > 1.20× typical month, for 6h. Warning severity. Catches the cycle while there's still time to intervene.
- **GPUPowerSustainedHigh** — GPU >200W for 30m. Info severity. P40 TDP 250W; sustained 200W = heavy active load.

## Next (HA side)

Will follow up: REST sensor pulls `power:gpu:watts`, integrate to kWh, add as Energy Dashboard Individual Device with `included_in_stat: sensor.beast_energy_spent` so the GPU slice subtracts cleanly from beast's iDRAC total.

## Note

Skipped B (BGE/EM16 alignment panel) — meaningful comparison needs day-aligned aggregates and Opower lags 1-2 days; defer to its own session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)