### PR TITLE
fix(network-policy): mcp-system toFQDNs → toEntities:world (Cilium 1.19 quirk)

### DIFF
--- a/kubernetes/apps/mcp-system/github-mcp/app/cnp-allow.yaml
+++ b/kubernetes/apps/mcp-system/github-mcp/app/cnp-allow.yaml
@@ -16,22 +16,20 @@ spec:
     # GitHub API surface. The github-mcp-server proxies REST + GraphQL
     # tools to api.github.com (and graphql.github.com for v4); also
     # touches uploads.github.com for release artifact uploads when an
-    # agent invokes the release tools.
+    # agent invokes the release tools. raw.githubusercontent.com and
+    # codeload.github.com cover repo content access.
     #
-    # NOTE: matchPattern (with trailing `.*` variants) is needed for
-    # resolvers that do search-domain expansion — cilium keys the FQDN
-    # cache on the queried name, not the resolved one.
-    - toFQDNs:
-        - matchPattern: "api.github.com"
-        - matchPattern: "api.github.com.*"
-        - matchPattern: "github.com"
-        - matchPattern: "github.com.*"
-        - matchPattern: "uploads.github.com"
-        - matchPattern: "uploads.github.com.*"
-        - matchPattern: "raw.githubusercontent.com"
-        - matchPattern: "raw.githubusercontent.com.*"
-        - matchPattern: "codeload.github.com"
-        - matchPattern: "codeload.github.com.*"
+    # Was a toFQDNs allow-list (api.github.com, github.com,
+    # uploads.github.com, raw.githubusercontent.com, codeload.github.com
+    # — with matchPattern + `.*` variants per the search-domain hack
+    # from PR #11492). Even with that workaround Cilium 1.19 doesn't
+    # reliably match through Kubernetes pod DNS search-domain
+    # augmentation (pod queries
+    # `api.github.com.mcp-system.svc.cluster.local.`; FQDN cache
+    # stores the augmented name; matching is unreliable). Broadened
+    # to toEntities:world:443 so it actually works. Tighten when FQDN
+    # matching is fixed.
+    - toEntities: [world]
       toPorts:
         - ports:
             - port: "443"

--- a/kubernetes/apps/mcp-system/immich-mcp/app/cnp-allow.yaml
+++ b/kubernetes/apps/mcp-system/immich-mcp/app/cnp-allow.yaml
@@ -29,10 +29,15 @@ spec:
               protocol: TCP
     # Startup `uv build claw2immich` fetches the claw2immich source +
     # wheel deps from PyPI. Without this the container crashloops
-    # before it can serve MCP traffic.
-    - toFQDNs:
-        - matchName: pypi.org
-        - matchName: files.pythonhosted.org
+    # before it can serve MCP traffic. Was a toFQDNs allow-list
+    # (pypi.org, files.pythonhosted.org). Cilium 1.19 matchName
+    # doesn't match through Kubernetes pod DNS search-domain
+    # augmentation (pod queries
+    # `pypi.org.mcp-system.svc.cluster.local.`; FQDN cache stores
+    # the augmented name; matchName doesn't match). Broadened to
+    # toEntities:world:443 so it actually works. Tighten when FQDN
+    # matching is fixed.
+    - toEntities: [world]
       toPorts:
         - ports:
             - port: "443"


### PR DESCRIPTION
## Summary

- Cilium 1.19 `toFQDNs:matchName` doesn't match through Kubernetes pod DNS search-domain augmentation. MCP pods query e.g. `api.github.com.mcp-system.svc.cluster.local.`; FQDN cache stores under the augmented name; matchName doesn't match. PR #11492's matchPattern + `.*` workaround proved unreliable.
- Replaces `toFQDNs` allow-lists in 2 mcp-system per-app CNPs with `toEntities: [world]` + port 443:
  - **github-mcp**: was api.github.com / github.com / uploads.github.com / raw.githubusercontent.com / codeload.github.com
  - **immich-mcp**: was pypi.org / files.pythonhosted.org (startup `uv build claw2immich`)
- FQDN names retained in comments.

## Test plan

- [ ] Flux reconciles `mcp-system` Kustomization
- [ ] Cilium picks up the new CNPs
- [ ] github-mcp tool invocations succeed end-to-end (api.github.com reachable)
- [ ] immich-mcp startup `uv build` succeeds, pod reaches Ready 1/1
- [ ] \`hubble observe --namespace mcp-system --verdict DROPPED --since 5m\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)