### PR TITLE
feat(network-policy): cert-manager default-deny + per-app overlays

### DIFF
--- a/kubernetes/apps/cert-manager/cert-manager/app/cnp-allow-webhook.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/app/cnp-allow-webhook.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: cert-manager-webhook-allow
+spec:
+  # Webhook pods carry `app.kubernetes.io/name: webhook` (distinct
+  # from controller/cainjector which use cert-manager/cainjector).
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: webhook
+  # Additive — default-deny is what triggers the lockdown; this rule
+  # punches a hole for kube-apiserver → webhook callback. Egress is
+  # apiserver-only and already covered by the baseline.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # kube-apiserver calls the admission webhook on port 10250 ("https"
+    # named port; svc 443 → containerPort 10250). Cilium policy
+    # matches on the pod's container port. The apiserver carries the
+    # reserved:kube-apiserver identity (not a pod identity), so use
+    # fromEntities — same reason allow-apiserver in baseline uses
+    # toEntities for egress (see project_cilium_ipblock_apiserver).
+    - fromEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "10250"
+              protocol: TCP

--- a/kubernetes/apps/cert-manager/cert-manager/app/cnp-allow.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/app/cnp-allow.yaml
@@ -1,0 +1,45 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: cert-manager-allow
+spec:
+  # Controller pods carry `app.kubernetes.io/name: cert-manager`
+  # (cainjector pods carry `app.kubernetes.io/name: cainjector`,
+  # webhook pods carry `app.kubernetes.io/name: webhook`). One label
+  # is enough to disambiguate from the other two cert-manager
+  # workloads in this namespace.
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: cert-manager
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it. Baseline covers kube-apiserver, DNS, host
+  # probes, intra-namespace (cainjector + webhook), monitoring scrape.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  egress:
+    # ACME directory endpoints (Let's Encrypt prod + staging) and the
+    # Cloudflare API (DNS-01 solver — see
+    # ./issuers/letsencrypt-production.yaml + letsencrypt-staging.yaml,
+    # both use the cloudflare DNS-01 solver against `cloudflare-token-secret`).
+    #
+    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
+    # pod DNS search-domain augmentation (pod queries e.g.
+    # `acme-v02.api.letsencrypt.org.cert-manager.svc.cluster.local.`;
+    # the FQDN cache stores the augmented name; matchName misses it).
+    # The bare + `.*` dual-form matchPattern covers both un-augmented
+    # and search-domain-augmented forms — see PR #11492 for the
+    # canonical example.
+    - toFQDNs:
+        - matchPattern: "acme-v02.api.letsencrypt.org"
+        - matchPattern: "acme-v02.api.letsencrypt.org.*"
+        - matchPattern: "acme-staging-v02.api.letsencrypt.org"
+        - matchPattern: "acme-staging-v02.api.letsencrypt.org.*"
+        - matchPattern: "api.cloudflare.com"
+        - matchPattern: "api.cloudflare.com.*"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/cert-manager/cert-manager/app/kustomization.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/app/kustomization.yaml
@@ -3,6 +3,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./cnp-allow.yaml
+  - ./cnp-allow-webhook.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
 configMapGenerator:

--- a/kubernetes/apps/cert-manager/kustomization.yaml
+++ b/kubernetes/apps/cert-manager/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: cert-manager
 components:
   - ../../components/alerts
   - ../../components/network-policy/baseline
+  - ../../components/network-policy/default-deny
 resources:
   - ./namespace.yaml
   - ./cert-manager/ks.yaml


### PR DESCRIPTION
## Summary

Locks down the `cert-manager` namespace with default-deny via the existing component reference, plus 2 per-app `CiliumNetworkPolicy` overlays for legitimate flows.

- **cert-manager controller** — egress to `acme-v02.api.letsencrypt.org`, `acme-staging-v02.api.letsencrypt.org`, `api.cloudflare.com` (443). Sources: the two ClusterIssuers and their shared Cloudflare DNS-01 solver (`cloudflare-token-secret`). Uses the bare + `.*` dual-form `matchPattern` to survive Cilium 1.19's search-domain-augmented FQDN cache (PR #11492 pattern).
- **cert-manager-webhook** — ingress from `kube-apiserver` entity on container port 10250 (the `https` named port; svc 443 → containerPort 10250). `fromEntities` is required because the apiserver carries the reserved `kube-apiserver` identity, not a pod identity (same reason `allow-apiserver` baseline uses `toEntities` — see `project_cilium_ipblock_apiserver`).
- **cainjector** — no overlay. apiserver-only egress; fully covered by the baseline `allow-apiserver` CNP. Per the "don't create empty CNPs" rule, no file added.

## Test plan

- [ ] Flux reconciles `cert-manager` namespace kustomization successfully (default-deny + 2 new CNPs appear).
- [ ] All 4 cert-manager pods stay `Ready` post-merge.
- [ ] No new error spam in `cert-manager` controller logs.
- [ ] Pending/active CertificateRequests continue to issue (or renew on next cycle); no ACME or Cloudflare API connection errors.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>