### PR TITLE
fix(network-policy): permit collab/open-webui → ai/{ollama,langgraph-agents}

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/cnp-allow.yaml
@@ -18,10 +18,15 @@ spec:
     # (agents.${SECRET_DOMAIN}). n8n's approval-receive workflow also
     # POSTs here, but that traffic still arrives via the internal
     # Envoy gateway (n8n → HTTPRoute → envoy → langgraph-agents).
+    # collab/open-webui hits the in-cluster Service directly via
+    # OPENAI_API_BASE_URLS (each agent id registered as a model).
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: network
             app.kubernetes.io/name: envoy
+        - matchLabels:
+            io.kubernetes.pod.namespace: collab
+            app.kubernetes.io/name: open-webui
       toPorts:
         - ports:
             - port: "8765"

--- a/kubernetes/apps/ai/ollama/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/ollama/app/cnp-allow.yaml
@@ -27,7 +27,7 @@ spec:
     # Cross-ns callers observed via Hubble + helmrelease survey:
     #   home/home-assistant   — voice assist / conversation agent
     #   media/suggestarr      — LLM-driven recommendation enrichment
-    #   collab/* (paperless-ai indirect via ai/paperless-ai; not direct)
+    #   collab/open-webui     — primary OLLAMA_BASE_URL
     #   mcp-system/*          — some MCP servers may proxy ollama calls
     # Intra-ns callers (kubeclaw-gateway, langgraph-agents, khoj,
     # comfyui prompt eval) are covered by baseline allow-intra-namespace.
@@ -38,6 +38,9 @@ spec:
         - matchLabels:
             io.kubernetes.pod.namespace: media
             app.kubernetes.io/name: suggestarr
+        - matchLabels:
+            io.kubernetes.pod.namespace: collab
+            app.kubernetes.io/name: open-webui
         - matchLabels:
             io.kubernetes.pod.namespace: mcp-system
       toPorts:


### PR DESCRIPTION
## Summary
Follow-up to #11513. open-webui timed out reaching `ai/ollama:11434` and `ai/langgraph-agents:8765` after the collab lockdown — both go cross-ns via cluster DNS (not via the envoy gateway), and neither ai-side CNP listed `collab/open-webui` as a permitted source.

Add `collab/open-webui` to the `fromEndpoints` selector on both `ollama-allow` and `langgraph-agents-allow`. Outbound side from open-webui was already declared in its own `cnp-allow.yaml` in #11513.

## Test plan
- [ ] After merge, `kubectl exec -n collab open-webui-0 -- curl http://ollama.ai:11434/` returns 200
- [ ] `kubectl exec -n collab open-webui-0 -- curl http://langgraph-agents.ai:8765/` returns a response (not timeout)
- [ ] open-webui chat works end-to-end against both backends