### PR TITLE
feat(network-policy): longhorn-system baseline (Phase 5)

### DIFF
--- a/kubernetes/apps/longhorn-system/kustomization.yaml
+++ b/kubernetes/apps/longhorn-system/kustomization.yaml
@@ -3,6 +3,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: longhorn-system
+components:
+  - ../../components/network-policy/baseline
 resources:
   - ./namespace.yaml
   - ./longhorn/ks.yaml


### PR DESCRIPTION
Phase 5 baseline. 1-line diff; 5 additive CNPs via the baseline component. Zero enforcement risk.