### PR TITLE
fix(network-policy): renovate toFQDNs → toEntities:world (Cilium 1.19 quirk)

### DIFF
--- a/kubernetes/apps/renovate/renovate-operator/app/cnp-allow.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/app/cnp-allow.yaml
@@ -34,15 +34,16 @@ spec:
     # spawned RenovateJob pods (covered by renovate-jobs-allow in
     # ../jobs/).
     #
-    # NOTE: matchPattern (with trailing `.*` variants) is needed for
-    # resolvers that do search-domain expansion — cilium keys the FQDN
-    # cache on the queried name, not the resolved one. See the actions-
-    # runner-controller CNP for the full rationale.
-    - toFQDNs:
-        - matchPattern: "api.github.com"
-        - matchPattern: "api.github.com.*"
-        - matchPattern: "github.com"
-        - matchPattern: "github.com.*"
+    # Was a toFQDNs allow-list (api.github.com, github.com — with
+    # matchPattern + `.*` variants per the search-domain hack from
+    # PR #11492). Even with that workaround Cilium 1.19 doesn't
+    # reliably match through Kubernetes pod DNS search-domain
+    # augmentation (pod queries
+    # `api.github.com.renovate.svc.cluster.local.`; FQDN cache stores
+    # the augmented name; matching is unreliable). Broadened to
+    # toEntities:world:443 so it actually works. Tighten when FQDN
+    # matching is fixed.
+    - toEntities: [world]
       toPorts:
         - ports:
             - port: "443"


### PR DESCRIPTION
## Summary

- Cilium 1.19 `toFQDNs:matchName` doesn't match through Kubernetes pod DNS search-domain augmentation. Operator queries `api.github.com.renovate.svc.cluster.local.`; FQDN cache stores under the augmented name; matchName doesn't match. PR #11492's matchPattern + `.*` workaround proved unreliable.
- Replaces operator's `toFQDNs` allow-list with `toEntities: [world]` + port 443. FQDN names retained in comments.
- Scope is `app/` (operator) only — `jobs/cnp-allow.yaml` is left as-is (already effectively world-open via `toFQDNs matchPattern: "*"` because RenovateJob pods scan arbitrary registries).

## Test plan

- [ ] Flux reconciles `renovate` Kustomization
- [ ] Cilium picks up the new CNP (\`kubectl get cnp -n renovate renovate-operator-allow\`)
- [ ] Next discovery job spawns successfully and operator reaches api.github.com
- [ ] Webhook delivery from GitHub still routes (envoy ingress unchanged)
- [ ] \`hubble observe --pod renovate/renovate-operator-* --verdict DROPPED --since 5m\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)