### PR TITLE
fix(network-policy): restore matchPattern precision (revert world swap)

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/operator/cnp-allow.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/operator/cnp-allow.yaml
@@ -18,18 +18,22 @@ spec:
     # GitHub API: the operator authenticates as a GitHub App, polls for
     # the registration token, and reconciles runner-scale-set state.
     #
-    # Was a toFQDNs allow-list (api.github.com, github.com,
-    # *.githubusercontent.com — with matchPattern + `.*` variants per
-    # the search-domain hack in PR #11492). Even with that workaround
-    # Cilium 1.19 doesn't reliably match through Kubernetes pod DNS
-    # search-domain augmentation (pod queries e.g.
+    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
+    # pod DNS search-domain augmentation (pod queries e.g.
     # `api.github.com.actions-runner-system.svc.cluster.local.`; the
-    # FQDN cache stores the augmented name; matching is unreliable).
-    # Broadened to toEntities:world:443 so it actually works. Tighten
-    # when FQDN matching is fixed.
+    # FQDN cache stores the augmented name; matchName misses it). The
+    # bare + `.*` dual-form matchPattern covers both un-augmented and
+    # search-domain-augmented forms — see PR #11492 for the canonical
+    # example.
     # api.github.com resolves to Azure / GitHub IPs (140.82.112.0/20
     # observed 140.82.112/113/114 .5/.6 in cilium-dbg fqdn cache).
-    - toEntities: [world]
+    - toFQDNs:
+        - matchPattern: "api.github.com"
+        - matchPattern: "api.github.com.*"
+        - matchPattern: "github.com"
+        - matchPattern: "github.com.*"
+        - matchPattern: "*.githubusercontent.com"
+        - matchPattern: "*.githubusercontent.com.*"
       toPorts:
         - ports:
             - port: "443"

--- a/kubernetes/apps/ai/comfyui/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/comfyui/app/cnp-allow.yaml
@@ -24,19 +24,42 @@ spec:
             - port: "8188"
               protocol: TCP
   egress:
-    # External HTTPS for provisioning. Was a toFQDNs allow-list (
-    # raw.githubusercontent.com, github.com, codeload.github.com,
-    # *.githubusercontent.com, huggingface.co, *.huggingface.co,
-    # cdn-lfs.huggingface.co, *.hf.co, civitai.com, *.civitai.com,
-    # pypi.org, files.pythonhosted.org) but Cilium 1.19 matchName
-    # doesn't match through Kubernetes pod DNS search-domain
-    # augmentation (pods query e.g. `huggingface.co.ai.svc.cluster.local.`
-    # and the FQDN cache stores the augmented name). Broadened to
-    # toEntities:world:443 so it actually works. Tighten when FQDN
-    # matching is fixed.
-    # The ai-dock/comfyui provisioning script pulls model weights +
-    # custom nodes from these hosts on first start and on AUTO_UPDATE.
-    - toEntities: [world]
+    # External HTTPS for provisioning. The ai-dock/comfyui provisioning
+    # script pulls model weights + custom nodes from these hosts on
+    # first start and on AUTO_UPDATE.
+    #
+    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
+    # pod DNS search-domain augmentation (pods query e.g.
+    # `huggingface.co.ai.svc.cluster.local.` and the FQDN cache stores
+    # the augmented name; matchName misses it). The bare + `.*`
+    # dual-form matchPattern covers both un-augmented and
+    # search-domain-augmented forms — see PR #11492 for the canonical
+    # example.
+    - toFQDNs:
+        - matchPattern: "github.com"
+        - matchPattern: "github.com.*"
+        - matchPattern: "codeload.github.com"
+        - matchPattern: "codeload.github.com.*"
+        - matchPattern: "raw.githubusercontent.com"
+        - matchPattern: "raw.githubusercontent.com.*"
+        - matchPattern: "*.githubusercontent.com"
+        - matchPattern: "*.githubusercontent.com.*"
+        - matchPattern: "huggingface.co"
+        - matchPattern: "huggingface.co.*"
+        - matchPattern: "*.huggingface.co"
+        - matchPattern: "*.huggingface.co.*"
+        - matchPattern: "cdn-lfs.huggingface.co"
+        - matchPattern: "cdn-lfs.huggingface.co.*"
+        - matchPattern: "*.hf.co"
+        - matchPattern: "*.hf.co.*"
+        - matchPattern: "civitai.com"
+        - matchPattern: "civitai.com.*"
+        - matchPattern: "*.civitai.com"
+        - matchPattern: "*.civitai.com.*"
+        - matchPattern: "pypi.org"
+        - matchPattern: "pypi.org.*"
+        - matchPattern: "files.pythonhosted.org"
+        - matchPattern: "files.pythonhosted.org.*"
       toPorts:
         - ports:
             - port: "443"

