### PR TITLE
fix(downloads): add Pattern E direct egress to authelia for OIDC

### DIFF
--- a/kubernetes/apps/downloads/jdownloader2-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/downloads/jdownloader2-oauth2-proxy/app/cnp-allow.yaml
@@ -38,3 +38,22 @@ spec:
         - ports:
             - port: "443"
               protocol: TCP
+    # OIDC token exchange — direct to authelia in-cluster Service
+    # (Pattern E). The Pattern A/B browser flow goes through envoy
+    # fine, but the server-side code exchange (oauth2-proxy callback
+    # → authelia after user login redirect back) needs this direct
+    # cross-ns allow. toEntities:[world]:443 and
+    # matchPattern:auth.${SECRET_DOMAIN} DO NOT work for the
+    # in-cluster path: split-horizon DNS returns the LB IP and
+    # Cilium socket-lb rewrites the connect() to the envoy pod IP +
+    # targetPort 10443 BEFORE policy check, so neither rule matches
+    # the rewritten destination. Authelia's CNP already permits
+    # fromEntities:cluster on 9091. Mirrors paperless PR #11525.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: auth
+            app.kubernetes.io/name: authelia
+      toPorts:
+        - ports:
+            - port: "9091"
+              protocol: TCP

--- a/kubernetes/apps/downloads/prowlarr-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/downloads/prowlarr-oauth2-proxy/app/cnp-allow.yaml
@@ -38,3 +38,22 @@ spec:
         - ports:
             - port: "443"
               protocol: TCP
+    # OIDC token exchange — direct to authelia in-cluster Service
+    # (Pattern E). The Pattern A/B browser flow goes through envoy
+    # fine, but the server-side code exchange (oauth2-proxy callback
+    # → authelia after user login redirect back) needs this direct
+    # cross-ns allow. toEntities:[world]:443 and
+    # matchPattern:auth.${SECRET_DOMAIN} DO NOT work for the
+    # in-cluster path: split-horizon DNS returns the LB IP and
+    # Cilium socket-lb rewrites the connect() to the envoy pod IP +
+    # targetPort 10443 BEFORE policy check, so neither rule matches
+    # the rewritten destination. Authelia's CNP already permits
+    # fromEntities:cluster on 9091. Mirrors paperless PR #11525.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: auth
+            app.kubernetes.io/name: authelia
+      toPorts:
+        - ports:
+            - port: "9091"
+              protocol: TCP

--- a/kubernetes/apps/downloads/qbittorrent-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/downloads/qbittorrent-oauth2-proxy/app/cnp-allow.yaml
@@ -38,3 +38,22 @@ spec:
         - ports:
             - port: "443"
               protocol: TCP
+    # OIDC token exchange — direct to authelia in-cluster Service
+    # (Pattern E). The Pattern A/B browser flow goes through envoy
+    # fine, but the server-side code exchange (oauth2-proxy callback
+    # → authelia after user login redirect back) needs this direct
+    # cross-ns allow. toEntities:[world]:443 and
+    # matchPattern:auth.${SECRET_DOMAIN} DO NOT work for the
+    # in-cluster path: split-horizon DNS returns the LB IP and
+    # Cilium socket-lb rewrites the connect() to the envoy pod IP +
+    # targetPort 10443 BEFORE policy check, so neither rule matches
+    # the rewritten destination. Authelia's CNP already permits
+    # fromEntities:cluster on 9091. Mirrors paperless PR #11525.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: auth
+            app.kubernetes.io/name: authelia
+      toPorts:
+        - ports:
+            - port: "9091"
+              protocol: TCP

--- a/kubernetes/apps/downloads/sabnzbd-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/downloads/sabnzbd-oauth2-proxy/app/cnp-allow.yaml
@@ -38,3 +38,22 @@ spec:
         - ports:
             - port: "443"
               protocol: TCP
+    # OIDC token exchange — direct to authelia in-cluster Service
+    # (Pattern E). The Pattern A/B browser flow goes through envoy
+    # fine, but the server-side code exchange (oauth2-proxy callback
+    # → authelia after user login redirect back) needs this direct
+    # cross-ns allow. toEntities:[world]:443 and
+    # matchPattern:auth.${SECRET_DOMAIN} DO NOT work for the
+    # in-cluster path: split-horizon DNS returns the LB IP and
+    # Cilium socket-lb rewrites the connect() to the envoy pod IP +
+    # targetPort 10443 BEFORE policy check, so neither rule matches
+    # the rewritten destination. Authelia's CNP already permits
+    # fromEntities:cluster on 9091. Mirrors paperless PR #11525.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: auth
+            app.kubernetes.io/name: authelia
+      toPorts:
+        - ports:
+            - port: "9091"
+              protocol: TCP

--- a/kubernetes/apps/downloads/slskd-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/downloads/slskd-oauth2-proxy/app/cnp-allow.yaml
@@ -38,3 +38,22 @@ spec:
         - ports:
             - port: "443"
               protocol: TCP
+    # OIDC token exchange — direct to authelia in-cluster Service
+    # (Pattern E). The Pattern A/B browser flow goes through envoy
+    # fine, but the server-side code exchange (oauth2-proxy callback
+    # → authelia after user login redirect back) needs this direct
+    # cross-ns allow. toEntities:[world]:443 and
+    # matchPattern:auth.${SECRET_DOMAIN} DO NOT work for the
+    # in-cluster path: split-horizon DNS returns the LB IP and
+    # Cilium socket-lb rewrites the connect() to the envoy pod IP +
+    # targetPort 10443 BEFORE policy check, so neither rule matches
+    # the rewritten destination. Authelia's CNP already permits
+    # fromEntities:cluster on 9091. Mirrors paperless PR #11525.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: auth
+            app.kubernetes.io/name: authelia
+      toPorts:
+        - ports:
+            - port: "9091"
+              protocol: TCP


### PR DESCRIPTION
## Summary

- Adds Pattern E direct in-cluster egress from 5 downloads oauth2-proxy pods to `auth/authelia:9091`
- Required for the server-side OIDC code exchange after browser redirect — Cilium socket-lb rewrites destination before policy check, so existing `toEntities:[world]:443` cannot match the in-cluster envoy hop
- Mirrors paperless fix in PR #11525

## Test plan

- [ ] Flux reconciles all 5 downloads oauth2-proxy policies
- [ ] Hubble shows ALLOWED for at least one downloads oauth2-proxy pod → `auth/authelia:9091`
- [ ] OIDC login to representative app (e.g. `prowlarr.${SECRET_DOMAIN}`) completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)