### PR TITLE
feat(network-policy): lock down observability namespace

### DIFF
--- a/kubernetes/apps/observability/exporters/blackbox-exporter/app/cnp-allow.yaml
+++ b/kubernetes/apps/observability/exporters/blackbox-exporter/app/cnp-allow.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: blackbox-exporter-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus-blackbox-exporter
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  # No additional ingress: Prometheus scrapes blackbox at /metrics
+  # via the baseline allow-monitoring-scrape rule, and probe results
+  # are pulled from Prometheus (which calls /probe?target=… on the
+  # same port).
+  egress:
+    # Blackbox probes LAN hosts (~60 devices: cameras, UPSes, iDRAC,
+    # ESPHome devices, WLED, Roborock, Kodi, voice satellites, NFS
+    # servers, etc.) with ICMP + tcp_connect + http_2xx modules.
+    # Targets are short LAN hostnames resolved via DNS to RFC1918
+    # addresses scattered across the home LAN — `world` is the
+    # simplest correct identity here (LAN-only because there's no
+    # default route to public internet at the pod level after this
+    # policy). Future tightening could restrict to ICMP + a small
+    # TCP/HTTP port set but the surface is wide and stable.
+    - toEntities:
+        - world
+        - host
+        - remote-node

--- a/kubernetes/apps/observability/exporters/blackbox-exporter/app/kustomization.yaml
+++ b/kubernetes/apps/observability/exporters/blackbox-exporter/app/kustomization.yaml
@@ -3,6 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./cnp-allow.yaml
   - ./helmrelease.yaml
   - ./httproute.yaml
   - ./ocirepository.yaml

--- a/kubernetes/apps/observability/exporters/mqtt-exporter/app/cnp-allow.yaml
+++ b/kubernetes/apps/observability/exporters/mqtt-exporter/app/cnp-allow.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: mqtt-exporter-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: mqtt-exporter
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  egress:
+    # emqx MQTT broker in home ns. Container env points at
+    # `emqx-headless.home.svc.cluster.local`. Default MQTT TCP port
+    # 1883 (no TLS) — verified container env is bare `MQTT_ADDRESS`
+    # with no port (defaults to 1883).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: home
+            app.kubernetes.io/name: emqx
+      toPorts:
+        - ports:
+            - port: "1883"
+              protocol: TCP

--- a/kubernetes/apps/observability/exporters/mqtt-exporter/app/kustomization.yaml
+++ b/kubernetes/apps/observability/exporters/mqtt-exporter/app/kustomization.yaml
@@ -5,5 +5,6 @@ kind: Kustomization
 components:
   - ../../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/observability/exporters/omada-exporter/app/cnp-allow.yaml
+++ b/kubernetes/apps/observability/exporters/omada-exporter/app/cnp-allow.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: omada-exporter-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: omada-exporter
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  egress:
+    # Omada controller on brain (LAN host, NOT in cluster). URL is
+    # `https://brain:8043` from `omada-exporter-secret`. brain is the
+    # home router and resolves to a RFC1918 LAN address; route is via
+    # node network. `world` is the right Cilium identity for an
+    # off-cluster LAN host.
+    - toEntities:
+        - world
+        - host
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "8043"
+              protocol: TCP

--- a/kubernetes/apps/observability/exporters/omada-exporter/app/kustomization.yaml
+++ b/kubernetes/apps/observability/exporters/omada-exporter/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 components:
   - ../../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./dashboard
   - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/observability/exporters/snmp-exporter/app/apc-ups/cnp-allow.yaml
+++ b/kubernetes/apps/observability/exporters/snmp-exporter/app/apc-ups/cnp-allow.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: snmp-exporter-apc-ups-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/instance: snmp-exporter-apc-ups
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  egress:
+    # SNMP polling against APC UPS network management cards at
+    # 192.168.5.36 (ups-1500) and 192.168.5.65 (ups-3000). LAN hosts,
+    # not cluster identities → `world`. SNMP is UDP port 161.
+    - toEntities:
+        - world
+        - host
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "161"
+              protocol: UDP

