### PR TITLE
fix(pump-oauth2-proxy): egress to network/envoy:10443, not world:443

### DIFF
--- a/kubernetes/apps/collab/pump-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/collab/pump-oauth2-proxy/app/cnp-allow.yaml
@@ -25,36 +25,24 @@ spec:
             - port: "4180"
               protocol: TCP
   egress:
-    # OIDC discovery + token exchange against Authelia. Upstream →
-    # pump-frontend.collab.svc.cluster.local:8080 is same-ns, baseline.
-    #
-    # auth.${SECRET_DOMAIN} is canonical (no CNAME chain). Cilium 1.19
-    # matchPattern silently fails for canonical FQDNs through K8s DNS
-    # search-domain augmentation — per memory
-    # project_cilium_matchpattern_fqdn_limits.md. Use toEntities:world+443.
-    - toEntities: [world]
-      toPorts:
-        - ports:
-            - port: "443"
-              protocol: TCP
-    # OIDC token exchange — direct to authelia in-cluster Service
-    # (Pattern E). The Pattern A/B browser flow goes through envoy
-    # fine, but the server-side code exchange (oauth2-proxy callback
-    # → authelia after user login redirect back) needs this direct
-    # cross-ns allow. toEntities:[world]:443 and
-    # matchPattern:auth.${SECRET_DOMAIN} DO NOT work for the
-    # in-cluster path: split-horizon DNS returns the LB IP and
-    # Cilium socket-lb rewrites the connect() to the envoy pod IP +
-    # targetPort 10443 BEFORE policy check, so neither rule matches
-    # the rewritten destination. Authelia's CNP already permits
-    # fromEntities:cluster on 9091. Mirrors paperless PR #11525.
-    # This is the documented fix for the pump.${SECRET_DOMAIN}
-    # /oauth2/... callback hang.
+    # OIDC discovery + token exchange against Authelia at
+    # auth.${SECRET_DOMAIN}. oauth2-proxy is configured with the
+    # external issuer URL, so every OIDC request hits split-horizon DNS
+    # which returns the envoy LB IP (10.45.0.13). Cilium's socket-lb
+    # rewrites the connect() to the envoy pod IP + targetPort 10443
+    # BEFORE policy evaluation (per memory
+    # project_cilium_l4_port_targetport.md), so the policy must allow
+    # the envoy pod on its container port, NOT world:443 (which doesn't
+    # match cluster LB IPs) and NOT authelia:9091 directly (which
+    # oauth2-proxy never connects to because of how it's configured).
+    # This is the documented fix for pump.${SECRET_DOMAIN} 500 on the
+    # /oauth2/callback step: "token exchange failed: dial tcp
+    # 10.45.0.13:443: i/o timeout".
     - toEndpoints:
         - matchLabels:
-            io.kubernetes.pod.namespace: auth
-            app.kubernetes.io/name: authelia
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
       toPorts:
         - ports:
-            - port: "9091"
+            - port: "10443"
               protocol: TCP


### PR DESCRIPTION
## Summary

- Replaces both prior misguided rules (`toEntities:[world]:443` + `authelia:9091`) with the correct `network/envoy:10443` egress
- Fixes pump.thesteamedcrab.com 500 "token exchange failed: dial tcp 10.45.0.13:443: i/o timeout"

## Why the prior fixes missed

oauth2-proxy is configured with `OIDC_ISSUER_URL=https://auth.thesteamedcrab.com`. Every server-side OIDC request hits split-horizon DNS → returns envoy LB IP `10.45.0.13`. Cilium socket-lb rewrites the connect() to envoy pod IP + targetPort 10443 BEFORE policy evaluation:

| Rule | What it allows | Why it doesn't match |
|---|---|---|
| `toEntities:[world]:443` | Egress to public internet on 443 | `world` excludes cluster LB IPs |
| `authelia:9091` direct | Direct in-cluster to authelia | oauth2-proxy never connects here — it uses the external URL |
| **`network/envoy:10443`** | Envoy pod on its container port | ✓ matches the socket-lb-rewritten destination |

## Verification path (post-merge)

1. Wait for Flux reconcile
2. Force-restart pump-oauth2-proxy pod (`kubectl rollout restart deployment -n collab pump-oauth2-proxy`)
3. Hit https://pump.thesteamedcrab.com from browser
4. Should successfully complete OIDC roundtrip

## Follow-up

If this works, the same rewrite applies to the 27 other oauth2-proxy CNPs touched in PRs #11547-11554. That rollout would replace `toEntities:[world]:443` + `authelia:9091` with `network/envoy:10443` for all of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)