### PR TITLE
feat(network-policy): lock down network namespace v2 (envoy targetPort fix)

### DIFF
--- a/kubernetes/apps/network/cloudflare-ddns/app/cnp-allow.yaml
+++ b/kubernetes/apps/network/cloudflare-ddns/app/cnp-allow.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: cloudflare-ddns-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: cloudflare-ddns
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  egress:
+    # api.cloudflare.com (zone record updates) + cloudflare.com/cdn-cgi
+    # /trace (IP4 detection via IP4_PROVIDER=cloudflare.trace).
+    # Cilium matchPattern unreliable for these canonical FQDNs — use
+    # `toEntities: [world]` + 443/TCP.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/network/cloudflare-ddns/app/kustomization.yaml
+++ b/kubernetes/apps/network/cloudflare-ddns/app/kustomization.yaml
@@ -5,5 +5,6 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/network/cloudflared/app/cnp-allow.yaml
+++ b/kubernetes/apps/network/cloudflared/app/cnp-allow.yaml
@@ -1,0 +1,55 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: cloudflared-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: cloudflared
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  # Ingress :8080 (metrics + readiness probe) covered by:
+  #   - baseline allow-host-probes (kubelet)
+  #   - baseline allow-monitoring-scrape (Prometheus)
+  egress:
+    # Cloudflare Tunnel control + data planes. Uses QUIC (UDP/7844) by
+    # default with TCP/7844 fallback. Connects to many CF edge IPs —
+    # `toEntities: [world]` is the standard pattern here; CF's edge
+    # IP pool rotates and FQDN matching is unreliable for these
+    # connect-by-IP control endpoints. Also include 443/TCP for HTTP/2
+    # fallback transport mode and discovery (TUNNEL_TRANSPORT_PROTOCOL
+    # in helmrelease is `quic`, but cloudflared may use HTTPS for
+    # tunnel registration / config fetch).
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "7844"
+              protocol: TCP
+            - port: "7844"
+              protocol: UDP
+            - port: "443"
+              protocol: TCP
+    # Tunnel origin — cloudflared proxies inbound CF traffic to the
+    # `external` envoy data plane via the in-cluster Service
+    # (https://external.network.svc.cluster.local:443 → pod :10443).
+    # Cilium L4 matches the pod targetPort (10443), not the svc port
+    # (443) — see project_cilium_l4_port_targetport.md. This is an
+    # intra-namespace flow but envoy data planes get caught by their
+    # own pod selector under default-deny, so an explicit allow here
+    # plus a matching ingress on envoy-proxy-allow is the safe pattern.
+    # Baseline allow-intra-namespace covers it but be explicit so
+    # this rule is greppable.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "10443"
+              protocol: TCP

--- a/kubernetes/apps/network/cloudflared/app/kustomization.yaml
+++ b/kubernetes/apps/network/cloudflared/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./dnsendpoint.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/network/envoy-gateway/app/cnp-allow-envoy-proxy.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/cnp-allow-envoy-proxy.yaml
@@ -1,0 +1,90 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: envoy-proxy-allow
+spec:
+  # Both `external` and `internal` Gateway data planes share this label;
+  # envoy-gateway labels every proxy pod with app.kubernetes.io/name=envoy.
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: envoy
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # Envoy listener ports — IMPORTANT: these are the POD's targetPorts,
+    # not the LoadBalancer Service ports. Cilium L4 enforcement happens
+    # after kube-proxy/Cilium-LB has rewritten the dest port from svc
+    # port to targetPort (memory: project_cilium_l4_port_targetport.md).
+    # The `external` + `internal` LB Services map:
+    #   80/TCP → 10080/TCP
+    #   443/TCP → 10443/TCP
+    #   443/UDP → 10443/UDP (QUIC/HTTP3)
+    # Using 80/443 here (svc port) was the root cause of iteration 1's
+    # silent ingress drop — packets arrived at the pod on 10080/10443
+    # and never matched the allow rule. Both `external` and `internal`
+    # Gateway data planes share the `app.kubernetes.io/name: envoy`
+    # label and bind the same targetPorts.
+    #
+    # Envoy is the cluster ingress proxy: be inclusive about source —
+    # every entity that could legitimately send a request to a
+    # published HTTPRoute:
+    #   - world: cloudflared (external tunnel egress) + LAN browsers
+    #            hitting LB IPs directly (externalTrafficPolicy: Local
+    #            preserves real source IP → reserved:world identity)
+    #   - cluster: in-cluster pods resolving *.${SECRET_DOMAIN} to LB IP
+    #   - host: node-local probes, kubelet-side, host-network pods
+    #   - remote-node: cross-node hairpin
+    - fromEntities:
+        - world
+        - cluster
+        - host
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "10080"
+              protocol: TCP
+            - port: "10443"
+              protocol: TCP
+            - port: "10443"
+              protocol: UDP
+    # Metrics port (19001) covered by baseline allow-monitoring-scrape.
+    # Admin port (19003) is bound on localhost only.
+  egress:
+    # Backend dispatch — envoy proxies traffic to HTTPRoute backends
+    # in ~17 namespaces across the cluster (auth, ai, collab, downloads,
+    # home, media, mcp-system, observability, kube-system, longhorn-system,
+    # databases, selfhosted, storage, rook-ceph, renovate, flux-system,
+    # and intra-ns to itself). `toEntities: [cluster]` covers every
+    # pod identity; we deliberately leave the port-list open because
+    # backends listen on a wide variety of ports (4180 oauth2-proxy,
+    # 8080, 5000, 9000, 11434, custom app ports). Restricting by port
+    # here would require enumerating every backend port across the
+    # whole cluster and would inevitably break a future HTTPRoute.
+    - toEntities:
+        - cluster
+    # Some backends run on the host network (e.g. node_exporter,
+    # potentially host-mode dashboards). Include host + remote-node
+    # so envoy can dispatch to those without surprise drops.
+    - toEntities:
+        - host
+        - remote-node
+    # External backends — at present envoy has no toServiceImport-style
+    # external upstream, but EnvoyExtensionPolicy/SecurityPolicy can
+    # reference external URIs (e.g. Authelia JWKS fetch, ExtAuth,
+    # OIDC discovery to issuer URLs). Permit world egress on HTTPS
+    # so future SecurityPolicy / EnvoyExtensionPolicy backends keep
+    # working. No DNS/FQDN list — these are control-plane URIs that
+    # change, and envoy is too critical to risk an FQDN cache miss.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+            - port: "80"
+              protocol: TCP

