### PR TITLE
feat(network-policy): mcp-system default-deny + per-app overlays

### DIFF
--- a/kubernetes/apps/mcp-system/arr-mcp/app/cnp-allow.yaml
+++ b/kubernetes/apps/mcp-system/arr-mcp/app/cnp-allow.yaml
@@ -1,0 +1,55 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: arr-mcp-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: arr-mcp
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it. Ingress from same-ns mcp-gateway broker is
+  # covered by baseline allow-intra-namespace.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  egress:
+    # Sonarr / Radarr / Lidarr in media ns (Pattern E). Env vars set:
+    #   SONARR_URL: http://sonarr.media.svc.cluster.local:8989
+    #   RADARR_URL: http://radarr.media.svc.cluster.local:7878
+    #   LIDARR_URL: http://lidarr.media.svc.cluster.local:8686
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: media
+            app.kubernetes.io/name: sonarr
+      toPorts:
+        - ports:
+            - port: "8989"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: media
+            app.kubernetes.io/name: radarr
+      toPorts:
+        - ports:
+            - port: "7878"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: media
+            app.kubernetes.io/name: lidarr
+      toPorts:
+        - ports:
+            - port: "8686"
+              protocol: TCP
+    # Prowlarr in downloads ns. Env: PROWLARR_URL points to
+    # http://prowlarr.downloads.svc.cluster.local:9696
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: downloads
+            app.kubernetes.io/name: prowlarr
+      toPorts:
+        - ports:
+            - port: "9696"
+              protocol: TCP

--- a/kubernetes/apps/mcp-system/arr-mcp/app/kustomization.yaml
+++ b/kubernetes/apps/mcp-system/arr-mcp/app/kustomization.yaml
@@ -5,5 +5,6 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/mcp-system/github-mcp/app/cnp-allow.yaml
+++ b/kubernetes/apps/mcp-system/github-mcp/app/cnp-allow.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: github-mcp-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: github-mcp
+  # Additive — default-deny is what triggers the lockdown.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  egress:
+    # GitHub API surface. The github-mcp-server proxies REST + GraphQL
+    # tools to api.github.com (and graphql.github.com for v4); also
+    # touches uploads.github.com for release artifact uploads when an
+    # agent invokes the release tools.
+    - toFQDNs:
+        - matchName: "api.github.com"
+        - matchName: "github.com"
+        - matchName: "uploads.github.com"
+        - matchName: "raw.githubusercontent.com"
+        - matchName: "codeload.github.com"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/mcp-system/github-mcp/app/kustomization.yaml
+++ b/kubernetes/apps/mcp-system/github-mcp/app/kustomization.yaml
@@ -5,5 +5,6 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/mcp-system/grafana-mcp/app/cnp-allow.yaml
+++ b/kubernetes/apps/mcp-system/grafana-mcp/app/cnp-allow.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: grafana-mcp-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: grafana-mcp
+  # Additive — default-deny is what triggers the lockdown.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  egress:
+    # Grafana in observability ns. Env: GRAFANA_URL points to
+    # http://grafana.observability.svc.cluster.local (port 80 svc).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: observability
+            app.kubernetes.io/name: grafana
+      toPorts:
+        - ports:
+            - port: "3000"
+              protocol: TCP

--- a/kubernetes/apps/mcp-system/grafana-mcp/app/kustomization.yaml
+++ b/kubernetes/apps/mcp-system/grafana-mcp/app/kustomization.yaml
@@ -5,5 +5,6 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/mcp-system/ha-mcp/app/cnp-allow.yaml
+++ b/kubernetes/apps/mcp-system/ha-mcp/app/cnp-allow.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: ha-mcp-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: ha-mcp
+  # Additive — default-deny is what triggers the lockdown.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  egress:
+    # ha-mcp talks to Home Assistant via HOMEASSISTANT_URL =
+    # https://hass.${SECRET_DOMAIN} — which resolves to the external
+    # envoy gateway LoadBalancer (10.45.0.13) and inside the cluster
+    # actually hits envoy pods on container port 10443. Observed in
+    # Hubble: ha-mcp → network/external-* on :10443.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "10443"
+              protocol: TCP
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/mcp-system/ha-mcp/app/kustomization.yaml
+++ b/kubernetes/apps/mcp-system/ha-mcp/app/kustomization.yaml
@@ -5,5 +5,6 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/mcp-system/immich-mcp/app/cnp-allow.yaml
+++ b/kubernetes/apps/mcp-system/immich-mcp/app/cnp-allow.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: immich-mcp-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: immich-mcp
+  # Additive — default-deny is what triggers the lockdown.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  egress:
+    # immich-server in media ns. Env: IMMICH_BASE_URL =
+    # http://immich-server.media.svc.cluster.local:2283
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: media
+            app.kubernetes.io/name: immich-server
+      toPorts:
+        - ports:
+            - port: "2283"
+              protocol: TCP

