### PR TITLE
feat(network-policy): lock down media namespace (default-deny + overlays)

### DIFF
--- a/kubernetes/apps/media/av1corrector-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/av1corrector-oauth2-proxy/app/cnp-allow.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: av1corrector-oauth2-proxy-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: av1corrector-oauth2-proxy
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal envoy gateway → av1corrector-oauth2-proxy:4180
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "4180"
+              protocol: TCP
+  egress:
+    # OIDC discovery + token exchange against Authelia (auth.${SECRET_DOMAIN}
+    # resolves to the internal envoy gateway VIP).
+    # Upstream → av1corrector.media:8000 is same-ns (baseline covers).
+    #
+    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
+    # pod DNS search-domain augmentation — see PR #11492.
+    - toFQDNs:
+        - matchPattern: "auth.thesteamedcrab.com"
+        - matchPattern: "auth.thesteamedcrab.com.*"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/media/av1corrector-oauth2-proxy/app/kustomization.yaml
+++ b/kubernetes/apps/media/av1corrector-oauth2-proxy/app/kustomization.yaml
@@ -5,5 +5,6 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/media/av1corrector/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/av1corrector/app/cnp-allow.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: av1corrector-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: av1corrector
+  # Additive — default-deny is what triggers the lockdown. Ingress
+  # from av1corrector-oauth2-proxy (same ns, :8000) and from
+  # kodi-playback-watcher (same ns, /jobs API) are covered by baseline
+  # allow-intra-namespace.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  egress:
+    # CNPG: postgres-av1corrector in databases ns (Pattern B). The
+    # init-db postgres-init initContainer also needs this on cold start.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
+            cnpg.io/cluster: postgres-av1corrector
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP

--- a/kubernetes/apps/media/av1corrector/app/kustomization.yaml
+++ b/kubernetes/apps/media/av1corrector/app/kustomization.yaml
@@ -7,5 +7,6 @@ components:
   - ../../../../components/repos/app-template
 
 resources:
+  - ./cnp-allow.yaml
   - ./helmrelease.yaml
   - ./nfs-pvc.yaml

--- a/kubernetes/apps/media/beets/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/beets/app/cnp-allow.yaml
@@ -1,0 +1,38 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: beets-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: beets
+  # Additive — default-deny is what triggers the lockdown. Beets runs
+  # as a CronJob (no long-running web UI in practice) but the chart
+  # exposes a Service+HTTPRoute on 8337 anyway.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal envoy gateway → beets:8337.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "8337"
+              protocol: TCP
+  egress:
+    # External: MusicBrainz lookups, Chromaprint AcoustID fingerprint
+    # service, Cover Art Archive, Discogs, etc. Plugin set + redirect
+    # CDNs change too often to enumerate per-FQDN.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+            - port: "80"
+              protocol: TCP

--- a/kubernetes/apps/media/beets/app/kustomization.yaml
+++ b/kubernetes/apps/media/beets/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./longhorn-pvc.yaml

--- a/kubernetes/apps/media/cutvideo/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/cutvideo/app/cnp-allow.yaml
@@ -1,0 +1,35 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: cutvideo-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: cutvideo
+  # Additive — default-deny is what triggers the lockdown.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal envoy gateway → cutvideo:8000.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "8000"
+              protocol: TCP
+  egress:
+    # CNPG: postgres-cutvideo in databases ns (Pattern B). Init-db
+    # postgres-init initContainer also needs this on cold start.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
+            cnpg.io/cluster: postgres-cutvideo
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP

--- a/kubernetes/apps/media/cutvideo/app/kustomization.yaml
+++ b/kubernetes/apps/media/cutvideo/app/kustomization.yaml
@@ -7,5 +7,6 @@ components:
   - ../../../../components/repos/app-template
 
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/media/flaresolverr/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/flaresolverr/app/cnp-allow.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: flaresolverr-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: flaresolverr
+  # Additive — default-deny is what triggers the lockdown. No
+  # HTTPRoute, no oauth2-proxy — only callers are cross-ns prowlarr in
+  # downloads ns (and same-ns *arr if any directly call it).
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # Cross-ns: prowlarr in downloads ns calls flaresolverr to solve CF
+    # challenges for indexer fetches.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: downloads
+            app.kubernetes.io/name: prowlarr
+      toPorts:
+        - ports:
+            - port: "8191"
+              protocol: TCP
+  egress:
+    # External: full headless-Chromium internet access to solve
+    # Cloudflare challenges on whatever indexer URLs prowlarr passes
+    # in. Target set is the entire CF-protected indexer corpus.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+            - port: "80"
+              protocol: TCP

