### PR TITLE
feat(network-policy): home namespace lockdown (default-deny + per-app allow)

### DIFF
--- a/kubernetes/apps/home/emqx/app/cnp-allow.yaml
+++ b/kubernetes/apps/home/emqx/app/cnp-allow.yaml
@@ -1,0 +1,54 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: emqx-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: emqx
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # 400+ LAN devices publish MQTT to this broker via the LoadBalancer
+    # VIP (SVC_EMQX_ADDR). Devices originate from the LAN (host /
+    # remote-node identities after kube-proxy/LB SNAT) and from the
+    # public Internet (world) in the ESPHome over-VPN case. The
+    # dashboard (18083) is also fronted by an internal HTTPRoute via
+    # envoy on the headless service.
+    #
+    # MQTT (1883), MQTT-TLS (8883), MQTT-WS (8083), MQTT-WSS (8084),
+    # dashboard (18083).
+    - fromEntities:
+        - world
+        - host
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "1883"
+              protocol: TCP
+            - port: "8883"
+              protocol: TCP
+            - port: "8083"
+              protocol: TCP
+            - port: "8084"
+              protocol: TCP
+            - port: "18083"
+              protocol: TCP
+    # Internal HTTPRoute dashboard ingress (envoy → emqx-headless:18083).
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "18083"
+              protocol: TCP
+    # Egress: no external integrations. zigbee2mqtt in same ns connects
+    # to emqx:1883; baseline allow-intra-namespace covers that as
+    # ingress for emqx and egress for zigbee2mqtt. emqx clustering is
+    # over the headless service inside the StatefulSet — also intra-ns.

--- a/kubernetes/apps/home/emqx/app/kustomization.yaml
+++ b/kubernetes/apps/home/emqx/app/kustomization.yaml
@@ -3,6 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./helmrepository.yaml

--- a/kubernetes/apps/home/esphome/app/cnp-allow.yaml
+++ b/kubernetes/apps/home/esphome/app/cnp-allow.yaml
@@ -1,0 +1,42 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: esphome-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: esphome
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # Internal HTTPRoute (envoy → esphome:6052) for the ESPHome dashboard.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "6052"
+              protocol: TCP
+  egress:
+    # ESPHome compiles firmware on-demand and reaches out to the public
+    # internet during compile: PlatformIO package index, GitHub for
+    # libraries / boards, ESPHome release server, PyPI, etc. The set is
+    # broad and changes per-device config — toEntities:world is the only
+    # practical option here. Documented as intentional.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+            - port: "80"
+              protocol: TCP
+    # NOTE: ESPHome devices on the IoT VLAN are reached via the multus-
+    # attached secondary NIC (esphome-iot-static). That traffic bypasses
+    # Cilium entirely — these CNPs only govern eth0 (Pod CIDR) traffic.

--- a/kubernetes/apps/home/esphome/app/kustomization.yaml
+++ b/kubernetes/apps/home/esphome/app/kustomization.yaml
@@ -5,5 +5,6 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./helmrelease.yaml
   - ./longhorn-pvc.yaml

--- a/kubernetes/apps/home/esphome/code/cnp-allow.yaml
+++ b/kubernetes/apps/home/esphome/code/cnp-allow.yaml
@@ -1,0 +1,38 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: esphome-code-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: esphome-code
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # Internal HTTPRoute (envoy → esphome-code:8080) — code-server UI.
+    # Runs with --auth none; internal gateway is LAN-only so no oauth.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+  egress:
+    # code-server fetches extensions / opens a terminal that can pull
+    # from the web (git clone, npm install, etc). User-driven, scope
+    # unbounded — toEntities:world.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+            - port: "80"
+              protocol: TCP

