### PR TITLE
fix(immich): bump immich-server startup probe to survive vchordrq reindex

### DIFF
--- a/kubernetes/apps/media/immich/app/helmrelease.yaml
+++ b/kubernetes/apps/media/immich/app/helmrelease.yaml
@@ -164,6 +164,20 @@ spec:
         main:
           containers:
             main:
+              # Immich bootstrap runs vchordrq reindexVectorsIfNeeded
+              # before HTTP listen(), so /api/server/ping returns
+              # connection-refused throughout. targetListCount() in
+              # server/src/repositories/database.repository.ts hardcodes
+              # lists=1 below 128k rows, so any manual lists rebuild
+              # gets reverted on every startup — and the dual
+              # clip_index + face_index reindex can exceed the chart's
+              # default 5-min startup budget. Bump to 15 min.
+              probes:
+                startup:
+                  spec:
+                    failureThreshold: 90
+                    periodSeconds: 10
+
               resources:
                 limits:
                   memory: 3Gi


### PR DESCRIPTION
## Summary

- immich-server is restart-looping (11+ restarts; WebUI returns Envoy connect-refused).
- Root cause: v2.6.3 bootstrap runs vchordrq `reindexVectorsIfNeeded` **before** `app.listen()`. The chart-default 5-min startup probe budget (failureThreshold=30, period=10s) is not enough for the dual clip_index (61k rows) + face_index (125k rows) reindex on this dataset, so kubelet kills the container mid-reindex.
- Auto-tune side note: `targetListCount()` at [`server/src/repositories/database.repository.ts:367`](https://github.com/immich-app/immich/blob/v2.6.3/server/src/repositories/database.repository.ts#L367) hardcodes `lists=1` below 128,000 rows. Any manual `lists=N` rebuild (e.g. the 1000-list rebuild from yesterday) gets reverted on every startup until row count crosses 128k. Until then we just need to let auto-tune finish its job.

## Change

Adds `probes.startup` override to `server.controllers.main.containers.main`:
- `failureThreshold: 90`
- `periodSeconds: 10`
- → 15-min budget

Mirrors the existing override on `machine-learning`. Doesn't touch liveness/readiness — once `app.listen()` returns, both succeed in <100ms. The HR's existing `disableWait: true` covers the helm-controller rollback trap from the 2026-05-04 incident.

## Test plan

- [ ] Flux reconciles, helm upgrade succeeds without rollback
- [ ] immich-server-0 reaches 1/1 within 15 min of (re)start
- [ ] `kubectl logs -n media immich-server-0 | grep -i reindex` shows reindex completing (not "do not restart" interrupted)
- [ ] photos.${SECRET_DOMAIN} returns the WebUI (not Envoy connect-refused)
- [ ] After convergence, subsequent restarts are fast (no reindex on second boot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)