--- a/kubernetes/apps/ai/khoj-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/khoj-oauth2-proxy/app/cnp-allow.yaml
@@ -24,18 +24,22 @@ spec:
             - port: "4180"
               protocol: TCP
   egress:
-    # OIDC discovery + token exchange against Authelia. Was a toFQDNs
-    # matchName "auth.thesteamedcrab.com" rule (auth.${SECRET_DOMAIN}
-    # resolves to the internal Envoy gateway VIP, which then routes to
-    # the auth namespace). Cilium 1.19 matchName doesn't match through
-    # Kubernetes pod DNS search-domain augmentation (pod queries
-    # `auth.thesteamedcrab.com.ai.svc.cluster.local.` and the FQDN
-    # cache stores the augmented name). Broadened to
-    # toEntities:world:443 so it actually works. Tighten when FQDN
-    # matching is fixed.
+    # OIDC discovery + token exchange against Authelia.
+    # auth.${SECRET_DOMAIN} resolves to the internal Envoy gateway VIP,
+    # which then routes to the auth namespace.
     # Upstream → khoj.ai.svc.cluster.local:42110. Same-ns; the baseline
     # allow-intra-namespace already covers that path.
-    - toEntities: [world]
+    #
+    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
+    # pod DNS search-domain augmentation (pod queries
+    # `auth.thesteamedcrab.com.ai.svc.cluster.local.` and the FQDN
+    # cache stores the augmented name; matchName misses it). The
+    # bare + `.*` dual-form matchPattern covers both un-augmented and
+    # search-domain-augmented forms — see PR #11492 for the canonical
+    # example.
+    - toFQDNs:
+        - matchPattern: "auth.thesteamedcrab.com"
+        - matchPattern: "auth.thesteamedcrab.com.*"
       toPorts:
         - ports:
             - port: "443"

--- a/kubernetes/apps/ai/khoj/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/khoj/app/cnp-allow.yaml
@@ -36,15 +36,24 @@ spec:
             - port: "8080"
               protocol: TCP
     # HuggingFace model downloads (embedding/search models cached to
-    # khoj-models PVC on first run + on model config changes). Was a
-    # toFQDNs allow-list (huggingface.co, *.huggingface.co,
-    # cdn-lfs.huggingface.co, *.hf.co). Cilium 1.19 matchName doesn't
-    # match through Kubernetes pod DNS search-domain augmentation
-    # (pod queries `huggingface.co.ai.svc.cluster.local.` and the FQDN
-    # cache stores the augmented name). Broadened to
-    # toEntities:world:443 so it actually works. Tighten when FQDN
-    # matching is fixed.
-    - toEntities: [world]
+    # khoj-models PVC on first run + on model config changes).
+    #
+    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
+    # pod DNS search-domain augmentation (pod queries
+    # `huggingface.co.ai.svc.cluster.local.` and the FQDN cache stores
+    # the augmented name; matchName misses it). The bare + `.*`
+    # dual-form matchPattern covers both un-augmented and
+    # search-domain-augmented forms — see PR #11492 for the canonical
+    # example.
+    - toFQDNs:
+        - matchPattern: "huggingface.co"
+        - matchPattern: "huggingface.co.*"
+        - matchPattern: "*.huggingface.co"
+        - matchPattern: "*.huggingface.co.*"
+        - matchPattern: "cdn-lfs.huggingface.co"
+        - matchPattern: "cdn-lfs.huggingface.co.*"
+        - matchPattern: "*.hf.co"
+        - matchPattern: "*.hf.co.*"
       toPorts:
         - ports:
             - port: "443"

--- a/kubernetes/apps/ai/kubeclaw/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/kubeclaw/app/cnp-allow.yaml
@@ -52,16 +52,32 @@ spec:
               protocol: TCP
     # External HTTPS for qmd-embed (HuggingFace embedding-model
     # downloads on first run + on model rotation) and qmd-update
