### PR TITLE
fix(network-policy): drop empty mcp-gateway-controller CNP

### DIFF
--- a/kubernetes/apps/mcp-system/mcp-gateway/app/cnp-allow.yaml
+++ b/kubernetes/apps/mcp-system/mcp-gateway/app/cnp-allow.yaml
@@ -29,21 +29,13 @@ spec:
             - port: "50051"
               protocol: TCP
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
-apiVersion: cilium.io/v2
-kind: CiliumNetworkPolicy
-metadata:
-  name: mcp-gateway-controller-allow
-spec:
-  endpointSelector:
-    matchLabels:
-      app.kubernetes.io/name: mcp-gateway-controller
-  # Additive — apiserver egress covered by baseline allow-apiserver;
-  # broker access (to push routing config + health-check) is same-ns
-  # so covered by baseline allow-intra-namespace.
-  enableDefaultDeny:
-    egress: false
-    ingress: false
+# mcp-gateway-controller intentionally has no per-app CNP:
+# - egress to kube-apiserver covered by baseline allow-apiserver
+# - egress to broker (same-ns) covered by baseline allow-intra-namespace
+# - no ingress from outside the namespace
+# An empty-spec CNP fails CRD validation ("spec must validate at least
+# one schema (anyOf)") so the controller relies on baseline allows
+# punching through default-deny.
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
 apiVersion: cilium.io/v2


### PR DESCRIPTION
## Summary

Follow-up to PR #11487. The mcp-gateway-controller-allow CNP I added had no ingress/egress rules — only an endpointSelector — which fails Cilium's CRD validation:

\`\`\`
spec must validate at least one schema (anyOf)
spec.ingress: Required value
\`\`\`

This blocked the entire \`mcp-gateway\` Flux Kustomization from reconciling, which in turn blocked all 12 per-app overlays that depend on \`mcp-gateway\` (only n8n-mcp landed). The other MCP pods were running under default-deny with **only** the baseline allow-policies — same-ns broker polling and DNS worked, but every cross-ns backend call was being silently dropped (visible in Hubble as DROPPED policy-verdicts).

The controller doesn't need a per-app CNP: apiserver + same-ns broker access are both covered by baseline. Replaced the empty CNP with a comment block explaining the omission.

## Test plan

- [x] mcp-gateway kustomize now renders 3 CNPs (broker + istio + jwt-rotator) instead of 4
- [ ] Post-merge: Flux mcp-gateway Kustomization goes Ready
- [ ] Post-merge: all 12 per-app overlays apply (`kubectl get cnp -n mcp-system` shows 17 total)
- [ ] Post-merge: ha-mcp / paperless-mcp / netbox-mcp egress to envoy:10443 stops being DROPPED

## Lesson for future PRs

Always render the rule set with `kubectl --dry-run=server apply -f`, not just `kustomize build`. Cilium's CRD validator catches empty-spec CNPs that kustomize happily emits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)