### PR TITLE
fix(network-policy): garage cnp-allow drop null egress block

### DIFF
--- a/kubernetes/apps/storage/garage/app/cnp-allow.yaml
+++ b/kubernetes/apps/storage/garage/app/cnp-allow.yaml
@@ -54,16 +54,10 @@ spec:
     # single-replica (replication_factor=1) so no peers, but allow
     # intra-ns to future-proof against the multi-node Garage path.
     # Covered by the baseline allow-intra-namespace; no extra rule needed.
-  egress:
-    # Garage substrate is NFS on brain (NFS_HOST_0 -
-    # /mnt/kubernetes/garage/{data,meta}). The volumes are mounted via
-    # PVC, but Garage opens lmdb metadata files and writes data blobs
-    # directly to those NFS-backed PVs. The NFS RPC originates from the
-    # kubelet (not the pod), so this isn't a pod-level egress concern —
-    # the baseline allow-host-probes + the kernel NFS client handle it
-    # at the host level.
-    #
-    # Pod-level egress here is the application-level S3-protocol
-    # surface; garage doesn't make outbound HTTP except for the
-    # metadata_auto_snapshot which writes locally.
-    # DNS + apiserver covered by baseline.
+  # No egress holes needed beyond baseline.
+  # Garage substrate is NFS on brain (NFS_HOST_0 -
+  # /mnt/kubernetes/garage/{data,meta}). The volumes are mounted via
+  # PVC, but the NFS RPC originates from the kubelet (not the pod), so
+  # it's not a pod-level egress concern — the kernel NFS client handles
+  # it at the host level. Garage itself doesn't make outbound HTTP.
+  # DNS + apiserver are covered by baseline.


### PR DESCRIPTION
## Summary

PR #11501 left an \`egress:\` key with only comments below it; Cilium rejects this as \`Invalid value: \"null\": spec.egress in body must be of type array\`. Flux dry-run flagged it and the CNP never reconciled.

Currently a no-op (cluster audit mode is on) but the HelmRelease was stuck not-ready. Followup to the storage tier lockdown.

## Test plan

- [x] \`kubectl kustomize kubernetes/apps/storage/garage/app/\` clean, 1 CNP
- [ ] Post-merge: \`flux get ks -n storage garage\` reports Ready
- [ ] Post-merge: \`kubectl get cnp -n storage garage-allow\` exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)