### PR TITLE
fix(network-policy): home-assistant egress to media/jellyfin + music-assistant

### DIFF
--- a/kubernetes/apps/home/home-assistant/app/cnp-allow.yaml
+++ b/kubernetes/apps/home/home-assistant/app/cnp-allow.yaml
@@ -58,6 +58,25 @@ spec:
         - ports:
             - port: "2525"
               protocol: TCP
+    # Media integrations (Pattern E — cross-ns to specific apps):
+    # HA's `media_player.jellyfin` integration and the Music Assistant
+    # integration both initiate connections from HA → media ns.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: media
+            app.kubernetes.io/name: jellyfin
+      toPorts:
+        - ports:
+            - port: "8096"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: media
+            app.kubernetes.io/name: music-assistant
+      toPorts:
+        - ports:
+            - port: "8095"
+              protocol: TCP
     # Home Assistant integrations call out to an unbounded set of cloud
     # APIs (weather, Pushover, OpenAI, voice cloud services, Frigate
     # MQTT/HTTP, calendar, etc.) plus arbitrary user-installed HACS


### PR DESCRIPTION
## Summary

- Post-#11511 (home lockdown) Hubble showed HA SYN packets being dropped to `media/jellyfin:8096` and `media/music-assistant:8095`.
- HA's `media_player.jellyfin` and Music Assistant integrations both initiate cross-ns connections from `home/home-assistant-0`.
- Adds Pattern E (cross-ns to specific app) egress allows in `cnp-allow.yaml`.

Labels verified live:
- `kubectl get pods -n media -l app.kubernetes.io/name=jellyfin` → `jellyfin-0` matches.
- `kubectl get pods -n media -l app.kubernetes.io/name=music-assistant` → `music-assistant-0` matches.

## Test plan

- [ ] Flux reconciles `cnp-allow` CiliumNetworkPolicy in `home` ns.
- [ ] `hubble observe --pod home/home-assistant-0 --to-namespace media` shows ALLOWED (not DENIED) for ports 8096 / 8095.
- [ ] HA `media_player.jellyfin` entity flips back to non-`unavailable`.
- [ ] Music Assistant integration health in HA returns to healthy.