### PR TITLE
feat(network-policy): lock down vpn + downloads namespaces

### DIFF
--- a/kubernetes/apps/downloads/jdownloader2-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/downloads/jdownloader2-oauth2-proxy/app/cnp-allow.yaml
@@ -1,0 +1,42 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: jdownloader2-oauth2-proxy-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: jdownloader2-oauth2-proxy
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal gateway → jdownloader2-oauth2-proxy:4180
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "4180"
+              protocol: TCP
+  egress:
+    # OIDC discovery + token exchange against Authelia, routed via the
+    # internal envoy gateway. Upstream → jdownloader2.downloads:5800 is
+    # covered by baseline allow-intra-namespace.
+    #
+    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
+    # pod DNS search-domain augmentation (pod queries
+    # `auth.thesteamedcrab.com.downloads.svc.cluster.local.`; FQDN
+    # cache stores the augmented name; matchName misses it). Bare +
+    # `.*` matchPattern covers both forms — see PR #11492.
+    - toFQDNs:
+        - matchPattern: "auth.thesteamedcrab.com"
+        - matchPattern: "auth.thesteamedcrab.com.*"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/downloads/jdownloader2-oauth2-proxy/app/kustomization.yaml
+++ b/kubernetes/apps/downloads/jdownloader2-oauth2-proxy/app/kustomization.yaml
@@ -5,5 +5,6 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/downloads/jdownloader2/app/cnp-allow.yaml
+++ b/kubernetes/apps/downloads/jdownloader2/app/cnp-allow.yaml
@@ -1,0 +1,36 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: jdownloader2-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: jdownloader2
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it. Ingress on :5800 from
+  # jdownloader2-oauth2-proxy (same ns) is covered by baseline
+  # allow-intra-namespace.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  egress:
+    # VPN egress. The pod-gateway webhook injected `setGateway=true`
+    # routing into this pod's iptables, so ALL non-cluster traffic
+    # exits via the VXLAN tunnel (UDP/4789) to the gateway pod, which
+    # in turn forwards via WireGuard. From Cilium's perspective the
+    # only egress packet is the encapsulated VXLAN UDP/4789 to the
+    # gateway pod's endpoint identity. DNS (172.16.1.1) and ALL
+    # external connectivity (hoster HTTPS, etc.) are tunneled inside
+    # this single VXLAN flow.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: vpn
+            app.kubernetes.io/instance: downloads-gateway
+            app.kubernetes.io/name: pod-gateway
+            app.kubernetes.io/controller: main
+      toPorts:
+        - ports:
+            - port: "4789"
+              protocol: UDP

--- a/kubernetes/apps/downloads/jdownloader2/app/kustomization.yaml
+++ b/kubernetes/apps/downloads/jdownloader2/app/kustomization.yaml
@@ -16,6 +16,7 @@ configMapGenerator:
         kustomize.toolkit.fluxcd.io/substitute: disabled
 
 resources:
+  - ./cnp-allow.yaml
   - ./helmrelease.yaml
   - ./longhorn-pvc.yaml
   - ./nfs-pvc.yaml

--- a/kubernetes/apps/downloads/kustomization.yaml
+++ b/kubernetes/apps/downloads/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 namespace: downloads
 components:
   - ../../components/network-policy/baseline
+  - ../../components/network-policy/default-deny
 resources:
   - ./namespace.yaml
   - ./jdownloader2/ks.yaml