--- a/kubernetes/apps/observability/exporters/snmp-exporter/app/apc-ups/kustomization.yaml
+++ b/kubernetes/apps/observability/exporters/snmp-exporter/app/apc-ups/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+  - ./cnp-allow.yaml
   - ./helmrelease.yaml
   - ./prometheusrule.yaml
 configMapGenerator:

--- a/kubernetes/apps/observability/exporters/snmp-exporter/app/dell-idrac/cnp-allow.yaml
+++ b/kubernetes/apps/observability/exporters/snmp-exporter/app/dell-idrac/cnp-allow.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: snmp-exporter-dell-idrac-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/instance: snmp-exporter-dell-idrac
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  egress:
+    # SNMP polling against beast's iDRAC at 192.168.1.22 (LAN host,
+    # not in cluster). SNMP is UDP port 161.
+    - toEntities:
+        - world
+        - host
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "161"
+              protocol: UDP

--- a/kubernetes/apps/observability/exporters/snmp-exporter/app/dell-idrac/kustomization.yaml
+++ b/kubernetes/apps/observability/exporters/snmp-exporter/app/dell-idrac/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+  - ./cnp-allow.yaml
   - ./dashboard
   - ./helmrelease.yaml
 configMapGenerator:

--- a/kubernetes/apps/observability/goldilocks-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/observability/goldilocks-oauth2-proxy/app/cnp-allow.yaml
@@ -1,0 +1,36 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: goldilocks-oauth2-proxy-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: goldilocks-oauth2-proxy
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal gateway → goldilocks-oauth2-proxy:4180.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "4180"
+              protocol: TCP
+  egress:
+    # OIDC discovery + token exchange against Authelia.
+    # Upstream → goldilocks-dashboard:80 is intra-ns; baseline covers.
+    #
+    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
+    # pod DNS search-domain augmentation — bare + `.*` dual-form.
+    - toFQDNs:
+        - matchPattern: "auth.thesteamedcrab.com"
+        - matchPattern: "auth.thesteamedcrab.com.*"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/observability/goldilocks-oauth2-proxy/app/kustomization.yaml
+++ b/kubernetes/apps/observability/goldilocks-oauth2-proxy/app/kustomization.yaml
@@ -5,5 +5,6 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/observability/grafana/app/cnp-allow.yaml
+++ b/kubernetes/apps/observability/grafana/app/cnp-allow.yaml
@@ -1,0 +1,65 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: grafana-allow
+spec:
+  # Grafana Deployment pods carry `app.kubernetes.io/name: grafana`.
+  # The image-renderer Deployment carries `app.kubernetes.io/name:
+  # grafana-image-renderer` — fronted via grafana intra-ns, so no
+  # separate ingress rule needed for it.
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: grafana
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal gateway → grafana:3000 (web UI).
+    # Anonymous-admin is enabled; gateway terminates TLS.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "3000"
+              protocol: TCP
+  egress:
+    # Postgres datasource: home_assistant DB via CNPG cluster
+    # `postgres-home-assistant` in databases ns (Pattern B).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
+            cnpg.io/cluster: postgres-home-assistant
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+    # Dashboard provisioning from external URLs at startup +
+    # provisioner reconcile (cert-manager, cnpg, flux, dcgm, repo's
+    # own raw.githubusercontent.com home_assistant + power JSONs).
+    # Also covers grafana.com plugin downloads, grafana.com gnetId
+    # dashboard fetches, and grafana.com news feed (disabled in
+    # values but the client still ranges over default URLs at boot).
+    #
+    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
+    # pod DNS search-domain augmentation — bare + `.*` dual-form
+    # matchPattern handles both un-augmented and search-domain-
+    # augmented forms.
+    - toFQDNs:
+        - matchPattern: "raw.githubusercontent.com"
+        - matchPattern: "raw.githubusercontent.com.*"
+        - matchPattern: "grafana.com"
+        - matchPattern: "grafana.com.*"
+        - matchPattern: "*.grafana.com"
+        - matchPattern: "*.grafana.com.*"
+        - matchPattern: "grafana.net"
+        - matchPattern: "grafana.net.*"
+        - matchPattern: "storage.googleapis.com"
+        - matchPattern: "storage.googleapis.com.*"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/observability/grafana/app/kustomization.yaml
+++ b/kubernetes/apps/observability/grafana/app/kustomization.yaml
@@ -3,6 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./helmrepository.yaml

