### PR TITLE
feat(netpol): lock down databases namespace

### DIFF
--- a/kubernetes/apps/databases/cloudnative-pg/app/cnp-allow-postgres.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/app/cnp-allow-postgres.yaml
@@ -1,0 +1,53 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: postgres-instances-allow
+spec:
+  # Matches every CNPG-managed postgres pod in the namespace
+  # (each carries cnpg.io/podRole=instance set by the operator,
+  # plus app.kubernetes.io/managed-by=cloudnative-pg).
+  endpointSelector:
+    matchLabels:
+      cnpg.io/podRole: instance
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # ~25 CNPG clusters serve consumers across home, collab, media, ai,
+    # auth, observability, renovate namespaces. Enumerating every
+    # consumer-side selector per-cluster is extremely fragile — a single
+    # missed allow takes that app's database offline. Use fromEntities:
+    # cluster (any pod, any namespace) → port 5432 to lock down the
+    # cross-cluster boundary without risking missed enumerations.
+    # The default-deny on databases ns still blocks the public internet
+    # and node-host paths from reaching postgres. Tighten to per-consumer
+    # selectors in a follow-up PR once we have hubble flow data showing
+    # the actual edge.
+    - fromEntities:
+        - cluster
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+  egress:
+    # CNPG instance manager pushes WAL + base backups to Garage via the
+    # barman-cloud plugin sidecar. The plugin shells out to barman-cloud
+    # commands which hit the S3 endpoint configured in the ObjectStore
+    # CR — `http://garage.storage.svc.cluster.local:3900`.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: storage
+            app.kubernetes.io/name: garage
+      toPorts:
+        - ports:
+            - port: "3900"
+              protocol: TCP
+  # Egress to peer CNPG instances (streaming replication) is covered by
+  # baseline allow-intra-namespace. The plugin-barman-cloud sidecar
+  # GRPC (intra-ns) is also covered there. kube-apiserver (cnpg-config
+  # watches by the instance manager) is covered by allow-apiserver.
+  # DNS by allow-dns.

--- a/kubernetes/apps/databases/cloudnative-pg/app/cnp-allow.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/app/cnp-allow.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: cloudnative-pg-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: cloudnative-pg
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # kube-apiserver → cnpg admission webhook on container port 9443.
+    # cnpg-webhook-service exposes svc:443 → targetPort: webhook-server
+    # (containerPort 9443). Cilium L4 matches the pod container port.
+    # ValidatingWebhookConfiguration `cnpg-validating-webhook-configuration`
+    # + mutating counterpart drive the call from apiserver.
+    - fromEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "9443"
+              protocol: TCP
+  # Egress: intra-namespace (CNPG instances + plugin-barman-cloud
+  # sidecar GRPC) is covered by baseline allow-intra-namespace.
+  # kube-apiserver (cluster watches + status patches) is covered by
+  # baseline allow-apiserver. DNS by allow-dns. Nothing else needed.

--- a/kubernetes/apps/databases/cloudnative-pg/app/kustomization.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/app/kustomization.yaml
@@ -3,6 +3,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./cnp-allow.yaml
+  - ./cnp-allow-postgres.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./helmrepository.yaml

--- a/kubernetes/apps/databases/cloudnative-pg/plugin-barman-cloud/cnp-allow.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/plugin-barman-cloud/cnp-allow.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: plugin-barman-cloud-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: plugin-barman-cloud
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  # Ingress: GRPC from cnpg operator + instance manager pods on
+  # container port 9090. All callers are intra-ns and are covered by
+  # the baseline allow-intra-namespace policy. No extra ingress rule.
+  egress:
+    # The plugin executes barman-cloud commands which speak S3 to the
+    # endpoint configured in each ObjectStore CR
+    # (components/cnpg-app-database/objectstore.yaml:
+    #  endpointURL: http://garage.storage.svc.cluster.local:3900).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: storage
+            app.kubernetes.io/name: garage
+      toPorts:
+        - ports:
+            - port: "3900"
+              protocol: TCP
+  # kube-apiserver + DNS covered by baseline.

--- a/kubernetes/apps/databases/cloudnative-pg/plugin-barman-cloud/kustomization.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/plugin-barman-cloud/kustomization.yaml
@@ -3,5 +3,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./cnp-allow.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml

--- a/kubernetes/apps/databases/dragonfly/cluster/cnp-allow.yaml
+++ b/kubernetes/apps/databases/dragonfly/cluster/cnp-allow.yaml
@@ -1,0 +1,42 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: dragonfly-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: dragonfly
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # Known consumers (`dragonfly.databases.svc.cluster.local:6379`):
+    #   auth/authelia         — session store
+    #   collab/nametag        — caching backend
+    #   collab/paperless      — broker / cache
+    #   collab/searxng        — redis cache (db=10)
+    #   collab/zulip          — broker / cache
+    #   collab/pump           — broker
+    #   home/netbox           — caching + django-q broker
+    #   media/immich          — task queue
+    #   media/romm            — task queue
+    #   renovate/renovate     — caching
+    # Enumerating each per-pod selector across 6 namespaces is fragile.
+    # Use fromEntities: cluster on port 6379 — the cross-cluster /
+    # default-deny boundary is what matters; missing a consumer here
+    # would take its primary cache/broker offline. Tighten in a
+    # follow-up PR once hubble flow data confirms the actual edge.
+    - fromEntities:
+        - cluster
+      toPorts:
+        - ports:
+            - port: "6379"
+              protocol: TCP
+  # Peer dragonfly replication (intra-ns 3-replica StatefulSet) covered
+  # by baseline allow-intra-namespace. Dragonfly-operator probes covered
+  # by allow-intra-namespace. Egress only goes to apiserver (baseline)
+  # and DNS (baseline).

