### PR TITLE
feat(network-policy): lock down collab namespace (default-deny + overlays)

### DIFF
--- a/kubernetes/apps/collab/atuin/app/cnp-allow.yaml
+++ b/kubernetes/apps/collab/atuin/app/cnp-allow.yaml
@@ -1,0 +1,36 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: atuin-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: atuin
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal gateway → atuin:8080. Metrics port 8081 is
+    # scraped by Prometheus, already covered by allow-monitoring-scrape.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+  egress:
+    # CNPG cluster postgres-atuin in databases ns (Pattern B).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
+            cnpg.io/cluster: postgres-atuin
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP

--- a/kubernetes/apps/collab/atuin/app/kustomization.yaml
+++ b/kubernetes/apps/collab/atuin/app/kustomization.yaml
@@ -5,5 +5,6 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/collab/glance-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/collab/glance-oauth2-proxy/app/cnp-allow.yaml
@@ -1,0 +1,42 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: glance-oauth2-proxy-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: glance-oauth2-proxy
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal gateway → glance-oauth2-proxy:4180
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "4180"
+              protocol: TCP
+  egress:
+    # OIDC discovery + token exchange against Authelia. Upstream →
+    # glance.collab.svc.cluster.local:8081 is same-ns, covered by
+    # baseline allow-intra-namespace.
+    #
+    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
+    # pod DNS search-domain augmentation (pod queries
+    # `auth.thesteamedcrab.com.collab.svc.cluster.local.`; FQDN cache
+    # stores the augmented name; matchName misses it). Bare + `.*`
+    # matchPattern covers both forms — see PR #11492.
+    - toFQDNs:
+        - matchPattern: "auth.thesteamedcrab.com"
+        - matchPattern: "auth.thesteamedcrab.com.*"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/collab/glance-oauth2-proxy/app/kustomization.yaml
+++ b/kubernetes/apps/collab/glance-oauth2-proxy/app/kustomization.yaml
@@ -5,5 +5,6 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/collab/glance-user-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/collab/glance-user-oauth2-proxy/app/cnp-allow.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: glance-user-oauth2-proxy-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: glance-user-oauth2-proxy
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal gateway (start.${SECRET_DOMAIN}) →
+    # glance-user-oauth2-proxy:4180
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "4180"
+              protocol: TCP
+  egress:
+    # OIDC discovery + token exchange against Authelia. Upstream →
+    # glance-user.collab.svc.cluster.local:8081 is same-ns, baseline.
+    #
+    # Cilium 1.19 search-domain augmentation quirk — bare + `.*`
+    # matchPattern covers both forms. See PR #11492.
+    - toFQDNs:
+        - matchPattern: "auth.thesteamedcrab.com"
+        - matchPattern: "auth.thesteamedcrab.com.*"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/collab/glance-user-oauth2-proxy/app/kustomization.yaml
+++ b/kubernetes/apps/collab/glance-user-oauth2-proxy/app/kustomization.yaml
@@ -5,5 +5,6 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/collab/glance-user/app/cnp-allow.yaml
+++ b/kubernetes/apps/collab/glance-user/app/cnp-allow.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: glance-user-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: glance-user
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # Inbound rides via glance-user-oauth2-proxy → glance-user:8081
+    # (same-ns; baseline allow-intra-namespace).
+  egress:
+    # Family-dashboard widgets call out to whatever feeds the user
+    # configured (weather, news, sports, calendars, RSS, etc.). Same
+    # rationale as glance: widget set evolves outside this repo, so
+    # allow broad HTTPS egress. No kube-apiserver access (no
+    # k8s-extension sidecar on this instance).
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+            - port: "80"
+              protocol: TCP

--- a/kubernetes/apps/collab/glance-user/app/kustomization.yaml
+++ b/kubernetes/apps/collab/glance-user/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./helmrelease.yaml
 configMapGenerator:
   - files:

