### PR TITLE
fix(collab): OIDC server-side egress → network/envoy:10443

### DIFF
--- a/kubernetes/apps/collab/glance-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/collab/glance-oauth2-proxy/app/cnp-allow.yaml
@@ -24,37 +24,24 @@ spec:
             - port: "4180"
               protocol: TCP
   egress:
-    # OIDC discovery + token exchange against Authelia. Upstream →
-    # glance.collab.svc.cluster.local:8081 is same-ns, covered by
-    # baseline allow-intra-namespace.
-    #
-    # auth.${SECRET_DOMAIN} is a split-horizon local FQDN at its
-    # canonical form (no CNAME chain). Per memory
-    # project_cilium_matchpattern_fqdn_limits.md, Cilium 1.19
-    # matchPattern silently fails for canonical FQDNs queried through
-    # K8s DNS search-domain augmentation. Use toEntities:world+443,
-    # matches the precedent in PRs #11498/#11512/#11517/#11533.
-    - toEntities: [world]
-      toPorts:
-        - ports:
-            - port: "443"
-              protocol: TCP
-    # OIDC token exchange — direct to authelia in-cluster Service
-    # (Pattern E). The Pattern A/B browser flow goes through envoy
-    # fine, but the server-side code exchange (oauth2-proxy callback
-    # → authelia after user login redirect back) needs this direct
-    # cross-ns allow. toEntities:[world]:443 and
-    # matchPattern:auth.${SECRET_DOMAIN} DO NOT work for the
-    # in-cluster path: split-horizon DNS returns the LB IP and
-    # Cilium socket-lb rewrites the connect() to the envoy pod IP +
-    # targetPort 10443 BEFORE policy check, so neither rule matches
-    # the rewritten destination. Authelia's CNP already permits
-    # fromEntities:cluster on 9091. Mirrors paperless PR #11525.
+    # OIDC discovery + token exchange against Authelia at
+    # auth.${SECRET_DOMAIN}. oauth2-proxy is configured with the
+    # external issuer URL, so every OIDC request hits split-horizon DNS
+    # which returns the envoy LB IP (10.45.0.13). Cilium's socket-lb
+    # rewrites the connect() to the envoy pod IP + targetPort 10443
+    # BEFORE policy evaluation (per memory
+    # project_cilium_l4_port_targetport.md), so the policy must allow
+    # the envoy pod on its container port, NOT world:443 (which doesn't
+    # match cluster LB IPs) and NOT authelia:9091 directly (which
+    # oauth2-proxy never connects to because of how it's configured).
+    # Mirrors pump-oauth2-proxy PR #11559.
+    # Upstream → glance.collab.svc.cluster.local:8081 is same-ns,
+    # covered by baseline allow-intra-namespace.
     - toEndpoints:
         - matchLabels:
-            io.kubernetes.pod.namespace: auth
-            app.kubernetes.io/name: authelia
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
       toPorts:
         - ports:
-            - port: "9091"
+            - port: "10443"
               protocol: TCP

--- a/kubernetes/apps/collab/glance-user-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/collab/glance-user-oauth2-proxy/app/cnp-allow.yaml
@@ -25,34 +25,24 @@ spec:
             - port: "4180"
               protocol: TCP
   egress:
-    # OIDC discovery + token exchange against Authelia. Upstream →
-    # glance-user.collab.svc.cluster.local:8081 is same-ns, baseline.
-    #
-    # auth.${SECRET_DOMAIN} is canonical (no CNAME chain). Cilium 1.19
-    # matchPattern silently fails for canonical FQDNs through K8s DNS
-    # search-domain augmentation — per memory
-    # project_cilium_matchpattern_fqdn_limits.md. Use toEntities:world+443.
-    - toEntities: [world]
-      toPorts:
-        - ports:
-            - port: "443"
-              protocol: TCP
-    # OIDC token exchange — direct to authelia in-cluster Service
-    # (Pattern E). The Pattern A/B browser flow goes through envoy
-    # fine, but the server-side code exchange (oauth2-proxy callback
-    # → authelia after user login redirect back) needs this direct
-    # cross-ns allow. toEntities:[world]:443 and
-    # matchPattern:auth.${SECRET_DOMAIN} DO NOT work for the
-    # in-cluster path: split-horizon DNS returns the LB IP and
-    # Cilium socket-lb rewrites the connect() to the envoy pod IP +
-    # targetPort 10443 BEFORE policy check, so neither rule matches
-    # the rewritten destination. Authelia's CNP already permits
-    # fromEntities:cluster on 9091. Mirrors paperless PR #11525.
+    # OIDC discovery + token exchange against Authelia at
+    # auth.${SECRET_DOMAIN}. oauth2-proxy is configured with the
+    # external issuer URL, so every OIDC request hits split-horizon DNS
+    # which returns the envoy LB IP (10.45.0.13). Cilium's socket-lb
+    # rewrites the connect() to the envoy pod IP + targetPort 10443
+    # BEFORE policy evaluation (per memory
+    # project_cilium_l4_port_targetport.md), so the policy must allow
+    # the envoy pod on its container port, NOT world:443 (which doesn't
+    # match cluster LB IPs) and NOT authelia:9091 directly (which
+    # oauth2-proxy never connects to because of how it's configured).
+    # Mirrors pump-oauth2-proxy PR #11559.
+    # Upstream → glance-user.collab.svc.cluster.local:8081 is same-ns,
+    # covered by baseline allow-intra-namespace.
     - toEndpoints:
         - matchLabels:
-            io.kubernetes.pod.namespace: auth
-            app.kubernetes.io/name: authelia
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
       toPorts:
         - ports:
-            - port: "9091"
+            - port: "10443"
               protocol: TCP

--- a/kubernetes/apps/collab/kitchenowl/app/cnp-allow.yaml
+++ b/kubernetes/apps/collab/kitchenowl/app/cnp-allow.yaml
@@ -26,35 +26,22 @@ spec:
             - port: "8080"
               protocol: TCP
   egress:
-    # OIDC discovery + token exchange against Authelia (OIDC_ISSUER =
-    # https://auth.${SECRET_DOMAIN}). Resolves to the internal Envoy
-    # gateway VIP which then routes to the auth namespace.
-    #
-    # auth.${SECRET_DOMAIN} is canonical (no CNAME chain). Cilium 1.19
-    # matchPattern silently fails for canonical FQDNs through K8s DNS
-    # search-domain augmentation — per memory
-    # project_cilium_matchpattern_fqdn_limits.md. Use toEntities:world+443.
-    - toEntities: [world]
-      toPorts:
-        - ports:
-            - port: "443"
-              protocol: TCP
-    # OIDC token exchange — direct to authelia in-cluster Service
-    # (Pattern E). The Pattern A/B browser flow goes through envoy
-    # fine, but the server-side code exchange (kitchenowl callback
-    # → authelia after user login redirect back) needs this direct
-    # cross-ns allow. toEntities:[world]:443 and
-    # matchPattern:auth.${SECRET_DOMAIN} DO NOT work for the
-    # in-cluster path: split-horizon DNS returns the LB IP and
-    # Cilium socket-lb rewrites the connect() to the envoy pod IP +
-    # targetPort 10443 BEFORE policy check, so neither rule matches
-    # the rewritten destination. Authelia's CNP already permits
-    # fromEntities:cluster on 9091. Mirrors paperless PR #11525.
+    # OIDC discovery + token exchange against Authelia at
+    # auth.${SECRET_DOMAIN} (OIDC_ISSUER). kitchenowl is configured
+    # with the external issuer URL, so every OIDC request hits
+    # split-horizon DNS which returns the envoy LB IP (10.45.0.13).
+    # Cilium's socket-lb rewrites the connect() to the envoy pod IP +
+    # targetPort 10443 BEFORE policy evaluation (per memory
+    # project_cilium_l4_port_targetport.md), so the policy must allow
+    # the envoy pod on its container port, NOT world:443 (which doesn't
+    # match cluster LB IPs) and NOT authelia:9091 directly (which
+    # kitchenowl never connects to because of how it's configured).
+    # Mirrors pump-oauth2-proxy PR #11559.
     - toEndpoints:
         - matchLabels:
-            io.kubernetes.pod.namespace: auth
-            app.kubernetes.io/name: authelia
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
       toPorts:
         - ports:
-            - port: "9091"
+            - port: "10443"
               protocol: TCP

--- a/kubernetes/apps/collab/open-webui/app/cnp-allow.yaml
+++ b/kubernetes/apps/collab/open-webui/app/cnp-allow.yaml
@@ -73,16 +73,6 @@ spec:
         - ports:
             - port: "8080"
               protocol: TCP
-    # OIDC discovery + token exchange against Authelia, and TTS via
-    # piper.${SECRET_DOMAIN} — both resolve to the internal Envoy
-    # gateway VIP. Both are canonical local FQDNs (no CNAME chain).
-    #
-    # Subsumed by the toEntities:[world]+443 rule below (web-search /
-    # external integrations). Kept commented for grep-ability; if the
-    # below world:443 rule is ever narrowed, restore an explicit allow
-    # here per project_cilium_matchpattern_fqdn_limits.md
-    # (toEntities:world, not matchPattern — canonical FQDNs).
-    #
     # External tool egress: open-webui's web-search backend (searxng,
     # in-cluster — covered intra-ns via baseline), plus an open list
     # of user-configured external integrations (image gen APIs, image
@@ -90,30 +80,35 @@ spec:
     # Anthropic if the user wires them in via the UI). Config lives in
     # the open-webui SQLite DB (not in git), so the surface is broad
     # by design. Err on the side of permitting HTTPS world egress.
+    #
+    # NOTE: world:443 does NOT cover the OIDC path to Authelia or TTS
+    # via piper.${SECRET_DOMAIN} — both resolve via split-horizon DNS
+    # to the cluster LB IP, which the `world` entity excludes. See the
+    # network/envoy:10443 rule below for that.
     - toEntities:
         - world
       toPorts:
         - ports:
             - port: "443"
               protocol: TCP
-    # OIDC token exchange — direct to authelia in-cluster Service
-    # (Pattern E). The Pattern A/B browser flow goes through envoy
-    # fine, but the server-side code exchange (open-webui callback
-    # → authelia after user login redirect back) needs this direct
-    # cross-ns allow. toEntities:[world]:443 and
-    # matchPattern:auth.${SECRET_DOMAIN} DO NOT work for the
-    # in-cluster path: split-horizon DNS returns the LB IP and
-    # Cilium socket-lb rewrites the connect() to the envoy pod IP +
-    # targetPort 10443 BEFORE policy check, so neither rule matches
-    # the rewritten destination. Authelia's CNP already permits
-    # fromEntities:cluster on 9091. Mirrors paperless PR #11525.
+    # OIDC discovery + token exchange against Authelia + TTS via
+    # piper.${SECRET_DOMAIN}. open-webui is configured with the
+    # external issuer URL, so every OIDC request hits split-horizon
+    # DNS which returns the envoy LB IP (10.45.0.13). Cilium's
+    # socket-lb rewrites the connect() to the envoy pod IP +
+    # targetPort 10443 BEFORE policy evaluation (per memory
+    # project_cilium_l4_port_targetport.md), so the policy must allow
+    # the envoy pod on its container port, NOT world:443 (which
+    # doesn't match cluster LB IPs) and NOT authelia:9091 directly
+    # (which open-webui never connects to because of how it's
+    # configured). Mirrors pump-oauth2-proxy PR #11559.
     - toEndpoints:
         - matchLabels:
-            io.kubernetes.pod.namespace: auth
-            app.kubernetes.io/name: authelia
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
       toPorts:
         - ports:
-            - port: "9091"
+            - port: "10443"
               protocol: TCP
     # Intra-ns to searxng:8080 (SEARXNG_QUERY_URL) is covered by
     # baseline allow-intra-namespace.

--- a/kubernetes/apps/collab/paperless/app/cnp-allow.yaml
+++ b/kubernetes/apps/collab/paperless/app/cnp-allow.yaml
@@ -60,27 +60,20 @@ spec:
               protocol: TCP
     # OIDC discovery + token exchange against Authelia (allauth
     # openid_connect provider, server_url = auth.${SECRET_DOMAIN}).
-    #
-    # auth.${SECRET_DOMAIN} is canonical (no CNAME chain). Cilium 1.19
-    # matchPattern silently fails for canonical FQDNs through K8s DNS
-    # search-domain augmentation — per memory
-    # project_cilium_matchpattern_fqdn_limits.md. Use toEntities:world+443.
-    - toEntities: [world]
-      toPorts:
-        - ports:
-            - port: "443"
-              protocol: TCP
-    # OIDC token exchange + userinfo: paperless (django-allauth) calls
-    # authelia server-side after user redirect. The toFQDNs rule above
-    # resolves to envoy's LB IP via split-horizon DNS but that hop
-    # times out (yields HTTP 500 at the OIDC login). Direct in-cluster
-    # path to authelia bypasses the envoy roundtrip entirely
-    # (Pattern E).
+    # paperless is configured with the external issuer URL, so every
+    # OIDC request hits split-horizon DNS which returns the envoy LB
+    # IP (10.45.0.13). Cilium's socket-lb rewrites the connect() to
+    # the envoy pod IP + targetPort 10443 BEFORE policy evaluation
+    # (per memory project_cilium_l4_port_targetport.md), so the policy
+    # must allow the envoy pod on its container port, NOT world:443
+    # (which doesn't match cluster LB IPs) and NOT authelia:9091
+    # directly (which paperless never connects to because of how it's
+    # configured). Mirrors pump-oauth2-proxy PR #11559.
     - toEndpoints:
         - matchLabels:
-            io.kubernetes.pod.namespace: auth
-            app.kubernetes.io/name: authelia
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
       toPorts:
         - ports:
-            - port: "9091"
+            - port: "10443"
               protocol: TCP


### PR DESCRIPTION
## Summary

Re-does the OIDC egress fix from PRs #11525 and #11550 to match the working pattern established by pump PR #11559.

Apps configured with the external OIDC issuer URL hit split-horizon DNS → envoy LB IP (10.45.0.13). Cilium socket-lb rewrites the connect() to envoy pod IP + targetPort 10443 BEFORE policy evaluation:

| Rule | Outcome |
|---|---|
| `toEntities:[world]:443` | misses — excludes cluster LB IPs |
| `authelia:9091` direct | misses — apps never connect here |
| **`network/envoy:10443`** | matches the socket-lb-rewritten destination |

## CNPs corrected

| App | Pattern |
|---|---|
| glance-oauth2-proxy | Simple — both rules → envoy:10443 |
| glance-user-oauth2-proxy | Simple — both rules → envoy:10443 |
| kitchenowl (native OIDC) | Simple — both rules → envoy:10443 |
| paperless (native OIDC) | Simple — both rules → envoy:10443 |
| open-webui | **KEEP** world:443 (predates wave, used for external tool integrations), REMOVE authelia:9091, ADD envoy:10443 |

## Test plan

- [ ] Wait for Flux reconcile
- [ ] Restart oauth2-proxy / paperless / kitchenowl / open-webui pods
- [ ] Hubble verify FORWARDED to network/envoy:10443 for at least one pod

🤖 Generated with [Claude Code](https://claude.com/claude-code)