### PR TITLE
fix(emqx): allow ingress from observability/mqtt-exporter on 1883

### DIFF
--- a/kubernetes/apps/home/emqx/app/cnp-allow.yaml
+++ b/kubernetes/apps/home/emqx/app/cnp-allow.yaml
@@ -48,6 +48,15 @@ spec:
         - ports:
             - port: "18083"
               protocol: TCP
+    # observability/mqtt-exporter subscribes for Prometheus metrics.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: observability
+            app.kubernetes.io/name: mqtt-exporter
+      toPorts:
+        - ports:
+            - port: "1883"
+              protocol: TCP
     # Egress: no external integrations. zigbee2mqtt in same ns connects
     # to emqx:1883; baseline allow-intra-namespace covers that as
     # ingress for emqx and egress for zigbee2mqtt. emqx clustering is


### PR DESCRIPTION
## Summary

- Adds cross-namespace ingress rule to `emqx-allow` CNP permitting `observability/mqtt-exporter` to subscribe on port 1883.
- mqtt-exporter (cluster identity) is not covered by the existing `fromEntities: [world, host, remote-node]` rule and was being denied:
  ```
  observability/mqtt-exporter-0 -> home/emqx-0:1883 (policy-verdict:none DENIED)
  ```

## Test plan

- [ ] After merge + Flux reconcile, verify Hubble shows ALLOWED:
  ```
  kubectl exec -n kube-system ds/cilium -- hubble observe --pod observability/mqtt-exporter-0 --since 30s | grep emqx
  ```
- [ ] Confirm mqtt-exporter pod exits CrashLoopBackOff and `up{job="mqtt-exporter"}` flips to 1 in Prometheus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)