--- a/kubernetes/apps/collab/glance/app/cnp-allow.yaml
+++ b/kubernetes/apps/collab/glance/app/cnp-allow.yaml
@@ -1,0 +1,34 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: glance-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: glance
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # Inbound to glance always rides through glance-oauth2-proxy →
+    # glance:8081 (same-ns; baseline allow-intra-namespace covers it).
+    # The k8s-extension sidecar on container port 8080 is glance-local
+    # only (glance scrapes it via localhost). No external ingress rule.
+  egress:
+    # Widgets pull from arbitrary upstreams configured in glance.yml
+    # (RSS feeds, Reddit, Hacker News, weather, GitHub, Docker Hub,
+    # Twitch, YouTube, calendar ICS, etc.). The widget set evolves
+    # outside this repo, so err on the side of broad HTTPS egress.
+    # Apiserver + DNS are covered by baseline.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+            - port: "80"
+              protocol: TCP

--- a/kubernetes/apps/collab/glance/app/kustomization.yaml
+++ b/kubernetes/apps/collab/glance/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./helmrelease.yaml
 configMapGenerator:
   - files:

--- a/kubernetes/apps/collab/it-tools/app/cnp-allow.yaml
+++ b/kubernetes/apps/collab/it-tools/app/cnp-allow.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: it-tools-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: it-tools
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal gateway → it-tools:80
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "80"
+              protocol: TCP
+  # No egress holes needed — it-tools is a pure client-side utility
+  # site (encoders/decoders/converters). All computation runs in the
+  # browser; the container only serves static assets. DNS + apiserver
+  # are covered by baseline.

--- a/kubernetes/apps/collab/it-tools/app/kustomization.yaml
+++ b/kubernetes/apps/collab/it-tools/app/kustomization.yaml
@@ -5,4 +5,5 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/collab/kitchenowl/app/cnp-allow.yaml
+++ b/kubernetes/apps/collab/kitchenowl/app/cnp-allow.yaml
@@ -1,0 +1,41 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: kitchenowl-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: kitchenowl
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal gateway → kitchenowl:8080. No oauth2-proxy
+    # in front of this one — kitchenowl handles OIDC natively against
+    # Authelia (OIDC_ISSUER env).
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+  egress:
+    # OIDC discovery + token exchange against Authelia (OIDC_ISSUER =
+    # https://auth.${SECRET_DOMAIN}). Resolves to the internal Envoy
+    # gateway VIP which then routes to the auth namespace.
+    #
+    # Cilium 1.19 search-domain augmentation quirk — bare + `.*`
+    # matchPattern covers both forms. See PR #11492.
+    - toFQDNs:
+        - matchPattern: "auth.thesteamedcrab.com"
+        - matchPattern: "auth.thesteamedcrab.com.*"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/collab/kitchenowl/app/kustomization.yaml
+++ b/kubernetes/apps/collab/kitchenowl/app/kustomization.yaml
@@ -3,6 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./longhorn-pvc.yaml

--- a/kubernetes/apps/collab/kustomization.yaml
+++ b/kubernetes/apps/collab/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: collab
 components:
   - ../../components/alerts
   - ../../components/network-policy/baseline
+  - ../../components/network-policy/default-deny
 resources:
   - ./namespace.yaml
   - ./atuin/ks.yaml

--- a/kubernetes/apps/collab/medikeep/app/cnp-allow.yaml
+++ b/kubernetes/apps/collab/medikeep/app/cnp-allow.yaml
@@ -1,0 +1,36 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: medikeep-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: medikeep
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal gateway → medikeep:8000 (React frontend).
+    # The FastAPI port (8005) is in-pod only.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "8000"
+              protocol: TCP
+  egress:
+    # CNPG cluster postgres-medikeep in databases ns (Pattern B).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
+            cnpg.io/cluster: postgres-medikeep
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP

--- a/kubernetes/apps/collab/medikeep/app/kustomization.yaml
+++ b/kubernetes/apps/collab/medikeep/app/kustomization.yaml
@@ -5,5 +5,6 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/collab/nametag/app/cnp-allow.yaml
+++ b/kubernetes/apps/collab/nametag/app/cnp-allow.yaml
@@ -1,0 +1,44 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: nametag-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: nametag
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal gateway → nametag:3000
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "3000"
+              protocol: TCP
+  egress:
+    # CNPG cluster postgres-nametag in databases ns (Pattern B).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
+            cnpg.io/cluster: postgres-nametag
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+    # Redis via shared dragonfly (REDIS_URL env).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
+            app.kubernetes.io/name: dragonfly
+      toPorts:
+        - ports:
+            - port: "6379"
+              protocol: TCP

--- a/kubernetes/apps/collab/nametag/app/kustomization.yaml
+++ b/kubernetes/apps/collab/nametag/app/kustomization.yaml
@@ -6,5 +6,6 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/collab/obsidian-couchdb/app/cnp-allow.yaml
+++ b/kubernetes/apps/collab/obsidian-couchdb/app/cnp-allow.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: obsidian-couchdb-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: obsidian-couchdb
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on the EXTERNAL gateway (obsidian.${SECRET_DOMAIN}
+    # via cloudflared) → obsidian-couchdb:5984. Both internal and
+    # external envoy pods carry app.kubernetes.io/name=envoy in the
+    # network ns, so the selector covers both.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "5984"
+              protocol: TCP
+  # No egress holes needed — CouchDB is self-contained for this
+  # single-node setup. No remote replication peers configured.

--- a/kubernetes/apps/collab/obsidian-couchdb/app/kustomization.yaml
+++ b/kubernetes/apps/collab/obsidian-couchdb/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./longhorn-pvc.yaml

--- a/kubernetes/apps/collab/open-webui/app/cnp-allow.yaml
+++ b/kubernetes/apps/collab/open-webui/app/cnp-allow.yaml
@@ -1,0 +1,105 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: open-webui-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: open-webui
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal gateway → open-webui:8080. OIDC SSO is
+    # handled in-app against Authelia (no oauth2-proxy sidecar).
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+  egress:
+    # ai/ollama — primary LLM backend (OLLAMA_BASE_URL).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: ai
+            app.kubernetes.io/name: ollama
+      toPorts:
+        - ports:
+            - port: "11434"
+              protocol: TCP
+    # ai/langgraph-agents — OpenAI-compatible surface, each agent id
+    # exposed as a model (OPENAI_API_BASE_URLS).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: ai
+            app.kubernetes.io/name: langgraph-agents
+      toPorts:
+        - ports:
+            - port: "8765"
+              protocol: TCP
+    # databases/qdrant — vector store (VECTOR_DB=qdrant, QDRANT_URI).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
+            app.kubernetes.io/name: qdrant
+      toPorts:
+        - ports:
+            - port: "6333"
+              protocol: TCP
+    # mcp-system/mcp-gateway — TOOL_SERVER_CONNECTIONS includes the
+    # gateway at mcp-gateway.mcp-system:8080/mcp. Select the whole ns
+    # (matches the langgraph-agents convention) — the mcp-system ns
+    # is itself default-deny locked-down.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: mcp-system
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+    # observability/holmesgpt — second tool server (cluster diagnostics).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: observability
+            app.kubernetes.io/name: holmesgpt
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+    # OIDC discovery + token exchange against Authelia, and TTS via
+    # piper.${SECRET_DOMAIN} — both resolve to the internal Envoy
+    # gateway VIP.
+    #
+    # Cilium 1.19 search-domain augmentation quirk — bare + `.*`
+    # matchPattern covers both forms. See PR #11492.
+    - toFQDNs:
+        - matchPattern: "auth.thesteamedcrab.com"
+        - matchPattern: "auth.thesteamedcrab.com.*"
+        - matchPattern: "piper.thesteamedcrab.com"
+        - matchPattern: "piper.thesteamedcrab.com.*"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+    # External tool egress: open-webui's web-search backend (searxng,
+    # in-cluster — covered intra-ns via baseline), plus an open list
+    # of user-configured external integrations (image gen APIs, image
+    # fetches for RAG citations, model registry pulls, OpenAI/Mistral/
+    # Anthropic if the user wires them in via the UI). Config lives in
+    # the open-webui SQLite DB (not in git), so the surface is broad
+    # by design. Err on the side of permitting HTTPS world egress.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+    # Intra-ns to searxng:8080 (SEARXNG_QUERY_URL) is covered by
+    # baseline allow-intra-namespace.

--- a/kubernetes/apps/collab/open-webui/app/kustomization.yaml
+++ b/kubernetes/apps/collab/open-webui/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./longhorn-pvc.yaml

--- a/kubernetes/apps/collab/paperless/app/cnp-allow-offsite-backup.yaml
+++ b/kubernetes/apps/collab/paperless/app/cnp-allow-offsite-backup.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: paperless-offsite-backup-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: paperless-offsite-backup
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  # No ingress — CronJob is purely outbound.
+  egress:
+    # In-cluster S3 to Garage (CNPG/Barman DB backup snapshots). The
+    # garage CNP's ingress already permits collab → garage:3900 at the
+    # ns level (see storage/garage/app/cnp-allow.yaml). This rule is
+    # the egress side from the CronJob's perspective.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: storage
+            app.kubernetes.io/name: garage
+      toPorts:
+        - ports:
+            - port: "3900"
+              protocol: TCP
+    # External S3 (AWS Glacier Deep Archive) via rclone's crypt remote.
+    # The crypt remote wraps an s3 remote whose endpoint is AWS S3
+    # (s3.amazonaws.com / s3-<region>.amazonaws.com), so this is true
+    # internet egress, not the internal Garage gateway. Use world:443.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/collab/paperless/app/cnp-allow.yaml
+++ b/kubernetes/apps/collab/paperless/app/cnp-allow.yaml
@@ -1,0 +1,72 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: paperless-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: paperless
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal gateway → paperless:8000. paperless-ngx
+    # handles OIDC natively (django-allauth).
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "8000"
+              protocol: TCP
+    # Cross-ns: ai/paperless-ai enriches docs via paperless's REST API
+    # (already declared on paperless-ai's egress side; this is the
+    # ingress counterpart).
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: ai
+            app.kubernetes.io/name: paperless-ai
+      toPorts:
+        - ports:
+            - port: "8000"
+              protocol: TCP
+    # Cross-ns: paperless-mcp's PAPERLESS_URL points at the external
+    # FQDN which traverses envoy back to paperless. Internal callers
+    # speaking directly to paperless:8000 (if any are added later)
+    # would also land here.
+  egress:
+    # CNPG cluster postgres-paperless in databases ns (Pattern B).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
+            cnpg.io/cluster: postgres-paperless
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+    # Redis broker via shared dragonfly (PAPERLESS_REDIS).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
+            app.kubernetes.io/name: dragonfly
+      toPorts:
+        - ports:
+            - port: "6379"
+              protocol: TCP
+    # OIDC discovery + token exchange against Authelia (allauth
+    # openid_connect provider, server_url = auth.${SECRET_DOMAIN}).
+    #
+    # Cilium 1.19 search-domain augmentation quirk — bare + `.*`
+    # matchPattern covers both forms. See PR #11492.
+    - toFQDNs:
+        - matchPattern: "auth.thesteamedcrab.com"
+        - matchPattern: "auth.thesteamedcrab.com.*"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/collab/paperless/app/cronjob-offsite-backup.yaml
+++ b/kubernetes/apps/collab/paperless/app/cronjob-offsite-backup.yaml
@@ -12,6 +12,10 @@ spec:
     spec:
       backoffLimit: 5
       template:
+        metadata:
+          labels:
+            # Used by paperless-offsite-backup-allow CNP egress selector
+            app.kubernetes.io/name: paperless-offsite-backup
         spec:
           restartPolicy: OnFailure
           # paperless-library-pvc is RWO Longhorn — multi-attach is single-node

--- a/kubernetes/apps/collab/paperless/app/kustomization.yaml
+++ b/kubernetes/apps/collab/paperless/app/kustomization.yaml
@@ -6,6 +6,8 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow-offsite-backup.yaml
+  - ./cnp-allow.yaml
   - ./cronjob-offsite-backup.yaml
   - ./externalsecret-offsite-backup.yaml
   - ./externalsecret.yaml

--- a/kubernetes/apps/collab/pump-cv/app/cnp-allow.yaml
+++ b/kubernetes/apps/collab/pump-cv/app/cnp-allow.yaml
@@ -1,0 +1,46 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: pump-cv-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: pump-cv
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it. Ingress on :8080 from pump (same ns) for
+  # the /api/cv/* admin proxy is covered by baseline
+  # allow-intra-namespace.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  egress:
+    # RTSP/TCP pulls from the two Reolink cameras on the security VLAN:
+    #   gym-front  10.10.40.26
+    #   gym-back   10.10.40.27
+    # OPENCV_FFMPEG_CAPTURE_OPTIONS forces rtsp_transport=tcp so the
+    # only port we need to allow is TCP/554 (control + interleaved
+    # media). Limit by /24 CIDR to the security VLAN.
+    - toCIDR:
+        - 10.10.40.0/24
+      toPorts:
+        - ports:
+            - port: "554"
+              protocol: TCP
+    # Ultralytics YOLOv8 model download from github releases on first
+    # run (then cached to ceph-block under /cache). Subsequent restarts
+    # use the cached weights. Bare + `.*` matchPattern covers both
+    # un-augmented and search-domain-augmented FQDN forms (Cilium 1.19
+    # search-domain quirk — see PR #11492).
+    - toFQDNs:
+        - matchPattern: "github.com"
+        - matchPattern: "github.com.*"
+        - matchPattern: "*.githubusercontent.com"
+        - matchPattern: "*.githubusercontent.com.*"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+    # Intra-ns pump-api:8851 (PUMP_API_BASE_URL) is covered by baseline
+    # allow-intra-namespace.

--- a/kubernetes/apps/collab/pump-cv/app/kustomization.yaml
+++ b/kubernetes/apps/collab/pump-cv/app/kustomization.yaml
@@ -6,6 +6,7 @@ components:
   - ../../../../components/repos/app-template
 resources:
   - ./clips-pvc.yaml
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
 configMapGenerator:

--- a/kubernetes/apps/collab/pump-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/collab/pump-oauth2-proxy/app/cnp-allow.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: pump-oauth2-proxy-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: pump-oauth2-proxy
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal gateway (pump.${SECRET_DOMAIN}) →
+    # pump-oauth2-proxy:4180
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "4180"
+              protocol: TCP
+  egress:
+    # OIDC discovery + token exchange against Authelia. Upstream →
+    # pump-frontend.collab.svc.cluster.local:8080 is same-ns, baseline.
+    #
+    # Cilium 1.19 search-domain augmentation quirk — bare + `.*`
+    # matchPattern covers both forms. See PR #11492.
+    - toFQDNs:
+        - matchPattern: "auth.thesteamedcrab.com"
+        - matchPattern: "auth.thesteamedcrab.com.*"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/collab/pump-oauth2-proxy/app/kustomization.yaml
+++ b/kubernetes/apps/collab/pump-oauth2-proxy/app/kustomization.yaml
@@ -5,5 +5,6 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/collab/pump/app/cnp-allow.yaml
+++ b/kubernetes/apps/collab/pump/app/cnp-allow.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: pump-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: pump
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it. Inbound only ever rides via
+  # pump-oauth2-proxy → pump-frontend:8080 (same-ns; baseline
+  # allow-intra-namespace). pump-cv → pump-api:8851 is same-ns too.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  egress:
+    # CNPG cluster postgres-pump in databases ns (Pattern B).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
+            cnpg.io/cluster: postgres-pump
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+    # Intra-ns pump-cv:8080 (PUMP_CV_URL admin/preview proxy) is
+    # covered by baseline allow-intra-namespace.

--- a/kubernetes/apps/collab/pump/app/kustomization.yaml
+++ b/kubernetes/apps/collab/pump/app/kustomization.yaml
@@ -7,5 +7,6 @@ components:
   - ../../../../components/repos/app-template
 
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/collab/searxng/app/cnp-allow.yaml
+++ b/kubernetes/apps/collab/searxng/app/cnp-allow.yaml
@@ -1,0 +1,53 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: searxng-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: searxng
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal gateway (search.${SECRET_DOMAIN}) →
+    # searxng:8080. In-cluster callers (open-webui via SEARXNG_QUERY_URL,
+    # khoj via KHOJ_SEARXNG_URL, mcp-system/searxng-mcp) hit the
+    # cluster Service directly; the same-ns and cross-ns paths are
+    # listed below for grep-ability.
+    - fromEndpoints:
+        # External users via internal gateway
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+        # In-cluster callers (cross-ns; same-ns open-webui covered by
+        # baseline allow-intra-namespace)
+        - matchLabels:
+            io.kubernetes.pod.namespace: ai
+            app.kubernetes.io/name: khoj
+        - matchLabels:
+            io.kubernetes.pod.namespace: mcp-system
+            app.kubernetes.io/name: searxng-mcp
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+  egress:
+    # searxng's entire purpose is fan-out queries to every search
+    # engine the operator has enabled in settings.yml (Google, Bing,
+    # Wikipedia, GitHub, Stack Overflow, Reddit, … — dozens of
+    # upstreams, each on different ports and FQDNs). Enumeration is
+    # not maintainable; allow broad world HTTPS + HTTP egress (some
+    # engines still 80→301).
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+            - port: "80"
+              protocol: TCP

--- a/kubernetes/apps/collab/searxng/app/kustomization.yaml
+++ b/kubernetes/apps/collab/searxng/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
 configMapGenerator:

--- a/kubernetes/apps/collab/swiparr/app/cnp-allow.yaml
+++ b/kubernetes/apps/collab/swiparr/app/cnp-allow.yaml
@@ -1,0 +1,35 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: swiparr-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: swiparr
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal gateway → swiparr:4321
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "4321"
+              protocol: TCP
+  egress:
+    # Jellyfin in media ns (JELLYFIN_URL = http://jellyfin.media:8096).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: media
+            app.kubernetes.io/name: jellyfin
+      toPorts:
+        - ports:
+            - port: "8096"
+              protocol: TCP

--- a/kubernetes/apps/collab/swiparr/app/kustomization.yaml
+++ b/kubernetes/apps/collab/swiparr/app/kustomization.yaml
@@ -6,5 +6,6 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./helmrelease.yaml
   - ./longhorn-pvc.yaml

--- a/kubernetes/apps/collab/zulip/app/cnp-allow.yaml
+++ b/kubernetes/apps/collab/zulip/app/cnp-allow.yaml
@@ -1,0 +1,78 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: zulip-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: zulip
+      app.kubernetes.io/instance: zulip
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it. Intra-ns to zulip-rabbitmq (5672) +
+  # zulip-memcached (11211) is covered by baseline allow-intra-namespace.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on external gateway (chat.${SECRET_DOMAIN} via
+    # cloudflared) → zulip:80. Both external and internal envoy pods
+    # carry app.kubernetes.io/name=envoy.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "80"
+              protocol: TCP
+    # ai/langgraph-agents posts to zulip's bot API on port 80 (see
+    # langgraph-agents/cnp-allow.yaml's matching egress rule).
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: ai
+            app.kubernetes.io/name: langgraph-agents
+      toPorts:
+        - ports:
+            - port: "80"
+              protocol: TCP
+  egress:
+    # CNPG cluster postgres-zulip in databases ns (Pattern B).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
+            cnpg.io/cluster: postgres-zulip
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+    # Redis via shared dragonfly (externalRedis.host).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
+            app.kubernetes.io/name: dragonfly
+      toPorts:
+        - ports:
+            - port: "6379"
+              protocol: TCP
+    # SMTP via internal Maddy relay in home ns (Pattern E).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: home
+            app.kubernetes.io/name: smtp-relay
+      toPorts:
+        - ports:
+            - port: "2525"
+              protocol: TCP
+    # Mobile push notifications via the Zulip-operated PNS at
+    # push.zulipchat.com (SETTING_ZULIP_SERVICE_PUSH_NOTIFICATIONS=true).
+    # Bare + `.*` matchPattern covers both forms (Cilium 1.19
+    # search-domain quirk — see PR #11492).
+    - toFQDNs:
+        - matchPattern: "push.zulipchat.com"
+        - matchPattern: "push.zulipchat.com.*"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/collab/zulip/app/kustomization.yaml
+++ b/kubernetes/apps/collab/zulip/app/kustomization.yaml
@@ -3,6 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./httproute.yaml


### PR DESCRIPTION
## Summary
- Drops `default-deny` CNP into the `collab` namespace alongside the existing baseline.
- Adds per-app `cnp-allow.yaml` overlays for 18 apps + the `paperless-offsite-backup` CronJob.
- Direct-enforce (no audit window) per agent task.

## Apps covered
atuin, glance + glance-oauth2-proxy, glance-user + glance-user-oauth2-proxy, it-tools, kitchenowl, medikeep, nametag, obsidian-couchdb, open-webui, paperless + paperless-offsite-backup, pump + pump-cv + pump-oauth2-proxy, searxng, swiparr, zulip.

## Key cross-ns flows preserved
- `network/envoy` → every HTTP-routed app on its container port
- `collab/{atuin,medikeep,nametag,paperless,pump,zulip}` → `databases/postgres-<app>:5432` (CNPG Pattern B)
- `collab/{nametag,paperless,zulip}` → `databases/dragonfly:6379`
- `collab/zulip` → `home/smtp-relay:2525` + `push.zulipchat.com:443`
- `collab/open-webui` → `ai/ollama`, `ai/langgraph-agents`, `databases/qdrant`, `mcp-system`, `observability/holmesgpt`, Authelia, Piper, `world:443`
- `collab/searxng` → `world:443/80` (every search engine)
- `collab/glance` + `glance-user` → `world:443/80` (widget fan-out)
- `collab/swiparr` → `media/jellyfin:8096`
- `collab/pump-cv` → `10.10.40.0/24:554` (Reolink cams) + `github.com:443` (YOLO model)
- All `*-oauth2-proxy` + native-OIDC apps (kitchenowl, open-webui, paperless) → `auth.${SECRET_DOMAIN}:443`
- Incoming: `ai/{paperless-ai,khoj}`, `mcp-system/searxng-mcp`, `ai/langgraph-agents` → matching collab apps

## CronJob label fix
`paperless-offsite-backup` pod template now carries `app.kubernetes.io/name=paperless-offsite-backup` so the matching CNP selector resolves.

## obsidian-couchdb note
Lives on the external (cloudflared) gateway. Internal + external envoy pods share `app.kubernetes.io/name=envoy` in the `network` ns, so a single fromEndpoints selector covers both paths.

## Test plan
- [ ] After merge, `kubectl get cnp -n collab` shows default-deny + per-app allow CNPs
- [ ] All pods still Ready
- [ ] Smoke: glance, paperless, zulip, open-webui, kitchenowl, obsidian-couchdb load via browser
- [ ] open-webui chat works (ollama + langgraph reachable; tool servers OK)
- [ ] zulip can receive new messages (postgres + dragonfly + smtp reachable)