### PR TITLE
fix(network-policy): netbox CNP target pod:8080, not svc:80

### DIFF
--- a/kubernetes/apps/home/netbox/app/cnp-allow.yaml
+++ b/kubernetes/apps/home/netbox/app/cnp-allow.yaml
@@ -14,23 +14,26 @@ spec:
     egress: false
     ingress: false
   ingress:
-    # Internal HTTPRoute (envoy → netbox:80) — netbox UI + REST API.
+    # Internal HTTPRoute (envoy → netbox via svc:80 → pod:8080). Cilium
+    # L4 policy is evaluated against the target port on the pod, not
+    # the service port, so this allows :8080 (the actual pod listener).
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: network
             app.kubernetes.io/name: envoy
       toPorts:
         - ports:
-            - port: "80"
+            - port: "8080"
               protocol: TCP
-    # netbox-mcp in mcp-system queries the netbox REST API.
+    # netbox-mcp in mcp-system queries the netbox REST API via the same
+    # service:80 → pod:8080 path.
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: mcp-system
             app.kubernetes.io/name: netbox-mcp
       toPorts:
         - ports:
-            - port: "80"
+            - port: "8080"
               protocol: TCP
     # Prometheus metrics port 9090 — baseline allow-monitoring-scrape
     # already covers prometheus → any-port for endpoints in this ns.


### PR DESCRIPTION
## Summary

- Follow-up to #11511: netbox 503 because Cilium L4 policy evaluates pod target port (8080), not service port (80).
- netbox Service maps :80 → named targetPort `http` → pod:8080 (granian server). My initial CNP allowed envoy → netbox:80, leaving SYNs to :8080 dropped.

Symptom captured live via cilium-dbg monitor:

```
xx drop (Policy denied) flow 0x0 to endpoint 589, identity 47539->29679:
  10.42.8.193:45212 -> 10.42.7.61:8080 tcp SYN
```

Envoy returned 503 after 10s upstream timeout. netbox pod was healthy and serving :8080 internally (other observed traffic from intra-cluster sources).

## Test plan

- [ ] `curl -sk https://netbox.thesteamedcrab.com/` returns non-503 (200 / 302 to login).
- [ ] netbox-mcp queries still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)