-    # (GitHub skill-repo updates). Was a toFQDNs allow-list
-    # (huggingface.co, *.huggingface.co, cdn-lfs.huggingface.co,
-    # *.hf.co, github.com, codeload.github.com,
-    # raw.githubusercontent.com, *.githubusercontent.com). Cilium 1.19
-    # matchName doesn't match through Kubernetes pod DNS search-domain
-    # augmentation (pod queries e.g. `huggingface.co.ai.svc.cluster.local.`
-    # and the FQDN cache stores the augmented name). Broadened to
-    # toEntities:world:443 so it actually works. Tighten when FQDN
-    # matching is fixed.
-    - toEntities: [world]
+    # (GitHub skill-repo updates).
+    #
+    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
+    # pod DNS search-domain augmentation (pod queries e.g.
+    # `huggingface.co.ai.svc.cluster.local.` and the FQDN cache stores
+    # the augmented name; matchName misses it). The bare + `.*`
+    # dual-form matchPattern covers both un-augmented and
+    # search-domain-augmented forms — see PR #11492 for the canonical
+    # example.
+    - toFQDNs:
+        - matchPattern: "huggingface.co"
+        - matchPattern: "huggingface.co.*"
+        - matchPattern: "*.huggingface.co"
+        - matchPattern: "*.huggingface.co.*"
+        - matchPattern: "cdn-lfs.huggingface.co"
+        - matchPattern: "cdn-lfs.huggingface.co.*"
+        - matchPattern: "*.hf.co"
+        - matchPattern: "*.hf.co.*"
+        - matchPattern: "github.com"
+        - matchPattern: "github.com.*"
+        - matchPattern: "codeload.github.com"
+        - matchPattern: "codeload.github.com.*"
+        - matchPattern: "raw.githubusercontent.com"
+        - matchPattern: "raw.githubusercontent.com.*"
+        - matchPattern: "*.githubusercontent.com"
+        - matchPattern: "*.githubusercontent.com.*"
       toPorts:
         - ports:
             - port: "443"

--- a/kubernetes/apps/ai/langgraph-agents/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/cnp-allow.yaml
@@ -71,19 +71,25 @@ spec:
         - ports:
             - port: "80"
               protocol: TCP
-    # External APIs. Was a toFQDNs allow-list (api.pushover.net for
-    # Tier-1 alert escalations, api.anthropic.com for the Claude API
-    # gated on ENABLE_CLAUDE_API). Cilium 1.19 matchName doesn't match
-    # through Kubernetes pod DNS search-domain augmentation (pod
-    # queries `api.pushover.net.ai.svc.cluster.local.` and the FQDN
-    # cache stores the augmented name). Broadened to
-    # toEntities:world:443 so it actually works. Tighten when FQDN
-    # matching is fixed.
+    # External APIs: api.pushover.net for Tier-1 alert escalations,
+    # api.anthropic.com for the Claude API gated on ENABLE_CLAUDE_API.
+    #
+    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
+    # pod DNS search-domain augmentation (pod queries
+    # `api.pushover.net.ai.svc.cluster.local.` and the FQDN cache
+    # stores the augmented name; matchName misses it). The bare +
+    # `.*` dual-form matchPattern covers both un-augmented and
+    # search-domain-augmented forms — see PR #11492 for the canonical
+    # example.
     # Langfuse: user intends self-hosted in-cluster. LANGFUSE_HOST is
     # currently empty so the client doesn't instantiate. When the
     # in-cluster Langfuse lands, add a toEndpoints rule here for the
     # langfuse ns + app label.
-    - toEntities: [world]
+    - toFQDNs:
+        - matchPattern: "api.pushover.net"
+        - matchPattern: "api.pushover.net.*"
+        - matchPattern: "api.anthropic.com"
+        - matchPattern: "api.anthropic.com.*"
       toPorts:
         - ports:
             - port: "443"

--- a/kubernetes/apps/ai/ollama/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/ollama/app/cnp-allow.yaml
@@ -46,18 +46,34 @@ spec:
               protocol: TCP
   egress:
     # Model registry — ollama pulls model blobs on first invocation
