### PR TITLE
fix(network-policy): unbreak longhorn-system cnp-allow apply

### DIFF
--- a/kubernetes/apps/longhorn-system/longhorn/app/cnp-allow.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn/app/cnp-allow.yaml
@@ -122,6 +122,13 @@ spec:
   enableDefaultDeny:
     egress: false
     ingress: false
+  # CNP schema requires at least one of ingress/egress/*Deny — these
+  # sidecars only need apiserver + intra-ns (both covered by baseline),
+  # so this rule is a structural no-op that allows nothing
+  # cross-namespace beyond what intra-ns already permits.
+  ingress:
+    - fromEndpoints:
+        - matchLabels: {}
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
 # instance-manager + engine-image (per-node, Longhorn data plane).
@@ -214,3 +221,9 @@ spec:
   enableDefaultDeny:
     egress: false
     ingress: false
+  # CNP schema requires at least one of ingress/egress/*Deny — these
+  # job pods only need apiserver + intra-ns (manager API), both covered
+  # by baseline. Structural no-op.
+  ingress:
+    - fromEndpoints:
+        - matchLabels: {}


### PR DESCRIPTION
## Summary

Hotfix follow-up to #11509. Two of the seven CNPs in that PR were selector-only stubs (csi-sidecars + recurring-jobs) which fail Cilium's schema validation (`spec must validate at least one schema (anyOf), spec.ingress: Required value`). Flux's apply for the whole `longhorn` Kustomization failed as a result, leaving `default-deny` active but **all seven** cnp-allow overlays absent.

This adds a `fromEndpoints: [matchLabels: {}]` ingress rule to both — equivalent to the intra-namespace baseline; structural no-op, allows nothing extra.

## Test plan

- [ ] Flux reconciles `longhorn` Kustomization clean.
- [ ] All seven `*-allow` CNPs present in `longhorn-system`.
- [ ] No Longhorn volumes in `error` state.