### PR TITLE
feat(network-policy): storage default-deny + per-app overlays

### DIFF
--- a/kubernetes/apps/storage/garage-webui-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/storage/garage-webui-oauth2-proxy/app/cnp-allow.yaml
@@ -1,0 +1,45 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: garage-webui-oauth2-proxy-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: garage-webui-oauth2-proxy
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal gateway (garage.${SECRET_DOMAIN}) →
+    # garage-webui-oauth2-proxy:4180 → upstream garage-webui:3909.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "4180"
+              protocol: TCP
+  egress:
+    # OIDC discovery + token exchange against Authelia.
+    # auth.${SECRET_DOMAIN} resolves to the internal Envoy gateway VIP,
+    # which then routes to the auth namespace.
+    # Upstream → garage-webui.storage.svc.cluster.local:3909. Same-ns;
+    # the baseline allow-intra-namespace already covers that path.
+    #
+    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
+    # pod DNS search-domain augmentation (pod queries
+    # `auth.thesteamedcrab.com.storage.svc.cluster.local.` and the
+    # FQDN cache stores the augmented name; matchName misses it). The
+    # bare + `.*` dual-form matchPattern covers both un-augmented and
+    # search-domain-augmented forms — see PR #11492 for the canonical
+    # example.
+    - toFQDNs:
+        - matchPattern: "auth.thesteamedcrab.com"
+        - matchPattern: "auth.thesteamedcrab.com.*"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/storage/garage-webui-oauth2-proxy/app/kustomization.yaml
+++ b/kubernetes/apps/storage/garage-webui-oauth2-proxy/app/kustomization.yaml
@@ -5,5 +5,6 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/storage/garage/app/cnp-allow.yaml
+++ b/kubernetes/apps/storage/garage/app/cnp-allow.yaml
@@ -1,0 +1,69 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: garage-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: garage
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # External S3 traffic enters via envoy (s3.thesteamedcrab.com →
+    # internal Envoy gateway → garage:3900). Also covers garage-webui
+    # → garage admin path (3903) when fronted by envoy.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "3900" # S3 API
+              protocol: TCP
+            - port: "3903" # Admin API
+              protocol: TCP
+    # In-cluster S3 clients reach garage directly via the cluster-DNS
+    # Service (garage.storage.svc.cluster.local:3900) — no envoy hop.
+    # Known consumers as of 2026-05-17:
+    #   databases/<cnpg-instance-manager>  — CNPG Barman ObjectStore
+    #     (20+ clusters; pod names rotate per backup, ns-level select)
+    #   media/immich-offsite-backup        — rclone CronJob (no labels
+    #     on pod template; auto-generated job-name churns)
+    #   collab/paperless-offsite-backup    — same pattern
+    # Selecting full namespaces is appropriate because CronJob and
+    # CNPG instance-manager pods rotate names; the cross-ns boundary
+    # is the meaningful gate, and these three namespaces are already
+    # default-deny locked-down themselves.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
+        - matchLabels:
+            io.kubernetes.pod.namespace: media
+        - matchLabels:
+            io.kubernetes.pod.namespace: collab
+      toPorts:
+        - ports:
+            - port: "3900" # S3 API
+              protocol: TCP
+    # Garage RPC port (3901) — peer-to-peer cluster gossip. Currently
+    # single-replica (replication_factor=1) so no peers, but allow
+    # intra-ns to future-proof against the multi-node Garage path.
+    # Covered by the baseline allow-intra-namespace; no extra rule needed.
+  egress:
+    # Garage substrate is NFS on brain (NFS_HOST_0 -
+    # /mnt/kubernetes/garage/{data,meta}). The volumes are mounted via
+    # PVC, but Garage opens lmdb metadata files and writes data blobs
+    # directly to those NFS-backed PVs. The NFS RPC originates from the
+    # kubelet (not the pod), so this isn't a pod-level egress concern —
+    # the baseline allow-host-probes + the kernel NFS client handle it
+    # at the host level.
+    #
+    # Pod-level egress here is the application-level S3-protocol
+    # surface; garage doesn't make outbound HTTP except for the
+    # metadata_auto_snapshot which writes locally.
+    # DNS + apiserver covered by baseline.

--- a/kubernetes/apps/storage/garage/app/kustomization.yaml
+++ b/kubernetes/apps/storage/garage/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./nfs-pvc.yaml

--- a/kubernetes/apps/storage/kustomization.yaml
+++ b/kubernetes/apps/storage/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 namespace: storage
 components:
   - ../../components/network-policy/baseline
+  - ../../components/network-policy/default-deny
 resources:
   - ./namespace.yaml
   - ./garage/ks.yaml


### PR DESCRIPTION
## Summary

Locks down the storage namespace with default-deny + 2 per-app CNPs. openebs gets no overlay (apiserver + intra-ns baseline covers it).

| App | Pattern | Notes |
|---|---|---|
| garage | Ingress from envoy :3900/:3903 + ingress from databases/media/collab ns on :3900 | Backbone of CNPG Barman + immich/paperless offsite-backup |
| garage-webui-oauth2-proxy | A (envoy :4180) + Authelia matchPattern :443 | Standard pattern |
| garage-webui | none | All ingress/egress is intra-ns |
| openebs-localpv-provisioner | none | apiserver only |

## Notable wrinkles

- **garage in-cluster S3 clients** all use the cluster Service DNS (`garage.storage.svc.cluster.local:3900`), not the external `s3.${SECRET_DOMAIN}` FQDN. External S3 traffic enters via envoy ingress, not a LoadBalancer — so no `fromEntities:world` is required.
- **CronJob pod label brittleness**: immich/paperless offsite-backup CronJob pod templates carry no `app.kubernetes.io/name` labels; job-name auto-rotates per run. Selecting full source namespaces is the meaningful gate (and all three are already locked-down themselves).
- **Garage NFS substrate** is mounted via PVC (brain NFS). NFS RPC is host-level (kubelet), not pod-level egress — no pod CNP rule needed.

## Test plan

- [x] `kubectl kustomize kubernetes/apps/storage/` = 6 ns-level CNPs (5 baseline + default-deny)
- [x] Per-app overlays render: garage (1) + garage-webui-oauth2-proxy (1) = 2
- [x] `yamllint` clean
- [ ] Post-merge: all 4 storage pods stay Ready
- [ ] Post-merge: `s3.${SECRET_DOMAIN}` reachable (curl 4xx OK; means envoy → garage path works)
- [ ] Post-merge: most-recent CNPG ScheduledBackup completes (Barman → garage path)
- [ ] Post-merge: no DROPPED policy-verdicts in Hubble for storage ns over the next hour

🤖 Generated with [Claude Code](https://claude.com/claude-code)