--- a/kubernetes/apps/observability/holmesgpt-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/observability/holmesgpt-oauth2-proxy/app/cnp-allow.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: holmesgpt-oauth2-proxy-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: holmesgpt-oauth2-proxy
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal gateway → holmesgpt-oauth2-proxy:4180.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "4180"
+              protocol: TCP
+  egress:
+    # OIDC discovery + token exchange against Authelia.
+    # auth.${SECRET_DOMAIN} resolves to the internal Envoy gateway VIP,
+    # which then routes to the auth namespace.
+    # Upstream → holmesgpt.observability.svc.cluster.local:8080 is
+    # intra-ns; baseline allow-intra-namespace covers that path.
+    #
+    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
+    # pod DNS search-domain augmentation — bare + `.*` dual-form.
+    - toFQDNs:
+        - matchPattern: "auth.thesteamedcrab.com"
+        - matchPattern: "auth.thesteamedcrab.com.*"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/observability/holmesgpt-oauth2-proxy/app/kustomization.yaml
+++ b/kubernetes/apps/observability/holmesgpt-oauth2-proxy/app/kustomization.yaml
@@ -5,5 +5,6 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/observability/holmesgpt/app/cnp-allow.yaml
+++ b/kubernetes/apps/observability/holmesgpt/app/cnp-allow.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: holmesgpt-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: holmesgpt
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  # No ingress rules needed: holmesgpt-oauth2-proxy is the only door,
+  # and baseline allow-intra-namespace already permits that path. The
+  # n8n webhook in `home` ns reaches holmesgpt via its oauth2-proxy
+  # (gateway path + cross-ns auth-bearing call) — see Pattern A.
+  egress:
+    # LLM backend — ollama in ai ns (Pattern E).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: ai
+            app.kubernetes.io/name: ollama
+      toPorts:
+        - ports:
+            - port: "11434"
+              protocol: TCP
+    # HolmesGPT investigates k8s resources at runtime — needs to query
+    # prometheus + alertmanager + loki (intra-ns; baseline covers) and
+    # the apiserver (baseline covers). No external egress required.

--- a/kubernetes/apps/observability/holmesgpt/app/kustomization.yaml
+++ b/kubernetes/apps/observability/holmesgpt/app/kustomization.yaml
@@ -5,5 +5,6 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./helmrelease.yaml
   - ./rbac.yaml