--- a/kubernetes/apps/downloads/prowlarr-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/downloads/prowlarr-oauth2-proxy/app/cnp-allow.yaml
@@ -1,0 +1,42 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: prowlarr-oauth2-proxy-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: prowlarr-oauth2-proxy
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal gateway → prowlarr-oauth2-proxy:4180
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "4180"
+              protocol: TCP
+  egress:
+    # OIDC discovery + token exchange against Authelia, routed via the
+    # internal envoy gateway. Upstream → prowlarr.downloads:9696 is
+    # covered by baseline allow-intra-namespace.
+    #
+    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
+    # pod DNS search-domain augmentation (pod queries
+    # `auth.thesteamedcrab.com.downloads.svc.cluster.local.`; FQDN
+    # cache stores the augmented name; matchName misses it). Bare +
+    # `.*` matchPattern covers both forms — see PR #11492.
+    - toFQDNs:
+        - matchPattern: "auth.thesteamedcrab.com"
+        - matchPattern: "auth.thesteamedcrab.com.*"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/downloads/prowlarr-oauth2-proxy/app/kustomization.yaml
+++ b/kubernetes/apps/downloads/prowlarr-oauth2-proxy/app/kustomization.yaml
@@ -5,5 +5,6 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/downloads/prowlarr/app/cnp-allow.yaml
+++ b/kubernetes/apps/downloads/prowlarr/app/cnp-allow.yaml
@@ -1,0 +1,96 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: prowlarr-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: prowlarr
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it. Ingress on :9696 from prowlarr-oauth2-proxy
+  # (same ns) is covered by baseline allow-intra-namespace.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # Cross-ns *arr callers hitting the prowlarr indexer API directly
+    # (NOT via oauth2-proxy — internal service URL).
+    #   media/sonarr   — http://prowlarr.downloads.svc.cluster.local:9696
+    #   media/radarr   — http://prowlarr.downloads.svc.cluster.local:9696
+    #   media/lidarr   — http://prowlarr.downloads.svc.cluster.local:9696
+    #   mcp-system/arr-mcp — PROWLARR_URL env (see arr-mcp/cnp-allow.yaml)
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: media
+            app.kubernetes.io/name: sonarr
+        - matchLabels:
+            io.kubernetes.pod.namespace: media
+            app.kubernetes.io/name: radarr
+        - matchLabels:
+            io.kubernetes.pod.namespace: media
+            app.kubernetes.io/name: lidarr
+        - matchLabels:
+            io.kubernetes.pod.namespace: mcp-system
+            app.kubernetes.io/name: arr-mcp
+      toPorts:
+        - ports:
+            - port: "9696"
+              protocol: TCP
+  egress:
+    # VPN egress. The pod-gateway webhook injected `setGateway=true`
+    # routing, so ALL non-cluster traffic (indexer probes, FlareSolverr
+    # if configured to point outside the cluster, etc.) exits via the
+    # VXLAN tunnel (UDP/4789) to the gateway pod. From Cilium's
+    # perspective the only egress packet is encapsulated VXLAN UDP/4789.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: vpn
+            app.kubernetes.io/instance: downloads-gateway
+            app.kubernetes.io/name: pod-gateway
+            app.kubernetes.io/controller: main
+      toPorts:
+        - ports:
+            - port: "4789"
+              protocol: UDP
+    # Cross-ns: FlareSolverr in media ns proxies Cloudflare-protected
+    # indexer fetches for prowlarr. Same-cluster Service call:
+    # http://flaresolverr.media.svc.cluster.local:8191
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: media
+            app.kubernetes.io/name: flaresolverr
+      toPorts:
+        - ports:
+            - port: "8191"
+              protocol: TCP
+    # Cross-ns: *arr API push-backs. Prowlarr sync-app feature pushes
+    # indexer config to each *arr instance over its API.
+    #   media/sonarr:8989
+    #   media/radarr:7878
+    #   media/lidarr:8686
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: media
+            app.kubernetes.io/name: sonarr
+      toPorts:
+        - ports:
+            - port: "8989"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: media
+            app.kubernetes.io/name: radarr
+      toPorts:
+        - ports:
+            - port: "7878"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: media
+            app.kubernetes.io/name: lidarr
+      toPorts:
+        - ports:
+            - port: "8686"
+              protocol: TCP

--- a/kubernetes/apps/downloads/prowlarr/app/kustomization.yaml
+++ b/kubernetes/apps/downloads/prowlarr/app/kustomization.yaml
@@ -6,6 +6,7 @@ components:
   - ../../../../components/repos/app-template
   - ../../../../components/theme-park
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./longhorn-pvc.yaml

