### PR TITLE
fix(network-policy): media cnp post-merge gap fixes

### DIFF
--- a/kubernetes/apps/media/immichkiosk/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/immichkiosk/app/cnp-allow.yaml
@@ -27,3 +27,16 @@ spec:
         - ports:
             - port: "3000"
               protocol: TCP
+  egress:
+    # immichkiosk reaches Immich via the public photos.${SECRET_DOMAIN}
+    # URL (KIOSK_IMMICH_URL is set to the public FQDN per the kiosk
+    # config, so traffic loops back through the external envoy gateway
+    # on container port 10443).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "10443"
+              protocol: TCP

--- a/kubernetes/apps/media/jellyfin/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/jellyfin/app/cnp-allow.yaml
@@ -45,6 +45,16 @@ spec:
         - ports:
             - port: "8096"
               protocol: TCP
+    # 4) Home Assistant integration: media_player.jellyfin polls + sends
+    #    play commands via the local jellyfin Service.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: home
+            app.kubernetes.io/name: home-assistant
+      toPorts:
+        - ports:
+            - port: "8096"
+              protocol: TCP
   egress:
     # Metadata providers. Jellyfin reaches out for movie/show artwork,
     # season metadata, theme music, etc. *arr metadata writers are OFF

--- a/kubernetes/apps/media/music-assistant/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/music-assistant/app/cnp-allow.yaml
@@ -28,6 +28,16 @@ spec:
               protocol: TCP
             - port: "8095"
               protocol: TCP
+    # Home Assistant integration: HA music_assistant integration polls
+    # + sends commands via the local music-assistant Service:8095.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: home
+            app.kubernetes.io/name: home-assistant
+      toPorts:
+        - ports:
+            - port: "8095"
+              protocol: TCP
   egress:
     # External: Spotify, Tidal, Apple Music, Sonos cloud APIs, plus
     # mDNS-style LAN discovery to local devices (Sonos, Chromecast,
@@ -40,4 +50,14 @@ spec:
             - port: "443"
               protocol: TCP
             - port: "80"
+              protocol: TCP
+    # Music-assistant calls back into Home Assistant (callback events,
+    # entity-state subscriptions) — HA REST + WebSocket on :8123.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: home
+            app.kubernetes.io/name: home-assistant
+      toPorts:
+        - ports:
+            - port: "8123"
               protocol: TCP

--- a/kubernetes/apps/media/romm/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/romm/app/cnp-allow.yaml
@@ -33,6 +33,16 @@ spec:
         - ports:
             - port: "5432"
               protocol: TCP
+    # Dragonfly (Redis) in databases ns — used as romm's task/cache
+    # broker.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
+            app.kubernetes.io/name: dragonfly
+      toPorts:
+        - ports:
+            - port: "6379"
+              protocol: TCP
     # External: 7+ ROM metadata providers (IGDB, TheGamesDB, Flashpoint,
     # HLTB, Hasheous, Launchbox, PlayMatch, etc.), Switch titleDB
     # updates, MAME XML feed. Provider set rotates; world keeps the

--- a/kubernetes/apps/media/suggestarr/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/suggestarr/app/cnp-allow.yaml
@@ -15,6 +15,16 @@ spec:
     egress: false
     ingress: false
   egress:
+    # Cross-ns: suggestarr's AI-suggestions feature calls ollama in the
+    # ai namespace for LLM-based recommendation reasoning.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: ai
+            app.kubernetes.io/name: ollama
+      toPorts:
+        - ports:
+            - port: "11434"
+              protocol: TCP
     # External metadata APIs (TMDb, Trakt, etc.) — surface too broad to
     # enumerate per-FQDN.
     - toEntities:


### PR DESCRIPTION
## Summary

Post-merge Hubble surfaced 5 legitimate cross-namespace flows that #11515 missed. Each was producing recurring SYN drops every 10-30s and breaking the affected integration. No cluster-wide impact — but these fix the gaps before downstream consumers notice.

## Drops fixed

| Flow | Why |
|---|---|
| `home/home-assistant → media/jellyfin:8096` | HA media_player.jellyfin integration |
| `home/home-assistant → media/music-assistant:8095` | HA music_assistant integration |
| `media/music-assistant → home/home-assistant:8123` | MA → HA callbacks / state subs |
| `media/suggestarr → ai/ollama:11434` | suggestarr AI-recommendation feature |
| `media/romm → databases/dragonfly:6379` | romm uses dragonfly as RQ broker |
| `media/immichkiosk → network/external-envoy:10443` | KIOSK_IMMICH_URL = public FQDN loopback |

## Test plan

- [ ] Hubble shows zero SYN drops for the 6 flows above in 5 min after merge
- [ ] HA jellyfin + music_assistant integrations remain online
- [ ] romm UI loads (heartbeat reaches dragonfly)
- [ ] immichkiosk continues rendering frames

🤖 Generated with [Claude Code](https://claude.com/claude-code)