### PR TITLE
fix(media): add Pattern E direct egress to authelia for OIDC

### DIFF
--- a/kubernetes/apps/media/av1corrector-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/av1corrector-oauth2-proxy/app/cnp-allow.yaml
@@ -38,3 +38,22 @@ spec:
         - ports:
             - port: "443"
               protocol: TCP
+    # OIDC token exchange — direct to authelia in-cluster Service
+    # (Pattern E). The Pattern A/B browser flow goes through envoy
+    # fine, but the server-side code exchange (oauth2-proxy callback
+    # → authelia after user login redirect back) needs this direct
+    # cross-ns allow. toEntities:[world]:443 and
+    # matchPattern:auth.${SECRET_DOMAIN} DO NOT work for the
+    # in-cluster path: split-horizon DNS returns the LB IP and
+    # Cilium socket-lb rewrites the connect() to the envoy pod IP +
+    # targetPort 10443 BEFORE policy check, so neither rule matches
+    # the rewritten destination. Authelia's CNP already permits
+    # fromEntities:cluster on 9091. Mirrors paperless PR #11525.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: auth
+            app.kubernetes.io/name: authelia
+      toPorts:
+        - ports:
+            - port: "9091"
+              protocol: TCP

--- a/kubernetes/apps/media/immich/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/immich/app/cnp-allow.yaml
@@ -60,9 +60,11 @@ spec:
               protocol: TCP
     # Intra-ns: immich-server → immich-machine-learning:3003 is covered
     # by baseline allow-intra-namespace.
-    # External: reverse-geocoding (Mapbox tile servers), Authelia OIDC
-    # discovery, version checks, app push (Firebase), thumbnail
-    # off-loads. Mapbox/tile FQDN set churns; world keeps it stable.
+    # External: reverse-geocoding (Mapbox tile servers), version
+    # checks, app push (Firebase), thumbnail off-loads. Mapbox/tile
+    # FQDN set churns; world keeps it stable. (Authelia OIDC is on
+    # a separate Pattern E rule below — the world+443 path can't
+    # reach the in-cluster auth.${SECRET_DOMAIN}.)
     - toEntities:
         - world
       toPorts:
@@ -70,6 +72,24 @@ spec:
             - port: "443"
               protocol: TCP
             - port: "80"
+              protocol: TCP
+    # OIDC token exchange — direct to authelia in-cluster Service
+    # (Pattern E). Immich's server-side OIDC integration (configured
+    # via system.json oauth.issuerUrl) does the code exchange
+    # server-side after user redirect. toEntities:[world]:443 and
+    # matchPattern:auth.${SECRET_DOMAIN} DO NOT work for this
+    # in-cluster path: split-horizon DNS returns the LB IP and
+    # Cilium socket-lb rewrites the connect() to the envoy pod IP +
+    # targetPort 10443 BEFORE policy check, so neither rule matches
+    # the rewritten destination. Authelia's CNP already permits
+    # fromEntities:cluster on 9091. Mirrors paperless PR #11525.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: auth
+            app.kubernetes.io/name: authelia
+      toPorts:
+        - ports:
+            - port: "9091"
               protocol: TCP
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json

--- a/kubernetes/apps/media/lidarr-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/lidarr-oauth2-proxy/app/cnp-allow.yaml
@@ -38,3 +38,22 @@ spec:
         - ports:
             - port: "443"
               protocol: TCP
+    # OIDC token exchange — direct to authelia in-cluster Service
+    # (Pattern E). The Pattern A/B browser flow goes through envoy
+    # fine, but the server-side code exchange (oauth2-proxy callback
+    # → authelia after user login redirect back) needs this direct
+    # cross-ns allow. toEntities:[world]:443 and
+    # matchPattern:auth.${SECRET_DOMAIN} DO NOT work for the
+    # in-cluster path: split-horizon DNS returns the LB IP and
+    # Cilium socket-lb rewrites the connect() to the envoy pod IP +
+    # targetPort 10443 BEFORE policy check, so neither rule matches
+    # the rewritten destination. Authelia's CNP already permits
+    # fromEntities:cluster on 9091. Mirrors paperless PR #11525.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: auth
+            app.kubernetes.io/name: authelia
+      toPorts:
+        - ports:
+            - port: "9091"
+              protocol: TCP

--- a/kubernetes/apps/media/medialyze-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/medialyze-oauth2-proxy/app/cnp-allow.yaml
@@ -38,3 +38,22 @@ spec:
         - ports:
             - port: "443"
               protocol: TCP
