### PR TITLE
fix(media): cilium toFQDNs matchPattern -> toEntities:world

### DIFF
--- a/kubernetes/apps/media/av1corrector-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/av1corrector-oauth2-proxy/app/cnp-allow.yaml
@@ -28,11 +28,12 @@ spec:
     # resolves to the internal envoy gateway VIP).
     # Upstream → av1corrector.media:8000 is same-ns (baseline covers).
     #
-    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
-    # pod DNS search-domain augmentation — see PR #11492.
-    - toFQDNs:
-        - matchPattern: "auth.thesteamedcrab.com"
-        - matchPattern: "auth.thesteamedcrab.com.*"
+    # auth.${SECRET_DOMAIN} is canonical (no CNAME chain). Cilium 1.19
+    # matchPattern silently fails for canonical FQDNs through K8s DNS
+    # search-domain augmentation — per memory
+    # project_cilium_matchpattern_fqdn_limits.md. Use toEntities:world+443,
+    # matches the precedent in PRs #11498/#11512/#11517/#11533.
+    - toEntities: [world]
       toPorts:
         - ports:
             - port: "443"

--- a/kubernetes/apps/media/jellyfin/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/jellyfin/app/cnp-allow.yaml
@@ -60,36 +60,21 @@ spec:
     # season metadata, theme music, etc. *arr metadata writers are OFF
     # in this cluster (see project_media_writers_plan.md), so jellyfin
     # is the canonical fetcher.
+    # Intended endpoints:
+    #   TheMovieDB: api.themoviedb.org, image.tmdb.org
+    #   Fanart.tv:  webservice.fanart.tv, assets.fanart.tv
+    #   TheTVDB:    api4.thetvdb.com, artworks.thetvdb.com
+    #   MusicBrainz / Cover Art Archive
+    #   Jellyfin plugin manifest + repo: repo.jellyfin.org
     #
-    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
-    # pod DNS search-domain augmentation (pod queries
-    # `api.themoviedb.org.media.svc.cluster.local.` and the FQDN cache
-    # stores the augmented name; matchName misses it). Bare + `.*`
-    # matchPattern covers both forms — see PR #11492.
-    - toFQDNs:
-        # TheMovieDB
-        - matchPattern: "api.themoviedb.org"
-        - matchPattern: "api.themoviedb.org.*"
-        - matchPattern: "image.tmdb.org"
-        - matchPattern: "image.tmdb.org.*"
-        # Fanart.tv
-        - matchPattern: "webservice.fanart.tv"
-        - matchPattern: "webservice.fanart.tv.*"
-        - matchPattern: "assets.fanart.tv"
-        - matchPattern: "assets.fanart.tv.*"
-        # TheTVDB (jellyfin plugin)
-        - matchPattern: "api4.thetvdb.com"
-        - matchPattern: "api4.thetvdb.com.*"
-        - matchPattern: "artworks.thetvdb.com"
-        - matchPattern: "artworks.thetvdb.com.*"
-        # MusicBrainz / Cover Art Archive (music library)
-        - matchPattern: "musicbrainz.org"
-        - matchPattern: "musicbrainz.org.*"
-        - matchPattern: "coverartarchive.org"
-        - matchPattern: "coverartarchive.org.*"
-        # Jellyfin plugin manifest + repo
-        - matchPattern: "repo.jellyfin.org"
-        - matchPattern: "repo.jellyfin.org.*"
+    # musicbrainz.org, coverartarchive.org, repo.jellyfin.org are
+    # canonical (no CNAME chain) — Cilium 1.19 matchPattern silently
+    # fails for canonical FQDNs through K8s DNS search-domain
+    # augmentation (per project_cilium_matchpattern_fqdn_limits.md).
+    # CNAME-fronted status uncertain for the TMDb / Fanart / TVDB CDNs;
+    # when uncertain default to toEntities:world+443. Matches the
+    # precedent in PRs #11498/#11512/#11517/#11533.
+    - toEntities: [world]
       toPorts:
         - ports:
             - port: "443"

--- a/kubernetes/apps/media/kodi-playback-watcher/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/kodi-playback-watcher/app/cnp-allow.yaml
@@ -19,16 +19,13 @@ spec:
     # KPW reaches it via:
     #   :9090 — Kodi JSON-RPC WebSocket (live playback events)
     #   :22   — SSH for /storage/.kodi/temp/kodi.log tail fallback