--- a/kubernetes/apps/home/esphome/code/kustomization.yaml
+++ b/kubernetes/apps/home/esphome/code/kustomization.yaml
@@ -5,4 +5,5 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/home/frigate-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/home/frigate-oauth2-proxy/app/cnp-allow.yaml
@@ -1,0 +1,42 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: frigate-oauth2-proxy-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: frigate-oauth2-proxy
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal gateway → frigate-oauth2-proxy:4180.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "4180"
+              protocol: TCP
+  egress:
+    # OIDC discovery + token exchange against Authelia.
+    # auth.${SECRET_DOMAIN} resolves to the internal Envoy gateway VIP,
+    # which then routes to the auth namespace. Upstream → frigate:5000
+    # is same-ns; baseline allow-intra-namespace covers that.
+    #
+    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
+    # pod DNS search-domain augmentation. matchPattern + matchPattern.*
+    # dual-form covers both un-augmented and search-domain-augmented
+    # forms — see PR #11492 for the canonical example.
+    - toFQDNs:
+        - matchPattern: "auth.thesteamedcrab.com"
+        - matchPattern: "auth.thesteamedcrab.com.*"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/home/frigate-oauth2-proxy/app/kustomization.yaml
+++ b/kubernetes/apps/home/frigate-oauth2-proxy/app/kustomization.yaml
@@ -5,5 +5,6 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/home/frigate/app/cnp-allow.yaml
+++ b/kubernetes/apps/home/frigate/app/cnp-allow.yaml
@@ -1,0 +1,41 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: frigate-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: frigate
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it. Ingress from frigate-oauth2-proxy in the
+  # same ns (4180 → frigate:5000) is covered by baseline
+  # allow-intra-namespace.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # home-assistant native Frigate integration polls the Frigate API
+    # (port 5000) and pulls go2rtc streams (1984 TCP/UDP, 8554 RTSP).
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: home
+            app.kubernetes.io/name: home-assistant
+      toPorts:
+        - ports:
+            - port: "5000"
+              protocol: TCP
+            - port: "1984"
+              protocol: TCP
+            - port: "1984"
+              protocol: UDP
+            - port: "8554"
+              protocol: TCP
+            - port: "8971"
+              protocol: TCP
+    # NOTE: cameras live on the SECURITY VLAN and are reached via the
+    # multus-attached secondary NIC (frigate-security-static). Camera
+    # RTSP/HTTP pulls bypass Cilium entirely — only eth0 traffic
+    # (apiserver, DNS, intra-cluster API consumers) is governed here.
+    # No external egress on eth0.

--- a/kubernetes/apps/home/frigate/app/kustomization.yaml
+++ b/kubernetes/apps/home/frigate/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./longhorn-pvc.yaml

--- a/kubernetes/apps/home/home-assistant/app/cnp-allow.yaml
+++ b/kubernetes/apps/home/home-assistant/app/cnp-allow.yaml
@@ -1,0 +1,83 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: home-assistant-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: home-assistant
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on EXTERNAL gateway (via cloudflared tunnel) →
+    # home-assistant:8123. Also reached directly on LAN via the
+    # LoadBalancer VIP (SVC_HOME_ASSISTANT_ADDR).
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "8123"
+              protocol: TCP
+    # LAN clients hitting the LoadBalancer VIP for the HA UI / native
+    # app, and the in-cluster prometheus scrape config that uses the
+    # HA REST API (not the standard /metrics endpoint, so the baseline
+    # allow-monitoring-scrape may not match — explicit here).
+    - fromEntities:
+        - world
+        - host
+        - remote-node
+        - cluster
+      toPorts:
+        - ports:
+            - port: "8123"
+              protocol: TCP
+  egress:
+    # Postgres recorder backend (Pattern B — CNPG cluster in databases).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
+            cnpg.io/cluster: postgres-home-assistant
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+    # smtp-relay in same ns for HA notifications. Intra-namespace, but
+    # listed for grep-ability.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: home
+            app.kubernetes.io/name: smtp-relay
+      toPorts:
+        - ports:
+            - port: "2525"
+              protocol: TCP
+    # Home Assistant integrations call out to an unbounded set of cloud
+    # APIs (weather, Pushover, OpenAI, voice cloud services, Frigate
+    # MQTT/HTTP, calendar, etc.) plus arbitrary user-installed HACS
+    # integrations. The set is user-driven and changes per-config;
+    # toEntities:world is the only practical option. Documented as
+    # intentional per the rollout-plan design decisions.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+            - port: "80"
+              protocol: TCP
+            - port: "8883"
+              protocol: TCP # external MQTT-TLS brokers
+            - port: "1883"
+              protocol: TCP # external MQTT plain (Mosquitto.org test broker, etc)
+    # NOTE: Home Assistant has multus-attached secondary NICs on the
+    # IoT and SECURITY VLANs (hass-iot-static, hass-security-static).
+    # Discovery (mDNS, broadcasts, device polling) over those NICs
+    # bypasses Cilium entirely; only eth0 (apiserver, DNS, cross-ns,
+    # external) is governed here.