--- a/kubernetes/apps/media/flaresolverr/app/kustomization.yaml
+++ b/kubernetes/apps/media/flaresolverr/app/kustomization.yaml
@@ -5,4 +5,5 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/media/gonic/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/gonic/app/cnp-allow.yaml
@@ -1,0 +1,38 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: gonic-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: gonic
+  # Additive — default-deny is what triggers the lockdown. Gonic uses
+  # the EXTERNAL envoy gateway (public via cloudflared tunnel), but
+  # the source pod identity is the same `app.kubernetes.io/name: envoy`
+  # label (gateway distinction is on the listener, not the pod).
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on external envoy gateway → gonic:80 (target 4747).
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "4747"
+              protocol: TCP
+  egress:
+    # Gonic scans NFS-mounted music library (kernel-level NFS, not a
+    # pod-egress concern). Optional last.fm scrobbling + cover-art
+    # fetches go to a small set of FQDNs; allow general 443 to keep
+    # plugin-evolution low-maintenance.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/media/gonic/app/kustomization.yaml
+++ b/kubernetes/apps/media/gonic/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./helmrelease.yaml
   - ./longhorn-pvc.yaml
   - ./nfs-pvc.yaml

--- a/kubernetes/apps/media/immich-pet-tagger/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/immich-pet-tagger/app/cnp-allow.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: immich-pet-tagger-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: immich-pet-tagger
+  # Additive — default-deny is what triggers the lockdown. Egress to
+  # immich-server (same ns, :2283) is covered by baseline. Local YOLO
+  # model — no external HF pulls at runtime once weights are persisted
+  # to the immich-pet-tagger-data PVC (downloaded once at first pod
+  # start). Allow world for that first-run + any future model refresh.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal envoy gateway → immich-pet-tagger:8000.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "8000"
+              protocol: TCP
+  egress:
+    # ultralytics downloads yolov8n.pt from
+    # github.com/ultralytics/assets on first poll if missing from cwd.
+    # Allow world 443 to keep the first-run flow + future model refresh
+    # unblocked.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/media/immich-pet-tagger/app/kustomization.yaml
+++ b/kubernetes/apps/media/immich-pet-tagger/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./longhorn-pvc.yaml

--- a/kubernetes/apps/media/immich-power-tools/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/immich-power-tools/app/cnp-allow.yaml
@@ -1,0 +1,37 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: immich-power-tools-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: immich-power-tools
+  # Additive — default-deny is what triggers the lockdown. Egress to
+  # immich-server (same ns, :2283) is covered by baseline
+  # allow-intra-namespace.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal envoy gateway → immich-power-tools:3000.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "3000"
+              protocol: TCP
+  egress:
+    # CNPG: postgres-immich in databases ns (direct DB queries — uses
+    # the same DB as immich-server).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
+            cnpg.io/cluster: postgres-immich
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP

--- a/kubernetes/apps/media/immich-power-tools/app/kustomization.yaml
+++ b/kubernetes/apps/media/immich-power-tools/app/kustomization.yaml
@@ -5,5 +5,6 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/media/immich/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/immich/app/cnp-allow.yaml
@@ -1,0 +1,142 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: immich-server-allow
+spec:
+  # Immich charts use a non-standard label set:
+  #   app.kubernetes.io/instance: immich
+  #   app.kubernetes.io/name:     server
+  # (vs the per-app pattern most charts use).
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/instance: immich
+      app.kubernetes.io/name: server
+  # Additive — default-deny is what triggers the lockdown.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal envoy gateway → immich-server:2283
+    # (photos.${SECRET_DOMAIN}).
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "2283"
+              protocol: TCP
+    # ServiceMonitor scrape from observability/prometheus is already
+    # covered by the baseline allow-monitoring-scrape — no rule needed.
+  egress:
+    # CNPG: postgres-immich in databases ns (Pattern B).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
+            cnpg.io/cluster: postgres-immich
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+    # Dragonfly (Redis) in databases ns.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
+            app.kubernetes.io/name: dragonfly
+      toPorts:
+        - ports:
+            - port: "6379"
+              protocol: TCP
+    # Intra-ns: immich-server → immich-machine-learning:3003 is covered
+    # by baseline allow-intra-namespace.
+    # External: reverse-geocoding (Mapbox tile servers), Authelia OIDC
+    # discovery, version checks, app push (Firebase), thumbnail
+    # off-loads. Mapbox/tile FQDN set churns; world keeps it stable.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+            - port: "80"
+              protocol: TCP
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: immich-machine-learning-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/instance: immich
+      app.kubernetes.io/name: machine-learning
+  # Additive — default-deny is what triggers the lockdown. Intra-ns
+  # ingress from immich-server (:3003) is covered by baseline.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  egress:
+    # External: HuggingFace model downloads (CLIP ViT-SO400M-16-SigLIP2,
+    # antelopev2 face model) cached to immich-machine-learning-cache PVC
+    # on first run + on model config changes. Plus general HF CDN
+    # (cdn-lfs, huggingface.co).
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: immich-offsite-backup-allow
+spec:
+  # The immich-offsite-backup CronJob is a raw batch/v1 CronJob (NOT
+  # via app-template), so its Job-spawned pods carry only the
+  # auto-generated batch labels — no app.kubernetes.io/* labels.
+  # Cilium endpointSelector can't regex on label values, so we select
+  # the union of "is a Job pod" AND "has no app.kubernetes.io/name
+  # set". The only raw-CronJob pods in media that match this are
+  # immich-offsite-backup-* and immichkiosk-transcode-* — both need
+  # external egress (S3 and immich-server, respectively). All other
+  # Job-based workloads (beets, recyclarr, lidarr-bridge) ARE
+  # app-template-based and carry app.kubernetes.io/name, so they
+  # don't match here and instead get their own per-app CNP.
+  endpointSelector:
+    matchExpressions:
+      - key: job-name
+        operator: Exists
+      - key: app.kubernetes.io/name
+        operator: DoesNotExist
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  egress:
+    # External: rclone sync to crypt:* on AWS S3 (encrypted backend
+    # over the public S3 endpoint). Plus immichkiosk-transcode hits
+    # immich-server intra-ns (covered by baseline allow-intra-namespace)
+    # and curl pulls alpine apk packages from dl-cdn.alpinelinux.org.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+            - port: "80"
+              protocol: TCP
+    # In-cluster: rclone → garage S3 API via the cluster Service name
+    # garage.storage.svc.cluster.local:3900 (rclone.conf points at
+    # the in-cluster name, not the FQDN).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: storage
+            app.kubernetes.io/name: garage
+      toPorts:
+        - ports:
+            - port: "3900"
+              protocol: TCP

