### PR TITLE
feat(network-policy): rook-ceph baseline (Phase 5)

### DIFF
--- a/kubernetes/apps/rook-ceph/kustomization.yaml
+++ b/kubernetes/apps/rook-ceph/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 namespace: rook-ceph
 components:
   - ../../components/alerts
+  - ../../components/network-policy/baseline
 resources:
   - ./namespace.yaml
   - ./rook-ceph/ks.yaml


### PR DESCRIPTION
Phase 5 baseline. 1-line diff; 5 additive CNPs via the baseline component. Zero enforcement risk.