### PR TITLE
fix(collab): cilium toFQDNs matchPattern -> toEntities:world

### DIFF
--- a/kubernetes/apps/collab/glance-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/collab/glance-oauth2-proxy/app/cnp-allow.yaml
@@ -28,14 +28,13 @@ spec:
     # glance.collab.svc.cluster.local:8081 is same-ns, covered by
     # baseline allow-intra-namespace.
     #
-    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
-    # pod DNS search-domain augmentation (pod queries
-    # `auth.thesteamedcrab.com.collab.svc.cluster.local.`; FQDN cache
-    # stores the augmented name; matchName misses it). Bare + `.*`
-    # matchPattern covers both forms — see PR #11492.
-    - toFQDNs:
-        - matchPattern: "auth.thesteamedcrab.com"
-        - matchPattern: "auth.thesteamedcrab.com.*"
+    # auth.${SECRET_DOMAIN} is a split-horizon local FQDN at its
+    # canonical form (no CNAME chain). Per memory
+    # project_cilium_matchpattern_fqdn_limits.md, Cilium 1.19
+    # matchPattern silently fails for canonical FQDNs queried through
+    # K8s DNS search-domain augmentation. Use toEntities:world+443,
+    # matches the precedent in PRs #11498/#11512/#11517/#11533.
+    - toEntities: [world]
       toPorts:
         - ports:
             - port: "443"

--- a/kubernetes/apps/collab/glance-user-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/collab/glance-user-oauth2-proxy/app/cnp-allow.yaml
@@ -28,11 +28,11 @@ spec:
     # OIDC discovery + token exchange against Authelia. Upstream →
     # glance-user.collab.svc.cluster.local:8081 is same-ns, baseline.
     #
-    # Cilium 1.19 search-domain augmentation quirk — bare + `.*`
-    # matchPattern covers both forms. See PR #11492.
-    - toFQDNs:
-        - matchPattern: "auth.thesteamedcrab.com"
-        - matchPattern: "auth.thesteamedcrab.com.*"
+    # auth.${SECRET_DOMAIN} is canonical (no CNAME chain). Cilium 1.19
+    # matchPattern silently fails for canonical FQDNs through K8s DNS
+    # search-domain augmentation — per memory
+    # project_cilium_matchpattern_fqdn_limits.md. Use toEntities:world+443.
+    - toEntities: [world]
       toPorts:
         - ports:
             - port: "443"

--- a/kubernetes/apps/collab/kitchenowl/app/cnp-allow.yaml
+++ b/kubernetes/apps/collab/kitchenowl/app/cnp-allow.yaml
@@ -30,11 +30,11 @@ spec:
     # https://auth.${SECRET_DOMAIN}). Resolves to the internal Envoy
     # gateway VIP which then routes to the auth namespace.
     #
-    # Cilium 1.19 search-domain augmentation quirk — bare + `.*`
-    # matchPattern covers both forms. See PR #11492.
-    - toFQDNs:
-        - matchPattern: "auth.thesteamedcrab.com"
-        - matchPattern: "auth.thesteamedcrab.com.*"
+    # auth.${SECRET_DOMAIN} is canonical (no CNAME chain). Cilium 1.19
+    # matchPattern silently fails for canonical FQDNs through K8s DNS
+    # search-domain augmentation — per memory
+    # project_cilium_matchpattern_fqdn_limits.md. Use toEntities:world+443.
+    - toEntities: [world]
       toPorts:
         - ports:
             - port: "443"

--- a/kubernetes/apps/collab/open-webui/app/cnp-allow.yaml
+++ b/kubernetes/apps/collab/open-webui/app/cnp-allow.yaml
@@ -75,19 +75,14 @@ spec:
               protocol: TCP
     # OIDC discovery + token exchange against Authelia, and TTS via
     # piper.${SECRET_DOMAIN} — both resolve to the internal Envoy
-    # gateway VIP.
+    # gateway VIP. Both are canonical local FQDNs (no CNAME chain).
     #
-    # Cilium 1.19 search-domain augmentation quirk — bare + `.*`
-    # matchPattern covers both forms. See PR #11492.
-    - toFQDNs:
-        - matchPattern: "auth.thesteamedcrab.com"
-        - matchPattern: "auth.thesteamedcrab.com.*"
-        - matchPattern: "piper.thesteamedcrab.com"
-        - matchPattern: "piper.thesteamedcrab.com.*"
-      toPorts:
-        - ports:
-            - port: "443"
-              protocol: TCP
+    # Subsumed by the toEntities:[world]+443 rule below (web-search /
+    # external integrations). Kept commented for grep-ability; if the
+    # below world:443 rule is ever narrowed, restore an explicit allow
+    # here per project_cilium_matchpattern_fqdn_limits.md
+    # (toEntities:world, not matchPattern — canonical FQDNs).
+    #
     # External tool egress: open-webui's web-search backend (searxng,
     # in-cluster — covered intra-ns via baseline), plus an open list
     # of user-configured external integrations (image gen APIs, image

