### PR TITLE
fix(observability): cilium toFQDNs matchPattern -> toEntities:world

### DIFF
--- a/kubernetes/apps/observability/goldilocks-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/observability/goldilocks-oauth2-proxy/app/cnp-allow.yaml
@@ -25,11 +25,12 @@ spec:
     # OIDC discovery + token exchange against Authelia.
     # Upstream → goldilocks-dashboard:80 is intra-ns; baseline covers.
     #
-    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
-    # pod DNS search-domain augmentation — bare + `.*` dual-form.
-    - toFQDNs:
-        - matchPattern: "auth.thesteamedcrab.com"
-        - matchPattern: "auth.thesteamedcrab.com.*"
+    # auth.${SECRET_DOMAIN} is canonical (no CNAME chain). Cilium 1.19
+    # matchPattern silently fails for canonical FQDNs through K8s DNS
+    # search-domain augmentation — per memory
+    # project_cilium_matchpattern_fqdn_limits.md. Use toEntities:world+443,
+    # matches the precedent in PRs #11498/#11512/#11517/#11533.
+    - toEntities: [world]
       toPorts:
         - ports:
             - port: "443"

--- a/kubernetes/apps/observability/grafana/app/cnp-allow.yaml
+++ b/kubernetes/apps/observability/grafana/app/cnp-allow.yaml
@@ -43,22 +43,18 @@ spec:
     # Also covers grafana.com plugin downloads, grafana.com gnetId
     # dashboard fetches, and grafana.com news feed (disabled in
     # values but the client still ranges over default URLs at boot).
+    # Intended endpoints:
+    #   raw.githubusercontent.com (CNAME-fronted via Fastly)
+    #   grafana.com, *.grafana.com, grafana.net (uncertain CNAME)
+    #   storage.googleapis.com (CNAME-fronted via Google)
     #
-    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
-    # pod DNS search-domain augmentation — bare + `.*` dual-form
-    # matchPattern handles both un-augmented and search-domain-
-    # augmented forms.
-    - toFQDNs:
-        - matchPattern: "raw.githubusercontent.com"
-        - matchPattern: "raw.githubusercontent.com.*"
-        - matchPattern: "grafana.com"
-        - matchPattern: "grafana.com.*"
-        - matchPattern: "*.grafana.com"
-        - matchPattern: "*.grafana.com.*"
-        - matchPattern: "grafana.net"
-        - matchPattern: "grafana.net.*"
-        - matchPattern: "storage.googleapis.com"
-        - matchPattern: "storage.googleapis.com.*"
+    # The grafana.* family CNAME status is uncertain; per memory
+    # project_cilium_matchpattern_fqdn_limits.md, when uncertain default
+    # to toEntities:world+443 (broad allow is the safe failure mode).
+    # That subsumes the CNAME-fronted hosts above so the whole rule
+    # collapses to world:443. Matches the precedent in PRs
+    # #11498/#11512/#11517/#11533.
+    - toEntities: [world]
       toPorts:
         - ports:
             - port: "443"

--- a/kubernetes/apps/observability/holmesgpt-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/observability/holmesgpt-oauth2-proxy/app/cnp-allow.yaml
@@ -28,11 +28,12 @@ spec:
     # Upstream → holmesgpt.observability.svc.cluster.local:8080 is
     # intra-ns; baseline allow-intra-namespace covers that path.
     #
-    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
-    # pod DNS search-domain augmentation — bare + `.*` dual-form.
-    - toFQDNs:
-        - matchPattern: "auth.thesteamedcrab.com"
-        - matchPattern: "auth.thesteamedcrab.com.*"
+    # auth.${SECRET_DOMAIN} is canonical (no CNAME chain). Cilium 1.19
+    # matchPattern silently fails for canonical FQDNs through K8s DNS
+    # search-domain augmentation — per memory
+    # project_cilium_matchpattern_fqdn_limits.md. Use toEntities:world+443,
+    # matches the precedent in PRs #11498/#11512/#11517/#11533.
+    - toEntities: [world]
       toPorts:
         - ports:
             - port: "443"

--- a/kubernetes/apps/observability/kube-ops-view-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/observability/kube-ops-view-oauth2-proxy/app/cnp-allow.yaml
@@ -25,11 +25,12 @@ spec:
     # OIDC discovery + token exchange against Authelia.
     # Upstream → kube-ops-view:8080 is intra-ns; baseline covers.
     #