--- a/kubernetes/apps/observability/kromgo/app/cnp-allow.yaml
+++ b/kubernetes/apps/observability/kromgo/app/cnp-allow.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: kromgo-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: kromgo
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on external gateway → kromgo:8080 (no oauth2-proxy,
+    # exposes a curated subset of Prometheus queries publicly for
+    # external dashboards / glance widgets).
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+  # Egress: prometheus query API at
+  # `kube-prometheus-stack-prometheus.observability.svc:9090` —
+  # intra-ns, covered by baseline allow-intra-namespace.

--- a/kubernetes/apps/observability/kromgo/app/kustomization.yaml
+++ b/kubernetes/apps/observability/kromgo/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./helmrelease.yaml
 configMapGenerator:
   - files:

--- a/kubernetes/apps/observability/kube-ops-view-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/observability/kube-ops-view-oauth2-proxy/app/cnp-allow.yaml
@@ -1,0 +1,36 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: kube-ops-view-oauth2-proxy-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: kube-ops-view-oauth2-proxy
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal gateway → kube-ops-view-oauth2-proxy:4180.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "4180"
+              protocol: TCP
+  egress:
+    # OIDC discovery + token exchange against Authelia.
+    # Upstream → kube-ops-view:8080 is intra-ns; baseline covers.
+    #
+    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
+    # pod DNS search-domain augmentation — bare + `.*` dual-form.
+    - toFQDNs:
+        - matchPattern: "auth.thesteamedcrab.com"
+        - matchPattern: "auth.thesteamedcrab.com.*"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/observability/kube-ops-view-oauth2-proxy/app/kustomization.yaml
+++ b/kubernetes/apps/observability/kube-ops-view-oauth2-proxy/app/kustomization.yaml
@@ -5,5 +5,6 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/cnp-allow.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/cnp-allow.yaml
@@ -1,0 +1,124 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: prometheus-allow
+spec:
+  # Prometheus StatefulSet pods carry `app.kubernetes.io/name: prometheus`.
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it. Baseline covers kube-apiserver, DNS, host
+  # probes, intra-namespace, and the universal `allow-monitoring-scrape`
+  # ingress.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal gateway → prometheus:9090 (web UI / API).
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "9090"
+              protocol: TCP
+  egress:
+    # Prometheus scrapes every namespace's metrics endpoints, plus
+    # kubelet/cAdvisor on every node, plus the kubeApiServer endpoints
+    # listed in the chart values (192.168.{1,4}.{9,10}). Enumerating
+    # all scrape targets is impossible at the policy layer — they
+    # span every pod CIDR, every node, every static endpoint in the
+    # SNMP/blackbox/probe configs.
+    #
+    # cluster: any pod identity in the k8s cluster (covers all
+    #   ServiceMonitor + PodMonitor + Probe targets that resolve to
+    #   pods).
+    # remote-node: cross-node kubelet :10250 + node-exporter :9100 via
+    #   nodeIP path on workers other than the prom pod's host.
+    # host: same as remote-node but for the pod's own node (kubelet
+    #   on localhost).
+    - toEntities:
+        - cluster
+        - host
+        - remote-node
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: alertmanager-allow
+spec:
+  # Alertmanager StatefulSet pods carry `app.kubernetes.io/name: alertmanager`.
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: alertmanager
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal gateway → alertmanager:9093 (web UI).
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "9093"
+              protocol: TCP
+  egress:
+    # n8n webhook receiver for `n8n-investigate` route in
+    # alertmanagerconfig — enriches critical alerts via HolmesGPT
+    # before falling through to pushover.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: home
+            app.kubernetes.io/name: n8n
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+    # Pushover notification API.
+    #
+    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
+    # pod DNS search-domain augmentation (pod queries e.g.
+    # `api.pushover.net.observability.svc.cluster.local.`; the FQDN
+    # cache stores the augmented name; matchName misses it). The bare
+    # + `.*` dual-form matchPattern covers both un-augmented and
+    # search-domain-augmented forms.
+    - toFQDNs:
+        - matchPattern: "api.pushover.net"
+        - matchPattern: "api.pushover.net.*"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: prometheus-operator-allow
+spec:
+  # Prometheus operator pod.
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # kube-apiserver calls the admission webhook on port 10250.
+    # Cilium policy matches on the pod's container port; apiserver
+    # carries the reserved:kube-apiserver identity (not a pod
+    # identity), so use fromEntities — same reason allow-apiserver in
+    # baseline uses toEntities for egress.
+    - fromEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "10250"
+              protocol: TCP

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/kustomization.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./alertmanagerconfig.yaml
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml

--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: observability
 components:
   - ../../components/alerts
   - ../../components/network-policy/baseline
+  - ../../components/network-policy/default-deny
 resources:
   - ./namespace.yaml
   - ./exporters

--- a/kubernetes/apps/observability/loki/app/cnp-allow.yaml
+++ b/kubernetes/apps/observability/loki/app/cnp-allow.yaml
@@ -1,0 +1,35 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: loki-allow
+spec:
+  # Loki SingleBinary pods carry `app.kubernetes.io/name: loki`.
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: loki
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  # No ingress rules needed: Loki is internal-only. Vector aggregator
+  # pushes to loki:3100 and Grafana queries loki:3100 — both intra-ns,
+  # covered by baseline allow-intra-namespace. No HTTPRoute exposes
+  # Loki publicly.
+  egress:
+    # Chunk + index storage on Rook Ceph RGW (S3 API). Loki's S3
+    # endpoint comes from the `loki-chunks-bucket-v1` ConfigMap which
+    # points at `rook-ceph-rgw-ceph-objectstore.rook-ceph.svc`. Use
+    # Pattern E (cross-ns endpoint match) rather than FQDN — the
+    # rook-ceph-rgw selector is stable.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: rook-ceph
+            app.kubernetes.io/name: ceph-rgw
+      toPorts:
+        - ports:
+            - port: "80"
+              protocol: TCP
+    # Ruler alerting target — Loki rule evaluations fire alerts at
+    # alertmanager-operated:9093 (intra-ns; baseline covers).
+    # No external egress required.

--- a/kubernetes/apps/observability/loki/app/kustomization.yaml
+++ b/kubernetes/apps/observability/loki/app/kustomization.yaml
@@ -3,7 +3,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./object-bucket-claim.yaml
+  - ./cnp-allow.yaml
   - ./configmap.yaml
   - ./helmrelease.yaml
+  - ./object-bucket-claim.yaml
   - ./prometheus-rule.yaml

--- a/kubernetes/apps/observability/speedtest-prometheus/app/cnp-allow.yaml
+++ b/kubernetes/apps/observability/speedtest-prometheus/app/cnp-allow.yaml
@@ -1,0 +1,33 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: speedtest-prometheus-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: speedtest-prometheus
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  egress:
+    # Ookla speedtest CLI talks to a rotating set of public speedtest
+    # server hosts to measure throughput. The target list is
+    # geolocated dynamically and refreshed every run — enumerating
+    # FQDNs would be brittle (servers come and go) and provides no
+    # security benefit (this pod's job IS to make outbound
+    # connections). Open egress on common ports speedtest uses
+    # (8080 = Ookla server control + tcp throughput).
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+            - port: "5060"
+              protocol: TCP
+            - port: "80"
+              protocol: TCP
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/observability/speedtest-prometheus/app/kustomization.yaml
+++ b/kubernetes/apps/observability/speedtest-prometheus/app/kustomization.yaml
@@ -7,5 +7,6 @@ components:
   - ../../../../components/repos/app-template
 
 resources:
+  - ./cnp-allow.yaml
   - ./helmrelease.yaml
   - ./prometheusrule.yaml

--- a/kubernetes/apps/observability/vector/aggregator/cnp-allow.yaml
+++ b/kubernetes/apps/observability/vector/aggregator/cnp-allow.yaml
@@ -1,0 +1,47 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: vector-aggregator-allow
+spec:
+  # Vector aggregator Deployment.
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: vector-aggregator
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # External LoadBalancer ingress on port 6002 — non-cluster Linux
+    # hosts (brain, beast, security-storage) ship journald to the
+    # aggregator via the Vector binary on the host. These are LAN
+    # hosts, not cluster identities, so the source is `world` from
+    # Cilium's perspective. Limited to port 6002 (vector→vector
+    # protocol, journald sink only).
+    - fromEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "6002"
+              protocol: TCP
+    # vector-agent → aggregator on 6000 (kubernetes_source) + 6002
+    # (journald_source) is intra-ns, covered by baseline
+    # allow-intra-namespace. Prometheus scrape of :8686 covered by
+    # allow-monitoring-scrape baseline.
+  egress:
+    # GeoIP DB updates via init container (geoipupdate from MaxMind).
+    # Runs only at pod start (`GEOIPUPDATE_FREQUENCY: "0"`) but the
+    # init container shares pod identity with `app`, so the policy
+    # has to permit it.
+    #
+    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
+    # pod DNS search-domain augmentation — bare + `.*` dual-form.
+    - toFQDNs:
+        - matchPattern: "updates.maxmind.com"
+        - matchPattern: "updates.maxmind.com.*"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+    # Sink → loki:3100 is intra-ns (covered by baseline).

--- a/kubernetes/apps/observability/vector/aggregator/kustomization.yaml
+++ b/kubernetes/apps/observability/vector/aggregator/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
 configMapGenerator:


### PR DESCRIPTION
## Summary

Flips the `observability` namespace from baseline-only to **default-deny + curated allow CNPs** per app. Brings observability into the same posture as `ai`, `cert-manager`, `rook-ceph`, etc.

15 new `cnp-allow.yaml` files; updates per-app `kustomization.yaml` entries and adds the `default-deny` component to the namespace kustomization.

### Per-app coverage

- **kube-prometheus-stack**: prometheus → `cluster+host+remote-node` (scrape any pod + kubelet + LAN-static apiserver/etcd endpoints); alertmanager → `home/n8n` (n8n-investigate webhook) + `api.pushover.net`; prometheus-operator ingress from kube-apiserver on `:10250`.
- **grafana**: ingress from `network/envoy`; egress to `databases/postgres-home-assistant` (Pattern B) + `grafana.com` / `raw.githubusercontent.com` / `storage.googleapis.com` for plugins, gnetId dashboards, repo-hosted JSONs.
- **loki**: egress to `rook-ceph/ceph-rgw` (S3 chunks + index store). No ingress rules — internal-only (vector + grafana intra-ns).
- **vector-aggregator**: `world` ingress on `:6002` (LAN journald shippers via LoadBalancer); egress to `updates.maxmind.com` (geoipupdate init container).
- **holmesgpt**: egress to `ai/ollama`.
- **holmesgpt-oauth2-proxy / kube-ops-view-oauth2-proxy / goldilocks-oauth2-proxy**: standard envoy → `:4180` + `auth.thesteamedcrab.com` OIDC.
- **kromgo**: ingress from `external` envoy (no oauth2-proxy).
- **blackbox-exporter**: `world+host+remote-node` (~60 LAN probe targets across cameras, UPS, iDRAC, ESPHome, WLED, NFS, voice satellites).
- **mqtt-exporter**: `home/emqx` :1883.
- **omada-exporter**: `world` :8043 (controller on `brain` — LAN host).
- **snmp-exporter apc-ups + dell-idrac**: `world` UDP :161 (LAN SNMP).
- **speedtest-prometheus**: `world` :80/:443/:5060/:8080 (Ookla rotating server pool).

### Apps relying on baseline only (no CNP added)

`vector-agent`, `node-exporter`, `smartctl-exporter`, `kube-state-metrics`, `silence-operator`, `goldilocks`, `kube-ops-view`, `netdata`, `kromgo`-egress — all covered by baseline DNS / apiserver / intra-namespace / host-probes / monitoring-scrape, so no CNP added per the "don't create empty CNPs" rule.

### Selector verification

Every `endpointSelector` matches at least one live pod (verified pre-merge). Baseline `sum(up)` = **281** captured for post-merge comparison.

## Test plan

- [ ] Pods stay Ready post-merge (no scheduling / probe regressions).
- [ ] `sum(up)` close to 281 (catches scrape-path drops).
- [ ] `curl https://grafana.thesteamedcrab.com` returns 302 (OIDC).
- [ ] `curl https://holmesgpt.thesteamedcrab.com` returns 302.
- [ ] `kubectl logs -n observability sts/loki -c loki --tail=10` shows ingestion OK (vector → loki → ceph rgw path intact).
- [ ] AlertManager → pushover delivery on next critical alert.

Rollback path: `git revert` the merge commit; baseline-only posture restored within ~30s of Flux reconcile.