--- a/kubernetes/apps/mcp-system/immich-mcp/app/kustomization.yaml
+++ b/kubernetes/apps/mcp-system/immich-mcp/app/kustomization.yaml
@@ -5,5 +5,6 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/mcp-system/kustomization.yaml
+++ b/kubernetes/apps/mcp-system/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 namespace: mcp-system
 components:
   - ../../components/network-policy/baseline
+  - ../../components/network-policy/default-deny
 resources:
   - ./namespace.yaml
   - ./arr-mcp/ks.yaml

--- a/kubernetes/apps/mcp-system/mcp-gateway/app/cnp-allow.yaml
+++ b/kubernetes/apps/mcp-system/mcp-gateway/app/cnp-allow.yaml
@@ -1,0 +1,129 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: mcp-gateway-broker-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: mcp-gateway
+  # Additive — default-deny is what triggers the lockdown. The broker
+  # is the central MCPRouter pod deployed by mcp-gateway-controller.
+  # Egress to per-namespace MCP servers in this ns is covered by
+  # baseline allow-intra-namespace.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # mcp-gateway-istio Service routes inbound mcp.${SECRET_DOMAIN}
+    # traffic to broker:8080. Same-ns label-selected.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: mcp-system
+            gateway.networking.k8s.io/gateway-name: mcp-gateway
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+            - port: "50051"
+              protocol: TCP
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: mcp-gateway-controller-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: mcp-gateway-controller
+  # Additive — apiserver egress covered by baseline allow-apiserver;
+  # broker access (to push routing config + health-check) is same-ns
+  # so covered by baseline allow-intra-namespace.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: mcp-gateway-istio-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      gateway.networking.k8s.io/gateway-name: mcp-gateway
+      gateway.istio.io/managed: istio.io-gateway-controller
+  # Additive — egress to broker + MCP servers is same-ns (baseline).
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # Public entrypoint: external clients reach mcp.${SECRET_DOMAIN}
+    # via cloudflared → external envoy → mcp-gateway-istio → broker.
+    # The HTTPRoute mcp-gateway-internal targets internal envoy.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+    # Cluster-internal MCP clients (kubeclaw, langgraph-agents, etc.)
+    # hit the istio Service directly by DNS; their source pods live
+    # in various namespaces. Allow from any namespace on 8080 — these
+    # are MCP tool invocations gated by Authelia JWT at the envoy
+    # SecurityPolicy layer (per project_mcp_gateway_auth_done.md).
+    - fromEntities:
+        - cluster
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+  egress:
+    # Istio sidecar control-plane: istiod XDS on 15012, webhook on 15017.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: istio-system
+            app: istiod
+      toPorts:
+        - ports:
+            - port: "15012"
+              protocol: TCP
+            - port: "15014"
+              protocol: TCP
+            - port: "15017"
+              protocol: TCP
+            - port: "443"
+              protocol: TCP
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: mcp-gateway-jwt-rotator-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: mcp-gateway-jwt-rotator
+  # Additive — apiserver covered by baseline (rotator runs
+  # `kubectl create secret`); egress to Authelia goes via envoy.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  egress:
+    # Authelia OIDC token endpoint:
+    # https://auth.${SECRET_DOMAIN}/api/oidc/token — routed via
+    # external envoy gateway, container port 10443.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "10443"
+              protocol: TCP
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/mcp-system/mcp-gateway/app/kustomization.yaml
+++ b/kubernetes/apps/mcp-system/mcp-gateway/app/kustomization.yaml
@@ -3,6 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./gateway.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/mcp-system/mcp-gateway/app/rotator-cronjob.yaml
+++ b/kubernetes/apps/mcp-system/mcp-gateway/app/rotator-cronjob.yaml
@@ -17,6 +17,13 @@ spec:
     spec:
       backoffLimit: 3
       template:
+        metadata:
+          labels:
+            # Stable selector used by the mcp-gateway-jwt-rotator-allow CNP.
+            # The auto-generated `job-name` label includes the CronJob run
+            # timestamp (e.g. mcp-gateway-jwt-rotator-29649870) and rotates
+            # every run, so it can't be used in a Cilium endpointSelector.
+            app.kubernetes.io/name: mcp-gateway-jwt-rotator
         spec:
           serviceAccountName: mcp-gateway-jwt-rotator
           restartPolicy: OnFailure