-    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
-    # pod DNS search-domain augmentation — bare + `.*` dual-form.
-    - toFQDNs:
-        - matchPattern: "auth.thesteamedcrab.com"
-        - matchPattern: "auth.thesteamedcrab.com.*"
+    # auth.${SECRET_DOMAIN} is canonical (no CNAME chain). Cilium 1.19
+    # matchPattern silently fails for canonical FQDNs through K8s DNS
+    # search-domain augmentation — per memory
+    # project_cilium_matchpattern_fqdn_limits.md. Use toEntities:world+443,
+    # matches the precedent in PRs #11498/#11512/#11517/#11533.
+    - toEntities: [world]
       toPorts:
         - ports:
             - port: "443"

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/cnp-allow.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/cnp-allow.yaml
@@ -88,15 +88,14 @@ spec:
               protocol: TCP
     # Pushover notification API.
     #
-    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
-    # pod DNS search-domain augmentation (pod queries e.g.
-    # `api.pushover.net.observability.svc.cluster.local.`; the FQDN
-    # cache stores the augmented name; matchName misses it). The bare
-    # + `.*` dual-form matchPattern covers both un-augmented and
-    # search-domain-augmented forms.
-    - toFQDNs:
-        - matchPattern: "api.pushover.net"
-        - matchPattern: "api.pushover.net.*"
+    # api.pushover.net is canonical (no CNAME chain). Cilium 1.19
+    # matchPattern silently fails for canonical FQDNs through K8s DNS
+    # search-domain augmentation — per memory
+    # project_cilium_matchpattern_fqdn_limits.md. Use toEntities:world+443,
+    # matches the precedent in PRs #11498/#11512/#11517/#11533. Alertmanager
+    # → Pushover is the Tier-1 escalation path; matchPattern silently
+    # failing here breaks paging.
+    - toEntities: [world]
       toPorts:
         - ports:
             - port: "443"

--- a/kubernetes/apps/observability/vector/aggregator/cnp-allow.yaml
+++ b/kubernetes/apps/observability/vector/aggregator/cnp-allow.yaml
@@ -35,11 +35,12 @@ spec:
     # init container shares pod identity with `app`, so the policy
     # has to permit it.
     #
-    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
-    # pod DNS search-domain augmentation — bare + `.*` dual-form.
-    - toFQDNs:
-        - matchPattern: "updates.maxmind.com"
-        - matchPattern: "updates.maxmind.com.*"
+    # updates.maxmind.com is canonical (no CNAME chain). Cilium 1.19
+    # matchPattern silently fails for canonical FQDNs through K8s DNS
+    # search-domain augmentation — per memory
+    # project_cilium_matchpattern_fqdn_limits.md. Use toEntities:world+443,
+    # matches the precedent in PRs #11498/#11512/#11517/#11533.
+    - toEntities: [world]
       toPorts:
         - ports:
             - port: "443"


### PR DESCRIPTION
## Summary

Replace canonical-only FQDN matchPattern allows (silently broken per `project_cilium_matchpattern_fqdn_limits.md`) with `toEntities:[world]` in the **observability** namespace.

| File | FQDNs converted |
|---|---|
| `kube-prometheus-stack/alertmanager` | `api.pushover.net` (Tier-1 paging path!) |
| `vector/aggregator` | `updates.maxmind.com` (GeoIP DB) |
| `grafana` | `grafana.com`, `*.grafana.com`, `grafana.net`, `storage.googleapis.com` (+ raw.githubusercontent.com subsumed) |
| `goldilocks-oauth2-proxy`, `holmesgpt-oauth2-proxy`, `kube-ops-view-oauth2-proxy` | `auth.thesteamedcrab.com` |

**Critical** — alertmanager → pushover is the Tier-1 escalation path. matchPattern silently failing here would break paging without any visible signal until an incident.

## Test plan

- [ ] Flux reconciles
- [ ] alertmanager test alert delivers to Pushover
- [ ] Grafana plugin install still works (canary)
- [ ] vector-aggregator next pod restart succeeds GeoIP refresh
- [ ] All 3 oauth2-proxy login flows still work

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>