### PR TITLE
fix(downloads,vpn): omit default-deny — VXLAN DHCP broadcast incompat

### DIFF
--- a/kubernetes/apps/downloads/kustomization.yaml
+++ b/kubernetes/apps/downloads/kustomization.yaml
@@ -5,7 +5,18 @@ kind: Kustomization
 namespace: downloads
 components:
   - ../../components/network-policy/baseline
-  - ../../components/network-policy/default-deny
+  # default-deny intentionally OMITTED for downloads ns. The pod-gateway
+  # sidecar's init container brings up a VXLAN tunnel to vpn/pod-gateway
+  # then runs `udhcpc` on vxlan0 to lease an IP. The DHCP discover is a
+  # 255.255.255.255 broadcast encapsulated inside the VXLAN unicast tunnel.
+  # Under cilium default-deny the broadcast return path (DHCP OFFER) is
+  # silently dropped — cilium's identity for the broadcast frame inside
+  # the tunnel doesn't match vpn/pod-gateway's identity. ICMP allow
+  # (PR #11548) was necessary but not sufficient: VXLAN tunnel comes
+  # up, then DHCP times out and the init container crashloops.
+  # Tracked in #11493 / pod-gateway upstream issues #414-#416.
+  # Revisit when cilium broadcast-identity handling improves or we
+  # replace pod-gateway with static-IP wireguard.
 resources:
   - ./namespace.yaml
   - ./jdownloader2/ks.yaml

--- a/kubernetes/apps/vpn/kustomization.yaml
+++ b/kubernetes/apps/vpn/kustomization.yaml
@@ -5,7 +5,12 @@ kind: Kustomization
 namespace: vpn
 components:
   - ../../components/network-policy/baseline
-  - ../../components/network-policy/default-deny
+  # default-deny intentionally OMITTED for vpn ns. Paired with the same
+  # omission in downloads/kustomization.yaml — pod-gateway is the VXLAN
+  # tunnel terminator for downloads/* clients, and the DHCP OFFER
+  # broadcast return path from this side gets dropped by default-deny
+  # before reaching the clients. See downloads/kustomization.yaml for
+  # full context.
 resources:
   - ./namespace.yaml
   - ./downloads-gateway/ks.yaml


### PR DESCRIPTION
## Summary

- Removes `default-deny` component from `downloads` and `vpn` namespace kustomizations
- ICMP allow (PR #11548) wasn't enough — DHCP discover broadcast inside VXLAN tunnel still drops under default-deny
- `baseline` (allow-dns/apiserver/intra-ns/monitoring) retained
- 19 of 21 namespaces keep full default-deny posture; downloads + vpn are the carve-outs

## Root cause

After PR #11548 the `ping 10.42.4.4` step in `gateway-sidecar`'s init container passes. The very next step (`udhcpc -i vxlan0`) sends a DHCP discover broadcast (255.255.255.255) encapsulated inside the VXLAN unicast tunnel to `vpn/pod-gateway-main-0`. dnsmasq logs DHCPACKs going out, but cilium's security identity for the broadcast frame inside the tunnel doesn't match `vpn/pod-gateway` — the OFFER is silently dropped. `udhcpc` retries 5×, exits 1, init crashloops.

Tested: 5 download pods went into CrashLoopBackOff for ~14h before rollback. Rolled back by deleting `default-deny` CNP in both namespaces and suspending `flux-system/cluster-apps`.

## Test plan

- [x] yamllint clean on both files
- [ ] After merge: `flux resume kustomization cluster-apps -n flux-system`
- [ ] Watch downloads pods stay 2/2 Running for ≥10 min
- [ ] Confirm `kubectl get cnp -n downloads` no longer shows `default-deny`
- [ ] Confirm 19 other namespaces still have `default-deny` CNP

## Follow-up

Revisit when:
- cilium ships better broadcast-identity handling, or
- we replace pod-gateway with a static-IP wireguard pattern that doesn't need DHCP

🤖 Generated with [Claude Code](https://claude.com/claude-code)