### PR TITLE
fix(network-policy): allow immich-mcp pypi egress for startup uv build

### DIFF
--- a/kubernetes/apps/mcp-system/immich-mcp/app/cnp-allow.yaml
+++ b/kubernetes/apps/mcp-system/immich-mcp/app/cnp-allow.yaml
@@ -27,3 +27,13 @@ spec:
         - ports:
             - port: "2283"
               protocol: TCP
+    # Startup `uv build claw2immich` fetches the claw2immich source +
+    # wheel deps from PyPI. Without this the container crashloops
+    # before it can serve MCP traffic.
+    - toFQDNs:
+        - matchName: pypi.org
+        - matchName: files.pythonhosted.org
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP


### PR DESCRIPTION
## Summary

- immich-mcp container does `uv build claw2immich` at startup which fetches from `pypi.org` and `files.pythonhosted.org`.
- This egress was missed in PR #11487 (mcp-system lockdown), so the pod is crashlooping at startup.
- Adds `toFQDNs` allow rules for both hosts on port 443. Pod stops crashlooping once Flux reconciles and Cilium picks up the new rule.

## Test plan

- [ ] Flux reconciles `mcp-system` Kustomization
- [ ] Cilium picks up the new CNP (`kubectl get cnp -n mcp-system immich-mcp-allow`)
- [ ] `immich-mcp` pod reaches `Ready 1/1`
- [ ] `hubble observe --pod mcp-system/immich-mcp --verdict DROPPED` shows no recent drops

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>