### PR TITLE
fix(external-secrets): onepassword-connect egress toFQDNs → toEntities:world

### DIFF
--- a/kubernetes/apps/external-secrets/onepassword-connect/app/cnp-allow.yaml
+++ b/kubernetes/apps/external-secrets/onepassword-connect/app/cnp-allow.yaml
@@ -16,15 +16,19 @@ spec:
     egress: false
     ingress: false
   egress:
-    # 1Password Cloud (sync container only). Confirmed via Cilium FQDN
-    # cache 2026-05-17: only `my.1password.com` is resolved. The bare
-    # + `.*` dual-form matchPattern covers both un-augmented and
-    # search-domain-augmented forms (Cilium 1.19 matchName misses the
-    # augmented `my.1password.com.external-secrets.svc.cluster.local.`
-    # form per PR #11492 / #11499).
-    - toFQDNs:
-        - matchPattern: "my.1password.com"
-        - matchPattern: "my.1password.com.*"
+    # 1Password Cloud (sync container only). Was a toFQDNs allow-list
+    # for `my.1password.com`. Cilium 1.19 matchPattern's `.*` token
+    # expands to `[-a-zA-Z0-9_]*` (single DNS label) in the generated
+    # regex, so the dual-form `my.1password.com` + `my.1password.com.*`
+    # pattern doesn't match the search-domain-augmented form actually
+    # cached in this cluster:
+    #   `my.1password.com.external-secrets.svc.cluster.local.`
+    # (four trailing labels — see PR #11512 follow-up). Broadened to
+    # toEntities:world:443 so it actually works. Tighten when FQDN
+    # search-domain augmentation in Cilium policy is fixed upstream
+    # (track PR #11498 / mcp-system precedent).
+    - toEntities:
+        - world
       toPorts:
         - ports:
             - port: "443"


### PR DESCRIPTION
## Summary

Follow-up to PR #11512 fixing an active outage.

The dual-form matchPattern (`my.1password.com` + `my.1password.com.*`) doesn't match the actual search-domain-augmented FQDN cached in this cluster: \`my.1password.com.external-secrets.svc.cluster.local.\` (four trailing labels). Cilium 1.19's \`.*\` token expands to \`[-a-zA-Z0-9_]*\` in the generated regex — single DNS label only.

\`cilium fqdn names\` confirmed:
\`\`\`
selectorString: my.1password.com.* → regexString: ^my[.]1password[.]com[.][-a-zA-Z0-9_]*[.]$
\`\`\`

\`cilium monitor -t drop\` showed identity 28113 → world drops for 10.42.4.38 → {44.223.248.210,52.7.185.92,23.23.116.69}:443.

op-connect sync container errors: \`failed to GetOverview\` / \`failed to Connect to notifier\`. Result: every ExternalSecret across the cluster eventually went stale (op-connect cache age fixed).

Broadened to \`toEntities:world:443\` matching precedent set in PR #11498 (mcp-system) and PR #11499 (retained-broad).

## Test plan

- [ ] op-connect sync container: \`kubectl logs\` shows no GetOverview / notifier errors.
- [ ] ExternalSecret refreshTime continues advancing in all namespaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)