--- a/kubernetes/apps/network/envoy-gateway/app/cnp-allow.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/cnp-allow.yaml
@@ -1,0 +1,45 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: envoy-gateway-allow
+spec:
+  # The envoy-gateway operator pod (control plane). Distinct from the
+  # data-plane envoy pods which use app.kubernetes.io/name=envoy and
+  # are covered by `envoy-proxy-allow`.
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: gateway-helm
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # xDS / extension-server gRPC ports — data-plane envoy pods
+    # connect back to envoy-gateway for config (xds 18000, ratelimit
+    # 18001, oidc 18002, metrics 19001, webhook 9443). Selecting by
+    # cluster covers data-plane pods in the same ns plus the
+    # kube-apiserver admission webhook calls (host) — see below.
+    - fromEntities:
+        - cluster
+        - host
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "18000"
+              protocol: TCP
+            - port: "18001"
+              protocol: TCP
+            - port: "18002"
+              protocol: TCP
+            - port: "19001"
+              protocol: TCP
+            - port: "9443"
+              protocol: TCP
+  # No additional egress needed beyond baseline — flows covered by:
+  #   - baseline allow-apiserver (kube-apiserver status updates)
+  #   - baseline allow-dns (CoreDNS for service discovery)
+  #   - baseline allow-intra-namespace (data-plane envoy connecting *to* the
+  #     operator for xDS is an ingress on this pod, not an egress)

--- a/kubernetes/apps/network/envoy-gateway/app/kustomization.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/kustomization.yaml
@@ -3,5 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./cnp-allow-envoy-proxy.yaml
+  - ./cnp-allow.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml

--- a/kubernetes/apps/network/external-dns/app/bind/cnp-allow.yaml
+++ b/kubernetes/apps/network/external-dns/app/bind/cnp-allow.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: external-dns-bind-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: external-dns-bind
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  # Ingress :7979 (metrics) covered by baseline allow-monitoring-scrape
+  # + allow-host-probes.
+  egress:
+    # bind9 on the home router (brain, 192.168.1.1) — RFC2136 dynamic
+    # DNS updates + AXFR zone transfers (TSIG signed). Both TCP and
+    # UDP/53 — small updates ride UDP, AXFR forces TCP. CIDR rule
+    # because brain is the home router (host-network identity, not a
+    # k8s pod), and Cilium's `kube-apiserver` entity matcher won't
+    # cover non-cluster LAN hosts.
+    - toCIDR:
+        - 192.168.1.1/32
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: TCP
+            - port: "53"
+              protocol: UDP

--- a/kubernetes/apps/network/external-dns/app/bind/kustomization.yaml
+++ b/kubernetes/apps/network/external-dns/app/bind/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 components:
   - ../../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./rbac.yaml