-    # Allow toFQDNs against the DNS name `kodi-familyroom.thesteamedcrab.com`
-    # which resolves through external-dns to the LAN IP.
-    #
-    # Cilium 1.19 toFQDNs.matchName doesn't match search-domain
-    # augmentation — see PR #11492 for the bare + .* pattern.
-    - toFQDNs:
-        - matchPattern: "kodi-familyroom.thesteamedcrab.com"
-        - matchPattern: "kodi-familyroom.thesteamedcrab.com.*"
-        - matchPattern: "kodi-familyroom"
-        - matchPattern: "kodi-familyroom.*"
+    # Target FQDN `kodi-familyroom.thesteamedcrab.com` is a canonical
+    # local DNS A record (no CNAME chain). Per memory
+    # project_cilium_matchpattern_fqdn_limits.md, Cilium 1.19
+    # matchPattern silently fails for canonical FQDNs through K8s DNS
+    # search-domain augmentation. Use toEntities:world + the same
+    # ports, matches the precedent in PRs #11498/#11512/#11517/#11533.
+    - toEntities: [world]
       toPorts:
         - ports:
             - port: "9090"

--- a/kubernetes/apps/media/lidarr-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/lidarr-oauth2-proxy/app/cnp-allow.yaml
@@ -28,11 +28,12 @@ spec:
     # resolves to the internal envoy gateway VIP).
     # Upstream → lidarr.media:8686 is same-ns (baseline covers).
     #
-    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
-    # pod DNS search-domain augmentation — see PR #11492.
-    - toFQDNs:
-        - matchPattern: "auth.thesteamedcrab.com"
-        - matchPattern: "auth.thesteamedcrab.com.*"
+    # auth.${SECRET_DOMAIN} is canonical (no CNAME chain). Cilium 1.19
+    # matchPattern silently fails for canonical FQDNs through K8s DNS
+    # search-domain augmentation — per memory
+    # project_cilium_matchpattern_fqdn_limits.md. Use toEntities:world+443,
+    # matches the precedent in PRs #11498/#11512/#11517/#11533.
+    - toEntities: [world]
       toPorts:
         - ports:
             - port: "443"

--- a/kubernetes/apps/media/medialyze-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/medialyze-oauth2-proxy/app/cnp-allow.yaml
@@ -28,11 +28,12 @@ spec:
     # resolves to the internal envoy gateway VIP).
     # Upstream → medialyze.media:8080 is same-ns (baseline covers).
     #
-    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
-    # pod DNS search-domain augmentation — see PR #11492.
-    - toFQDNs:
-        - matchPattern: "auth.thesteamedcrab.com"
-        - matchPattern: "auth.thesteamedcrab.com.*"
+    # auth.${SECRET_DOMAIN} is canonical (no CNAME chain). Cilium 1.19
+    # matchPattern silently fails for canonical FQDNs through K8s DNS
+    # search-domain augmentation — per memory
+    # project_cilium_matchpattern_fqdn_limits.md. Use toEntities:world+443,
+    # matches the precedent in PRs #11498/#11512/#11517/#11533.
+    - toEntities: [world]
       toPorts:
         - ports:
             - port: "443"

--- a/kubernetes/apps/media/music-assistant-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/music-assistant-oauth2-proxy/app/cnp-allow.yaml
@@ -28,11 +28,12 @@ spec:
     # resolves to the internal envoy gateway VIP).
     # Upstream → music-assistant.media:8095 is same-ns (baseline covers).
     #
-    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
-    # pod DNS search-domain augmentation — see PR #11492.
-    - toFQDNs:
-        - matchPattern: "auth.thesteamedcrab.com"
-        - matchPattern: "auth.thesteamedcrab.com.*"
+    # auth.${SECRET_DOMAIN} is canonical (no CNAME chain). Cilium 1.19
+    # matchPattern silently fails for canonical FQDNs through K8s DNS
+    # search-domain augmentation — per memory
+    # project_cilium_matchpattern_fqdn_limits.md. Use toEntities:world+443,
+    # matches the precedent in PRs #11498/#11512/#11517/#11533.
+    - toEntities: [world]
       toPorts:
         - ports:
             - port: "443"

--- a/kubernetes/apps/media/radarr-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/radarr-oauth2-proxy/app/cnp-allow.yaml
@@ -28,11 +28,12 @@ spec:
     # resolves to the internal envoy gateway VIP).
     # Upstream → radarr.media:7878 is same-ns (baseline covers).
     #