--- a/kubernetes/apps/media/immich/app/kustomization.yaml
+++ b/kubernetes/apps/media/immich/app/kustomization.yaml
@@ -3,6 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./cnp-allow.yaml
   - ./cronjob-offsite-backup.yaml
   - ./externalsecret-offsite-backup.yaml
   - ./externalsecret.yaml

--- a/kubernetes/apps/media/immichkiosk/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/immichkiosk/app/cnp-allow.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: immichkiosk-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: immichkiosk
+  # Additive — default-deny is what triggers the lockdown. Egress to
+  # immich-server (same ns, :2283) covered by baseline.
+  # The sister CronJob `immichkiosk-transcode` is a raw batch/v1 (no
+  # app.kubernetes.io/* labels) and is covered by the
+  # immich-offsite-backup-allow CNP in immich/app/cnp-allow.yaml which
+  # matches all label-less Job pods in this namespace.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal envoy gateway → immichkiosk:3000.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "3000"
+              protocol: TCP

--- a/kubernetes/apps/media/immichkiosk/app/kustomization.yaml
+++ b/kubernetes/apps/media/immichkiosk/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./cronjob-transcode.yaml
   - ./externalsecret-transcode.yaml
   - ./externalsecret.yaml

--- a/kubernetes/apps/media/jellyfin/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/jellyfin/app/cnp-allow.yaml
@@ -1,0 +1,90 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: jellyfin-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: jellyfin
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # 1) HTTPRoute on internal envoy gateway → jellyfin:8096
+    #    (jellyfin.${SECRET_DOMAIN}).
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "8096"
+              protocol: TCP
+    # 2) Cilium LoadBalancer Service at 10.45.0.11:8096. LAN Kodi
+    #    clients (kodi-familyroom 192.168.1.11, etc.) and other LAN
+    #    consumers connect directly to the LB IP — these arrive at
+    #    the pod as `reserved:world`. Renee's primary playback path —
+    #    must remain reachable.
+    - fromEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "8096"
+              protocol: TCP
+    # 3) In-cluster callers (janitorr → /Users/MediaSegments, etc.)
+    #    reach jellyfin via cluster-DNS Service.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: media
+            app.kubernetes.io/name: janitorr
+      toPorts:
+        - ports:
+            - port: "8096"
+              protocol: TCP
+  egress:
+    # Metadata providers. Jellyfin reaches out for movie/show artwork,
+    # season metadata, theme music, etc. *arr metadata writers are OFF
+    # in this cluster (see project_media_writers_plan.md), so jellyfin
+    # is the canonical fetcher.
+    #
+    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
+    # pod DNS search-domain augmentation (pod queries
+    # `api.themoviedb.org.media.svc.cluster.local.` and the FQDN cache
+    # stores the augmented name; matchName misses it). Bare + `.*`
+    # matchPattern covers both forms — see PR #11492.
+    - toFQDNs:
+        # TheMovieDB
+        - matchPattern: "api.themoviedb.org"
+        - matchPattern: "api.themoviedb.org.*"
+        - matchPattern: "image.tmdb.org"
+        - matchPattern: "image.tmdb.org.*"
+        # Fanart.tv
+        - matchPattern: "webservice.fanart.tv"
+        - matchPattern: "webservice.fanart.tv.*"
+        - matchPattern: "assets.fanart.tv"
+        - matchPattern: "assets.fanart.tv.*"
+        # TheTVDB (jellyfin plugin)
+        - matchPattern: "api4.thetvdb.com"
+        - matchPattern: "api4.thetvdb.com.*"
+        - matchPattern: "artworks.thetvdb.com"
+        - matchPattern: "artworks.thetvdb.com.*"
+        # MusicBrainz / Cover Art Archive (music library)
+        - matchPattern: "musicbrainz.org"
+        - matchPattern: "musicbrainz.org.*"
+        - matchPattern: "coverartarchive.org"
+        - matchPattern: "coverartarchive.org.*"
+        # Jellyfin plugin manifest + repo
+        - matchPattern: "repo.jellyfin.org"
+        - matchPattern: "repo.jellyfin.org.*"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+  # NFS mounts (movies, music, television PVs on beast + brain) are
+  # opened by the kubelet at the host level, NOT by the pod. The
+  # underlying RPC traffic is host networking, so no pod-level egress
+  # rule is needed for NFS.

