### PR TITLE
fix(longhorn): allow longhorn-manager egress to world:443

### DIFF
--- a/kubernetes/apps/longhorn-system/longhorn/app/cnp-allow.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn/app/cnp-allow.yaml
@@ -52,6 +52,18 @@ spec:
         - ports:
             - port: "2049"
               protocol: TCP
+    # Upstream telemetry + upgrade-availability checks. longhorn-manager
+    # periodically calls metrics.longhorn.io / update.longhorn.io (AWS
+    # us-west-2, stable but not published as CIDRs). Per
+    # project_cilium_matchpattern_fqdn_limits.md, canonical FQDNs at
+    # external endpoints fail matchPattern silently; use
+    # toEntities:world + port:443 as the broad-but-reliable pattern.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
 # longhorn-ui (Deployment) — fronted by HTTPRoute


### PR DESCRIPTION
## Summary

- Add `toEntities: [world] + port: 443` egress to `longhorn-manager-allow` CNP for upstream telemetry / upgrade-availability checks.
- Hubble showed ongoing drops to AWS us-west-2 IPs (`34.208.215.203`, `52.35.128.158`, `54.188.244.155`) on `:443` — `metrics.longhorn.io` / `update.longhorn.io` style endpoints.
- Follows the `toEntities:world` pattern documented in `project_cilium_matchpattern_fqdn_limits.md` (matchPattern silently fails for canonical FQDNs at external endpoints).

## Scope note

Original task included an `mqtt-exporter` → `home/emqx:1883` egress fix in the same PR. Verified live: the CNP rule was already present in the repo file and applied to the cluster; current Hubble shows zero drops in the last 30s, only stale entries in the buffer. Nothing to do for mqtt-exporter — keeping this PR scoped to the longhorn fix that actually needed code.

## Test plan

- [ ] Flux reconciles after merge
- [ ] `hubble observe --pod longhorn-system/longhorn-manager --since 30s --verdict DROPPED` returns zero rows
- [ ] `kubectl get cnp -n longhorn-system longhorn-manager-allow -o yaml` shows `world + 443` egress

Generated with [Claude Code](https://claude.com/claude-code)