--- a/kubernetes/apps/home/home-assistant/app/kustomization.yaml
+++ b/kubernetes/apps/home/home-assistant/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./longhorn-pvc.yaml

--- a/kubernetes/apps/home/home-assistant/code/cnp-allow.yaml
+++ b/kubernetes/apps/home/home-assistant/code/cnp-allow.yaml
@@ -1,0 +1,38 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: home-assistant-code-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: home-assistant-code
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # Internal HTTPRoute (envoy → home-assistant-code:8080) — code-server
+    # UI. Runs with --auth none; internal gateway is LAN-only so no oauth.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+  egress:
+    # code-server fetches extensions / opens a terminal that can pull
+    # from the web (git clone, npm install, etc). User-driven, scope
+    # unbounded — toEntities:world.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+            - port: "80"
+              protocol: TCP

--- a/kubernetes/apps/home/home-assistant/code/kustomization.yaml
+++ b/kubernetes/apps/home/home-assistant/code/kustomization.yaml
@@ -5,4 +5,5 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/home/kustomization.yaml
+++ b/kubernetes/apps/home/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: home
 components:
   - ../../components/alerts
   - ../../components/network-policy/baseline
+  - ../../components/network-policy/default-deny
 resources:
   - ./namespace.yaml
   - ./priority-class.yaml

--- a/kubernetes/apps/home/matter-server/app/cnp-allow.yaml
+++ b/kubernetes/apps/home/matter-server/app/cnp-allow.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: matter-server-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: matter-server
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it. home-assistant in same ns is the only
+  # in-cluster consumer; baseline allow-intra-namespace covers that.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # Internal HTTPRoute (envoy → matter-server:5580) — debug UI.
+    # LAN clients hit the LoadBalancer VIP (SVC_MATTER_ADDR) directly.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "5580"
+              protocol: TCP
+    - fromEntities:
+        - world
+        - host
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "5580"
+              protocol: TCP
+    # NOTE: Matter devices live on the IoT VLAN and are reached via
+    # the multus-attached secondary NIC (matter-server-iot-static,
+    # --primary-interface=net1). All device traffic bypasses Cilium
+    # entirely.

--- a/kubernetes/apps/home/matter-server/app/kustomization.yaml
+++ b/kubernetes/apps/home/matter-server/app/kustomization.yaml
@@ -3,5 +3,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./cnp-allow.yaml
   - ./helmrelease.yaml
   - ./longhorn-pvc.yaml

--- a/kubernetes/apps/home/n8n/app/cnp-allow.yaml
+++ b/kubernetes/apps/home/n8n/app/cnp-allow.yaml
@@ -1,0 +1,69 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: n8n-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: n8n
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # Internal HTTPRoute (envoy → n8n:8080) — n8n web UI + webhook
+    # endpoints.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+    # alertmanager posts to n8n's /webhook/alert-investigate (used by
+    # the HolmesGPT triage workflow).
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: observability
+            app.kubernetes.io/name: alertmanager
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+    # n8n-mcp in mcp-system queries the n8n API (N8N_API_URL).
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: mcp-system
+            app.kubernetes.io/name: n8n-mcp
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+  egress:
+    # Postgres backend (Pattern B — CNPG cluster in databases).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
+            cnpg.io/cluster: postgres-n8n
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+    # n8n workflows call out to an unbounded set of services: HTTP nodes
+    # to arbitrary user URLs, HolmesGPT in the cluster (through envoy),
+    # Pushover, mailgun, Zulip, etc. Workflow URLs live in Postgres and
+    # change at user discretion; toEntities:world is the only practical
+    # option. Documented as intentional per the rollout-plan design
+    # decisions.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+            - port: "80"
+              protocol: TCP

--- a/kubernetes/apps/home/n8n/app/kustomization.yaml
+++ b/kubernetes/apps/home/n8n/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./longhorn-pvc.yaml

