### PR TITLE
fix(cert-manager): cilium toFQDNs matchPattern -> toEntities:world

### DIFF
--- a/kubernetes/apps/cert-manager/cert-manager/app/cnp-allow.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/app/cnp-allow.yaml
@@ -25,20 +25,14 @@ spec:
     # ./issuers/letsencrypt-production.yaml + letsencrypt-staging.yaml,
     # both use the cloudflare DNS-01 solver against `cloudflare-token-secret`).
     #
-    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
-    # pod DNS search-domain augmentation (pod queries e.g.
-    # `acme-v02.api.letsencrypt.org.cert-manager.svc.cluster.local.`;
-    # the FQDN cache stores the augmented name; matchName misses it).
-    # The bare + `.*` dual-form matchPattern covers both un-augmented
-    # and search-domain-augmented forms — see PR #11492 for the
-    # canonical example.
-    - toFQDNs:
-        - matchPattern: "acme-v02.api.letsencrypt.org"
-        - matchPattern: "acme-v02.api.letsencrypt.org.*"
-        - matchPattern: "acme-staging-v02.api.letsencrypt.org"
-        - matchPattern: "acme-staging-v02.api.letsencrypt.org.*"
-        - matchPattern: "api.cloudflare.com"
-        - matchPattern: "api.cloudflare.com.*"
+    # acme-v02.api.letsencrypt.org, acme-staging-v02.api.letsencrypt.org,
+    # and api.cloudflare.com are canonical FQDNs (no CNAME chain). Cilium
+    # 1.19 matchPattern silently fails for canonical FQDNs going through
+    # K8s DNS search-domain augmentation — see memory
+    # project_cilium_matchpattern_fqdn_limits.md. Use toEntities:world +
+    # port:443, the broad-but-reliable pattern matching PRs
+    # #11498/#11512/#11517/#11533.
+    - toEntities: [world]
       toPorts:
         - ports:
             - port: "443"


### PR DESCRIPTION
## Summary

- ACME directory endpoints (`acme-v02.api.letsencrypt.org`, `acme-staging-v02.api.letsencrypt.org`) and `api.cloudflare.com` are **canonical** FQDNs with no CNAME chain.
- Per memory `project_cilium_matchpattern_fqdn_limits.md`, Cilium 1.19's `matchPattern` silently fails for canonical FQDNs queried through K8s DNS search-domain augmentation. The shipped PR #11499 `matchPattern + .*` allows are non-functional for cert-manager.
- Replace with `toEntities: [world]` + port `443/TCP` — same precedent as PRs #11498/#11512/#11517/#11533.

## Test plan

- [ ] Flux reconciles within 60s
- [ ] No DROPPED flows from cert-manager pods to `:443` external: `kubectl exec -n kube-system ds/cilium -- hubble observe --pod cert-manager/cert-manager --verdict DROPPED --since 60s`
- [ ] Next cert renewal succeeds (check `Certificate` status / cert-manager logs)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>