--- a/kubernetes/apps/collab/paperless/app/cnp-allow.yaml
+++ b/kubernetes/apps/collab/paperless/app/cnp-allow.yaml
@@ -61,11 +61,11 @@ spec:
     # OIDC discovery + token exchange against Authelia (allauth
     # openid_connect provider, server_url = auth.${SECRET_DOMAIN}).
     #
-    # Cilium 1.19 search-domain augmentation quirk — bare + `.*`
-    # matchPattern covers both forms. See PR #11492.
-    - toFQDNs:
-        - matchPattern: "auth.thesteamedcrab.com"
-        - matchPattern: "auth.thesteamedcrab.com.*"
+    # auth.${SECRET_DOMAIN} is canonical (no CNAME chain). Cilium 1.19
+    # matchPattern silently fails for canonical FQDNs through K8s DNS
+    # search-domain augmentation — per memory
+    # project_cilium_matchpattern_fqdn_limits.md. Use toEntities:world+443.
+    - toEntities: [world]
       toPorts:
         - ports:
             - port: "443"

--- a/kubernetes/apps/collab/pump-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/collab/pump-oauth2-proxy/app/cnp-allow.yaml
@@ -28,11 +28,11 @@ spec:
     # OIDC discovery + token exchange against Authelia. Upstream →
     # pump-frontend.collab.svc.cluster.local:8080 is same-ns, baseline.
     #
-    # Cilium 1.19 search-domain augmentation quirk — bare + `.*`
-    # matchPattern covers both forms. See PR #11492.
-    - toFQDNs:
-        - matchPattern: "auth.thesteamedcrab.com"
-        - matchPattern: "auth.thesteamedcrab.com.*"
+    # auth.${SECRET_DOMAIN} is canonical (no CNAME chain). Cilium 1.19
+    # matchPattern silently fails for canonical FQDNs through K8s DNS
+    # search-domain augmentation — per memory
+    # project_cilium_matchpattern_fqdn_limits.md. Use toEntities:world+443.
+    - toEntities: [world]
       toPorts:
         - ports:
             - port: "443"

--- a/kubernetes/apps/collab/zulip/app/cnp-allow.yaml
+++ b/kubernetes/apps/collab/zulip/app/cnp-allow.yaml
@@ -67,11 +67,11 @@ spec:
               protocol: TCP
     # Mobile push notifications via the Zulip-operated PNS at
     # push.zulipchat.com (SETTING_ZULIP_SERVICE_PUSH_NOTIFICATIONS=true).
-    # Bare + `.*` matchPattern covers both forms (Cilium 1.19
-    # search-domain quirk — see PR #11492).
-    - toFQDNs:
-        - matchPattern: "push.zulipchat.com"
-        - matchPattern: "push.zulipchat.com.*"
+    # Uncertain whether push.zulipchat.com has a CNAME chain or is
+    # canonical; per project_cilium_matchpattern_fqdn_limits.md, when
+    # uncertain default to toEntities:world+443 (broad allow is the
+    # safe failure mode). Matches PRs #11498/#11512/#11517/#11533.
+    - toEntities: [world]
       toPorts:
         - ports:
             - port: "443"


### PR DESCRIPTION
## Summary

Replace canonical-only FQDN matchPattern allows (silently broken per memory `project_cilium_matchpattern_fqdn_limits.md`) with `toEntities:[world]+443` across the **collab** namespace.

| File | FQDNs converted |
|---|---|
| `glance-oauth2-proxy`, `glance-user-oauth2-proxy`, `kitchenowl`, `paperless`, `pump-oauth2-proxy` | `auth.thesteamedcrab.com` (canonical local DNS) |
| `open-webui` | auth + piper.thesteamedcrab.com (subsumed by existing world:443) |
| `zulip` | `push.zulipchat.com` (uncertain CNAME, lean replace) |

**Untouched** (CNAME-fronted, matchPattern works):
- `pump-cv` (github.com + *.githubusercontent.com)

## Test plan

- [ ] Flux reconciles
- [ ] OIDC login flows still work for all 5 oauth2-proxy apps
- [ ] paperless allauth OIDC succeeds (PR #11525 already covers direct egress to authelia)
- [ ] No drops from collab pods to `:443` external

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>