### PR TITLE
fix(network-policy): ai toFQDNs → toEntities:world (Cilium 1.19 quirk)

### DIFF
--- a/kubernetes/apps/ai/comfyui/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/comfyui/app/cnp-allow.yaml
@@ -24,24 +24,19 @@ spec:
             - port: "8188"
               protocol: TCP
   egress:
-    # Provisioning script fetches model weights + custom nodes from the
-    # ai-dock provisioning URL on first start and on AUTO_UPDATE runs.
-    # ai-dock/comfyui pulls from raw.githubusercontent.com, HuggingFace,
-    # CivitAI, and PyPI mirrors. Allow HTTPS to those plus the broader
-    # GitHub release surface.
-    - toFQDNs:
-        - matchName: "raw.githubusercontent.com"
-        - matchName: "github.com"
-        - matchName: "codeload.github.com"
-        - matchPattern: "*.githubusercontent.com"
-        - matchName: "huggingface.co"
-        - matchPattern: "*.huggingface.co"
-        - matchName: "cdn-lfs.huggingface.co"
-        - matchPattern: "*.hf.co"
-        - matchName: "civitai.com"
-        - matchPattern: "*.civitai.com"
-        - matchName: "pypi.org"
-        - matchName: "files.pythonhosted.org"
+    # External HTTPS for provisioning. Was a toFQDNs allow-list (
+    # raw.githubusercontent.com, github.com, codeload.github.com,
+    # *.githubusercontent.com, huggingface.co, *.huggingface.co,
+    # cdn-lfs.huggingface.co, *.hf.co, civitai.com, *.civitai.com,
+    # pypi.org, files.pythonhosted.org) but Cilium 1.19 matchName
+    # doesn't match through Kubernetes pod DNS search-domain
+    # augmentation (pods query e.g. `huggingface.co.ai.svc.cluster.local.`
+    # and the FQDN cache stores the augmented name). Broadened to
+    # toEntities:world:443 so it actually works. Tighten when FQDN
+    # matching is fixed.
+    # The ai-dock/comfyui provisioning script pulls model weights +
+    # custom nodes from these hosts on first start and on AUTO_UPDATE.
+    - toEntities: [world]
       toPorts:
         - ports:
             - port: "443"

--- a/kubernetes/apps/ai/khoj-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/khoj-oauth2-proxy/app/cnp-allow.yaml
@@ -24,13 +24,18 @@ spec:
             - port: "4180"
               protocol: TCP
   egress:
-    # OIDC discovery + token exchange against Authelia. auth.SECRET_DOMAIN
+    # OIDC discovery + token exchange against Authelia. Was a toFQDNs
+    # matchName "auth.thesteamedcrab.com" rule (auth.${SECRET_DOMAIN}
     # resolves to the internal Envoy gateway VIP, which then routes to
-    # the auth namespace. toFQDNs is the cleanest expression.
+    # the auth namespace). Cilium 1.19 matchName doesn't match through
+    # Kubernetes pod DNS search-domain augmentation (pod queries
+    # `auth.thesteamedcrab.com.ai.svc.cluster.local.` and the FQDN
+    # cache stores the augmented name). Broadened to
+    # toEntities:world:443 so it actually works. Tighten when FQDN
+    # matching is fixed.
     # Upstream → khoj.ai.svc.cluster.local:42110. Same-ns; the baseline
     # allow-intra-namespace already covers that path.
-    - toFQDNs:
-        - matchName: "auth.thesteamedcrab.com"
+    - toEntities: [world]
       toPorts:
         - ports:
             - port: "443"

--- a/kubernetes/apps/ai/khoj/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/khoj/app/cnp-allow.yaml
@@ -36,12 +36,15 @@ spec:
             - port: "8080"
               protocol: TCP
     # HuggingFace model downloads (embedding/search models cached to
-    # khoj-models PVC on first run + on model config changes).
-    - toFQDNs:
-        - matchName: "huggingface.co"
-        - matchPattern: "*.huggingface.co"
-        - matchName: "cdn-lfs.huggingface.co"
-        - matchPattern: "*.hf.co"
+    # khoj-models PVC on first run + on model config changes). Was a
+    # toFQDNs allow-list (huggingface.co, *.huggingface.co,
+    # cdn-lfs.huggingface.co, *.hf.co). Cilium 1.19 matchName doesn't
+    # match through Kubernetes pod DNS search-domain augmentation
+    # (pod queries `huggingface.co.ai.svc.cluster.local.` and the FQDN
+    # cache stores the augmented name). Broadened to
+    # toEntities:world:443 so it actually works. Tighten when FQDN
+    # matching is fixed.
+    - toEntities: [world]
       toPorts:
         - ports:
             - port: "443"

--- a/kubernetes/apps/ai/kubeclaw/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/kubeclaw/app/cnp-allow.yaml
@@ -50,18 +50,18 @@ spec:
               protocol: TCP
             - port: "50051"
               protocol: TCP
