### PR TITLE
feat(observability): per-UPS workers CPU split + Power dashboard refresh (B+C)

### DIFF
--- a/kubernetes/apps/observability/exporters/snmp-exporter/app/apc-ups/prometheusrule.yaml
+++ b/kubernetes/apps/observability/exporters/snmp-exporter/app/apc-ups/prometheusrule.yaml
@@ -75,16 +75,19 @@ spec:
         # PoE delivered per Omada switch
         - record: power:omada_poe:watts
           expr: sum by (device_name) (omada_port_power_watts)
-        # CPU package power across the 4 physical cluster nodes (master1,
-        # worker2, worker3, worker4). Filter on `kubernetes_node` label
-        # which the cluster ServiceMonitor relabel injects — brain's
-        # external scrape config doesn't set it, so brain is excluded.
-        # The other 6 cluster nodes are KVM guests on beast and have no
-        # /sys/class/powercap exposed — beast's iDRAC already accounts
-        # for their power. RAPL captures ~60-70% of true system power
-        # on M910x (CPU package only; RAM, NIC, disk, board not measured).
+        # CPU package power across the 4 physical cluster nodes. Per the
+        # 2026-05-17 rack walk (reference_rack_ups_topology.md):
+        #   - UPS-3000 powers: master1, worker3, worker4
+        #   - UPS-1500 powers: worker2
+        # Split into per-UPS rules so Energy Dashboard included_in_stat
+        # attribution slots under the correct UPS parent. Rollup retained
+        # for the existing Workers (CPU) Individual Device.
         - record: power:workers_cpu:watts
           expr: sum(rate(node_rapl_package_joules_total{kubernetes_node!=""}[2m]))
+        - record: power:workers_ups_3000_cpu:watts
+          expr: sum(rate(node_rapl_package_joules_total{kubernetes_node=~"(master1|worker3|worker4)\\.thesteamedcrab\\.com"}[2m]))
+        - record: power:workers_ups_1500_cpu:watts
+          expr: rate(node_rapl_package_joules_total{kubernetes_node="worker2.thesteamedcrab.com"}[2m])
         # brain CPU package power. brain runs as systemd node-exporter
         # with a User=root drop-in to read RAPL (mode 400 root-only since
         # Platypus mitigation). Captured in lovenet-network-configuration

--- a/kubernetes/apps/observability/grafana/dashboards/power.json
+++ b/kubernetes/apps/observability/grafana/dashboards/power.json
@@ -1089,6 +1089,390 @@
           "sort": "desc"
         }
       }
+    },
+    {
+      "type": "row",
+      "id": 106,
+      "title": "Cluster + CPU + GPU power (RAPL + DCGM)",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 46
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "stat",
+      "id": 60,
+      "title": "Workers CPU (4 phys)",
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 47
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "power:workers_cpu:watts",
+          "refId": "A",
+          "legendFormat": ""
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "watt",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 140.0
+              },
+              {
+                "color": "red",
+                "value": 200
+              }
+            ]
+          }
+        }
+      },
+      "options": {
+        "graphMode": "area",
+        "colorMode": "value",
+        "justifyMode": "center",
+        "textMode": "value_and_name",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "id": 61,
+      "title": "Brain CPU",
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 47
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "power:brain_cpu:watts",
+          "refId": "A",
+          "legendFormat": ""
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "watt",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 35.0
+              },
+              {
+                "color": "red",
+                "value": 50
+              }
+            ]
+          }
+        }
+      },
+      "options": {
+        "graphMode": "area",
+        "colorMode": "value",
+        "justifyMode": "center",
+        "textMode": "value_and_name",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "id": 62,
+      "title": "GPU (P40)",
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 47
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "power:gpu:watts",
+          "refId": "A",
+          "legendFormat": ""
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "watt",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 175.0
+              },
+              {
+                "color": "red",
+                "value": 250
+              }
+            ]
+          }
+        }
+      },
+      "options": {
+        "graphMode": "area",
+        "colorMode": "value",
+        "justifyMode": "center",
+        "textMode": "value_and_name",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "id": 63,
+      "title": "UPS 3000 Other",
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 47
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "power:ups_3000_other:watts",
+          "refId": "A",
+          "legendFormat": ""
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "watt",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 350.0
+              },
+              {
+                "color": "red",
+                "value": 500
+              }
+            ]
+          }
+        }
+      },
+      "options": {
+        "graphMode": "area",
+        "colorMode": "value",
+        "justifyMode": "center",
+        "textMode": "value_and_name",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "id": 64,
+      "title": "Workers (per-UPS) + Brain + GPU \u2014 over time",
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 52
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "power:workers_ups_3000_cpu:watts",
+          "refId": "A",
+          "legendFormat": "Workers on UPS-3000 (m1,w3,w4)"
+        },
+        {
+          "expr": "power:workers_ups_1500_cpu:watts",
+          "refId": "B",
+          "legendFormat": "Workers on UPS-1500 (w2)"
+        },
+        {
+          "expr": "power:brain_cpu:watts",
+          "refId": "C",
+          "legendFormat": "Brain CPU"
+        },
+        {
+          "expr": "power:gpu:watts",
+          "refId": "D",
+          "legendFormat": "GPU (P40)"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "watt",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 25,
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            },
+            "pointSize": 5,
+            "showPoints": "never"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "id": 65,
+      "title": "Beast (iDRAC) vs GPU (DCGM) \u2014 what fraction of beast is the GPU?",
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 60
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "power:beast:watts",
+          "refId": "A",
+          "legendFormat": "Beast total (iDRAC)"
+        },
+        {
+          "expr": "power:gpu:watts",
+          "refId": "B",
+          "legendFormat": "GPU (P40)"
+        },
+        {
+          "expr": "power:beast:watts - power:gpu:watts",
+          "refId": "C",
+          "legendFormat": "Beast minus GPU (CPU+RAM+disk+board)"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "watt",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "pointSize": 5,
+            "showPoints": "never"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
     }
   ],
   "refresh": "30s",
@@ -1109,6 +1493,6 @@
   "timezone": "America/New_York",
   "title": "Power Overview",
   "uid": "power-overview",
-  "version": 2,
+  "version": 3,
   "weekStart": ""
 }


### PR DESCRIPTION
Two related observability tweaks — bundled because they share the same recording-rule file.

## B — Per-UPS workers CPU split

Per the rack walk on 2026-05-17 (`reference_rack_ups_topology.md`):
- UPS-3000: master1, worker3, worker4
- UPS-1500: worker2

Three new/refreshed recording rules:

| Metric | Members |
|---|---|
| `power:workers_cpu:watts` | (rollup retained) all 4 |
| `power:workers_ups_3000_cpu:watts` | master1, worker3, worker4 |
| `power:workers_ups_1500_cpu:watts` | worker2 |

Once MCP reconnects, the Energy Dashboard `included_in_stat` for each new split can land under its proper UPS parent.

## C — Power Overview dashboard refresh

Adds the post-build sensors (workers, brain CPU, GPU, UPS 3000 Other) to the existing dashboard:

- New row: **Cluster + CPU + GPU power (RAPL + DCGM)**
- 4 stat panels: Workers CPU, Brain CPU, GPU (P40), UPS 3000 Other
- Stacked time-series: workers per-UPS + brain + GPU
- Comparison time-series: Beast (iDRAC) vs GPU (DCGM) vs Beast-minus-GPU

29 panels total now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)