### PR TITLE
feat(network-policy): lock down auth namespace (default-deny + overlays)

### DIFF
--- a/kubernetes/apps/auth/authelia/app/cnp-allow.yaml
+++ b/kubernetes/apps/auth/authelia/app/cnp-allow.yaml
@@ -1,0 +1,75 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: authelia-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: authelia
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on external gateway → authelia:9091. ~24 oauth2-proxy
+    # instances cluster-wide (plus the mcp-gateway rotator and Envoy's
+    # SecurityPolicy JWKS fetcher) all hit https://auth.${SECRET_DOMAIN}
+    # which is routed through the external Envoy. Both `external` and
+    # `internal` envoy deployments share app.kubernetes.io/name: envoy.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "9091"
+              protocol: TCP
+    # Inclusive belt-and-suspenders: allow any in-cluster pod to reach
+    # authelia:9091. Nothing in the current cluster talks to the
+    # authelia Service IP directly (every flow rides envoy via
+    # auth.${SECRET_DOMAIN}), but Authelia is the auth choke point
+    # for ~24 oauth2-proxies — losing it locks the user out of every
+    # OIDC-protected app. Better to permit a flow that isn't used
+    # than to break one we missed.
+    - fromEntities:
+        - cluster
+      toPorts:
+        - ports:
+            - port: "9091"
+              protocol: TCP
+  # Metrics port 9959 is covered by the baseline allow-monitoring-scrape.
+  # LLDAP egress (intra-ns, port 3893) is covered by allow-intra-namespace.
+  egress:
+    # CNPG cluster `postgres-authelia` in databases ns (Pattern B).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
+            cnpg.io/cluster: postgres-authelia
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+    # Session store: Dragonfly redis in databases ns
+    # (configmap.yaml: session.redis.host=dragonfly.databases.svc.cluster.local).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
+            app.kubernetes.io/name: dragonfly
+      toPorts:
+        - ports:
+            - port: "6379"
+              protocol: TCP
+    # SMTP relay for password-reset / notification emails — Maddy in
+    # home ns on port 2525 (Pattern E). configmap.yaml notifier.smtp
+    # block: smtp://smtp-relay.home.svc.cluster.local:2525.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: home
+            app.kubernetes.io/name: smtp-relay
+      toPorts:
+        - ports:
+            - port: "2525"
+              protocol: TCP

--- a/kubernetes/apps/auth/authelia/app/kustomization.yaml
+++ b/kubernetes/apps/auth/authelia/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
-  - ./externalsecret.yaml
+  - ./cnp-allow.yaml
   - ./configmap.yaml
+  - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/auth/kustomization.yaml
+++ b/kubernetes/apps/auth/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 namespace: auth
 components:
   - ../../components/network-policy/baseline
+  - ../../components/network-policy/default-deny
 resources:
   - ./namespace.yaml
   - ./authelia/ks.yaml

--- a/kubernetes/apps/auth/lldap/app/cnp-allow.yaml
+++ b/kubernetes/apps/auth/lldap/app/cnp-allow.yaml
@@ -1,0 +1,53 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: lldap-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: lldap
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal gateway → lldap:8080 (web UI for user/group
+    # management). Both `external` and `internal` envoy deployments
+    # share app.kubernetes.io/name: envoy.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+  # LDAP (3893) from authelia is intra-ns and is covered by the baseline
+  # allow-intra-namespace policy. No other in-cluster LDAP clients
+  # (confirmed via repo grep — zulip helmrelease only mentions LLDAP in
+  # a comment).
+  egress:
+    # CNPG cluster `postgres-lldap` in databases ns (Pattern B).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
+            cnpg.io/cluster: postgres-lldap
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+    # SMTP relay for password-reset emails — Maddy in home ns on port
+    # 2525 (Pattern E). LLDAP_SMTP_OPTIONS__ENABLE_PASSWORD_RESET=true
+    # in helmrelease.yaml; LLDAP_SMTP_OPTIONS__SERVER points at
+    # smtp-relay.home.svc.cluster.local.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: home
+            app.kubernetes.io/name: smtp-relay
+      toPorts:
+        - ports:
+            - port: "2525"
+              protocol: TCP

--- a/kubernetes/apps/auth/lldap/app/kustomization.yaml
+++ b/kubernetes/apps/auth/lldap/app/kustomization.yaml
@@ -5,5 +5,6 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml


### PR DESCRIPTION
## Summary

Drops default-deny into `auth` and adds per-app `cnp-allow.yaml` overlays
for `authelia` + `lldap`.

**Extremely high-stakes namespace** — breaking either app locks the user
out of every OIDC-protected app cluster-wide (~24 oauth2-proxy
instances depend on Authelia). Policy is intentionally permissive:
authelia ingress on 9091 allows both `network/envoy` (the only known
path — every oauth2-proxy reaches Authelia via `auth.${SECRET_DOMAIN}`
through the external gateway) **and** `fromEntities: cluster` as
belt-and-suspenders for unmodelled in-cluster callers.

### Cross-ns flows preserved

- `network/envoy` → `auth/authelia:9091` (external gateway)
- `network/envoy` → `auth/lldap:8080` (internal gateway, LLDAP web UI)
- `auth/authelia` → `databases/postgres-authelia:5432`
- `auth/authelia` → `databases/dragonfly:6379` (session store)
- `auth/authelia` → `home/smtp-relay:2525` (notifier SMTP)
- `auth/lldap` → `databases/postgres-lldap:5432`
- `auth/lldap` → `home/smtp-relay:2525` (password reset emails)
- `auth/authelia` → `auth/lldap:3893` (LDAP) — intra-ns; baseline covers
- monitoring scrape on metrics ports — baseline covers

### Verification

Pod labels (`app.kubernetes.io/name: {authelia,lldap}`), HTTPRoute
backend ports (authelia 9091, lldap 8080), and CNPG cluster names
(`postgres-authelia`, `postgres-lldap` in `databases`) all verified
against the live cluster before writing. Repo-wide grep confirmed no
in-cluster service-direct callers of `authelia.auth.svc:9091` or
`lldap.auth.svc:3893` outside the auth namespace.

Direct-enforce (no audit window) per the agent task.

## Test plan

- [ ] Flux Local CI passes
- [ ] Post-merge: `kubectl get cnp -n auth` shows `default-deny`, `authelia-allow`, `lldap-allow`
- [ ] Post-merge: `curl https://auth.thesteamedcrab.com/.well-known/openid-configuration` returns 200
- [ ] Post-merge: `curl https://glance.thesteamedcrab.com` returns 302 (oauth2-proxy → Authelia redirect)
- [ ] Pods stay Ready in `auth` namespace