### PR TITLE
feat(network-policy): lock down cilium-secrets namespace

### DIFF
--- a/kubernetes/apps/cilium-secrets/kustomization.yaml
+++ b/kubernetes/apps/cilium-secrets/kustomization.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+# cilium-secrets is a chart-managed namespace (Cilium Helm chart creates it
+# at install time as the holding namespace for Gateway/Ingress TLS Secrets
+# consumed by the cilium-secrets-sync controller). We intentionally do NOT
+# manage the Namespace object here — only the network-policy lockdown.
+#
+# There are typically zero pods in this namespace (Secret-only); the CNPs
+# are documentation-by-default-deny: if a pod ever appears here, it gets
+# baseline + default-deny treatment automatically.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: cilium-secrets
+components:
+  - ../../components/network-policy/baseline
+  - ../../components/network-policy/default-deny

--- a/kubernetes/apps/kustomization.yaml
+++ b/kubernetes/apps/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ai
   - auth
   - cert-manager
+  - cilium-secrets
   - collab
   # - kuadrant
   - databases


### PR DESCRIPTION
## Summary

- Add baseline + default-deny CNPs to `cilium-secrets`, the only
  remaining namespace without a network-policy posture.
- New group `kubernetes/apps/cilium-secrets/` applies the standard
  baseline + default-deny components; the Namespace object itself is
  intentionally not managed (cilium Helm chart owns it).
- Net effect post-merge: 6 CNPs (`allow-apiserver`, `allow-dns`,
  `allow-host-probes`, `allow-intra-namespace`,
  `allow-monitoring-scrape`, `default-deny`) appear in
  `cilium-secrets`. The namespace currently has zero pods, so the
  posture is documentation-by-default; any pod that ever lands here is
  denied out of the gate and must opt into specific holes.

## Test plan

- [x] `kubectl kustomize kubernetes/apps/cilium-secrets/` renders 6 CNPs
      in the cilium-secrets namespace
- [x] `kubectl kustomize kubernetes/apps/` renders cleanly (454 objects)
- [x] yamllint clean
- [ ] Post-merge: `kubectl get cnp -n cilium-secrets` shows 6 CNPs
- [ ] Post-merge: no pod disruption (none expected — zero pods in ns)