--- a/kubernetes/apps/downloads/qbittorrent-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/downloads/qbittorrent-oauth2-proxy/app/cnp-allow.yaml
@@ -1,0 +1,42 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: qbittorrent-oauth2-proxy-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: qbittorrent-oauth2-proxy
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal gateway → qbittorrent-oauth2-proxy:4180
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "4180"
+              protocol: TCP
+  egress:
+    # OIDC discovery + token exchange against Authelia, routed via the
+    # internal envoy gateway. Upstream → qbittorrent.downloads:8080 is
+    # covered by baseline allow-intra-namespace.
+    #
+    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
+    # pod DNS search-domain augmentation (pod queries
+    # `auth.thesteamedcrab.com.downloads.svc.cluster.local.`; FQDN
+    # cache stores the augmented name; matchName misses it). Bare +
+    # `.*` matchPattern covers both forms — see PR #11492.
+    - toFQDNs:
+        - matchPattern: "auth.thesteamedcrab.com"
+        - matchPattern: "auth.thesteamedcrab.com.*"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/downloads/qbittorrent-oauth2-proxy/app/kustomization.yaml
+++ b/kubernetes/apps/downloads/qbittorrent-oauth2-proxy/app/kustomization.yaml
@@ -5,5 +5,6 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/downloads/qbittorrent/app/cnp-allow.yaml
+++ b/kubernetes/apps/downloads/qbittorrent/app/cnp-allow.yaml
@@ -1,0 +1,56 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: qbittorrent-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: qbittorrent
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it. Ingress on :8080 from qbittorrent-oauth2-proxy
+  # (same ns) is covered by baseline allow-intra-namespace.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # Cross-ns *arr download-client callers. Each *arr posts torrents +
+    # polls download status against the qbittorrent WebUI API.
+    #   media/sonarr / radarr / lidarr → qbittorrent.downloads:8080
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: media
+            app.kubernetes.io/name: sonarr
+        - matchLabels:
+            io.kubernetes.pod.namespace: media
+            app.kubernetes.io/name: radarr
+        - matchLabels:
+            io.kubernetes.pod.namespace: media
+            app.kubernetes.io/name: lidarr
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+  egress:
+    # VPN egress. ALL torrent traffic (peer connections, tracker
+    # announces, DHT) routes through the VXLAN tunnel to the gateway
+    # pod, then out via WireGuard. The Mullvad port-forward delivers
+    # inbound BT peer connections through the same WireGuard tunnel,
+    # which arrives at vxlan0 on this pod (so it's the same flow's
+    # return path — no separate ingress rule needed).
+    #
+    # The qbittorrent-bittorrent LoadBalancer Service (10.45.0.14:24589)
+    # exists in the chart for legacy reasons but has no endpoints
+    # because the pod listens on vxlan0, not eth0 (verified
+    # 2026-05-17). External BT ingress flows via VPN, NOT via LB.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: vpn
+            app.kubernetes.io/instance: downloads-gateway
+            app.kubernetes.io/name: pod-gateway
+            app.kubernetes.io/controller: main
+      toPorts:
+        - ports:
+            - port: "4789"
+              protocol: UDP

--- a/kubernetes/apps/downloads/qbittorrent/app/kustomization.yaml
+++ b/kubernetes/apps/downloads/qbittorrent/app/kustomization.yaml
@@ -6,6 +6,7 @@ components:
   - ../../../../components/repos/app-template
   - ../../../../components/theme-park
 resources:
+  - ./cnp-allow.yaml
   - ./helmrelease.yaml
   - ./longhorn-pvc.yaml
   - ./nfs-pvc.yaml