--- a/kubernetes/apps/media/jellyfin/app/kustomization.yaml
+++ b/kubernetes/apps/media/jellyfin/app/kustomization.yaml
@@ -6,6 +6,7 @@ components:
   - ../../../../components/repos/app-template
   - ../../../../components/theme-park
 resources:
+  - ./cnp-allow.yaml
   - ./helmrelease.yaml
   - ./longhorn-pvc.yaml
   - ./nfs-pvc.yaml

--- a/kubernetes/apps/media/kodi-playback-watcher/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/kodi-playback-watcher/app/cnp-allow.yaml
@@ -1,0 +1,37 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: kodi-playback-watcher-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: kodi-playback-watcher
+  # Additive — default-deny is what triggers the lockdown. Egress to
+  # av1corrector (same ns, :8000) is covered by baseline
+  # allow-intra-namespace.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  egress:
+    # External: kodi-familyroom is a LAN host (192.168.1.11).
+    # KPW reaches it via:
+    #   :9090 — Kodi JSON-RPC WebSocket (live playback events)
+    #   :22   — SSH for /storage/.kodi/temp/kodi.log tail fallback
+    # Allow toFQDNs against the DNS name `kodi-familyroom.thesteamedcrab.com`
+    # which resolves through external-dns to the LAN IP.
+    #
+    # Cilium 1.19 toFQDNs.matchName doesn't match search-domain
+    # augmentation — see PR #11492 for the bare + .* pattern.
+    - toFQDNs:
+        - matchPattern: "kodi-familyroom.thesteamedcrab.com"
+        - matchPattern: "kodi-familyroom.thesteamedcrab.com.*"
+        - matchPattern: "kodi-familyroom"
+        - matchPattern: "kodi-familyroom.*"
+      toPorts:
+        - ports:
+            - port: "9090"
+              protocol: TCP
+            - port: "22"
+              protocol: TCP

--- a/kubernetes/apps/media/kodi-playback-watcher/app/kustomization.yaml
+++ b/kubernetes/apps/media/kodi-playback-watcher/app/kustomization.yaml
@@ -7,4 +7,5 @@ components:
   - ../../../../components/repos/app-template
 
 resources:
+  - ./cnp-allow.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: media
 components:
   - ../../components/alerts
   - ../../components/network-policy/baseline
+  - ../../components/network-policy/default-deny
 resources:
   - ./namespace.yaml
   - ./priority-class.yaml

--- a/kubernetes/apps/media/lidarr-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/lidarr-oauth2-proxy/app/cnp-allow.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: lidarr-oauth2-proxy-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: lidarr-oauth2-proxy
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal envoy gateway → lidarr-oauth2-proxy:4180
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "4180"
+              protocol: TCP
+  egress:
+    # OIDC discovery + token exchange against Authelia (auth.${SECRET_DOMAIN}
+    # resolves to the internal envoy gateway VIP).
+    # Upstream → lidarr.media:8686 is same-ns (baseline covers).
+    #
+    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
+    # pod DNS search-domain augmentation — see PR #11492.
+    - toFQDNs:
+        - matchPattern: "auth.thesteamedcrab.com"
+        - matchPattern: "auth.thesteamedcrab.com.*"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/media/lidarr-oauth2-proxy/app/kustomization.yaml
+++ b/kubernetes/apps/media/lidarr-oauth2-proxy/app/kustomization.yaml
@@ -5,5 +5,6 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/media/lidarr/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/lidarr/app/cnp-allow.yaml
@@ -1,0 +1,72 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: lidarr-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: lidarr
+  # Additive — default-deny is what triggers the lockdown. Ingress on
+  # :8686 from lidarr-oauth2-proxy and from lidarr-bridge / soularr
+  # (same ns) is covered by baseline allow-intra-namespace.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # Cross-ns: prowlarr sync-app pushes indexer config into lidarr.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: downloads
+            app.kubernetes.io/name: prowlarr
+      toPorts:
+        - ports:
+            - port: "8686"
+              protocol: TCP
+  egress:
+    # CNPG: postgres-lidarr in databases ns (Pattern B).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
+            cnpg.io/cluster: postgres-lidarr
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+    # Cross-ns: download-client APIs in downloads ns (Pattern E).
+    #   sabnzbd:8080, qbittorrent:8080 (lidarr uses both depending on
+    #   release type — keep both even if currently sab-only).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: downloads
+            app.kubernetes.io/name: sabnzbd
+        - matchLabels:
+            io.kubernetes.pod.namespace: downloads
+            app.kubernetes.io/name: qbittorrent
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+    # Cross-ns: prowlarr indexer API in downloads ns.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: downloads
+            app.kubernetes.io/name: prowlarr
+      toPorts:
+        - ports:
+            - port: "9696"
+              protocol: TCP
+    # External metadata + indexer probes: lidarr fetches album metadata
+    # (MusicBrainz, lidarr-metadata API, etc.) and also probes/contacts
+    # indexers directly when prowlarr forwards search calls. Indexer
+    # surface is too large and rotates too often to enumerate per-FQDN
+    # — use `world` on 443/80.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+            - port: "80"
+              protocol: TCP