--- a/kubernetes/apps/databases/dragonfly/cluster/kustomization.yaml
+++ b/kubernetes/apps/databases/dragonfly/cluster/kustomization.yaml
@@ -4,4 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./cluster.yaml
+  - ./cnp-allow.yaml
   - ./podmonitor.yaml

--- a/kubernetes/apps/databases/kustomization.yaml
+++ b/kubernetes/apps/databases/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 namespace: databases
 components:
   - ../../components/network-policy/baseline
+  - ../../components/network-policy/default-deny
 resources:
   - ./namespace.yaml
   - ./priority-class.yaml

--- a/kubernetes/apps/databases/pgadmin/app/cnp-allow.yaml
+++ b/kubernetes/apps/databases/pgadmin/app/cnp-allow.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: pgadmin-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: pgadmin4
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal gateway → pgadmin-pgadmin4:80
+    # (pgadmin.${SECRET_DOMAIN}). Both `external` and `internal` envoy
+    # deployments share app.kubernetes.io/name: envoy.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "80"
+              protocol: TCP
+  # Egress: pgadmin connects to every postgres-* CNPG cluster on 5432
+  # intra-namespace — covered by baseline allow-intra-namespace.
+  # DNS + apiserver covered by baseline.

--- a/kubernetes/apps/databases/pgadmin/app/kustomization.yaml
+++ b/kubernetes/apps/databases/pgadmin/app/kustomization.yaml
@@ -3,6 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./helmrepository.yaml

--- a/kubernetes/apps/databases/qdrant/app/cnp-allow.yaml
+++ b/kubernetes/apps/databases/qdrant/app/cnp-allow.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: qdrant-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: qdrant
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # Known consumer (`http://qdrant.databases.svc.cluster.local:6333`):
+    #   collab/open-webui   — VECTOR_DB=qdrant, QDRANT_URI
+    # Use fromEntities: cluster on the HTTP+GRPC pair — vector DB tends
+    # to attract new consumers (LangGraph, additional RAG agents) and a
+    # missed enumeration silently breaks RAG. Tighten in follow-up once
+    # the consumer set stabilizes.
+    - fromEntities:
+        - cluster
+      toPorts:
+        - ports:
+            - port: "6333"  # HTTP API
+              protocol: TCP
+            - port: "6334"  # gRPC API
+              protocol: TCP
+  # qdrant single-pod, no cluster gossip. Egress only DNS + apiserver
+  # (baseline).

--- a/kubernetes/apps/databases/qdrant/app/kustomization.yaml
+++ b/kubernetes/apps/databases/qdrant/app/kustomization.yaml
@@ -5,5 +5,6 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./helmrelease.yaml
   - ./pvc.yaml


### PR DESCRIPTION
## Summary

Last consumer-side namespace lockdown — direct-enforce. Adds per-app CNPs + default-deny component for the databases ns.

Every CNPG cluster in databases serves apps in home, collab, media, ai, auth, observability, and renovate (~25 clusters, ~30+ distinct consumers). Per the task brief, used `fromEntities: cluster` on the highest-fanout endpoints (postgres-* :5432, dragonfly :6379, qdrant :6333/:6334) to avoid taking an app offline due to a missed allow. Tighten to per-consumer selectors in a follow-up PR once hubble flow data confirms the actual edges.

CNPs added:
- `cloudnative-pg-allow`: ingress from `reserved:kube-apiserver` -> :9443 (admission webhook)
- `postgres-instances-allow`: ingress `cluster` -> :5432; egress to `garage.storage:3900` (Barman ObjectStore endpoint)
- `plugin-barman-cloud-allow`: egress to `garage.storage:3900`
- `dragonfly-allow`: ingress `cluster` -> :6379
- `pgadmin-allow`: ingress `envoy.network` -> :80
- `qdrant-allow`: ingress `cluster` -> :6333/:6334

Peer-pod, DNS, apiserver, monitoring-scrape, and CNPG/Barman intra-ns GRPC are all covered by the existing baseline component.

## Test plan

- [x] kustomize build (top-level + each subpath) renders all 6 CNPs + default-deny
- [x] yamllint clean (warnings only, matching the established `auth/authelia` style)
- [ ] Post-merge: all 73 databases pods stay 2/2 Ready (CNPG) + 7 1/1 Ready (operators / cache / vector)
- [ ] Post-merge: representative consumer pods do not restart (sample home/collab/media/ai/auth)
- [ ] Post-merge: `hubble observe --namespace databases --verdict DROPPED --since 60s` clean
- [ ] Post-merge: TCP probe from auth/authelia -> postgres-authelia-rw.databases:5432