### PR TITLE
fix(paperless): allow direct OIDC egress to authelia (5xx login fix)

### DIFF
--- a/kubernetes/apps/collab/paperless/app/cnp-allow.yaml
+++ b/kubernetes/apps/collab/paperless/app/cnp-allow.yaml
@@ -70,3 +70,17 @@ spec:
         - ports:
             - port: "443"
               protocol: TCP
+    # OIDC token exchange + userinfo: paperless (django-allauth) calls
+    # authelia server-side after user redirect. The toFQDNs rule above
+    # resolves to envoy's LB IP via split-horizon DNS but that hop
+    # times out (yields HTTP 500 at the OIDC login). Direct in-cluster
+    # path to authelia bypasses the envoy roundtrip entirely
+    # (Pattern E).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: auth
+            app.kubernetes.io/name: authelia
+      toPorts:
+        - ports:
+            - port: "9091"
+              protocol: TCP


### PR DESCRIPTION
## Summary

- paperless OIDC login was returning HTTP 500. Root cause: django-allauth fetches `.well-known/openid-configuration` from `auth.${SECRET_DOMAIN}`, which split-horizon-resolves to envoy's LB IP (`10.45.0.13`) and times out on the in-cluster roundtrip to itself.
- Adds a direct cross-ns egress (Pattern E) from paperless to `authelia.auth:9091`, bypassing the envoy roundtrip for server-side OIDC discovery/token exchange/userinfo.
- Authelia's own CNP already permits `fromEntities: cluster` on 9091, so no auth-side change is needed.

## Evidence

- `kubectl exec -n collab paperless-0 -- curl https://auth.thesteamedcrab.com/.well-known/openid-configuration` resolves to `10.45.0.13:443` (envoy external) and times out.
- `kubectl exec -n collab paperless-0 -- curl http://authelia.auth.svc:9091/.well-known/openid-configuration` also times out today (denied by current CNP — exit 124). This PR is the fix.
- paperless logs show `requests.exceptions.ConnectTimeout: HTTPSConnectionPool(host='auth.thesteamedcrab.com', port=443)` at `allauth/socialaccount/providers/openid_connect/views.py:25 (openid_config)`.

## Test plan

- [ ] Flux reconciles paperless-allow CNP; `kubectl get cnp -n collab paperless-allow` shows new toEndpoints rule
- [ ] Hubble: `kubectl exec -n kube-system ds/cilium -- hubble observe --pod collab/paperless-0 --to-namespace auth --since 1m` shows ALLOWED flow on retry
- [ ] User retries OIDC login at https://paperless.thesteamedcrab.com/ — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)