--- a/kubernetes/apps/downloads/sabnzbd-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/downloads/sabnzbd-oauth2-proxy/app/cnp-allow.yaml
@@ -1,0 +1,42 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: sabnzbd-oauth2-proxy-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: sabnzbd-oauth2-proxy
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal gateway → sabnzbd-oauth2-proxy:4180
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "4180"
+              protocol: TCP
+  egress:
+    # OIDC discovery + token exchange against Authelia, routed via the
+    # internal envoy gateway. Upstream → sabnzbd.downloads:8080 is
+    # covered by baseline allow-intra-namespace.
+    #
+    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
+    # pod DNS search-domain augmentation (pod queries
+    # `auth.thesteamedcrab.com.downloads.svc.cluster.local.`; FQDN
+    # cache stores the augmented name; matchName misses it). Bare +
+    # `.*` matchPattern covers both forms — see PR #11492.
+    - toFQDNs:
+        - matchPattern: "auth.thesteamedcrab.com"
+        - matchPattern: "auth.thesteamedcrab.com.*"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/downloads/sabnzbd-oauth2-proxy/app/kustomization.yaml
+++ b/kubernetes/apps/downloads/sabnzbd-oauth2-proxy/app/kustomization.yaml
@@ -5,5 +5,6 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/downloads/sabnzbd/app/cnp-allow.yaml
+++ b/kubernetes/apps/downloads/sabnzbd/app/cnp-allow.yaml
@@ -1,0 +1,50 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: sabnzbd-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: sabnzbd
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it. Ingress on :8080 from sabnzbd-oauth2-proxy
+  # (same ns) is covered by baseline allow-intra-namespace.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # Cross-ns *arr download-client callers. Each *arr posts NZBs +
+    # polls download status against the sabnzbd WebUI API.
+    #   media/sonarr / radarr / lidarr → sabnzbd.downloads:8080
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: media
+            app.kubernetes.io/name: sonarr
+        - matchLabels:
+            io.kubernetes.pod.namespace: media
+            app.kubernetes.io/name: radarr
+        - matchLabels:
+            io.kubernetes.pod.namespace: media
+            app.kubernetes.io/name: lidarr
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+  egress:
+    # VPN egress. ALL newsgroup connections (news.newsgroup.ninja, etc.)
+    # route through the VXLAN tunnel to the gateway pod, then out via
+    # WireGuard. The DataPacket NY pin (us-nyc-wg-301) is what keeps
+    # the 2-IP-cap-sensitive newsgroup provider from rejecting flows
+    # — see memory project_mullvad_nat_egress_topology.md.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: vpn
+            app.kubernetes.io/instance: downloads-gateway
+            app.kubernetes.io/name: pod-gateway
+            app.kubernetes.io/controller: main
+      toPorts:
+        - ports:
+            - port: "4789"
+              protocol: UDP

--- a/kubernetes/apps/downloads/sabnzbd/app/kustomization.yaml
+++ b/kubernetes/apps/downloads/sabnzbd/app/kustomization.yaml
@@ -6,6 +6,7 @@ components:
   - ../../../../components/repos/app-template
   - ../../../../components/theme-park
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./longhorn-pvc.yaml

--- a/kubernetes/apps/downloads/slskd-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/downloads/slskd-oauth2-proxy/app/cnp-allow.yaml
@@ -1,0 +1,42 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: slskd-oauth2-proxy-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: slskd-oauth2-proxy
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal gateway → slskd-oauth2-proxy:4180
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "4180"
+              protocol: TCP
+  egress:
+    # OIDC discovery + token exchange against Authelia, routed via the
+    # internal envoy gateway. Upstream → slskd.downloads:5030 is
+    # covered by baseline allow-intra-namespace.
+    #
+    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
+    # pod DNS search-domain augmentation (pod queries
+    # `auth.thesteamedcrab.com.downloads.svc.cluster.local.`; FQDN
+    # cache stores the augmented name; matchName misses it). Bare +
+    # `.*` matchPattern covers both forms — see PR #11492.
+    - toFQDNs:
+        - matchPattern: "auth.thesteamedcrab.com"
+        - matchPattern: "auth.thesteamedcrab.com.*"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/downloads/slskd-oauth2-proxy/app/kustomization.yaml
+++ b/kubernetes/apps/downloads/slskd-oauth2-proxy/app/kustomization.yaml
@@ -5,5 +5,6 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/downloads/slskd/app/cnp-allow.yaml
+++ b/kubernetes/apps/downloads/slskd/app/cnp-allow.yaml
@@ -1,0 +1,42 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: slskd-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: slskd
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it. Ingress on :5030 from slskd-oauth2-proxy
+  # (same ns) is covered by baseline allow-intra-namespace.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # Cross-ns: soularr in media ns polls the slskd API to orchestrate
+    # Lidarr → Soulseek searches. Env in soularr config.ini:
+    #   host_url = http://slskd.downloads.svc.cluster.local:5030
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: media
+            app.kubernetes.io/name: soularr
+      toPorts:
+        - ports:
+            - port: "5030"
+              protocol: TCP
+  egress:
+    # VPN egress. ALL Soulseek P2P traffic (peer connections to the
+    # Soulseek network on port 50300) routes through the VXLAN tunnel
+    # to the gateway pod, then out via WireGuard.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: vpn
+            app.kubernetes.io/instance: downloads-gateway
+            app.kubernetes.io/name: pod-gateway
+            app.kubernetes.io/controller: main
+      toPorts:
+        - ports:
+            - port: "4789"
+              protocol: UDP

