### PR TITLE
feat(network-policy): actions-runner-system default-deny + per-app overlays

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/operator/cnp-allow.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/operator/cnp-allow.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: actions-runner-controller-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: gha-rs-controller
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it. The Helm chart uses
+  # `app.kubernetes.io/name: gha-rs-controller` (not "actions-runner-controller").
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  egress:
+    # GitHub API: the operator authenticates as a GitHub App, polls for
+    # the registration token, and reconciles runner-scale-set state.
+    # api.github.com resolves to Azure IPs (e.g. 20.85.130.105 in
+    # observed Hubble flows). The codeload.github.com hostname is not
+    # used by the controller itself (only by runners), but allow it
+    # here too for symmetry / future webhook subscriptions.
+    - toFQDNs:
+        - matchName: "api.github.com"
+        - matchName: "github.com"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/operator/kustomization.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/operator/kustomization.yaml
@@ -3,6 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/cnp-allow.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/cnp-allow.yaml
@@ -1,0 +1,40 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: arc-runner-set-home-ops-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: arc-runner-set-home-ops
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it. Selector matches both the long-running
+  # listener pod (arc-runner-set-home-ops-*-listener) AND ephemeral
+  # runner pods (arc-runner-set-home-ops-*-runner-*) — they share the
+  # gha-runner-scale-set chart's pod label.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  egress:
+    # Conservative wildcard for the runner pods: these execute user-
+    # authored GitHub Actions workflows, which can `git clone`,
+    # `docker pull`, fetch artifacts from any URL, talk to
+    # registries, etc. Locking egress to a specific allow-list would
+    # break every workflow that introduces a new external dependency,
+    # so the trust boundary is the controller's GitHub-App scoping,
+    # not the network.
+    #
+    # TODO: tighten if/when a registry mirror (ZOT) becomes mandatory
+    # for runner pulls. As-is this matches the pre-default-deny baseline.
+    - toFQDNs:
+        - matchPattern: "*"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+            - port: "80"
+              protocol: TCP
+    # The listener also opens a long-lived gRPC-over-HTTPS session to
+    # GitHub's runner service, which uses port 443 (covered by the
+    # wildcard above).

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/kustomization.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/kustomization.yaml
@@ -3,5 +3,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./cnp-allow.yaml
   - ./home-ops.yaml
   - ./ocirepository.yaml

--- a/kubernetes/apps/actions-runner-system/kustomization.yaml
+++ b/kubernetes/apps/actions-runner-system/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: actions-runner-system
 components:
   - ../../components/alerts
   - ../../components/network-policy/baseline
+  - ../../components/network-policy/default-deny
 resources:
   - ./namespace.yaml
   - ./actions-runner-controller/ks.yaml


### PR DESCRIPTION
## Summary

Locks down the actions-runner-system namespace with default-deny + 2 per-app CNPs.

- `actions-runner-controller` (operator): tight egress to GitHub API only.
- `arc-runner-set-home-ops` (listener + ephemeral runners): conservative `toFQDNs: *` wildcard on 443/80 — the runner executes user-authored CI workflows that need broad egress.

## Patterns

| App | Pod label | Pattern |
|---|---|---|
| operator | `gha-rs-controller` (NOT `actions-runner-controller`) | D: FQDN allow (api.github.com, github.com) |
| runners | `arc-runner-set-home-ops` | D-broad: wildcard `*:443`/`*:80` for runner workflows |

The chart applies the same `arc-runner-set-home-ops` label to both the listener and ephemeral runner pods, so one CNP covers both.

## Test plan

- [x] `kubectl kustomize kubernetes/apps/actions-runner-system/` = 6 CNPs (5 baseline + default-deny)
- [x] Per-app overlays each render 1 CNP
- [x] `yamllint` clean
- [ ] Post-merge: pods stay Ready, no policy-verdict DROPPED in Hubble for actions-runner-system
- [ ] Post-merge: next runner job (`arc-runner-set-home-ops-*-runner-*`) completes successfully

## Notes

- Wildcard egress on the runner pods is intentional and documented inline. Tightening to a specific allow-list would break every workflow that introduces a new external dependency. Revisit if ZOT becomes a mandatory mirror for runner pulls.
- Per-app overlays go straight to enforce (no audit annotation). Baseline allows remain in audit mode at the component level.

Part of the multi-hour autonomous NetworkPolicy rollout following ai/ (PR #11473).

🤖 Generated with [Claude Code](https://claude.com/claude-code)