### PR TITLE
fix(home): cilium toFQDNs matchPattern -> toEntities:world

### DIFF
--- a/kubernetes/apps/home/frigate-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/home/frigate-oauth2-proxy/app/cnp-allow.yaml
@@ -29,13 +29,12 @@ spec:
     # which then routes to the auth namespace. Upstream → frigate:5000
     # is same-ns; baseline allow-intra-namespace covers that.
     #
-    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
-    # pod DNS search-domain augmentation. matchPattern + matchPattern.*
-    # dual-form covers both un-augmented and search-domain-augmented
-    # forms — see PR #11492 for the canonical example.
-    - toFQDNs:
-        - matchPattern: "auth.thesteamedcrab.com"
-        - matchPattern: "auth.thesteamedcrab.com.*"
+    # auth.${SECRET_DOMAIN} is canonical (no CNAME chain). Cilium 1.19
+    # matchPattern silently fails for canonical FQDNs through K8s DNS
+    # search-domain augmentation — per memory
+    # project_cilium_matchpattern_fqdn_limits.md. Use toEntities:world+443,
+    # matches the precedent in PRs #11498/#11512/#11517/#11533.
+    - toEntities: [world]
       toPorts:
         - ports:
             - port: "443"

--- a/kubernetes/apps/home/smtp-relay/app/cnp-allow.yaml
+++ b/kubernetes/apps/home/smtp-relay/app/cnp-allow.yaml
@@ -56,11 +56,12 @@ spec:
     # memory project_smtp_relay_broken_since_day1.md — must be
     # `tls://` on 465, NOT starttls.
     #
-    # matchPattern + matchPattern.* covers the search-domain-augmented
-    # FQDN form (Cilium 1.19 quirk — see PR #11492).
-    - toFQDNs:
-        - matchPattern: "smtp.mailgun.org"
-        - matchPattern: "smtp.mailgun.org.*"
+    # smtp.mailgun.org is a canonical FQDN. Per memory
+    # project_cilium_matchpattern_fqdn_limits.md, Cilium 1.19
+    # matchPattern silently fails for canonical FQDNs through K8s DNS
+    # search-domain augmentation. Use toEntities:world+465, matches the
+    # precedent in PRs #11498/#11512/#11517/#11533.
+    - toEntities: [world]
       toPorts:
         - ports:
             - port: "465"


### PR DESCRIPTION
## Summary

Replace canonical-only FQDN matchPattern allows (silently broken per `project_cilium_matchpattern_fqdn_limits.md`) with `toEntities:[world]` in the **home** namespace:

| File | FQDN | Port |
|---|---|---|
| `frigate-oauth2-proxy/app/cnp-allow.yaml` | `auth.thesteamedcrab.com` | 443 |
| `smtp-relay/app/cnp-allow.yaml` | `smtp.mailgun.org` | 465 |

The smtp-relay fix is potentially impactful — outbound mail (Authelia, HA notify, zulip, netbox) currently routes here, and per `project_smtp_relay_broken_since_day1.md` the relay was broken multiple ways recently. matchPattern silently failing on `smtp.mailgun.org` would re-break it.

## Test plan

- [ ] Flux reconciles
- [ ] frigate OIDC login still works
- [ ] Send test SMTP via smtp-relay → Maddy logs show "delivered" not "accepted"

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>