--- a/kubernetes/apps/downloads/slskd/app/kustomization.yaml
+++ b/kubernetes/apps/downloads/slskd/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./longhorn-pvc.yaml

--- a/kubernetes/apps/vpn/downloads-gateway/app/cnp-allow.yaml
+++ b/kubernetes/apps/vpn/downloads-gateway/app/cnp-allow.yaml
@@ -1,0 +1,38 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: downloads-gateway-webhook-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/instance: downloads-gateway
+      app.kubernetes.io/name: pod-gateway
+      app.kubernetes.io/controller: webhook
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # MutatingWebhookConfiguration `gateway-admision-controller` is
+    # called by kube-apiserver on pod creation in any namespace
+    # labeled `routed-gateway`. Apiserver source carries the reserved
+    # `kube-apiserver` identity (NOT a pod identity), so a CIDR rule
+    # would silently drop in Cilium 1.19; use the entity selector.
+    # See: memory project_cilium_ipblock_apiserver.md
+    - fromEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+# NOTE: the existing CNP `downloads-gateway-pod-gateway` (in
+# ./networkpolicy.yaml) is the load-bearing policy for the pod-gateway
+# StatefulSet (main pod). It allows ingress from `fromEntities: cluster`
+# (covers VXLAN/4789 UDP from downloads/* clients) and egress on
+# UDP/51820 to 0.0.0.0/0 (WireGuard handshake to Mullvad). It is
+# explicitly NOT modified here — the existing rules + the baseline
+# allow-* CNPs (DNS, apiserver, host-probes, intra-ns, monitoring)
+# are sufficient for the gateway pod under default-deny.

--- a/kubernetes/apps/vpn/downloads-gateway/app/kustomization.yaml
+++ b/kubernetes/apps/vpn/downloads-gateway/app/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./helmrepository.yaml

--- a/kubernetes/apps/vpn/kustomization.yaml
+++ b/kubernetes/apps/vpn/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 namespace: vpn
 components:
   - ../../components/network-policy/baseline
+  - ../../components/network-policy/default-deny
 resources:
   - ./namespace.yaml
   - ./downloads-gateway/ks.yaml


### PR DESCRIPTION
## Summary

- Adds `default-deny` to both `vpn` and `downloads` namespaces in one PR
- Per-app `cnp-allow.yaml` overlays for all download clients + oauth2-proxies + pod-gateway webhook
- Composed AROUND the existing load-bearing `downloads-gateway-pod-gateway` CNP (VXLAN/4789 + WG/51820) — that CNP is intentionally NOT modified

## Cross-namespace flows preserved

- `downloads/*` → `vpn/downloads-gateway-main-0` UDP/4789 (VXLAN tunnel; all routed-pod internet egress encapsulates here)
- `media/{sonarr,radarr,lidarr}` → `downloads/{prowlarr,qbittorrent,sabnzbd}` (indexer + download client APIs)
- `media/soularr` → `downloads/slskd:5030`
- `mcp-system/arr-mcp` → `downloads/prowlarr:9696`
- `downloads/prowlarr` → `media/{sonarr,radarr,lidarr,flaresolverr}` (sync-app push-back + CF challenge solver)
- `network/envoy` → `downloads/*-oauth2-proxy:4180`
- `*-oauth2-proxy` → `auth.${SECRET_DOMAIN}:443` (Authelia, dual-form matchPattern)
- `kube-apiserver` → `vpn/downloads-gateway-webhook:8080` (mutating admission webhook)

Direct-enforce (no audit-mode window) per agent task.

## Test plan

- [ ] Flux reconciles both Kustomizations clean
- [ ] `kubectl exec -n vpn downloads-gateway-pod-gateway-main-0 -c gluetun -- wg show` shows active peer
- [ ] qbittorrent/sabnzbd/slskd web UIs reachable via envoy (oauth2 flow OK)
- [ ] Public IP from a qbittorrent exec still resolves to Mullvad DataPacket NY (143.244.47.x)
- [ ] *arr → prowlarr indexer searches still work
- [ ] sabnzbd downloads still arrive (newsgroup connectivity intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)