-    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
-    # pod DNS search-domain augmentation — see PR #11492.
-    - toFQDNs:
-        - matchPattern: "auth.thesteamedcrab.com"
-        - matchPattern: "auth.thesteamedcrab.com.*"
+    # auth.${SECRET_DOMAIN} is canonical (no CNAME chain). Cilium 1.19
+    # matchPattern silently fails for canonical FQDNs through K8s DNS
+    # search-domain augmentation — per memory
+    # project_cilium_matchpattern_fqdn_limits.md. Use toEntities:world+443,
+    # matches the precedent in PRs #11498/#11512/#11517/#11533.
+    - toEntities: [world]
       toPorts:
         - ports:
             - port: "443"

--- a/kubernetes/apps/media/sonarr-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/sonarr-oauth2-proxy/app/cnp-allow.yaml
@@ -28,11 +28,12 @@ spec:
     # resolves to the internal envoy gateway VIP).
     # Upstream → sonarr.media:8989 is same-ns (baseline covers).
     #
-    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
-    # pod DNS search-domain augmentation — see PR #11492.
-    - toFQDNs:
-        - matchPattern: "auth.thesteamedcrab.com"
-        - matchPattern: "auth.thesteamedcrab.com.*"
+    # auth.${SECRET_DOMAIN} is canonical (no CNAME chain). Cilium 1.19
+    # matchPattern silently fails for canonical FQDNs through K8s DNS
+    # search-domain augmentation — per memory
+    # project_cilium_matchpattern_fqdn_limits.md. Use toEntities:world+443,
+    # matches the precedent in PRs #11498/#11512/#11517/#11533.
+    - toEntities: [world]
       toPorts:
         - ports:
             - port: "443"

--- a/kubernetes/apps/media/soularr-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/soularr-oauth2-proxy/app/cnp-allow.yaml
@@ -28,11 +28,12 @@ spec:
     # resolves to the internal envoy gateway VIP).
     # Upstream → soularr.media:1000 is same-ns (baseline covers).
     #
-    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
-    # pod DNS search-domain augmentation — see PR #11492.
-    - toFQDNs:
-        - matchPattern: "auth.thesteamedcrab.com"
-        - matchPattern: "auth.thesteamedcrab.com.*"
+    # auth.${SECRET_DOMAIN} is canonical (no CNAME chain). Cilium 1.19
+    # matchPattern silently fails for canonical FQDNs through K8s DNS
+    # search-domain augmentation — per memory
+    # project_cilium_matchpattern_fqdn_limits.md. Use toEntities:world+443,
+    # matches the precedent in PRs #11498/#11512/#11517/#11533.
+    - toEntities: [world]
       toPorts:
         - ports:
             - port: "443"

--- a/kubernetes/apps/media/suggestarr-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/suggestarr-oauth2-proxy/app/cnp-allow.yaml
@@ -28,11 +28,12 @@ spec:
     # resolves to the internal envoy gateway VIP).
     # Upstream → suggestarr.media:5000 is same-ns (baseline covers).
     #
-    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
-    # pod DNS search-domain augmentation — see PR #11492.
-    - toFQDNs:
-        - matchPattern: "auth.thesteamedcrab.com"
-        - matchPattern: "auth.thesteamedcrab.com.*"
+    # auth.${SECRET_DOMAIN} is canonical (no CNAME chain). Cilium 1.19
+    # matchPattern silently fails for canonical FQDNs through K8s DNS
+    # search-domain augmentation — per memory
+    # project_cilium_matchpattern_fqdn_limits.md. Use toEntities:world+443,
+    # matches the precedent in PRs #11498/#11512/#11517/#11533.
+    - toEntities: [world]
       toPorts:
         - ports:
             - port: "443"


### PR DESCRIPTION
## Summary

Replace canonical-only FQDN matchPattern allows (silently broken per `project_cilium_matchpattern_fqdn_limits.md`) with `toEntities:[world]` across the **media** namespace (10 files).

| File group | FQDNs converted |
|---|---|
| 8 oauth2-proxies (av1corrector/lidarr/medialyze/music-assistant/radarr/sonarr/soularr/suggestarr) | `auth.thesteamedcrab.com` |
| `jellyfin` | TMDb/Fanart/TVDB/MusicBrainz/CoverArtArchive/repo.jellyfin.org metadata providers |
| `kodi-playback-watcher` | `kodi-familyroom.thesteamedcrab.com` (9090 + 22) |

**Untouched** (CNAME-fronted, matchPattern works):
- `recyclarr` (github.com + *.githubusercontent.com)

## Test plan

- [ ] Flux reconciles
- [ ] OIDC login still works for all 8 *arr oauth2-proxies
- [ ] Jellyfin metadata fetches succeed on next library scan
- [ ] kodi-playback-watcher still tracks playback state from kodi-familyroom

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>