### PR TITLE
feat(network-policy): renovate default-deny + per-app overlays

### DIFF
--- a/kubernetes/apps/renovate/kustomization.yaml
+++ b/kubernetes/apps/renovate/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: renovate
 components:
   - ../../components/alerts
   - ../../components/network-policy/baseline
+  - ../../components/network-policy/default-deny
 resources:
   - ./namespace.yaml
   - ./renovate-operator/ks.yaml

--- a/kubernetes/apps/renovate/renovate-operator/app/cnp-allow.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/app/cnp-allow.yaml
@@ -1,0 +1,42 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: renovate-operator-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app: renovate-operator
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it. The renovate-operator chart uses a bare
+  # `app: renovate-operator` label (NOT `app.kubernetes.io/name`).
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal gateway → renovate-operator:8081 (named
+    # "http"). renovate.${SECRET_DOMAIN} is the webhook endpoint used
+    # by GitHub repository webhook deliveries that arrive via
+    # cloudflared → envoy → here. Port 8082 is the operator's metrics
+    # port; the baseline allow-monitoring-scrape covers Prometheus.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "8081"
+              protocol: TCP
+  egress:
+    # GitHub API: operator polls api.github.com for repo discovery and
+    # PR state. The operator itself does not clone repos — that's the
+    # spawned RenovateJob pods (covered by renovate-jobs-allow in
+    # ../jobs/).
+    - toFQDNs:
+        - matchName: "api.github.com"
+        - matchName: "github.com"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/renovate/renovate-operator/app/kustomization.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/app/kustomization.yaml
@@ -3,5 +3,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./cnp-allow.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml

--- a/kubernetes/apps/renovate/renovate-operator/jobs/cnp-allow.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/jobs/cnp-allow.yaml
@@ -1,0 +1,53 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: renovate-jobs-allow
+spec:
+  # Selector covers both `executor` and `discovery` Job pods spawned
+  # by the operator from the RenovateJob CRs in this directory. They
+  # carry `renovate-operator.mogenius.com/job-type` but no
+  # `app.kubernetes.io/name`. Matching the label key without a value
+  # is not supported in CNP, so list both known values.
+  endpointSelector:
+    matchExpressions:
+      - key: renovate-operator.mogenius.com/job-type
+        operator: In
+        values: ["executor", "discovery"]
+  # Additive — default-deny is what triggers the lockdown.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  egress:
+    # Dragonfly (Redis) in databases ns — RENOVATE_REDIS_URL is set to
+    # `redis://dragonfly.databases.svc.cluster.local:6379` for the
+    # repository cache shared across runs.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
+            app.kubernetes.io/name: dragonfly
+      toPorts:
+        - ports:
+            - port: "6379"
+              protocol: TCP
+    # Conservative wildcard for renovate scanning: discovery + executor
+    # pods clone GitHub repos, query every registry mentioned by every
+    # tracked dependency (ghcr.io, registry.k8s.io, docker.io, quay.io,
+    # gcr.io, mcr.microsoft.com, etc.), pull npm/pypi/crates/maven
+    # metadata, fetch helm chart indexes from arbitrary hosts, and call
+    # api.github.com to open PRs. The set of upstream registries grows
+    # every time a new dependency lands in the repo, so an allow-list
+    # would silently break renovate runs on dependency churn.
+    #
+    # TODO: tighten once a registry mirror (ZOT) or HTTP forward proxy
+    # mediates all renovate egress. As-is this matches pre-default-deny
+    # behavior.
+    - toFQDNs:
+        - matchPattern: "*"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+            - port: "80"
+              protocol: TCP

--- a/kubernetes/apps/renovate/renovate-operator/jobs/kustomization.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/jobs/kustomization.yaml
@@ -3,5 +3,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./cnp-allow.yaml
   - ./home-ops.yaml
   - ./pump.yaml


### PR DESCRIPTION
## Summary

Locks down the renovate namespace with default-deny + 2 per-app CNPs.

- `renovate-operator`: tight egress to GitHub API only + ingress from envoy (webhook).
- `renovate-jobs` (executor + discovery): conservative `toFQDNs: *` wildcard on 443/80, plus a tight rule for `dragonfly.databases:6379` (RENOVATE_REDIS_URL cache).

## Patterns

| App | Selector | Pattern |
|---|---|---|
| operator | `app: renovate-operator` (bare, NOT `app.kubernetes.io/name`) | A (envoy ingress on 8081) + D (api.github.com) |
| jobs | matchExpressions `renovate-operator.mogenius.com/job-type In [executor, discovery]` | B (dragonfly:6379) + D-broad (`*:443`/`*:80`) |

## Test plan

- [x] `kubectl kustomize kubernetes/apps/renovate/` = 6 CNPs (5 baseline + default-deny)
- [x] Both per-app overlays render 1 CNP
- [x] `yamllint` clean
- [ ] Post-merge: renovate-operator stays Ready
- [ ] Post-merge: next scheduled `rwlove-home-ops` job completes and opens PRs as normal
- [ ] Post-merge: no DROPPED policy-verdicts in Hubble for `renovate` ns

## Notes

- Wildcard egress for the scan pods is intentional. Renovate queries every registry mentioned by any tracked dependency; the set grows with dependency churn so a fixed allow-list would silently break runs.
- The renovate-jobs CNP is co-located in `jobs/` with the `RenovateJob` CRs it constrains, not in `app/`.
- Per-app overlays go straight to enforce (no audit annotation). Baseline allows remain in audit mode at the component level.

Part of the multi-hour autonomous NetworkPolicy rollout following ai/ (PR #11473) and actions-runner-system (PR #11485).

🤖 Generated with [Claude Code](https://claude.com/claude-code)