-    # qmd-embed CronJob downloads embedding models from HuggingFace on
-    # first run and on model rotation. qmd-update may also reach GitHub
-    # for skill repo updates.
-    - toFQDNs:
-        - matchName: "huggingface.co"
-        - matchPattern: "*.huggingface.co"
-        - matchName: "cdn-lfs.huggingface.co"
-        - matchPattern: "*.hf.co"
-        - matchName: "github.com"
-        - matchName: "codeload.github.com"
-        - matchName: "raw.githubusercontent.com"
-        - matchPattern: "*.githubusercontent.com"
+    # External HTTPS for qmd-embed (HuggingFace embedding-model
+    # downloads on first run + on model rotation) and qmd-update
+    # (GitHub skill-repo updates). Was a toFQDNs allow-list
+    # (huggingface.co, *.huggingface.co, cdn-lfs.huggingface.co,
+    # *.hf.co, github.com, codeload.github.com,
+    # raw.githubusercontent.com, *.githubusercontent.com). Cilium 1.19
+    # matchName doesn't match through Kubernetes pod DNS search-domain
+    # augmentation (pod queries e.g. `huggingface.co.ai.svc.cluster.local.`
+    # and the FQDN cache stores the augmented name). Broadened to
+    # toEntities:world:443 so it actually works. Tighten when FQDN
+    # matching is fixed.
+    - toEntities: [world]
       toPorts:
         - ports:
             - port: "443"

--- a/kubernetes/apps/ai/langgraph-agents/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/cnp-allow.yaml
@@ -71,16 +71,19 @@ spec:
         - ports:
             - port: "80"
               protocol: TCP
-    # External APIs:
-    #   - api.pushover.net    — Tier-1 alert escalations
-    #   - api.anthropic.com   — Claude API (gated on ENABLE_CLAUDE_API)
+    # External APIs. Was a toFQDNs allow-list (api.pushover.net for
+    # Tier-1 alert escalations, api.anthropic.com for the Claude API
+    # gated on ENABLE_CLAUDE_API). Cilium 1.19 matchName doesn't match
+    # through Kubernetes pod DNS search-domain augmentation (pod
+    # queries `api.pushover.net.ai.svc.cluster.local.` and the FQDN
+    # cache stores the augmented name). Broadened to
+    # toEntities:world:443 so it actually works. Tighten when FQDN
+    # matching is fixed.
     # Langfuse: user intends self-hosted in-cluster. LANGFUSE_HOST is
     # currently empty so the client doesn't instantiate. When the
     # in-cluster Langfuse lands, add a toEndpoints rule here for the
     # langfuse ns + app label.
-    - toFQDNs:
-        - matchName: "api.pushover.net"
-        - matchName: "api.anthropic.com"
+    - toEntities: [world]
       toPorts:
         - ports:
             - port: "443"

--- a/kubernetes/apps/ai/ollama/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/ollama/app/cnp-allow.yaml
@@ -46,19 +46,18 @@ spec:
               protocol: TCP
   egress:
     # Model registry — ollama pulls model blobs on first invocation
-    # (`ollama pull <model>`) and on Modelfile changes. Targets registry
-    # are ollama.com (OCI-style manifests) and the GCS-backed blob host
-    # `dd20bb891979d25aebc8bec07b2b3bbc.r2.cloudflarestorage.com` (which
-    # rotates; broaden to all of cloudflarestorage.com to absorb that).
-    # HuggingFace also serves some community model GGUFs.
-    - toFQDNs:
-        - matchName: "ollama.com"
-        - matchName: "registry.ollama.ai"
-        - matchPattern: "*.ollama.ai"
-        - matchPattern: "*.cloudflarestorage.com"
-        - matchName: "huggingface.co"
-        - matchPattern: "*.huggingface.co"
-        - matchName: "cdn-lfs.huggingface.co"
+    # (`ollama pull <model>`) and on Modelfile changes. Was a toFQDNs
+    # allow-list (ollama.com, registry.ollama.ai, *.ollama.ai,
+    # *.cloudflarestorage.com for the rotating GCS-backed R2 blob host
+    # e.g. dd20bb891979d25aebc8bec07b2b3bbc.r2.cloudflarestorage.com,
+    # huggingface.co, *.huggingface.co, cdn-lfs.huggingface.co for
+    # community model GGUFs). Cilium 1.19 matchName doesn't match
+    # through Kubernetes pod DNS search-domain augmentation (pod
+    # queries e.g. `ollama.com.ai.svc.cluster.local.` and the FQDN
+    # cache stores the augmented name). Broadened to
+    # toEntities:world:443 so it actually works. Tighten when FQDN
+    # matching is fixed.
+    - toEntities: [world]
       toPorts:
         - ports:
             - port: "443"


### PR DESCRIPTION
## Summary

- Cilium 1.19 `toFQDNs:matchName` doesn't match through Kubernetes pod DNS search-domain augmentation. Pods query e.g. `huggingface.co.ai.svc.cluster.local.`; CoreDNS returns the IP; Cilium's FQDN cache stores under the augmented name; `matchName "huggingface.co"` doesn't match; connection denied.
- Replaces `toFQDNs` allow-lists in 6 ai-ns per-app CNPs (comfyui, khoj, khoj-oauth2-proxy, kubeclaw, langgraph-agents, ollama) with `toEntities: [world]` + port restriction (broad allow for external HTTPS).
- FQDN names retained in comments for documentation/future tightening.

## Test plan

- [ ] Flux reconciles `ai` Kustomization
- [ ] Cilium picks up the new CNPs (`kubectl get cnp -n ai`)
- [ ] khoj-oauth2-proxy OIDC discovery succeeds (no DROPPED to Authelia)
- [ ] ollama pulls a model successfully (no DROPPED to ollama.com / cloudflarestorage / huggingface)
- [ ] comfyui provisioning fetches model weights
- [ ] langgraph-agents Pushover / Anthropic calls succeed when invoked
- [ ] `hubble observe --namespace ai --verdict DROPPED --since 5m` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)