--- a/kubernetes/apps/media/lidarr/app/kustomization.yaml
+++ b/kubernetes/apps/media/lidarr/app/kustomization.yaml
@@ -6,6 +6,7 @@ components:
   - ../../../../components/repos/app-template
   - ../../../../components/theme-park
 resources:
+  - ./cnp-allow.yaml
   - ./dashboard
   - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/media/medialyze-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/medialyze-oauth2-proxy/app/cnp-allow.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: medialyze-oauth2-proxy-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: medialyze-oauth2-proxy
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal envoy gateway → medialyze-oauth2-proxy:4180
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "4180"
+              protocol: TCP
+  egress:
+    # OIDC discovery + token exchange against Authelia (auth.${SECRET_DOMAIN}
+    # resolves to the internal envoy gateway VIP).
+    # Upstream → medialyze.media:8080 is same-ns (baseline covers).
+    #
+    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
+    # pod DNS search-domain augmentation — see PR #11492.
+    - toFQDNs:
+        - matchPattern: "auth.thesteamedcrab.com"
+        - matchPattern: "auth.thesteamedcrab.com.*"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/media/medialyze-oauth2-proxy/app/kustomization.yaml
+++ b/kubernetes/apps/media/medialyze-oauth2-proxy/app/kustomization.yaml
@@ -5,5 +5,6 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/media/music-assistant-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/music-assistant-oauth2-proxy/app/cnp-allow.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: music-assistant-oauth2-proxy-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: music-assistant-oauth2-proxy
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal envoy gateway → music-assistant-oauth2-proxy:4180
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "4180"
+              protocol: TCP
+  egress:
+    # OIDC discovery + token exchange against Authelia (auth.${SECRET_DOMAIN}
+    # resolves to the internal envoy gateway VIP).
+    # Upstream → music-assistant.media:8095 is same-ns (baseline covers).
+    #
+    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
+    # pod DNS search-domain augmentation — see PR #11492.
+    - toFQDNs:
+        - matchPattern: "auth.thesteamedcrab.com"
+        - matchPattern: "auth.thesteamedcrab.com.*"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/media/music-assistant-oauth2-proxy/app/kustomization.yaml
+++ b/kubernetes/apps/media/music-assistant-oauth2-proxy/app/kustomization.yaml
@@ -5,5 +5,6 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/media/music-assistant/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/music-assistant/app/cnp-allow.yaml
@@ -1,0 +1,43 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: music-assistant-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: music-assistant
+  # Additive — default-deny is what triggers the lockdown. Ingress from
+  # music-assistant-oauth2-proxy (same ns, :8095 upstream) is covered by
+  # baseline allow-intra-namespace.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # LoadBalancer Service at 10.45.0.20 exposes :1780 (HTTP2 streaming)
+    # and :1704 (Snapserver) directly to LAN clients (sonos, snapcast,
+    # HA media_player, etc.). These arrive from `reserved:world`.
+    - fromEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "1780"
+              protocol: TCP
+            - port: "1704"
+              protocol: TCP
+            - port: "8095"
+              protocol: TCP
+  egress:
+    # External: Spotify, Tidal, Apple Music, Sonos cloud APIs, plus
+    # mDNS-style LAN discovery to local devices (Sonos, Chromecast,
+    # AirPlay). Provider set + LAN device set both rotate; world keeps
+    # the policy maintenance-free.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+            - port: "80"
+              protocol: TCP

--- a/kubernetes/apps/media/music-assistant/app/kustomization.yaml
+++ b/kubernetes/apps/media/music-assistant/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./helmrelease.yaml
   - ./longhorn-pvc.yaml
   - ./nfs-pvc.yaml

--- a/kubernetes/apps/media/radarr-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/radarr-oauth2-proxy/app/cnp-allow.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: radarr-oauth2-proxy-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: radarr-oauth2-proxy
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal envoy gateway → radarr-oauth2-proxy:4180
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "4180"
+              protocol: TCP
+  egress:
+    # OIDC discovery + token exchange against Authelia (auth.${SECRET_DOMAIN}
+    # resolves to the internal envoy gateway VIP).
+    # Upstream → radarr.media:7878 is same-ns (baseline covers).
+    #
+    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
+    # pod DNS search-domain augmentation — see PR #11492.
+    - toFQDNs:
+        - matchPattern: "auth.thesteamedcrab.com"
+        - matchPattern: "auth.thesteamedcrab.com.*"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/media/radarr-oauth2-proxy/app/kustomization.yaml
+++ b/kubernetes/apps/media/radarr-oauth2-proxy/app/kustomization.yaml
@@ -5,5 +5,6 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/media/radarr/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/radarr/app/cnp-allow.yaml
@@ -1,0 +1,68 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: radarr-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: radarr
+  # Additive — default-deny is what triggers the lockdown. Ingress on
+  # :7878 from radarr-oauth2-proxy (same ns) is covered by baseline
+  # allow-intra-namespace.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # Cross-ns: prowlarr sync-app pushes indexer config; janitorr +
+    # seerr + suggestarr call radarr API to add/list/remove movies.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: downloads
+            app.kubernetes.io/name: prowlarr
+      toPorts:
+        - ports:
+            - port: "7878"
+              protocol: TCP
+  egress:
+    # CNPG: postgres-radarr in databases ns (Pattern B).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
+            cnpg.io/cluster: postgres-radarr
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+    # Cross-ns: download-client APIs in downloads ns (Pattern E).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: downloads
+            app.kubernetes.io/name: sabnzbd
+        - matchLabels:
+            io.kubernetes.pod.namespace: downloads
+            app.kubernetes.io/name: qbittorrent
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+    # Cross-ns: prowlarr indexer API in downloads ns.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: downloads
+            app.kubernetes.io/name: prowlarr
+      toPorts:
+        - ports:
+            - port: "9696"
+              protocol: TCP
+    # External metadata + indexer probes (TMDb, IMDb, trakt, indexer
+    # surface). Indexer set rotates; world on 443/80.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+            - port: "80"
+              protocol: TCP