-    # (`ollama pull <model>`) and on Modelfile changes. Was a toFQDNs
-    # allow-list (ollama.com, registry.ollama.ai, *.ollama.ai,
-    # *.cloudflarestorage.com for the rotating GCS-backed R2 blob host
-    # e.g. dd20bb891979d25aebc8bec07b2b3bbc.r2.cloudflarestorage.com,
-    # huggingface.co, *.huggingface.co, cdn-lfs.huggingface.co for
-    # community model GGUFs). Cilium 1.19 matchName doesn't match
-    # through Kubernetes pod DNS search-domain augmentation (pod
-    # queries e.g. `ollama.com.ai.svc.cluster.local.` and the FQDN
-    # cache stores the augmented name). Broadened to
-    # toEntities:world:443 so it actually works. Tighten when FQDN
-    # matching is fixed.
-    - toEntities: [world]
+    # (`ollama pull <model>`) and on Modelfile changes.
+    # *.cloudflarestorage.com covers the rotating GCS-backed R2 blob
+    # host (e.g. dd20bb891979d25aebc8bec07b2b3bbc.r2.cloudflarestorage.com).
+    # huggingface.co + *.huggingface.co + cdn-lfs.huggingface.co cover
+    # community model GGUFs.
+    #
+    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
+    # pod DNS search-domain augmentation (pod queries e.g.
+    # `ollama.com.ai.svc.cluster.local.` and the FQDN cache stores
+    # the augmented name; matchName misses it). The bare + `.*`
+    # dual-form matchPattern covers both un-augmented and
+    # search-domain-augmented forms — see PR #11492 for the canonical
+    # example.
+    - toFQDNs:
+        - matchPattern: "ollama.com"
+        - matchPattern: "ollama.com.*"
+        - matchPattern: "registry.ollama.ai"
+        - matchPattern: "registry.ollama.ai.*"
+        - matchPattern: "*.ollama.ai"
+        - matchPattern: "*.ollama.ai.*"
+        - matchPattern: "*.cloudflarestorage.com"
+        - matchPattern: "*.cloudflarestorage.com.*"
+        - matchPattern: "huggingface.co"
+        - matchPattern: "huggingface.co.*"
+        - matchPattern: "*.huggingface.co"
+        - matchPattern: "*.huggingface.co.*"
+        - matchPattern: "cdn-lfs.huggingface.co"
+        - matchPattern: "cdn-lfs.huggingface.co.*"
       toPorts:
         - ports:
             - port: "443"

--- a/kubernetes/apps/mcp-system/github-mcp/app/cnp-allow.yaml
+++ b/kubernetes/apps/mcp-system/github-mcp/app/cnp-allow.yaml
@@ -19,17 +19,24 @@ spec:
     # agent invokes the release tools. raw.githubusercontent.com and
     # codeload.github.com cover repo content access.
     #
-    # Was a toFQDNs allow-list (api.github.com, github.com,
-    # uploads.github.com, raw.githubusercontent.com, codeload.github.com
-    # — with matchPattern + `.*` variants per the search-domain hack
-    # from PR #11492). Even with that workaround Cilium 1.19 doesn't
-    # reliably match through Kubernetes pod DNS search-domain
-    # augmentation (pod queries
-    # `api.github.com.mcp-system.svc.cluster.local.`; FQDN cache
-    # stores the augmented name; matching is unreliable). Broadened
-    # to toEntities:world:443 so it actually works. Tighten when FQDN
-    # matching is fixed.
-    - toEntities: [world]
+    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
+    # pod DNS search-domain augmentation (pod queries
+    # `api.github.com.mcp-system.svc.cluster.local.`; the FQDN cache
+    # stores the augmented name; matchName misses it). The bare +
+    # `.*` dual-form matchPattern covers both un-augmented and
+    # search-domain-augmented forms — see PR #11492 for the canonical
+    # example.
+    - toFQDNs:
+        - matchPattern: "api.github.com"
+        - matchPattern: "api.github.com.*"
+        - matchPattern: "graphql.github.com"
+        - matchPattern: "graphql.github.com.*"
+        - matchPattern: "uploads.github.com"
+        - matchPattern: "uploads.github.com.*"
+        - matchPattern: "codeload.github.com"
+        - matchPattern: "codeload.github.com.*"
+        - matchPattern: "*.githubusercontent.com"
+        - matchPattern: "*.githubusercontent.com.*"
       toPorts:
         - ports:
             - port: "443"

--- a/kubernetes/apps/mcp-system/immich-mcp/app/cnp-allow.yaml
+++ b/kubernetes/apps/mcp-system/immich-mcp/app/cnp-allow.yaml
@@ -29,15 +29,20 @@ spec:
               protocol: TCP
     # Startup `uv build claw2immich` fetches the claw2immich source +
     # wheel deps from PyPI. Without this the container crashloops
