### PR TITLE
fix(immich-mcp): pypi egress toFQDNs → toEntities:world

### DIFF
--- a/kubernetes/apps/mcp-system/immich-mcp/app/cnp-allow.yaml
+++ b/kubernetes/apps/mcp-system/immich-mcp/app/cnp-allow.yaml
@@ -31,18 +31,12 @@ spec:
     # wheel deps from PyPI. Without this the container crashloops
     # before it can serve MCP traffic.
     #
-    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
-    # pod DNS search-domain augmentation (pod queries
-    # `pypi.org.mcp-system.svc.cluster.local.`; the FQDN cache stores
-    # the augmented name; matchName misses it). The bare + `.*`
-    # dual-form matchPattern covers both un-augmented and
-    # search-domain-augmented forms — see PR #11492 for the canonical
-    # example.
-    - toFQDNs:
-        - matchPattern: "pypi.org"
-        - matchPattern: "pypi.org.*"
-        - matchPattern: "files.pythonhosted.org"
-        - matchPattern: "files.pythonhosted.org.*"
+    # pypi.org + files.pythonhosted.org are canonical FQDNs (no CNAME chain).
+    # Cilium 1.19 matchPattern .* doesn't match through K8s DNS search-domain
+    # augmentation in this case (per memory project_cilium_matchpattern_fqdn_limits.md).
+    # Use toEntities:world+443 — broader but actually works. Same pattern as
+    # PRs #11498/#11512/#11517 for canonical FQDN external egress.
+    - toEntities: [world]
       toPorts:
         - ports:
             - port: "443"


### PR DESCRIPTION
## Summary

- PR #11499 restored `matchPattern` for `pypi.org` / `files.pythonhosted.org`, but these are canonical FQDNs (no CNAME chain) and Cilium 1.19 `matchPattern` silently fails through K8s DNS search-domain augmentation in this case — see memory `project_cilium_matchpattern_fqdn_limits.md`.
- `immich-mcp` has been CrashLoopBackOff for ~3h (37 restarts) because `uv build claw2immich` at startup can't reach PyPI.
- Switch the pypi egress rule to `toEntities: [world]` on port 443 — broader, but actually works. Same pattern as PRs #11498 / #11512 / #11517 for canonical FQDN external egress.

## Test plan

- [ ] PR merges and Flux reconciles the CNP
- [ ] `kubectl get pod -n mcp-system -l app.kubernetes.io/name=immich-mcp` reports Running 1/1
- [ ] Pod logs show MCP server serving traffic (no PyPI timeout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)