+    # OIDC token exchange — direct to authelia in-cluster Service
+    # (Pattern E). The Pattern A/B browser flow goes through envoy
+    # fine, but the server-side code exchange (oauth2-proxy callback
+    # → authelia after user login redirect back) needs this direct
+    # cross-ns allow. toEntities:[world]:443 and
+    # matchPattern:auth.${SECRET_DOMAIN} DO NOT work for the
+    # in-cluster path: split-horizon DNS returns the LB IP and
+    # Cilium socket-lb rewrites the connect() to the envoy pod IP +
+    # targetPort 10443 BEFORE policy check, so neither rule matches
+    # the rewritten destination. Authelia's CNP already permits
+    # fromEntities:cluster on 9091. Mirrors paperless PR #11525.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: auth
+            app.kubernetes.io/name: authelia
+      toPorts:
+        - ports:
+            - port: "9091"
+              protocol: TCP

--- a/kubernetes/apps/media/music-assistant-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/music-assistant-oauth2-proxy/app/cnp-allow.yaml
@@ -38,3 +38,22 @@ spec:
         - ports:
             - port: "443"
               protocol: TCP
+    # OIDC token exchange — direct to authelia in-cluster Service
+    # (Pattern E). The Pattern A/B browser flow goes through envoy
+    # fine, but the server-side code exchange (oauth2-proxy callback
+    # → authelia after user login redirect back) needs this direct
+    # cross-ns allow. toEntities:[world]:443 and
+    # matchPattern:auth.${SECRET_DOMAIN} DO NOT work for the
+    # in-cluster path: split-horizon DNS returns the LB IP and
+    # Cilium socket-lb rewrites the connect() to the envoy pod IP +
+    # targetPort 10443 BEFORE policy check, so neither rule matches
+    # the rewritten destination. Authelia's CNP already permits
+    # fromEntities:cluster on 9091. Mirrors paperless PR #11525.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: auth
+            app.kubernetes.io/name: authelia
+      toPorts:
+        - ports:
+            - port: "9091"
+              protocol: TCP

--- a/kubernetes/apps/media/radarr-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/radarr-oauth2-proxy/app/cnp-allow.yaml
@@ -38,3 +38,22 @@ spec:
         - ports:
             - port: "443"
               protocol: TCP
+    # OIDC token exchange — direct to authelia in-cluster Service
+    # (Pattern E). The Pattern A/B browser flow goes through envoy
+    # fine, but the server-side code exchange (oauth2-proxy callback
+    # → authelia after user login redirect back) needs this direct
+    # cross-ns allow. toEntities:[world]:443 and
+    # matchPattern:auth.${SECRET_DOMAIN} DO NOT work for the
+    # in-cluster path: split-horizon DNS returns the LB IP and
+    # Cilium socket-lb rewrites the connect() to the envoy pod IP +
+    # targetPort 10443 BEFORE policy check, so neither rule matches
+    # the rewritten destination. Authelia's CNP already permits
+    # fromEntities:cluster on 9091. Mirrors paperless PR #11525.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: auth
+            app.kubernetes.io/name: authelia
+      toPorts:
+        - ports:
+            - port: "9091"
+              protocol: TCP

--- a/kubernetes/apps/media/romm/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/romm/app/cnp-allow.yaml
@@ -55,3 +55,22 @@ spec:
               protocol: TCP
             - port: "80"
               protocol: TCP
+    # OIDC token exchange — direct to authelia in-cluster Service
+    # (Pattern E). RomM uses Authlib server-side OIDC
+    # (OIDC_SERVER_METADATA_URL points at auth.${SECRET_DOMAIN}) to
+    # do the code exchange after user login redirect.
+    # toEntities:[world]:443 and matchPattern:auth.${SECRET_DOMAIN}
+    # DO NOT work for this in-cluster path: split-horizon DNS
+    # returns the LB IP and Cilium socket-lb rewrites the connect()
+    # to the envoy pod IP + targetPort 10443 BEFORE policy check, so
+    # neither rule matches the rewritten destination. Authelia's CNP
+    # already permits fromEntities:cluster on 9091. Mirrors
+    # paperless PR #11525.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: auth
+            app.kubernetes.io/name: authelia
+      toPorts:
+        - ports:
+            - port: "9091"
+              protocol: TCP

--- a/kubernetes/apps/media/sonarr-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/sonarr-oauth2-proxy/app/cnp-allow.yaml
@@ -38,3 +38,22 @@ spec:
         - ports:
             - port: "443"
               protocol: TCP
