### PR TITLE
fix(downloads): cilium toFQDNs matchPattern -> toEntities:world

### DIFF
--- a/kubernetes/apps/downloads/jdownloader2-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/downloads/jdownloader2-oauth2-proxy/app/cnp-allow.yaml
@@ -28,14 +28,12 @@ spec:
     # internal envoy gateway. Upstream → jdownloader2.downloads:5800 is
     # covered by baseline allow-intra-namespace.
     #
-    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
-    # pod DNS search-domain augmentation (pod queries
-    # `auth.thesteamedcrab.com.downloads.svc.cluster.local.`; FQDN
-    # cache stores the augmented name; matchName misses it). Bare +
-    # `.*` matchPattern covers both forms — see PR #11492.
-    - toFQDNs:
-        - matchPattern: "auth.thesteamedcrab.com"
-        - matchPattern: "auth.thesteamedcrab.com.*"
+    # auth.${SECRET_DOMAIN} is canonical (no CNAME chain). Cilium 1.19
+    # matchPattern silently fails for canonical FQDNs through K8s DNS
+    # search-domain augmentation — per memory
+    # project_cilium_matchpattern_fqdn_limits.md. Use toEntities:world+443,
+    # matches the precedent in PRs #11498/#11512/#11517/#11533.
+    - toEntities: [world]
       toPorts:
         - ports:
             - port: "443"

--- a/kubernetes/apps/downloads/prowlarr-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/downloads/prowlarr-oauth2-proxy/app/cnp-allow.yaml
@@ -28,14 +28,12 @@ spec:
     # internal envoy gateway. Upstream → prowlarr.downloads:9696 is
     # covered by baseline allow-intra-namespace.
     #
-    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
-    # pod DNS search-domain augmentation (pod queries
-    # `auth.thesteamedcrab.com.downloads.svc.cluster.local.`; FQDN
-    # cache stores the augmented name; matchName misses it). Bare +
-    # `.*` matchPattern covers both forms — see PR #11492.
-    - toFQDNs:
-        - matchPattern: "auth.thesteamedcrab.com"
-        - matchPattern: "auth.thesteamedcrab.com.*"
+    # auth.${SECRET_DOMAIN} is canonical (no CNAME chain). Cilium 1.19
+    # matchPattern silently fails for canonical FQDNs through K8s DNS
+    # search-domain augmentation — per memory
+    # project_cilium_matchpattern_fqdn_limits.md. Use toEntities:world+443,
+    # matches the precedent in PRs #11498/#11512/#11517/#11533.
+    - toEntities: [world]
       toPorts:
         - ports:
             - port: "443"

--- a/kubernetes/apps/downloads/qbittorrent-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/downloads/qbittorrent-oauth2-proxy/app/cnp-allow.yaml
@@ -28,14 +28,12 @@ spec:
     # internal envoy gateway. Upstream → qbittorrent.downloads:8080 is
     # covered by baseline allow-intra-namespace.
     #
-    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
-    # pod DNS search-domain augmentation (pod queries
-    # `auth.thesteamedcrab.com.downloads.svc.cluster.local.`; FQDN
-    # cache stores the augmented name; matchName misses it). Bare +
-    # `.*` matchPattern covers both forms — see PR #11492.
-    - toFQDNs:
-        - matchPattern: "auth.thesteamedcrab.com"
-        - matchPattern: "auth.thesteamedcrab.com.*"
+    # auth.${SECRET_DOMAIN} is canonical (no CNAME chain). Cilium 1.19
+    # matchPattern silently fails for canonical FQDNs through K8s DNS
+    # search-domain augmentation — per memory
+    # project_cilium_matchpattern_fqdn_limits.md. Use toEntities:world+443,
+    # matches the precedent in PRs #11498/#11512/#11517/#11533.
+    - toEntities: [world]
       toPorts:
         - ports:
             - port: "443"

--- a/kubernetes/apps/downloads/sabnzbd-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/downloads/sabnzbd-oauth2-proxy/app/cnp-allow.yaml
@@ -28,14 +28,12 @@ spec:
     # internal envoy gateway. Upstream → sabnzbd.downloads:8080 is
     # covered by baseline allow-intra-namespace.
     #
-    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
-    # pod DNS search-domain augmentation (pod queries
-    # `auth.thesteamedcrab.com.downloads.svc.cluster.local.`; FQDN
-    # cache stores the augmented name; matchName misses it). Bare +
-    # `.*` matchPattern covers both forms — see PR #11492.
-    - toFQDNs:
-        - matchPattern: "auth.thesteamedcrab.com"
-        - matchPattern: "auth.thesteamedcrab.com.*"
+    # auth.${SECRET_DOMAIN} is canonical (no CNAME chain). Cilium 1.19
+    # matchPattern silently fails for canonical FQDNs through K8s DNS
+    # search-domain augmentation — per memory
+    # project_cilium_matchpattern_fqdn_limits.md. Use toEntities:world+443,
+    # matches the precedent in PRs #11498/#11512/#11517/#11533.
+    - toEntities: [world]
       toPorts:
         - ports:
             - port: "443"

--- a/kubernetes/apps/downloads/slskd-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/downloads/slskd-oauth2-proxy/app/cnp-allow.yaml
@@ -28,14 +28,12 @@ spec:
     # internal envoy gateway. Upstream → slskd.downloads:5030 is
     # covered by baseline allow-intra-namespace.
     #
-    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
-    # pod DNS search-domain augmentation (pod queries
-    # `auth.thesteamedcrab.com.downloads.svc.cluster.local.`; FQDN
-    # cache stores the augmented name; matchName misses it). Bare +
-    # `.*` matchPattern covers both forms — see PR #11492.
-    - toFQDNs:
-        - matchPattern: "auth.thesteamedcrab.com"
-        - matchPattern: "auth.thesteamedcrab.com.*"
+    # auth.${SECRET_DOMAIN} is canonical (no CNAME chain). Cilium 1.19
+    # matchPattern silently fails for canonical FQDNs through K8s DNS
+    # search-domain augmentation — per memory
+    # project_cilium_matchpattern_fqdn_limits.md. Use toEntities:world+443,
+    # matches the precedent in PRs #11498/#11512/#11517/#11533.
+    - toEntities: [world]
       toPorts:
         - ports:
             - port: "443"


### PR DESCRIPTION
## Summary

All 5 oauth2-proxy CNPs in the **downloads** namespace had matchPattern allows for `auth.thesteamedcrab.com` (canonical local DNS, no CNAME).

Per memory `project_cilium_matchpattern_fqdn_limits.md`, matchPattern silently fails for canonical FQDNs through K8s DNS search-domain augmentation. Replace with `toEntities:[world]+443`.

Files: jdownloader2, prowlarr, qbittorrent, sabnzbd, slskd oauth2-proxies.

Matches the precedent in PRs #11498/#11512/#11517/#11533.

## Test plan

- [ ] Flux reconciles
- [ ] OIDC login flows still work for all 5 apps
- [ ] No drops from `<app>-oauth2-proxy` pods to `:443`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>