--- a/kubernetes/apps/mcp-system/n8n-mcp/app/cnp-allow.yaml
+++ b/kubernetes/apps/mcp-system/n8n-mcp/app/cnp-allow.yaml
@@ -1,0 +1,38 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: n8n-mcp-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: n8n-mcp
+  # Additive — default-deny is what triggers the lockdown.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # n8n-mcp has its own HTTPRoute to n8n-mcp.${SECRET_DOMAIN} on the
+    # internal envoy gateway (not behind mcp-gateway, per
+    # project_mcp_gateway_auth_done.md — n8n-mcp was pulled out for
+    # credentialRef-on-invocation limitations).
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "3000"
+              protocol: TCP
+  egress:
+    # n8n in home ns. Env: N8N_API_URL =
+    # http://n8n.home.svc.cluster.local:8080
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: home
+            app.kubernetes.io/name: n8n
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP

--- a/kubernetes/apps/mcp-system/n8n-mcp/app/kustomization.yaml
+++ b/kubernetes/apps/mcp-system/n8n-mcp/app/kustomization.yaml
@@ -5,5 +5,6 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/mcp-system/netbox-mcp/app/cnp-allow.yaml
+++ b/kubernetes/apps/mcp-system/netbox-mcp/app/cnp-allow.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: netbox-mcp-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: netbox-mcp
+  # Additive — default-deny is what triggers the lockdown.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  egress:
+    # netbox-mcp talks to Netbox via NETBOX_URL =
+    # https://netbox.${SECRET_DOMAIN} — resolves to external envoy LB
+    # and hits envoy pods on container port 10443 (same pattern as
+    # ha-mcp). Tightening to in-cluster netbox-web Service would
+    # require config refactor; envoy passthrough is the path.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "10443"
+              protocol: TCP
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/mcp-system/netbox-mcp/app/kustomization.yaml
+++ b/kubernetes/apps/mcp-system/netbox-mcp/app/kustomization.yaml
@@ -5,5 +5,6 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/mcp-system/omada-mcp/app/cnp-allow.yaml
+++ b/kubernetes/apps/mcp-system/omada-mcp/app/cnp-allow.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: omada-mcp-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: omada-mcp
+  # Additive — default-deny is what triggers the lockdown.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  egress:
+    # Omada controller on brain (192.168.1.1) port 8043. Env:
+    # OMADA_BASE_URL = https://brain:8043. Brain runs the controller
+    # on the host network, so this is a CIDR egress not a pod
+    # selector. Per project_cilium_ipblock_apiserver.md: CIDR rules
+    # are safe for non-apiserver targets; only `reserved:kube-apiserver`
+    # needs entity matching.
+    - toCIDR:
+        - "192.168.1.1/32"
+      toPorts:
+        - ports:
+            - port: "8043"
+              protocol: TCP

--- a/kubernetes/apps/mcp-system/omada-mcp/app/kustomization.yaml
+++ b/kubernetes/apps/mcp-system/omada-mcp/app/kustomization.yaml
@@ -5,5 +5,6 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/mcp-system/paperless-mcp/app/cnp-allow.yaml
+++ b/kubernetes/apps/mcp-system/paperless-mcp/app/cnp-allow.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: paperless-mcp-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: paperless-mcp
+  # Additive — default-deny is what triggers the lockdown.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  egress:
+    # paperless-mcp talks to Paperless-ngx via PAPERLESS_URL =
+    # https://paperless.${SECRET_DOMAIN} — resolves to external envoy
+    # LB and hits envoy pods on container port 10443 (same pattern as
+    # ha-mcp / netbox-mcp).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "10443"
+              protocol: TCP
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/mcp-system/paperless-mcp/app/kustomization.yaml
+++ b/kubernetes/apps/mcp-system/paperless-mcp/app/kustomization.yaml
@@ -5,5 +5,6 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/mcp-system/prometheus-mcp/app/cnp-allow.yaml
+++ b/kubernetes/apps/mcp-system/prometheus-mcp/app/cnp-allow.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: prometheus-mcp-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus-mcp
+  # Additive — default-deny is what triggers the lockdown.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  egress:
+    # Prometheus in observability ns. Env: PROMETHEUS_URL =
+    # http://kube-prometheus-stack-prometheus.observability.svc.cluster.local:9090
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: observability
+            app.kubernetes.io/name: prometheus
+      toPorts:
+        - ports:
+            - port: "9090"
+              protocol: TCP

--- a/kubernetes/apps/mcp-system/prometheus-mcp/app/kustomization.yaml
+++ b/kubernetes/apps/mcp-system/prometheus-mcp/app/kustomization.yaml
@@ -5,5 +5,6 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./helmrelease.yaml
   - ./mcpserverregistration.yaml