+    # OIDC token exchange — direct to authelia in-cluster Service
+    # (Pattern E). The Pattern A/B browser flow goes through envoy
+    # fine, but the server-side code exchange (oauth2-proxy callback
+    # → authelia after user login redirect back) needs this direct
+    # cross-ns allow. toEntities:[world]:443 and
+    # matchPattern:auth.${SECRET_DOMAIN} DO NOT work for the
+    # in-cluster path: split-horizon DNS returns the LB IP and
+    # Cilium socket-lb rewrites the connect() to the envoy pod IP +
+    # targetPort 10443 BEFORE policy check, so neither rule matches
+    # the rewritten destination. Authelia's CNP already permits
+    # fromEntities:cluster on 9091. Mirrors paperless PR #11525.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: auth
+            app.kubernetes.io/name: authelia
+      toPorts:
+        - ports:
+            - port: "9091"
+              protocol: TCP

--- a/kubernetes/apps/media/soularr-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/soularr-oauth2-proxy/app/cnp-allow.yaml
@@ -38,3 +38,22 @@ spec:
         - ports:
             - port: "443"
               protocol: TCP
+    # OIDC token exchange — direct to authelia in-cluster Service
+    # (Pattern E). The Pattern A/B browser flow goes through envoy
+    # fine, but the server-side code exchange (oauth2-proxy callback
+    # → authelia after user login redirect back) needs this direct
+    # cross-ns allow. toEntities:[world]:443 and
+    # matchPattern:auth.${SECRET_DOMAIN} DO NOT work for the
+    # in-cluster path: split-horizon DNS returns the LB IP and
+    # Cilium socket-lb rewrites the connect() to the envoy pod IP +
+    # targetPort 10443 BEFORE policy check, so neither rule matches
+    # the rewritten destination. Authelia's CNP already permits
+    # fromEntities:cluster on 9091. Mirrors paperless PR #11525.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: auth
+            app.kubernetes.io/name: authelia
+      toPorts:
+        - ports:
+            - port: "9091"
+              protocol: TCP

--- a/kubernetes/apps/media/stash/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/stash/app/cnp-allow.yaml
@@ -35,3 +35,20 @@ spec:
               protocol: TCP
             - port: "80"
               protocol: TCP
+    # OIDC token exchange — direct to authelia in-cluster Service
+    # (Pattern E). Stash uses native server-side OIDC (STASH_OIDC_*)
+    # to talk to Authelia after the user login redirect. The
+    # toEntities:[world]:443 above doesn't suffice for this path:
+    # split-horizon DNS resolves auth.${SECRET_DOMAIN} to the LB IP
+    # and Cilium socket-lb rewrites the connect() to the envoy pod IP
+    # + targetPort 10443 BEFORE policy check, so neither rule matches
+    # the rewritten destination. Authelia's CNP already permits
+    # fromEntities:cluster on 9091. Mirrors paperless PR #11525.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: auth
+            app.kubernetes.io/name: authelia
+      toPorts:
+        - ports:
+            - port: "9091"
+              protocol: TCP

--- a/kubernetes/apps/media/suggestarr-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/suggestarr-oauth2-proxy/app/cnp-allow.yaml
@@ -38,3 +38,22 @@ spec:
         - ports:
             - port: "443"
               protocol: TCP
+    # OIDC token exchange — direct to authelia in-cluster Service
+    # (Pattern E). The Pattern A/B browser flow goes through envoy
+    # fine, but the server-side code exchange (oauth2-proxy callback
+    # → authelia after user login redirect back) needs this direct
+    # cross-ns allow. toEntities:[world]:443 and
+    # matchPattern:auth.${SECRET_DOMAIN} DO NOT work for the
+    # in-cluster path: split-horizon DNS returns the LB IP and
+    # Cilium socket-lb rewrites the connect() to the envoy pod IP +
+    # targetPort 10443 BEFORE policy check, so neither rule matches
+    # the rewritten destination. Authelia's CNP already permits
+    # fromEntities:cluster on 9091. Mirrors paperless PR #11525.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: auth
+            app.kubernetes.io/name: authelia
+      toPorts:
+        - ports:
+            - port: "9091"
+              protocol: TCP


### PR DESCRIPTION
## Summary

- Adds Pattern E direct in-cluster egress to `auth/authelia:9091` for 11 media-ns pods
- Required for the server-side OIDC code exchange after browser redirect — Cilium socket-lb rewrites destination before policy check, so existing `toEntities:[world]:443` (or `matchPattern`) cannot match the in-cluster envoy hop
- Mirrors paperless fix in PR #11525

Covers 8 oauth2-proxy sidecars plus 3 apps doing native server-side OIDC (stash, immich, romm).

## Test plan

- [ ] Flux reconciles all 11 media policies
- [ ] Hubble shows ALLOWED for at least one media pod → `auth/authelia:9091`
- [ ] OIDC login to a representative app (e.g. `radarr.${SECRET_DOMAIN}`, `photos.${SECRET_DOMAIN}`) completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)