--- a/kubernetes/apps/network/external-dns/app/cloudflare/cnp-allow.yaml
+++ b/kubernetes/apps/network/external-dns/app/cloudflare/cnp-allow.yaml
@@ -1,0 +1,34 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: external-dns-cloudflare-allow
+spec:
+  # Chart sets fullnameOverride: externaldns-cloudflare which becomes
+  # both the resource prefix and the app.kubernetes.io/instance value;
+  # app.kubernetes.io/name comes from the upstream chart and is
+  # `external-dns`.
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: external-dns
+      app.kubernetes.io/instance: external-dns-cloudflare
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  # Ingress :7979 (metrics) covered by baseline allow-monitoring-scrape
+  # + allow-host-probes.
+  egress:
+    # api.cloudflare.com (DNS record sync). Canonical FQDN — Cilium
+    # matchPattern is unreliable for non-CNAME FQDNs (see
+    # project_cilium_matchpattern_fqdn_limits.md), so use
+    # `toEntities: [world]` + 443/TCP. external-dns also fetches the
+    # Cloudflare API at /client/v4/* exclusively over HTTPS.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/network/external-dns/app/cloudflare/kustomization.yaml
+++ b/kubernetes/apps/network/external-dns/app/cloudflare/kustomization.yaml
@@ -3,5 +3,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/network/kustomization.yaml
+++ b/kubernetes/apps/network/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: network
 components:
   - ../../components/alerts
   - ../../components/network-policy/baseline
+  - ../../components/network-policy/default-deny
 resources:
   - ./namespace.yaml
   - ./cloudflare-ddns/ks.yaml

--- a/kubernetes/apps/network/wg-easy/app/cnp-allow.yaml
+++ b/kubernetes/apps/network/wg-easy/app/cnp-allow.yaml
@@ -1,0 +1,51 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: wg-easy-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: wg-easy
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # WireGuard listener — UDP/51820 from anywhere (this IS the only
+    # OOB access path to the cluster per memory `feedback_vpn_gateway_
+    # migrations_lan_only.md`; over-restricting risks locking the
+    # operator out of remote management). LoadBalancer service routes
+    # external WG peers (mobile, laptop) here.
+    - fromEntities:
+        - world
+        - cluster
+        - host
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "51820"
+              protocol: UDP
+    # Web UI :51821 via envoy `internal` Gateway (vpn.${SECRET_DOMAIN}
+    # is published on the internal LB).
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "51821"
+              protocol: TCP
+  egress:
+    # WG peers terminate inside the pod and their decapsulated packets
+    # are forwarded into the cluster + LAN (admin connects from phone
+    # over WG, hits HA/Plex/etc.). The set of destinations is broad
+    # by design — a VPN gateway needs to reach everywhere a normal
+    # client could. Permit cluster + host + remote-node + world.
+    - toEntities:
+        - cluster
+        - host
+        - remote-node
+        - world

--- a/kubernetes/apps/network/wg-easy/app/kustomization.yaml
+++ b/kubernetes/apps/network/wg-easy/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./longhorn-pvc.yaml

--- a/kubernetes/apps/network/whoami/app/cnp-allow.yaml
+++ b/kubernetes/apps/network/whoami/app/cnp-allow.yaml
@@ -1,0 +1,34 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: whoami-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: whoami
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # Test echo server — only useful path is envoy → whoami:8080 for
+    # debugging HTTPRoute / Gateway connectivity. Permit `cluster` so
+    # ad-hoc `curl` from a debug pod in another ns also works.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+    - fromEntities:
+        - cluster
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+  # No egress needed beyond baseline (DNS, intra-ns).

--- a/kubernetes/apps/network/whoami/app/kustomization.yaml
+++ b/kubernetes/apps/network/whoami/app/kustomization.yaml
@@ -7,4 +7,5 @@ components:
   - ../../../../components/repos/app-template
 
 resources:
+  - ./cnp-allow.yaml
   - ./helmrelease.yaml


### PR DESCRIPTION
## Summary

Re-apply network namespace lockdown reverted in #11527.

**Root cause of iteration 1's failure**: envoy data-plane ingress allow used LoadBalancer Service ports (80/443) instead of the actual pod targetPorts (10080/10443). Cilium L4 enforcement happens at the pod's network namespace AFTER kube-proxy/Cilium-LB has rewritten the dest port from svc-port to targetPort, so external HTTPS traffic arriving at envoy pods on :10443 silently dropped under default-deny. Per memory `project_cilium_l4_port_targetport.md`.

## Fix

Changed envoy data plane CNP ingress ports: 80→10080, 443→10443 (TCP+UDP). Also fixed cloudflared egress to envoy: 443→10443 (same root cause).

Everything else identical to #11524.

## Test plan

- [x] Server-side dry-run for all 8 CNPs validates
- [x] Baseline external smoke test pre-merge (photos/glance/ollama/jellyfin/renovate-webhook all 200/302)
- [ ] Post-merge MANDATORY dual-path validation within 90s of merge:
  - In-cluster `--resolve` to LB IP for envoy→backend path
  - Real external (laptop → CF tunnel/BGP → envoy) for full ingress path
- [ ] If external path returns 000 (timeout) → immediate rollback via `kubectl delete cnp -n network default-deny` + Hubble drop analysis + fix-PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)