--- a/kubernetes/apps/home/netbox/app/cnp-allow.yaml
+++ b/kubernetes/apps/home/netbox/app/cnp-allow.yaml
@@ -1,0 +1,75 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: netbox-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: netbox
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # Internal HTTPRoute (envoy → netbox:80) — netbox UI + REST API.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "80"
+              protocol: TCP
+    # netbox-mcp in mcp-system queries the netbox REST API.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: mcp-system
+            app.kubernetes.io/name: netbox-mcp
+      toPorts:
+        - ports:
+            - port: "80"
+              protocol: TCP
+    # Prometheus metrics port 9090 — baseline allow-monitoring-scrape
+    # already covers prometheus → any-port for endpoints in this ns.
+  egress:
+    # Postgres backend (Pattern B — CNPG cluster in databases).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
+            cnpg.io/cluster: postgres-netbox
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+    # Dragonfly (Redis-compatible) caching + tasks DB (Pattern E).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
+            app.kubernetes.io/name: dragonfly
+      toPorts:
+        - ports:
+            - port: "6379"
+              protocol: TCP
+    # smtp-relay in same ns for netbox email notifications. Intra-
+    # namespace, listed for grep-ability.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: home
+            app.kubernetes.io/name: smtp-relay
+      toPorts:
+        - ports:
+            - port: "2525"
+              protocol: TCP
+    # Garage S3 backend for netbox file storage (Pattern E —
+    # garage.storage.svc.cluster.local:3900).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: storage
+            app.kubernetes.io/name: garage
+      toPorts:
+        - ports:
+            - port: "3900"
+              protocol: TCP

--- a/kubernetes/apps/home/netbox/app/kustomization.yaml
+++ b/kubernetes/apps/home/netbox/app/kustomization.yaml
@@ -3,6 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./httproute.yaml

--- a/kubernetes/apps/home/node-red/app/cnp-allow.yaml
+++ b/kubernetes/apps/home/node-red/app/cnp-allow.yaml
@@ -1,0 +1,41 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: node-red-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: node-red
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # Internal HTTPRoute (envoy → node-red:1880) — Node-RED editor + UI.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "1880"
+              protocol: TCP
+  egress:
+    # Node-RED flows call MQTT (emqx in same ns — intra-namespace), HA
+    # REST, and arbitrary external HTTP nodes (similar shape to n8n).
+    # Flow URLs live in the flow DB and change at user discretion;
+    # toEntities:world is the only practical option.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+            - port: "80"
+              protocol: TCP
+    # NOTE: node-red has a multus-attached secondary NIC on the IoT
+    # VLAN (node-red-iot-static) — IoT device probes / mDNS /
+    # broadcasts go over that NIC and bypass Cilium.

--- a/kubernetes/apps/home/node-red/app/kustomization.yaml
+++ b/kubernetes/apps/home/node-red/app/kustomization.yaml
@@ -5,5 +5,6 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./helmrelease.yaml
   - ./longhorn-pvc.yaml

--- a/kubernetes/apps/home/smtp-relay/app/cnp-allow.yaml
+++ b/kubernetes/apps/home/smtp-relay/app/cnp-allow.yaml
@@ -1,0 +1,67 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: smtp-relay-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: smtp-relay
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # In-cluster SMTP clients post mail to smtp-relay:2525. Known
+    # consumers as of 2026-05-17:
+    #   auth/lldap         — LLDAP_SMTP_OPTIONS__SERVER
+    #   auth/authelia      — Authelia SMTP notifier
+    #   collab/zulip       — SETTING_EMAIL_HOST
+    #   home/netbox        — netbox email.server
+    #   home/home-assistant — HA notify SMTP integration
+    # Plus LoadBalancer VIP (SVC_SMTP_RELAY_ADDR) so LAN devices
+    # / cron scripts on hosts can submit mail too.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: auth
+            app.kubernetes.io/name: lldap
+        - matchLabels:
+            io.kubernetes.pod.namespace: auth
+            app.kubernetes.io/name: authelia
+        - matchLabels:
+            io.kubernetes.pod.namespace: collab
+            app.kubernetes.io/name: zulip
+        - matchLabels:
+            io.kubernetes.pod.namespace: home
+            app.kubernetes.io/name: netbox
+        - matchLabels:
+            io.kubernetes.pod.namespace: home
+            app.kubernetes.io/name: home-assistant
+      toPorts:
+        - ports:
+            - port: "2525"
+              protocol: TCP
+    - fromEntities:
+        - world
+        - host
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "2525"
+              protocol: TCP
+  egress:
+    # Outbound to Mailgun on the SMTPS submission port (465). See
+    # memory project_smtp_relay_broken_since_day1.md — must be
+    # `tls://` on 465, NOT starttls.
+    #
+    # matchPattern + matchPattern.* covers the search-domain-augmented
+    # FQDN form (Cilium 1.19 quirk — see PR #11492).
+    - toFQDNs:
+        - matchPattern: "smtp.mailgun.org"
+        - matchPattern: "smtp.mailgun.org.*"
+      toPorts:
+        - ports:
+            - port: "465"
+              protocol: TCP

