### PR TITLE
feat(auth): lockdown namespace with default-deny + per-app allow CNPs

### DIFF
--- a/kubernetes/apps/auth/authelia/app/cnp-allow.yaml
+++ b/kubernetes/apps/auth/authelia/app/cnp-allow.yaml
@@ -1,0 +1,64 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: authelia-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: authelia
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on external gateway → authelia:9091. ~24 oauth2-proxy
+    # instances cluster-wide (plus the mcp-gateway rotator and Envoy's
+    # SecurityPolicy JWKS fetcher) all hit https://auth.${SECRET_DOMAIN}
+    # which is routed through the external Envoy. Nothing in-cluster
+    # talks to the authelia Service IP directly. Both `external` and
+    # `internal` envoy deployments share app.kubernetes.io/name: envoy.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "9091"
+              protocol: TCP
+    # Metrics port (9959) — allow-monitoring-scrape baseline already
+    # covers ingress from observability/prometheus on any port. No
+    # additional rule needed.
+  egress:
+    # LLDAP (intra-ns, port 3893) — covered by allow-intra-namespace
+    # baseline; not listed here.
+    # CNPG cluster `postgres-authelia` in databases ns (Pattern B).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
+            cnpg.io/cluster: postgres-authelia
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+    # Session store: Dragonfly redis in databases ns, database_index 5.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
+            app.kubernetes.io/name: dragonfly
+      toPorts:
+        - ports:
+            - port: "6379"
+              protocol: TCP
+    # SMTP relay for password-reset / notification emails — Maddy in
+    # home ns on port 2525 (Pattern E).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: home
+            app.kubernetes.io/name: smtp-relay
+      toPorts:
+        - ports:
+            - port: "2525"
+              protocol: TCP

--- a/kubernetes/apps/auth/authelia/app/kustomization.yaml
+++ b/kubernetes/apps/auth/authelia/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
-  - ./externalsecret.yaml
+  - ./cnp-allow.yaml
   - ./configmap.yaml
+  - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/auth/kustomization.yaml
+++ b/kubernetes/apps/auth/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 namespace: auth
 components:
   - ../../components/network-policy/baseline
+  - ../../components/network-policy/default-deny
 resources:
   - ./namespace.yaml
   - ./authelia/ks.yaml

--- a/kubernetes/apps/auth/lldap/app/cnp-allow.yaml
+++ b/kubernetes/apps/auth/lldap/app/cnp-allow.yaml
@@ -1,0 +1,49 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: lldap-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: lldap
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal gateway → lldap:8080 (web UI for user/group
+    # management). The internal envoy deployment shares
+    # app.kubernetes.io/name: envoy with external.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+    # LDAP (3893) from authelia is intra-ns; allow-intra-namespace
+    # baseline covers that path. No other in-cluster LDAP clients.
+  egress:
+    # CNPG cluster `postgres-lldap` in databases ns (Pattern B).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
+            cnpg.io/cluster: postgres-lldap
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+    # SMTP relay for password-reset emails — Maddy in home ns on port
+    # 2525 (Pattern E). LLDAP_SMTP_OPTIONS__ENABLE_PASSWORD_RESET=true.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: home
+            app.kubernetes.io/name: smtp-relay
+      toPorts:
+        - ports:
+            - port: "2525"
+              protocol: TCP

--- a/kubernetes/apps/auth/lldap/app/kustomization.yaml
+++ b/kubernetes/apps/auth/lldap/app/kustomization.yaml
@@ -5,5 +5,6 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml


### PR DESCRIPTION
## Summary

- Add `default-deny` component to the `auth` namespace alongside the existing baseline.
- Add per-app `authelia-allow` and `lldap-allow` CiliumNetworkPolicies covering all enumerated ingress/egress paths.
- Direct-enforce (no audit-mode) — traffic patterns are fully derived from helmrelease + configmap; pre-merge curl confirms authelia=200 / glance redirect=302.

**EXTREMELY HIGH STAKES.** Breaking Authelia or LLDAP locks out every OIDC-protected app cluster-wide.

### Ingress

| App | Source | Port | Notes |
|---|---|---|---|
| authelia | network/envoy | 9091 | All oauth2-proxies + mcp-gateway rotator + SecurityPolicy JWKS hit `auth.${SECRET_DOMAIN}` via external Envoy; no in-cluster Service-IP callers |
| authelia | observability/prometheus | 9959 | Already covered by namespace-wide `allow-monitoring-scrape` baseline |
| lldap | network/envoy | 8080 | Web UI via internal Envoy |
| lldap | auth/authelia | 3893 | Intra-ns; covered by `allow-intra-namespace` baseline |

### Egress

| App | Destination | Port | Pattern |
|---|---|---|---|
| authelia | databases/postgres-authelia | 5432 | B (CNPG) |
| authelia | databases/dragonfly | 6379 | Session store, db_index 5 |
| authelia | home/smtp-relay | 2525 | E (SMTP, Maddy) |
| lldap | databases/postgres-lldap | 5432 | B (CNPG) |
| lldap | home/smtp-relay | 2525 | E (password-reset emails) |

## Test plan

- [x] Pre-merge baseline: authelia well-known=200, glance redirect=302
- [x] `kubectl kustomize` of `kubernetes/apps/auth/` includes all 5 baseline CNPs + default-deny + Kustomizations
- [x] Per-app `kubectl kustomize` includes `authelia-allow` / `lldap-allow`
- [ ] Post-merge: pods come back Ready, `kubectl get cnp -n auth` shows 7 CNPs (5 baseline + 1 default-deny + 1 app-allow per app = 7)
- [ ] Post-merge: authelia well-known=200, glance redirect=302
- [ ] Post-merge: oauth2-proxied apps continue working (sampling: glance redirect chain completes)

## Rollback

```bash
flux suspend kustomization -n flux-system cluster-apps
kubectl delete cnp -n auth default-deny authelia-allow lldap-allow
flux resume kustomization -n flux-system cluster-apps
```