### PR TITLE
feat(network-policy): istio-system default-deny + istiod overlay

### DIFF
--- a/kubernetes/apps/istio-system/istio/app/istiod/cnp-allow.yaml
+++ b/kubernetes/apps/istio-system/istio/app/istiod/cnp-allow.yaml
@@ -1,0 +1,44 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: istiod-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app: istiod
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it. Egress to kube-apiserver is covered by the
+  # baseline allow-apiserver CNP; DNS by allow-dns.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # XDS (mTLS, port 15012) — every Istio sidecar in the cluster
+    # connects here for config + secret distribution. Today the only
+    # consumer is mcp-system/mcp-gateway-istio, but new sidecars can
+    # appear in any namespace, so scope is fromEntities: cluster.
+    - fromEntities:
+        - cluster
+      toPorts:
+        - ports:
+            - port: "15012"
+              protocol: TCP
+    # XDS legacy plaintext (15010) — left open at cluster scope for
+    # legacy clients / debug. Sidecars use 15012 by default.
+    - fromEntities:
+        - cluster
+      toPorts:
+        - ports:
+            - port: "15010"
+              protocol: TCP
+    # Admission webhooks (sidecar-injector mutating + istio validators)
+    # — apiserver calls istiod:443 to inject sidecars and validate
+    # Istio CR submissions. Source identity is reserved:kube-apiserver.
+    - fromEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/istio-system/istio/app/istiod/kustomization.yaml
+++ b/kubernetes/apps/istio-system/istio/app/istiod/kustomization.yaml
@@ -3,6 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./cnp-allow.yaml
   - ./helmrelease.yaml
   - ./podmonitor-sidecars.yaml
   - ./servicemonitor.yaml

--- a/kubernetes/apps/istio-system/kustomization.yaml
+++ b/kubernetes/apps/istio-system/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: istio-system
 components:
   - ../../components/alerts
   - ../../components/network-policy/baseline
+  - ../../components/network-policy/default-deny
 resources:
   - ./namespace.yaml
   - ./istio/ks.yaml


### PR DESCRIPTION
## Summary

- Adds `default-deny` component to `kubernetes/apps/istio-system/kustomization.yaml`, flipping the namespace from audit-mode (baseline-only) to enforced lockdown.
- Adds a single per-app `cnp-allow.yaml` for `istiod` — the only workload in the namespace.

## istiod ingress allowances

- **15012 (XDS mTLS)** from `fromEntities: cluster` — every Istio sidecar (today: `mcp-system/mcp-gateway-istio`; tomorrow: any new sidecar in any namespace) needs config + secret distribution from istiod.
- **15010 (XDS legacy plaintext)** from `fromEntities: cluster` — retained for completeness.
- **443 (admission webhooks)** from `fromEntities: kube-apiserver` — sidecar-injector mutating webhook + 2 istio validating webhooks. Apiserver identity per `project_cilium_ipblock_apiserver.md`.

## Egress

Fully covered by baseline:

- `allow-apiserver` → istiod's config watch loop
- `allow-dns` → CoreDNS
- `allow-intra-namespace` → istiod-to-istiod (2 replicas)

## Notes

- No istio-cni DaemonSet in this cluster (sidecar mode, not ambient) — no overlay needed.
- Pod selector `app: istiod` verified against live pods.
- istio-base is helm-only (CRDs/RBAC) — no pods.
- Limited blast radius: `mcp-system/mcp-gateway-istio` is the sole consumer.

## Test plan

- [ ] Flux reconciles cleanly; `istiod-allow` CNP becomes `Valid: true`.
- [ ] istiod pods stay Ready (2/2).
- [ ] `mcp-system/mcp-gateway-istio` stays Ready; no xDS connection-refused spam.
- [ ] `kubectl logs -n istio-system deploy/istiod --tail=30` shows no new error patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)