--- a/kubernetes/apps/media/radarr/app/kustomization.yaml
+++ b/kubernetes/apps/media/radarr/app/kustomization.yaml
@@ -6,6 +6,7 @@ components:
   - ../../../../components/repos/app-template
   - ../../../../components/theme-park
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./longhorn-pvc.yaml

--- a/kubernetes/apps/media/recyclarr/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/recyclarr/app/cnp-allow.yaml
@@ -1,0 +1,34 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: recyclarr-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: recyclarr
+  # Additive — default-deny is what triggers the lockdown. Egress to
+  # sonarr/radarr in same ns is covered by baseline allow-intra-namespace.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  egress:
+    # External: clones github.com/recyclarr/config-templates (trash-guides
+    # JSON snapshots) at the start of each `recyclarr sync` run.
+    # github.com FQDN cache + .* augmentation per PR #11492.
+    - toFQDNs:
+        - matchPattern: "github.com"
+        - matchPattern: "github.com.*"
+        - matchPattern: "*.github.com"
+        - matchPattern: "*.github.com.*"
+        - matchPattern: "raw.githubusercontent.com"
+        - matchPattern: "raw.githubusercontent.com.*"
+        - matchPattern: "codeload.github.com"
+        - matchPattern: "codeload.github.com.*"
+        - matchPattern: "objects.githubusercontent.com"
+        - matchPattern: "objects.githubusercontent.com.*"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/media/recyclarr/app/kustomization.yaml
+++ b/kubernetes/apps/media/recyclarr/app/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: media
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
 configMapGenerator:

--- a/kubernetes/apps/media/romm/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/romm/app/cnp-allow.yaml
@@ -1,0 +1,47 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: romm-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: romm
+  # Additive — default-deny is what triggers the lockdown.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal envoy gateway → romm:8080.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+  egress:
+    # CNPG: postgres-romm in databases ns (Pattern B). The init-db
+    # postgres-init initContainer also needs this on cold start.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
+            cnpg.io/cluster: postgres-romm
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+    # External: 7+ ROM metadata providers (IGDB, TheGamesDB, Flashpoint,
+    # HLTB, Hasheous, Launchbox, PlayMatch, etc.), Switch titleDB
+    # updates, MAME XML feed. Provider set rotates; world keeps the
+    # policy maintenance-free.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+            - port: "80"
+              protocol: TCP

--- a/kubernetes/apps/media/romm/app/kustomization.yaml
+++ b/kubernetes/apps/media/romm/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./longhorn-pvc.yaml

--- a/kubernetes/apps/media/seerr/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/seerr/app/cnp-allow.yaml
@@ -1,0 +1,40 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: seerr-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: seerr
+  # Additive — default-deny is what triggers the lockdown. Seerr's
+  # HTTPRoute targets the seerr Service directly (no oauth2-proxy
+  # sidecar) — ingress from envoy lands here. Egress to intra-ns
+  # sonarr/radarr/jellyfin/janitorr is covered by baseline.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal envoy gateway → seerr:5055
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "5055"
+              protocol: TCP
+  egress:
+    # External metadata APIs: TMDb, Trakt, Plex.tv (login), TheTVDB,
+    # Jellyfin OAuth provider Discord webhook integrations, push
+    # notification providers, etc. Surface is too large to enumerate;
+    # world on 443/80.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+            - port: "80"
+              protocol: TCP

--- a/kubernetes/apps/media/seerr/app/kustomization.yaml
+++ b/kubernetes/apps/media/seerr/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./ceph-pvc.yaml
   - ./helmrelease.yaml
   - ./longhorn-pvc.yaml