--- a/kubernetes/apps/mcp-system/searxng-mcp/app/cnp-allow.yaml
+++ b/kubernetes/apps/mcp-system/searxng-mcp/app/cnp-allow.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: searxng-mcp-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: searxng-mcp
+  # Additive — default-deny is what triggers the lockdown.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  egress:
+    # searxng in collab ns. Env: SEARXNG_URL =
+    # http://searxng.collab.svc.cluster.local:8080
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: collab
+            app.kubernetes.io/name: searxng
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP

--- a/kubernetes/apps/mcp-system/searxng-mcp/app/kustomization.yaml
+++ b/kubernetes/apps/mcp-system/searxng-mcp/app/kustomization.yaml
@@ -5,4 +5,5 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./helmrelease.yaml


### PR DESCRIPTION
## Summary

Locks down the mcp-system namespace with default-deny + per-app CNPs for 12 of 14 MCP servers + a 4-policy umbrella for mcp-gateway.

## Patterns at a glance

| App | Pattern | Backend |
|---|---|---|
| arr-mcp | E (×4) | media/sonarr, radarr, lidarr; downloads/prowlarr |
| github-mcp | D | api.github.com + 4 others |
| grafana-mcp | E | observability/grafana:3000 |
| ha-mcp | E (via envoy) | network/envoy:10443 |
| immich-mcp | E | media/immich-server:2283 |
| kubectl-mcp | — (baseline only) | apiserver |
| n8n-mcp | A + E | envoy→3000 ingress; home/n8n:8080 egress |
| netbox-mcp | E (via envoy) | network/envoy:10443 |
| omada-mcp | C (toCIDR) | 192.168.1.1:8043 (brain) |
| paperless-mcp | E (via envoy) | network/envoy:10443 |
| prometheus-mcp | E | observability/prometheus:9090 |
| searxng-mcp | E | collab/searxng:8080 |
| time-mcp | — (baseline only) | self-contained |
| mcp-gateway | 4 CNPs | broker / controller / istio / rotator |

## Notable wrinkles

- **mcp-gateway-istio** accepts ingress from envoy (HTTPRoute internal) AND `fromEntities: cluster` — in-cluster MCP clients hit the istio Service by DNS, gated by Authelia JWT at the envoy SecurityPolicy layer per `project_mcp_gateway_auth_done.md`. Tightening to specific consumer ns would require enumerating every MCP client which churns.
- **mcp-gateway-jwt-rotator**: the auto-generated `job-name` label rotates per CronJob run, so I added a stable `app.kubernetes.io/name: mcp-gateway-jwt-rotator` label on the pod template (rotator-cronjob.yaml change), then selected on that.
- **omada-mcp** uses `toCIDR: 192.168.1.1/32:8043` for the controller on brain (host network). Safe per `project_cilium_ipblock_apiserver.md` — only the kube-apiserver entity requires `reserved:kube-apiserver`.
- **ha-mcp / netbox-mcp / paperless-mcp** all reach their backends through envoy passthrough (FQDN resolves to external LB, envoy pods listen on container port 10443). Tightening to a direct in-cluster Service per app would require config refactors.
- **kubectl-mcp + time-mcp** got no overlay — baseline allows are sufficient.

## Test plan

- [x] `kubectl kustomize kubernetes/apps/mcp-system/` = 6 ns-level CNPs (5 baseline + default-deny)
- [x] Per-app overlays render expected counts (12×1, mcp-gateway×4, kubectl-mcp/time-mcp×0)
- [x] `yamllint` clean
- [ ] Post-merge: all 14 MCP pods stay Ready; mcp-gateway broker continues 60s polling
- [ ] Post-merge: mcp-gateway controller registers all MCPServerRegistrations (`kubectl get mcpserverregistration -n mcp-system`)
- [ ] Post-merge: laptop/agent MCP invocations succeed (try `kubectl-tools`, `ha-tools`, `omada-tools` from a configured client)
- [ ] Post-merge: no DROPPED policy-verdicts in Hubble for mcp-system over the next hour

## Notes

- Several MCP servers (arr/grafana/prometheus/etc.) had zero observable cross-ns traffic in the past 24h (only mcp-gateway broker polling), so their overlays are based on helmrelease env vars rather than live Hubble flows. Expect to revisit if a tool invocation drops post-merge.
- Per-app overlays go straight to enforce (no audit annotation). Baseline allows remain in audit mode at the component level.

Part of the multi-hour autonomous NetworkPolicy rollout following ai/ (PR #11473), actions-runner-system (#11485), and renovate (#11486).

🤖 Generated with [Claude Code](https://claude.com/claude-code)