### PR TITLE
chore(mcp-system): tighten mcp-gateway listeners to from: Same

### DIFF
--- a/kubernetes/apps/mcp-system/mcp-gateway/app/gateway.yaml
+++ b/kubernetes/apps/mcp-system/mcp-gateway/app/gateway.yaml
@@ -13,21 +13,30 @@ spec:
     annotations:
       lbipam.cilium.io/ips: "${SVC_MCPGATEWAY_ADDR}"
   listeners:
-    - name: mcp # gateway listener
-      hostname: "mcp.${SECRET_DOMAIN}" # public accessibly MCP host one used by client
+    # Public-facing broker entry. External clients reach this via the
+    # envoy internal Gateway (mcp-gateway-internal HTTPRoute) → the
+    # mcp-gateway-istio Service. Only mcp-gateway-broker (this ns)
+    # attaches here; restricting to Same prevents any other ns from
+    # creating a rogue HTTPRoute that would hijack mcp.${SECRET_DOMAIN}.
+    - name: mcp
+      hostname: "mcp.${SECRET_DOMAIN}"
       protocol: HTTP
       port: 8080
       allowedRoutes:
         namespaces:
-          from: All # TODO? Same like internal/external?
+          from: Same
+    # Internal MCP-server fan-out. The MCPRouter inside the gateway pod
+    # consumes routes attached to *.mcp.local. All MCP servers live in
+    # mcp-system today; if that changes, relax to Selector with a
+    # namespace label opt-in rather than going back to All.
     - name: mcps
+      hostname: "*.mcp.local"
       port: 8080
       protocol: HTTP
-      hostname: "*.mcp.local" # this hostname can be any wildcard. It is here to simplify routing, ensure the MCP Server routes attach to this listener only, can be protected by the AuthPolicy and routed to via envoy and the MCPRouter.
       # tls:
       #   certificateRefs:
       #     - kind: Secret
       #       name: "${SECRET_DOMAIN/./-}-tls"
       allowedRoutes:
         namespaces:
-          from: All # any namespace can register an MCP server route
+          from: Same


### PR DESCRIPTION
## Summary

Both `mcp-gateway` listeners (`mcp` and `mcps`) were `from: All` with a `# TODO? Same like internal/external?` comment. That framing conflated two things — envoy's `internal` vs `external` split is via *separate Gateway resources*, not via `allowedRoutes.namespaces.from`.

The real question was: should the listeners restrict which namespaces can attach HTTPRoutes? All 14 currently-attached routes live in mcp-system:

- `mcp` listener — 1 route: `mcp-gateway-broker` (the public-facing entry consumed by the envoy internal Gateway via `mcp-gateway-istio` Service)
- `mcps` listener — 13 routes: the individual MCP server routes (arr-mcp, github-mcp, ha-mcp, etc.)

Restricting both to `from: Same`:

- **No functional change** today.
- **Defense-in-depth**: prevents another ns from creating an HTTPRoute that could hijack `mcp.${SECRET_DOMAIN}` or shadow an internal `*.mcp.local` hostname.
- If a future MCP server lands outside `mcp-system`, the path forward is `from: Selector` with a namespace-label opt-in, not reverting to `All`. The new in-file comments capture this intent.

## Test plan

- [ ] CI: flux-local diff/test pass.
- [ ] After merge: `kubectl get gateway mcp-gateway -n mcp-system -o jsonpath='{.status.listeners[*].attachedRoutes}'` still shows `1 13` (broker + 13 MCP servers).
- [ ] `kubectl get httproute -A -o json | jq '.items[] | select(.spec.parentRefs[]? .name == "mcp-gateway") | .status.parents[].conditions[] | select(.type == "Accepted") | .status'` shows `True` for every attached route.
- [ ] mcp.${SECRET_DOMAIN} still serves end-to-end (claude-code → cloudflared → envoy `internal/https` → mcp-gateway-istio → broker → MCP server pod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)