--- a/kubernetes/apps/media/sonarr-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/sonarr-oauth2-proxy/app/cnp-allow.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: sonarr-oauth2-proxy-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: sonarr-oauth2-proxy
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal envoy gateway → sonarr-oauth2-proxy:4180
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "4180"
+              protocol: TCP
+  egress:
+    # OIDC discovery + token exchange against Authelia (auth.${SECRET_DOMAIN}
+    # resolves to the internal envoy gateway VIP).
+    # Upstream → sonarr.media:8989 is same-ns (baseline covers).
+    #
+    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
+    # pod DNS search-domain augmentation — see PR #11492.
+    - toFQDNs:
+        - matchPattern: "auth.thesteamedcrab.com"
+        - matchPattern: "auth.thesteamedcrab.com.*"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/media/sonarr-oauth2-proxy/app/kustomization.yaml
+++ b/kubernetes/apps/media/sonarr-oauth2-proxy/app/kustomization.yaml
@@ -5,5 +5,6 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/media/sonarr/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/sonarr/app/cnp-allow.yaml
@@ -1,0 +1,66 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: sonarr-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: sonarr
+  # Additive — default-deny is what triggers the lockdown. Ingress on
+  # :8989 from sonarr-oauth2-proxy (same ns) is covered by baseline
+  # allow-intra-namespace.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # Cross-ns: prowlarr sync-app + janitorr + seerr/suggestarr push/poll.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: downloads
+            app.kubernetes.io/name: prowlarr
+      toPorts:
+        - ports:
+            - port: "8989"
+              protocol: TCP
+  egress:
+    # CNPG: postgres-sonarr in databases ns (Pattern B).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
+            cnpg.io/cluster: postgres-sonarr
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+    # Cross-ns: download-client APIs in downloads ns (Pattern E).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: downloads
+            app.kubernetes.io/name: sabnzbd
+        - matchLabels:
+            io.kubernetes.pod.namespace: downloads
+            app.kubernetes.io/name: qbittorrent
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+    # Cross-ns: prowlarr indexer API in downloads ns.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: downloads
+            app.kubernetes.io/name: prowlarr
+      toPorts:
+        - ports:
+            - port: "9696"
+              protocol: TCP
+    # External metadata + indexer probes (TVDB, trakt, indexer surface).
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+            - port: "80"
+              protocol: TCP

--- a/kubernetes/apps/media/sonarr/app/kustomization.yaml
+++ b/kubernetes/apps/media/sonarr/app/kustomization.yaml
@@ -6,6 +6,7 @@ components:
   - ../../../../components/repos/app-template
   - ../../../../components/theme-park
 resources:
+  - ./cnp-allow.yaml
   - ./dashboard
   - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/media/soularr-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/soularr-oauth2-proxy/app/cnp-allow.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: soularr-oauth2-proxy-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: soularr-oauth2-proxy
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal envoy gateway → soularr-oauth2-proxy:4180
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "4180"
+              protocol: TCP
+  egress:
+    # OIDC discovery + token exchange against Authelia (auth.${SECRET_DOMAIN}
+    # resolves to the internal envoy gateway VIP).
+    # Upstream → soularr.media:1000 is same-ns (baseline covers).
+    #
+    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
+    # pod DNS search-domain augmentation — see PR #11492.
+    - toFQDNs:
+        - matchPattern: "auth.thesteamedcrab.com"
+        - matchPattern: "auth.thesteamedcrab.com.*"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/media/soularr-oauth2-proxy/app/kustomization.yaml
+++ b/kubernetes/apps/media/soularr-oauth2-proxy/app/kustomization.yaml
@@ -5,5 +5,6 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/media/soularr/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/soularr/app/cnp-allow.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: soularr-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: soularr
+  # Additive — default-deny is what triggers the lockdown. Ingress on
+  # :1000 from soularr-oauth2-proxy (same ns) and egress to lidarr in
+  # this ns are both covered by baseline allow-intra-namespace.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  egress:
+    # Cross-ns: slskd API in downloads ns (Pattern E). Soularr orchestrates
+    # Lidarr → Soulseek searches by calling the slskd HTTP API.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: downloads
+            app.kubernetes.io/name: slskd
+      toPorts:
+        - ports:
+            - port: "5030"
+              protocol: TCP

--- a/kubernetes/apps/media/soularr/app/kustomization.yaml
+++ b/kubernetes/apps/media/soularr/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./longhorn-pvc.yaml

--- a/kubernetes/apps/media/stash/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/stash/app/cnp-allow.yaml
@@ -1,0 +1,37 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: stash-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: stash
+  # Additive — default-deny is what triggers the lockdown. Stash has
+  # native OIDC against Authelia (STASH_OIDC_ISSUER) — no oauth2-proxy
+  # sidecar.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal envoy gateway → stash:9999.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "9999"
+              protocol: TCP
+  egress:
+    # OIDC against Authelia. Plus stash-box/scrapers reach many
+    # external metadata providers — scraper plugin set rotates often.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+            - port: "80"
+              protocol: TCP

--- a/kubernetes/apps/media/stash/app/kustomization.yaml
+++ b/kubernetes/apps/media/stash/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - cnp-allow.yaml
   - externalsecret.yaml
   - helmrelease.yaml
   - longhorn-pvc.yaml