--- a/kubernetes/apps/home/smtp-relay/app/kustomization.yaml
+++ b/kubernetes/apps/home/smtp-relay/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
 configMapGenerator:

--- a/kubernetes/apps/home/zigbee2mqtt/app/cnp-allow.yaml
+++ b/kubernetes/apps/home/zigbee2mqtt/app/cnp-allow.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: zigbee2mqtt-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: zigbee2mqtt
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # Internal HTTPRoute (envoy → zigbee2mqtt:8080) — z2m UI.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+  # emqx connection (mqtt://emqx.home:1883) is intra-namespace —
+  # covered by baseline allow-intra-namespace. Zigbee serial dongle is
+  # on a host /dev path with no network egress.

--- a/kubernetes/apps/home/zigbee2mqtt/app/kustomization.yaml
+++ b/kubernetes/apps/home/zigbee2mqtt/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./longhorn-pvc.yaml

--- a/kubernetes/apps/home/zwave-js-ui/app/cnp-allow.yaml
+++ b/kubernetes/apps/home/zwave-js-ui/app/cnp-allow.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: zwave-js-ui-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: zwave-js-ui
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # Internal HTTPRoute (envoy → zwave-js-ui:8091) — zwave-js UI.
+    # home-assistant connects to the websocket on :3000 — intra-ns,
+    # covered by baseline allow-intra-namespace.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "8091"
+              protocol: TCP
+  # No egress holes needed: Z-Wave dongle is on a host /dev path, no
+  # network egress.

--- a/kubernetes/apps/home/zwave-js-ui/app/kustomization.yaml
+++ b/kubernetes/apps/home/zwave-js-ui/app/kustomization.yaml
@@ -5,5 +5,6 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./helmrelease.yaml
   - ./longhorn-pvc.yaml


### PR DESCRIPTION
## Summary

- Adds `default-deny` component to `home` namespace alongside `baseline`.
- Ships per-app CiliumNetworkPolicy overlays for 14 home apps (no CNP for wyoming-services — baseline allow-intra-namespace covers HA → kokoro/openwakeword/whisper).
- Direct-enforce (no audit-mode soak); user pre-surveyed the namespace traffic surface.

## Design decisions (already user-approved)

- **Multus-attached pods** (home-assistant, frigate, esphome, matter-server, node-red): secondary NIC on IoT/security VLAN bypasses Cilium. CNPs only govern eth0.
- **n8n + home-assistant external egress**: `toEntities: world` on 443/80 (and 1883/8883 for HA MQTT) — workflow URLs / HA integrations are unbounded.
- **EMQX MQTT**: ingress `fromEntities: [world, host, remote-node]` on 1883/8883/8083/8084/18083 for 400+ LAN devices.
- **wyoming-services**: skipped per "no empty CNPs" rule — baseline allow-intra-namespace fully covers it.
- **smtp-relay → mailgun**: `toFQDNs` `matchPattern: smtp.mailgun.org` + `.*` on 465 only (confirmed in maddy.conf; uses `tls://` per smtp-day1 memory).
- **frigate-oauth2-proxy → Authelia**: `matchPattern: auth.thesteamedcrab.com` + `.*`.
- **netbox cross-ns**: postgres-netbox (Pattern B), dragonfly (Pattern E), garage (Pattern E), smtp-relay (intra-ns).

All toFQDNs use the `matchPattern: "<fqdn>"` + `matchPattern: "<fqdn>.*"` dual-form per Cilium 1.19 DNS search-domain quirk (PR #11492).

## Test plan

- [ ] `kubectl get cnp -n home` shows 6 baseline + default-deny + 14 per-app overlays.
- [ ] All home pods stay Running (no pod crashes from suddenly-denied egress).
- [ ] Smoke tests: hass / frigate / esphome / n8n / netbox / node-red / zigbee2mqtt / zwave-js-ui return reasonable HTTP codes.
- [ ] MQTT publishes from LAN devices to emqx still land (zigbee2mqtt, ESPHome devices).
- [ ] SMTP sends from auth/authelia + collab/zulip + home/netbox land in Mailgun.
- [ ] HA Postgres recorder writes continue (no n8n / hass restart loops).

## Rollback

If anything breaks: `flux suspend kustomization -n flux-system home && kubectl delete cnp -n home <name>` then revert via new PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)