### PR TITLE
feat(network-policy): external-secrets default-deny + per-app overlays (Phase 7)

### DIFF
--- a/kubernetes/apps/external-secrets/external-secrets/app/cnp-allow-webhook.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/app/cnp-allow-webhook.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: external-secrets-webhook-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: external-secrets-webhook
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # kube-apiserver → ValidatingWebhookConfiguration callback to the
+    # external-secrets-webhook Service (port 443 → containerPort 10250)
+    # for ExternalSecret / ClusterSecretStore admission. Without this
+    # apiserver loses ability to admit ES CRs once default-deny lands.
+    # Kubelet readiness/startup probes (host-network → :8081) +
+    # Prometheus scrape (:8080) are covered by baseline allow-host-probes
+    # and allow-monitoring-scrape respectively.
+    - fromEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "10250"
+              protocol: TCP
+  # Egress: external-secrets-webhook is a leaf service (no upstreams
+  # beyond the apiserver, already covered by the baseline
+  # allow-apiserver policy). No explicit egress rules required.

--- a/kubernetes/apps/external-secrets/external-secrets/app/kustomization.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/app/kustomization.yaml
@@ -3,6 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./cnp-allow-webhook.yaml
   - ./helmrelease.yaml
 configMapGenerator:
   - files:

--- a/kubernetes/apps/external-secrets/kustomization.yaml
+++ b/kubernetes/apps/external-secrets/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: external-secrets
 components:
   - ../../components/alerts
   - ../../components/network-policy/baseline
+  - ../../components/network-policy/default-deny
 resources:
   - ./namespace.yaml
   - ./external-secrets/ks.yaml

--- a/kubernetes/apps/external-secrets/onepassword-connect/app/cnp-allow.yaml
+++ b/kubernetes/apps/external-secrets/onepassword-connect/app/cnp-allow.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: onepassword-connect-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: onepassword-connect
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it. Ingress from the external-secrets controller
+  # (same namespace, port 8080) is covered by baseline
+  # allow-intra-namespace.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  egress:
+    # 1Password Cloud (sync container only). Confirmed via Cilium FQDN
+    # cache 2026-05-17: only `my.1password.com` is resolved. The bare
+    # + `.*` dual-form matchPattern covers both un-augmented and
+    # search-domain-augmented forms (Cilium 1.19 matchName misses the
+    # augmented `my.1password.com.external-secrets.svc.cluster.local.`
+    # form per PR #11492 / #11499).
+    - toFQDNs:
+        - matchPattern: "my.1password.com"
+        - matchPattern: "my.1password.com.*"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/external-secrets/onepassword-connect/app/kustomization.yaml
+++ b/kubernetes/apps/external-secrets/onepassword-connect/app/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./clustersecretstore.yaml
+  - ./cnp-allow.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
 configMapGenerator:


### PR DESCRIPTION
## Summary

Lock down the `external-secrets` namespace with default-deny + per-app allow overlays. Baseline (PR #11481) already in place; this adds the two policy holes that baseline doesn't cover and flips default-deny on.

- **external-secrets controller** + **cert-controller**: covered by baseline alone (apiserver + intra-namespace DNS).
- **external-secrets-webhook**: new `cnp-allow-webhook.yaml` opens kube-apiserver ingress on containerPort 10250 (ValidatingWebhookConfiguration callbacks for ES/CSS admission).
- **onepassword-connect**: new `cnp-allow.yaml` opens egress to `my.1password.com:443` using matchPattern + `.*` dual-form (Cilium 1.19 search-domain augmentation quirk; see PRs #11492 / #11499).

Single 1Password Connect provider in cluster — `connectHost: http://onepassword-connect.external-secrets.svc.cluster.local:8080` already covered by baseline `allow-intra-namespace`. No other ClusterSecretStore providers in use.

## Test plan

- [ ] All pods Ready in `external-secrets` ns post-merge.
- [ ] `kubectl get externalsecret -A` continues to refresh on schedule (no stuck/stale).
- [ ] `kubectl logs deploy/external-secrets -n external-secrets` shows no 1Password / connect / auth errors.
- [ ] `kubectl get validatingwebhookconfiguration secretstore-validate` admission still works (try creating a test ExternalSecret).

🤖 Generated with [Claude Code](https://claude.com/claude-code)