--- a/kubernetes/apps/media/suggestarr-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/suggestarr-oauth2-proxy/app/cnp-allow.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: suggestarr-oauth2-proxy-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: suggestarr-oauth2-proxy
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal envoy gateway → suggestarr-oauth2-proxy:4180
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "4180"
+              protocol: TCP
+  egress:
+    # OIDC discovery + token exchange against Authelia (auth.${SECRET_DOMAIN}
+    # resolves to the internal envoy gateway VIP).
+    # Upstream → suggestarr.media:5000 is same-ns (baseline covers).
+    #
+    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
+    # pod DNS search-domain augmentation — see PR #11492.
+    - toFQDNs:
+        - matchPattern: "auth.thesteamedcrab.com"
+        - matchPattern: "auth.thesteamedcrab.com.*"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/media/suggestarr-oauth2-proxy/app/kustomization.yaml
+++ b/kubernetes/apps/media/suggestarr-oauth2-proxy/app/kustomization.yaml
@@ -5,5 +5,6 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/media/suggestarr/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/suggestarr/app/cnp-allow.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: suggestarr-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: suggestarr
+  # Additive — default-deny is what triggers the lockdown. Ingress on
+  # :5000 from suggestarr-oauth2-proxy (same ns) and egress to intra-ns
+  # sonarr/radarr/seerr are both covered by baseline allow-intra-namespace.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  egress:
+    # External metadata APIs (TMDb, Trakt, etc.) — surface too broad to
+    # enumerate per-FQDN.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+            - port: "80"
+              protocol: TCP

--- a/kubernetes/apps/media/suggestarr/app/kustomization.yaml
+++ b/kubernetes/apps/media/suggestarr/app/kustomization.yaml
@@ -6,5 +6,6 @@ components:
   - ../../../../components/repos/app-template
   - ../../../../components/theme-park
 resources:
+  - ./cnp-allow.yaml
   - ./helmrelease.yaml
   - ./longhorn-pvc.yaml

--- a/kubernetes/apps/media/theme-park/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/theme-park/app/cnp-allow.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: theme-park-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: theme-park
+  # Additive — default-deny is what triggers the lockdown. Theme-park
+  # is a static-asset web server (CSS/JS/font themes for *arr apps);
+  # no DB, no upstream APIs, no oauth2-proxy.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal envoy gateway → theme-park:8080.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP

--- a/kubernetes/apps/media/theme-park/app/kustomization.yaml
+++ b/kubernetes/apps/media/theme-park/app/kustomization.yaml
@@ -3,4 +3,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./cnp-allow.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/media/videodupfinder/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/videodupfinder/app/cnp-allow.yaml
@@ -1,0 +1,34 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: videodupfinder-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: videodupfinder
+  # Additive — default-deny is what triggers the lockdown.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal envoy gateway → videodupfinder:8000.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "8000"
+              protocol: TCP
+  egress:
+    # CNPG: postgres-videodupfinder in databases ns (Pattern B).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
+            cnpg.io/cluster: postgres-videodupfinder
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP

--- a/kubernetes/apps/media/videodupfinder/app/kustomization.yaml
+++ b/kubernetes/apps/media/videodupfinder/app/kustomization.yaml
@@ -7,5 +7,6 @@ components:
   - ../../../../components/repos/app-template
 
 resources:
+  - ./cnp-allow.yaml
   - ./helmrelease.yaml
   - ./nfs-pvc.yaml


### PR DESCRIPTION
## Summary

Drops default-deny CNP into the `media` namespace and adds per-app
`cnp-allow.yaml` overlays for every media-stack app. Direct-enforce
(no audit window). Composed around the existing downloads + vpn
lockdowns (#11505).

**Jellyfin remains reachable** — three ingress rules on :8096:
- `network/envoy` (HTTPRoute, `jellyfin.${SECRET_DOMAIN}`)
- `world` (LoadBalancer `10.45.0.11` for LAN Kodi clients — Renee's playback)
- `media/janitorr` (intra-ns API caller)

## Cross-ns flows preserved

- `media/{sonarr,radarr,lidarr,immich,immich-power-tools,romm,av1corrector,cutvideo,videodupfinder}` → `databases/postgres-{app}` (Pattern B)
- `media/immich-server` → `databases/dragonfly`
- `media/{sonarr,radarr,lidarr}` → `downloads/{prowlarr,qbittorrent,sabnzbd}` (Pattern E)
- `media/soularr` → `downloads/slskd`
- `media/immich-offsite-backup` (raw CronJob, label-less) → `storage/garage`
- `media/flaresolverr` ← `downloads/prowlarr` (cross-ns ingress)
- `media/kodi-playback-watcher` → `kodi-familyroom.thesteamedcrab.com` LAN host (toFQDNs)

External `world:443/:80` egress for the apps that need it (jellyfin uses precise FQDN allowlist for metadata; *arr stack uses broad world for indexer surface; gonic/music-assistant/seerr/suggestarr/beets/romm/stash/flaresolverr/recyclarr/immich-{server,ml,pet-tagger} per app needs).

`janitorr`, `lidarr-bridge`, `medialyze` get no per-app CNP — all flows intra-ns (baseline covers).

## Test plan

- [ ] Flux reconciles media namespace cleanly (no Failed Kustomizations)
- [ ] All media pods stay Ready
- [ ] Jellyfin HTTPRoute: `curl https://jellyfin.thesteamedcrab.com` → 200/302
- [ ] Jellyfin LoadBalancer (LAN path): `curl http://10.45.0.11:8096/System/Info/Public` → 200
- [ ] *arr ingresses: sonarr/radarr/lidarr UI loads via oauth2-proxy
- [ ] Immich ingress: `https://photos.thesteamedcrab.com` loads
- [ ] No CNP `Dropped` flows for legitimate traffic in Hubble for 10 min post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)