### PR TITLE
fix(storage): cilium toFQDNs matchPattern -> toEntities:world

### DIFF
--- a/kubernetes/apps/storage/garage-webui-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/storage/garage-webui-oauth2-proxy/app/cnp-allow.yaml
@@ -29,16 +29,12 @@ spec:
     # Upstream → garage-webui.storage.svc.cluster.local:3909. Same-ns;
     # the baseline allow-intra-namespace already covers that path.
     #
-    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
-    # pod DNS search-domain augmentation (pod queries
-    # `auth.thesteamedcrab.com.storage.svc.cluster.local.` and the
-    # FQDN cache stores the augmented name; matchName misses it). The
-    # bare + `.*` dual-form matchPattern covers both un-augmented and
-    # search-domain-augmented forms — see PR #11492 for the canonical
-    # example.
-    - toFQDNs:
-        - matchPattern: "auth.thesteamedcrab.com"
-        - matchPattern: "auth.thesteamedcrab.com.*"
+    # auth.${SECRET_DOMAIN} is canonical (no CNAME chain). Cilium 1.19
+    # matchPattern silently fails for canonical FQDNs through K8s DNS
+    # search-domain augmentation — per memory
+    # project_cilium_matchpattern_fqdn_limits.md. Use toEntities:world+443,
+    # matches the precedent in PRs #11498/#11512/#11517/#11533.
+    - toEntities: [world]
       toPorts:
         - ports:
             - port: "443"


### PR DESCRIPTION
## Summary

`garage-webui-oauth2-proxy` CNP had matchPattern allow for `auth.thesteamedcrab.com` (canonical local DNS, no CNAME). Per `project_cilium_matchpattern_fqdn_limits.md` these silently fail through K8s DNS search-domain augmentation. Replace with `toEntities:[world]+443`.

Matches the precedent in PRs #11498/#11512/#11517/#11533.

## Test plan

- [ ] Flux reconciles
- [ ] garage-webui OIDC login flow still works

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>