### PR TITLE
fix(longhorn): allow egress to beast NFS backup target

### DIFF
--- a/kubernetes/apps/longhorn-system/longhorn/app/cnp-allow.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn/app/cnp-allow.yaml
@@ -3,11 +3,13 @@
 # longhorn-manager (DaemonSet, every node)
 # - Heavy networking: peer managers cross-node, admission/recovery
 #   webhooks from kube-apiserver, instance-manager / engine-image /
-#   share-manager spawning + control, NFS backup target on host.
-# - NFS to the backup target (beast:/mnt/mass_storage/longhorn-backups)
-#   is mounted in the host kernel network namespace by the node's
-#   `mount.nfs`, NOT from inside the manager pod — so no pod-level egress
-#   rule for that flow is required.
+#   share-manager spawning + control, NFS backup target.
+# - NFS to the backup target (beast:/mnt/mass_storage/longhorn-backups,
+#   192.168.1.27) IS opened from inside the longhorn-manager pod
+#   netns — Hubble confirms drops with the manager pod as source. Beast
+#   is a LAN host (not a k8s node), so its Cilium identity is `world`
+#   and the cluster/host/remote-node entity rule does not cover it;
+#   an explicit toCIDR rule is required.
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -42,6 +44,14 @@ spec:
         - cluster
         - host
         - remote-node
+    # NFS backup target on beast (LAN host, `world` identity in Cilium).
+    # Required for backupTarget=nfs://beast:/mnt/mass_storage/longhorn-backups.
+    - toCIDR:
+        - 192.168.1.27/32
+      toPorts:
+        - ports:
+            - port: "2049"
+              protocol: TCP
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
 # longhorn-ui (Deployment) — fronted by HTTPRoute
@@ -167,6 +177,16 @@ spec:
         - cluster
         - host
         - remote-node
+    # NFS backup target on beast (LAN host, `world` identity in Cilium).
+    # instance-manager opens the backup-target NFS socket from inside the
+    # pod netns when reconciling BackingImage / volume backups; Hubble
+    # confirms drops with instance-manager as the source.
+    - toCIDR:
+        - 192.168.1.27/32
+      toPorts:
+        - ports:
+            - port: "2049"
+              protocol: TCP
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
 # share-manager (per-RWX-volume NFS exporter). Currently 3 pods:


### PR DESCRIPTION
## Summary

- longhorn-manager and instance-manager pods silently drop SYNs to `beast:2049`, breaking the Longhorn backup target (`nfs://beast:/mnt/mass_storage/longhorn-backups`).
- Beast (192.168.1.27) is a LAN host (not a k8s node) so its Cilium identity is `world` — existing `cluster/host/remote-node` entity egress does not cover it.
- Adds explicit `toCIDR: 192.168.1.27/32` egress on TCP/2049 in both `longhorn-manager-allow` and `longhorn-data-plane-allow` CNPs.
- Corrects the stale file-level comment that claimed NFS only happens in host netns; Hubble shows the pod netns as the source.

## Hubble evidence (pre-fix)

```
longhorn-system/longhorn-manager-lghgl (ID:1298) <> 192.168.1.27:2049 (world) Policy denied DROPPED (TCP Flags: SYN)
longhorn-system/instance-manager-3e208ee0456e655aafe3d8ebb97faf5f (ID:9278) <> 192.168.1.27:2049 (world) Policy denied DROPPED (TCP Flags: SYN)
```

## Test plan

- [ ] Flux reconciles longhorn-system kustomization
- [ ] `hubble observe --namespace longhorn-system --since 30s` shows no more `world (192.168.1.27:2049)` drops
- [ ] Longhorn UI > Setting > Backup Target reports healthy
- [ ] Next scheduled `weekly-backups` RecurringJob succeeds

Generated with [Claude Code](https://claude.com/claude-code)