### PR TITLE
fix(ai): cilium toFQDNs matchPattern -> toEntities:world

### DIFF
--- a/kubernetes/apps/ai/comfyui/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/comfyui/app/cnp-allow.yaml
@@ -27,39 +27,19 @@ spec:
     # External HTTPS for provisioning. The ai-dock/comfyui provisioning
     # script pulls model weights + custom nodes from these hosts on
     # first start and on AUTO_UPDATE.
+    # Intended endpoints:
+    #   github.com family, *.githubusercontent.com (CNAME-fronted)
+    #   huggingface.co + *.huggingface.co + *.hf.co (CNAME-fronted)
+    #   civitai.com (CNAME-fronted)
+    #   pypi.org + files.pythonhosted.org (canonical — matchPattern
+    #     silently fails per project_cilium_matchpattern_fqdn_limits.md,
+    #     same gap immich-mcp hit in PR #11533)
     #
-    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
-    # pod DNS search-domain augmentation (pods query e.g.
-    # `huggingface.co.ai.svc.cluster.local.` and the FQDN cache stores
-    # the augmented name; matchName misses it). The bare + `.*`
-    # dual-form matchPattern covers both un-augmented and
-    # search-domain-augmented forms — see PR #11492 for the canonical
-    # example.
-    - toFQDNs:
-        - matchPattern: "github.com"
-        - matchPattern: "github.com.*"
-        - matchPattern: "codeload.github.com"
-        - matchPattern: "codeload.github.com.*"
-        - matchPattern: "raw.githubusercontent.com"
-        - matchPattern: "raw.githubusercontent.com.*"
-        - matchPattern: "*.githubusercontent.com"
-        - matchPattern: "*.githubusercontent.com.*"
-        - matchPattern: "huggingface.co"
-        - matchPattern: "huggingface.co.*"
-        - matchPattern: "*.huggingface.co"
-        - matchPattern: "*.huggingface.co.*"
-        - matchPattern: "cdn-lfs.huggingface.co"
-        - matchPattern: "cdn-lfs.huggingface.co.*"
-        - matchPattern: "*.hf.co"
-        - matchPattern: "*.hf.co.*"
-        - matchPattern: "civitai.com"
-        - matchPattern: "civitai.com.*"
-        - matchPattern: "*.civitai.com"
-        - matchPattern: "*.civitai.com.*"
-        - matchPattern: "pypi.org"
-        - matchPattern: "pypi.org.*"
-        - matchPattern: "files.pythonhosted.org"
-        - matchPattern: "files.pythonhosted.org.*"
+    # Since the pypi family alone forces a toEntities:[world]+443 to
+    # avoid silent breakage, the whole rule collapses to world:443 —
+    # adding matchPattern allows for the CNAME-fronted ones would be
+    # redundant. Matches the precedent in PRs #11498/#11512/#11517/#11533.
+    - toEntities: [world]
       toPorts:
         - ports:
             - port: "443"

--- a/kubernetes/apps/ai/khoj-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/khoj-oauth2-proxy/app/cnp-allow.yaml
@@ -25,21 +25,15 @@ spec:
               protocol: TCP
   egress:
     # OIDC discovery + token exchange against Authelia.
-    # auth.${SECRET_DOMAIN} resolves to the internal Envoy gateway VIP,
-    # which then routes to the auth namespace.
-    # Upstream → khoj.ai.svc.cluster.local:42110. Same-ns; the baseline
-    # allow-intra-namespace already covers that path.
-    #
-    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
-    # pod DNS search-domain augmentation (pod queries
-    # `auth.thesteamedcrab.com.ai.svc.cluster.local.` and the FQDN
-    # cache stores the augmented name; matchName misses it). The
-    # bare + `.*` dual-form matchPattern covers both un-augmented and
-    # search-domain-augmented forms — see PR #11492 for the canonical
-    # example.
-    - toFQDNs:
-        - matchPattern: "auth.thesteamedcrab.com"
-        - matchPattern: "auth.thesteamedcrab.com.*"
+    # auth.${SECRET_DOMAIN} is a split-horizon local FQDN at its
+    # canonical form — no CNAME chain. Per memory
+    # project_cilium_matchpattern_fqdn_limits.md, Cilium 1.19
+    # matchPattern silently fails for canonical FQDNs queried through
+    # K8s DNS search-domain augmentation. Use toEntities:world+443,
+    # matches the precedent in PRs #11498/#11512/#11517/#11533.
+    # Upstream → khoj.ai.svc.cluster.local:42110 is intra-namespace,
+    # covered by baseline allow-intra-namespace.
+    - toEntities: [world]
       toPorts:
         - ports:
             - port: "443"

--- a/kubernetes/apps/ai/langgraph-agents/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/cnp-allow.yaml
@@ -79,22 +79,16 @@ spec:
     # External APIs: api.pushover.net for Tier-1 alert escalations,
     # api.anthropic.com for the Claude API gated on ENABLE_CLAUDE_API.
     #
