### PR TITLE
fix(ai): oauth2-proxy OIDC egress → network/envoy:10443

### DIFF
--- a/kubernetes/apps/ai/khoj-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/khoj-oauth2-proxy/app/cnp-allow.yaml
@@ -24,36 +24,24 @@ spec:
             - port: "4180"
               protocol: TCP
   egress:
-    # OIDC discovery + token exchange against Authelia.
-    # auth.${SECRET_DOMAIN} is a split-horizon local FQDN at its
-    # canonical form — no CNAME chain. Per memory
-    # project_cilium_matchpattern_fqdn_limits.md, Cilium 1.19
-    # matchPattern silently fails for canonical FQDNs queried through
-    # K8s DNS search-domain augmentation. Use toEntities:world+443,
-    # matches the precedent in PRs #11498/#11512/#11517/#11533.
+    # OIDC discovery + token exchange against Authelia at
+    # auth.${SECRET_DOMAIN}. oauth2-proxy is configured with the
+    # external issuer URL, so every OIDC request hits split-horizon DNS
+    # which returns the envoy LB IP (10.45.0.13). Cilium's socket-lb
+    # rewrites the connect() to the envoy pod IP + targetPort 10443
+    # BEFORE policy evaluation (per memory
+    # project_cilium_l4_port_targetport.md), so the policy must allow
+    # the envoy pod on its container port, NOT world:443 (which doesn't
+    # match cluster LB IPs) and NOT authelia:9091 directly (which
+    # oauth2-proxy never connects to because of how it's configured).
+    # Mirrors pump-oauth2-proxy PR #11559.
     # Upstream → khoj.ai.svc.cluster.local:42110 is intra-namespace,
     # covered by baseline allow-intra-namespace.
-    - toEntities: [world]
-      toPorts:
-        - ports:
-            - port: "443"
-              protocol: TCP
-    # OIDC token exchange — direct to authelia in-cluster Service
-    # (Pattern E). The Pattern A/B browser flow goes through envoy
-    # fine, but the server-side code exchange (oauth2-proxy callback
-    # → authelia after user login redirect back) needs this direct
-    # cross-ns allow. toEntities:[world]:443 and
-    # matchPattern:auth.${SECRET_DOMAIN} DO NOT work for the
-    # in-cluster path: split-horizon DNS returns the LB IP and
-    # Cilium socket-lb rewrites the connect() to the envoy pod IP +
-    # targetPort 10443 BEFORE policy check, so neither rule matches
-    # the rewritten destination. Authelia's CNP already permits
-    # fromEntities:cluster on 9091. Mirrors paperless PR #11525.
     - toEndpoints:
         - matchLabels:
-            io.kubernetes.pod.namespace: auth
-            app.kubernetes.io/name: authelia
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
       toPorts:
         - ports:
-            - port: "9091"
+            - port: "10443"
               protocol: TCP


### PR DESCRIPTION
## Summary

Re-does the OIDC egress fix from PR #11549 to match the working pattern established by pump PR #11559.

Replaces both prior misguided rules (`toEntities:[world]:443` + `authelia:9091`) with the single correct `network/envoy:10443` egress. See pump PR #11559 for rationale.

## CNPs corrected

- khoj-oauth2-proxy

## Test plan

- [ ] Wait for Flux reconcile
- [ ] Hubble verify FORWARDED to network/envoy:10443

🤖 Generated with [Claude Code](https://claude.com/claude-code)