-    # before it can serve MCP traffic. Was a toFQDNs allow-list
-    # (pypi.org, files.pythonhosted.org). Cilium 1.19 matchName
-    # doesn't match through Kubernetes pod DNS search-domain
-    # augmentation (pod queries
-    # `pypi.org.mcp-system.svc.cluster.local.`; FQDN cache stores
-    # the augmented name; matchName doesn't match). Broadened to
-    # toEntities:world:443 so it actually works. Tighten when FQDN
-    # matching is fixed.
-    - toEntities: [world]
+    # before it can serve MCP traffic.
+    #
+    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
+    # pod DNS search-domain augmentation (pod queries
+    # `pypi.org.mcp-system.svc.cluster.local.`; the FQDN cache stores
+    # the augmented name; matchName misses it). The bare + `.*`
+    # dual-form matchPattern covers both un-augmented and
+    # search-domain-augmented forms — see PR #11492 for the canonical
+    # example.
+    - toFQDNs:
+        - matchPattern: "pypi.org"
+        - matchPattern: "pypi.org.*"
+        - matchPattern: "files.pythonhosted.org"
+        - matchPattern: "files.pythonhosted.org.*"
       toPorts:
         - ports:
             - port: "443"


### PR DESCRIPTION
## Summary

- Restores per-FQDN `toFQDNs` allowlists across 9 CNPs in 3 namespaces, reverting the overzealous `toEntities: world` + `:443` swaps from PRs #11494, #11495, #11496, and #11498.
- Uses the bare + `.*` dual-form `matchPattern` pattern (canonical example: PR #11492) that works correctly through Kubernetes pod DNS search-domain augmentation in Cilium 1.19.
- Trades the "works but loses precision" worldwide allow for the original per-FQDN allowlists. No app behavior change expected — the FQDNs match what was originally allowed before Cilium 1.19's `matchName` quirk forced the temporary broadening.

## Background

PR #11492 (user's manual fix) discovered that Cilium 1.19's `toFQDNs.matchName` doesn't match through Kubernetes pod DNS search-domain augmentation. Pods query e.g. `api.github.com.actions-runner-system.svc.cluster.local.` and the FQDN cache stores the augmented name; `matchName` misses it. The fix was to pair each FQDN with its `.*` variant via `matchPattern`:

```yaml
- toFQDNs:
    - matchPattern: "api.github.com"
    - matchPattern: "api.github.com.*"
```

A subsequent comprehensive-fix agent over-corrected by swapping every `toFQDNs` block to `toEntities: [world]` + `port: 443`. Works, but loses FQDN precision. This PR restores the precision using the working pattern.

## Files changed

- `kubernetes/apps/actions-runner-system/actions-runner-controller/operator/cnp-allow.yaml` (api.github.com, github.com, *.githubusercontent.com)
- `kubernetes/apps/mcp-system/github-mcp/app/cnp-allow.yaml` (api.github.com, graphql.github.com, uploads.github.com, codeload.github.com, *.githubusercontent.com)
- `kubernetes/apps/mcp-system/immich-mcp/app/cnp-allow.yaml` (pypi.org, files.pythonhosted.org)
- `kubernetes/apps/ai/comfyui/app/cnp-allow.yaml` (github + huggingface + civitai + pypi family)
- `kubernetes/apps/ai/khoj/app/cnp-allow.yaml` (huggingface family)
- `kubernetes/apps/ai/khoj-oauth2-proxy/app/cnp-allow.yaml` (auth.thesteamedcrab.com)
- `kubernetes/apps/ai/kubeclaw/app/cnp-allow.yaml` (huggingface + github family)
- `kubernetes/apps/ai/langgraph-agents/app/cnp-allow.yaml` (api.pushover.net, api.anthropic.com)
- `kubernetes/apps/ai/ollama/app/cnp-allow.yaml` (ollama + huggingface + *.cloudflarestorage.com family)

## Out of scope (intentionally not changed)

- actions-runner-system Runners CNP — already uses `matchPattern: "*"` (runners legitimately need world access).
- Renovate scan jobs — same reasoning (any registry).
- paperless-ai — no external FQDN in original (ollama-only).
- sync-receiver — no overlay, relies on baseline allow-host-probes.

## Test plan

- [x] `kubectl kustomize` builds clean for each of the 9 affected dirs (CNP count: 1 each)
- [x] `yamllint` clean on all 9 files
- [ ] Post-merge: `hubble observe --verdict DROPPED` should be near-zero across `ai`, `actions-runner-system`, `mcp-system` namespaces (any drop = missing CNAME or sub-pattern in the matchPattern list)
- [ ] No pod restarts expected (CNP updates don't restart pods)