-    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
-    # pod DNS search-domain augmentation (pod queries
-    # `api.pushover.net.ai.svc.cluster.local.` and the FQDN cache
-    # stores the augmented name; matchName misses it). The bare +
-    # `.*` dual-form matchPattern covers both un-augmented and
-    # search-domain-augmented forms — see PR #11492 for the canonical
-    # example.
+    # Both are canonical FQDNs (no CNAME chain). Per memory
+    # project_cilium_matchpattern_fqdn_limits.md, Cilium 1.19
+    # matchPattern silently fails for canonical FQDNs queried through
+    # K8s DNS search-domain augmentation — use toEntities:world+443,
+    # matches the precedent in PRs #11498/#11512/#11517/#11533.
     # Langfuse: user intends self-hosted in-cluster. LANGFUSE_HOST is
     # currently empty so the client doesn't instantiate. When the
     # in-cluster Langfuse lands, add a toEndpoints rule here for the
     # langfuse ns + app label.
-    - toFQDNs:
-        - matchPattern: "api.pushover.net"
-        - matchPattern: "api.pushover.net.*"
-        - matchPattern: "api.anthropic.com"
-        - matchPattern: "api.anthropic.com.*"
+    - toEntities: [world]
       toPorts:
         - ports:
             - port: "443"

--- a/kubernetes/apps/ai/ollama/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/ollama/app/cnp-allow.yaml
@@ -50,33 +50,21 @@ spec:
   egress:
     # Model registry — ollama pulls model blobs on first invocation
     # (`ollama pull <model>`) and on Modelfile changes.
-    # *.cloudflarestorage.com covers the rotating GCS-backed R2 blob
-    # host (e.g. dd20bb891979d25aebc8bec07b2b3bbc.r2.cloudflarestorage.com).
-    # huggingface.co + *.huggingface.co + cdn-lfs.huggingface.co cover
-    # community model GGUFs.
+    # Intended endpoints:
+    #   - ollama.com, registry.ollama.ai, *.ollama.ai (canonical)
+    #   - *.cloudflarestorage.com (R2 blob host, e.g.
+    #     dd20bb891979d25aebc8bec07b2b3bbc.r2.cloudflarestorage.com)
+    #   - huggingface.co, *.huggingface.co, cdn-lfs.huggingface.co
     #
-    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
-    # pod DNS search-domain augmentation (pod queries e.g.
-    # `ollama.com.ai.svc.cluster.local.` and the FQDN cache stores
-    # the augmented name; matchName misses it). The bare + `.*`
-    # dual-form matchPattern covers both un-augmented and
-    # search-domain-augmented forms — see PR #11492 for the canonical
-    # example.
-    - toFQDNs:
-        - matchPattern: "ollama.com"
-        - matchPattern: "ollama.com.*"
-        - matchPattern: "registry.ollama.ai"
-        - matchPattern: "registry.ollama.ai.*"
-        - matchPattern: "*.ollama.ai"
-        - matchPattern: "*.ollama.ai.*"
-        - matchPattern: "*.cloudflarestorage.com"
-        - matchPattern: "*.cloudflarestorage.com.*"
-        - matchPattern: "huggingface.co"
-        - matchPattern: "huggingface.co.*"
-        - matchPattern: "*.huggingface.co"
-        - matchPattern: "*.huggingface.co.*"
-        - matchPattern: "cdn-lfs.huggingface.co"
-        - matchPattern: "cdn-lfs.huggingface.co.*"
+    # The ollama.* family is canonical-only (no CNAME chain) and
+    # matchPattern silently fails on it (per memory
+    # project_cilium_matchpattern_fqdn_limits.md). Since we'd have
+    # to fall back to toEntities:[world]+443 to cover those, the
+    # whole rule collapses to world:443 — adding matchPattern allows
+    # for the CNAME-fronted ones (HF, R2) would be redundant
+    # (world:443 already covers them). Matches the precedent in
+    # PRs #11498/#11512/#11517/#11533.
+    - toEntities: [world]
       toPorts:
         - ports:
             - port: "443"


### PR DESCRIPTION
## Summary

Replace canonical-only FQDN matchPattern allows (silently broken per memory `project_cilium_matchpattern_fqdn_limits.md`) with `toEntities:[world]+443` across the **ai** namespace.

| File | FQDNs converted | Reason |
|---|---|---|
| `langgraph-agents/app/cnp-allow.yaml` | `api.pushover.net`, `api.anthropic.com` | canonical |
| `ai/khoj-oauth2-proxy/app/cnp-allow.yaml` | `auth.thesteamedcrab.com` | canonical local DNS |
| `ai/ollama/app/cnp-allow.yaml` | `ollama.com`, `registry.ollama.ai`, `*.ollama.ai` (+ HF/R2 collapsed in) | canonical |
| `ai/comfyui/app/cnp-allow.yaml` | `pypi.org`, `files.pythonhosted.org` (+ GH/HF/civitai collapsed in) | canonical, same as PR #11533 |

**Untouched** (all CNAME-fronted, matchPattern works via Cilium CNAME-walk):
- `khoj` (huggingface family only)
- `kubeclaw` (github + huggingface families only)

## Test plan

- [ ] Flux reconciles within 60s
- [ ] No DROPPED flows from ai pods to `:443` external endpoints
- [ ] langgraph-agents Pushover notifications succeed on next Tier-1 alert
- [ ] ollama can pull a fresh model (canary)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>