### PR TITLE
fix(network-policy): correct immich-server selector in immich-mcp egress

### DIFF
--- a/kubernetes/apps/mcp-system/immich-mcp/app/cnp-allow.yaml
+++ b/kubernetes/apps/mcp-system/immich-mcp/app/cnp-allow.yaml
@@ -15,10 +15,14 @@ spec:
   egress:
     # immich-server in media ns. Env: IMMICH_BASE_URL =
     # http://immich-server.media.svc.cluster.local:2283
+    # NOTE: the immich-server pod label is `app.kubernetes.io/name: server`
+    # (the chart sets the suffix-less form), NOT `immich-server`. Pair
+    # with `app.kubernetes.io/instance: immich` for disambiguation.
     - toEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: media
-            app.kubernetes.io/name: immich-server
+            app.kubernetes.io/instance: immich
+            app.kubernetes.io/name: server
       toPorts:
         - ports:
             - port: "2283"


### PR DESCRIPTION
## Summary

Follow-up fix to PR #11487. The immich chart sets the suffix-less label `app.kubernetes.io/name: server` on the immich-server pod, not `immich-server`. With the wrong selector, immich-mcp's egress to immich-server:2283 was dropped by default-deny, causing the claw2immich startup health check to crashloop on \`Connection refused\`.

Paired with `app.kubernetes.io/instance: immich` to avoid accidentally matching any other "server"-named component in the media namespace.

## Test plan

- [ ] Post-merge: immich-mcp pod stays Ready (currently CrashLoopBackOff)
- [ ] Post-merge: kubectl logs shows the startup health-check succeeding

## Note

immich-server-0 itself is currently 0/1 from an unrelated multus / NodeNotReady flap. The CNP fix lets the mcp pod connect once immich-server comes Ready; it does not address the immich-server outage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)