### PR TITLE
fix(immich): allow ingress from mcp-system/immich-mcp to immich-server

### DIFF
--- a/kubernetes/apps/media/immich/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/immich/app/cnp-allow.yaml
@@ -28,6 +28,15 @@ spec:
         - ports:
             - port: "2283"
               protocol: TCP
+    # mcp-system/immich-mcp uses the Immich REST API for tool discovery
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: mcp-system
+            app.kubernetes.io/name: immich-mcp
+      toPorts:
+        - ports:
+            - port: "2283"
+              protocol: TCP
     # ServiceMonitor scrape from observability/prometheus is already
     # covered by the baseline allow-monitoring-scrape — no rule needed.
   egress:


### PR DESCRIPTION
## Summary
- Add cross-ns ingress rule to `immich-server-allow` CNP permitting `mcp-system/immich-mcp` → `immich-server:2283`.
- Unblocks `immich-mcp` readiness probe; pod is currently in CrashLoopBackOff because its Immich REST API tool-discovery call is dropped by the default-deny on immich-server.

## Test plan
- [ ] Flux reconciles `media-immich` Kustomization
- [ ] `immich-mcp` pod transitions Running 1/1

Generated with Claude Code