### PR TITLE
fix(downloads): allow ICMP egress to vpn/pod-gateway for gateway-sidecar init

### DIFF
--- a/kubernetes/apps/downloads/jdownloader2/app/cnp-allow.yaml
+++ b/kubernetes/apps/downloads/jdownloader2/app/cnp-allow.yaml
@@ -34,3 +34,18 @@ spec:
         - ports:
             - port: "4789"
               protocol: UDP
+    # ICMP echo to the pod-gateway. The gateway-sidecar init container
+    # (angelnu/pod-gateway client_init.sh v7+) runs an ICMP liveness
+    # check against the gateway pod IP before declaring the tunnel up.
+    # Without this, init fails → CrashLoopBackOff under default-deny.
+    # See memory project_pod_gateway_upstream_issues.md (#414).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: vpn
+            app.kubernetes.io/instance: downloads-gateway
+            app.kubernetes.io/name: pod-gateway
+            app.kubernetes.io/controller: main
+      icmps:
+        - fields:
+            - type: 8  # echo request
+              family: IPv4

--- a/kubernetes/apps/downloads/prowlarr/app/cnp-allow.yaml
+++ b/kubernetes/apps/downloads/prowlarr/app/cnp-allow.yaml
@@ -54,6 +54,21 @@ spec:
         - ports:
             - port: "4789"
               protocol: UDP
+    # ICMP echo to the pod-gateway. The gateway-sidecar init container
+    # (angelnu/pod-gateway client_init.sh v7+) runs an ICMP liveness
+    # check against the gateway pod IP before declaring the tunnel up.
+    # Without this, init fails → CrashLoopBackOff under default-deny.
+    # See memory project_pod_gateway_upstream_issues.md (#414).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: vpn
+            app.kubernetes.io/instance: downloads-gateway
+            app.kubernetes.io/name: pod-gateway
+            app.kubernetes.io/controller: main
+      icmps:
+        - fields:
+            - type: 8  # echo request
+              family: IPv4
     # Cross-ns: FlareSolverr in media ns proxies Cloudflare-protected
     # indexer fetches for prowlarr. Same-cluster Service call:
     # http://flaresolverr.media.svc.cluster.local:8191

--- a/kubernetes/apps/downloads/qbittorrent/app/cnp-allow.yaml
+++ b/kubernetes/apps/downloads/qbittorrent/app/cnp-allow.yaml
@@ -54,3 +54,18 @@ spec:
         - ports:
             - port: "4789"
               protocol: UDP
+    # ICMP echo to the pod-gateway. The gateway-sidecar init container
+    # (angelnu/pod-gateway client_init.sh v7+) runs an ICMP liveness
+    # check against the gateway pod IP before declaring the tunnel up.
+    # Without this, init fails → CrashLoopBackOff under default-deny.
+    # See memory project_pod_gateway_upstream_issues.md (#414).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: vpn
+            app.kubernetes.io/instance: downloads-gateway
+            app.kubernetes.io/name: pod-gateway
+            app.kubernetes.io/controller: main
+      icmps:
+        - fields:
+            - type: 8  # echo request
+              family: IPv4

--- a/kubernetes/apps/downloads/sabnzbd/app/cnp-allow.yaml
+++ b/kubernetes/apps/downloads/sabnzbd/app/cnp-allow.yaml
@@ -48,3 +48,18 @@ spec:
         - ports:
             - port: "4789"
               protocol: UDP
+    # ICMP echo to the pod-gateway. The gateway-sidecar init container
+    # (angelnu/pod-gateway client_init.sh v7+) runs an ICMP liveness
+    # check against the gateway pod IP before declaring the tunnel up.
+    # Without this, init fails → CrashLoopBackOff under default-deny.
+    # See memory project_pod_gateway_upstream_issues.md (#414).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: vpn
+            app.kubernetes.io/instance: downloads-gateway
+            app.kubernetes.io/name: pod-gateway
+            app.kubernetes.io/controller: main
+      icmps:
+        - fields:
+            - type: 8  # echo request
+              family: IPv4

--- a/kubernetes/apps/downloads/slskd/app/cnp-allow.yaml
+++ b/kubernetes/apps/downloads/slskd/app/cnp-allow.yaml
@@ -40,3 +40,18 @@ spec:
         - ports:
             - port: "4789"
               protocol: UDP
+    # ICMP echo to the pod-gateway. The gateway-sidecar init container
+    # (angelnu/pod-gateway client_init.sh v7+) runs an ICMP liveness
+    # check against the gateway pod IP before declaring the tunnel up.
+    # Without this, init fails → CrashLoopBackOff under default-deny.
+    # See memory project_pod_gateway_upstream_issues.md (#414).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: vpn
+            app.kubernetes.io/instance: downloads-gateway
+            app.kubernetes.io/name: pod-gateway
+            app.kubernetes.io/controller: main
+      icmps:
+        - fields:
+            - type: 8  # echo request
+              family: IPv4


### PR DESCRIPTION
## Summary

- Adds ICMP (echo-request) egress allow from each downloads/* pod (qbittorrent, sabnzbd, slskd, jdownloader2, prowlarr) to vpn/pod-gateway alongside the existing VXLAN UDP/4789 rule.
- Unblocks the `gateway-sidecar` init container's ICMP liveness check against the pod-gateway IP, which had been failing under default-deny → 14h CrashLoopBackOff on all 5 download pods.
- The vpn-side `downloads-gateway-pod-gateway` CNP already allows ingress `fromEntities: cluster` (covers ICMP from downloads pods); no vpn-side edit required.
- Related upstream: angelnu/helm-charts#414. Memory: `project_pod_gateway_upstream_issues.md`.

## Context

The orchestrator manually deleted the `downloads` + `vpn` `default-deny` CNPs and restarted all 5 download pods to break the loop (pods now 2/2 Running). `flux-system/cluster-apps` Kustomization is suspended pending this fix; once merged, resuming Flux will reapply default-deny + the new ICMP allow rule together.

## Test plan

- [ ] Merge.
- [ ] `flux resume kustomization -n flux-system cluster-apps`.
- [ ] Verify `default-deny` CNP reappears in `downloads` + `vpn` namespaces.
- [ ] Verify all 5 downloads/* pods stay 2/2 Running for at least 60s (no init-container restarts).
- [ ] If pods restart: `kubectl delete cnp -n downloads default-deny && kubectl delete cnp -n vpn default-deny` and surface for diagnosis.