### PR TITLE
fix(netpol): full default-deny rollback + correct all oauth2-proxy CNPs

### DIFF
--- a/docs/src/networkpolicy_rollout_plan.md
+++ b/docs/src/networkpolicy_rollout_plan.md
@@ -87,6 +87,71 @@ downloads + vpn rely on cluster-perimeter controls (1P/SSO/firewalld,
 no public ingress to these workloads, only `bt.thesteamedcrab.com` +
 arr/sab/slskd UIs which are still gated by oauth2-proxy).
 
+## Full rollback 2026-05-18 — reset and redesign
+
+**Outcome:** All default-deny CNPs deleted from the 19 remaining
+locked-down namespaces. `cluster-apps` Flux Kustomization SUSPENDED
+to persist the rollback before this commit lands. Posture is now
+**zero default-deny** cluster-wide. Baseline + per-app allow CNPs
+remain in git and in-cluster but have no enforcement effect without
+a default-deny.
+
+**Trigger:** User browser-testing on 2026-05-18 surfaced 5+ broken
+apps despite every namespace passing audit-mode soak and in-cluster
+smoke tests:
+
+- `collab/pump` — OIDC `/oauth2/callback` token exchange failing
+  (fixed in PR #11559 ahead of the rollback; the fix shape became
+  the canonical pattern for every oauth2-proxy CNP).
+- `media/suggestarr`, `media/av1corrector`, `media/lidarr`,
+  `media/medialyze`, `media/music-assistant` — same OIDC token
+  exchange failure as pump.
+- `observability/kube-ops-view`, `observability/goldilocks`,
+  `observability/netdata`, `observability/blackbox` — non-oauth
+  reachability gaps from various directions (not all root-caused
+  yet).
+
+**Why a full reset rather than incremental fixes:** the failures
+were not a handful of edge cases — they were a systemic blind spot
+in the verification step. The audit-mode soak window cannot exercise
+flows that don't happen during the soak (server-side OIDC
+`/oauth2/callback` only fires when a user actually completes a
+browser login), and in-cluster `curl --resolve` smoke tests bypass
+the socket-lb rewrite path that breaks the policy match (see
+`project_cilium_l4_port_targetport.md`). Continuing to land
+incremental fixes on top of a partially-broken lockdown would
+keep extending the user-impact window every time a new app's
+OIDC pattern surfaces.
+
+**What was rolled back in git (this commit):**
+
+1. Removed the `network-policy/default-deny` component import from
+   all 19 namespace `kustomization.yaml` files that previously had
+   it. `baseline` (DNS, apiserver, intra-ns, monitoring scrape,
+   host probes) stays — these allows are harmless without a
+   default-deny.
+2. Corrected the 20 oauth2-proxy CNPs cluster-wide to the
+   `envoy:10443` egress pattern (was `toEntities:[world]:443` +
+   direct `authelia:9091`, which doesn't match the socket-lb-rewritten
+   destination). Mirrors the pump fix (PR #11559) and the storage
+   fix (PR #11560). These rules are inert under the current
+   no-default-deny posture but will be correct when the next
+   re-rollout enables enforcement.
+
+**Re-rollout plan (when work resumes):**
+
+- One namespace at a time, smallest first (start with `selfhosted`).
+- After enabling default-deny on a namespace, **user performs real
+  external-URL browser verification** (laptop → DNS → cloudflared →
+  envoy → backend → oauth2-proxy callback completes → app loads)
+  before the next namespace is touched.
+- Pattern-A CNPs are no longer accepted as "verified" by `curl URL`
+  returning 302 — the full OIDC round-trip must be exercised by a
+  human session.
+- The audit-mode soak window stays as a discovery mechanism but is
+  no longer the *gate* for flipping enforce; the user's browser
+  check is.
+
 ## Where the testing missed (honest retrospective)
 
 The network-operator agent's prime directive is "you cannot break

--- a/kubernetes/apps/actions-runner-system/kustomization.yaml
+++ b/kubernetes/apps/actions-runner-system/kustomization.yaml
@@ -6,7 +6,6 @@ namespace: actions-runner-system
 components:
   - ../../components/alerts
   - ../../components/network-policy/baseline
-  - ../../components/network-policy/default-deny
 resources:
   - ./namespace.yaml
   - ./actions-runner-controller/ks.yaml

--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -5,7 +5,6 @@ kind: Kustomization
 namespace: ai
 components:
   - ../../components/network-policy/baseline
-  - ../../components/network-policy/default-deny
 resources:
   - ./namespace.yaml
   - ./priority-class.yaml

--- a/kubernetes/apps/auth/kustomization.yaml
+++ b/kubernetes/apps/auth/kustomization.yaml
@@ -5,7 +5,6 @@ kind: Kustomization
 namespace: auth
 components:
   - ../../components/network-policy/baseline
-  - ../../components/network-policy/default-deny
 resources:
   - ./namespace.yaml
   - ./authelia/ks.yaml

--- a/kubernetes/apps/cert-manager/kustomization.yaml
+++ b/kubernetes/apps/cert-manager/kustomization.yaml
@@ -6,7 +6,6 @@ namespace: cert-manager
 components:
   - ../../components/alerts
   - ../../components/network-policy/baseline
-  - ../../components/network-policy/default-deny
 resources:
   - ./namespace.yaml
   - ./cert-manager/ks.yaml

--- a/kubernetes/apps/cilium-secrets/kustomization.yaml
+++ b/kubernetes/apps/cilium-secrets/kustomization.yaml
@@ -13,4 +13,3 @@ kind: Kustomization
 namespace: cilium-secrets
 components:
   - ../../components/network-policy/baseline
-  - ../../components/network-policy/default-deny

--- a/kubernetes/apps/collab/kustomization.yaml
+++ b/kubernetes/apps/collab/kustomization.yaml
@@ -6,7 +6,6 @@ namespace: collab
 components:
   - ../../components/alerts
   - ../../components/network-policy/baseline
-  - ../../components/network-policy/default-deny
 resources:
   - ./namespace.yaml
   - ./atuin/ks.yaml

--- a/kubernetes/apps/databases/kustomization.yaml
+++ b/kubernetes/apps/databases/kustomization.yaml
@@ -5,7 +5,6 @@ kind: Kustomization
 namespace: databases
 components:
   - ../../components/network-policy/baseline
-  - ../../components/network-policy/default-deny
 resources:
   - ./namespace.yaml
   - ./priority-class.yaml

--- a/kubernetes/apps/downloads/jdownloader2-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/downloads/jdownloader2-oauth2-proxy/app/cnp-allow.yaml
@@ -24,36 +24,24 @@ spec:
             - port: "4180"
               protocol: TCP
   egress:
-    # OIDC discovery + token exchange against Authelia, routed via the
-    # internal envoy gateway. Upstream → jdownloader2.downloads:5800 is
+    # OIDC discovery + token exchange against Authelia at
+    # auth.${SECRET_DOMAIN}. oauth2-proxy is configured with the
+    # external issuer URL, so every OIDC request hits split-horizon DNS
+    # which returns the envoy LB IP (10.45.0.13). Cilium's socket-lb
+    # rewrites the connect() to the envoy pod IP + targetPort 10443
+    # BEFORE policy evaluation (per memory
+    # project_cilium_l4_port_targetport.md), so the policy must allow
+    # the envoy pod on its container port, NOT world:443 (which doesn't
+    # match cluster LB IPs) and NOT authelia:9091 directly (which
+    # oauth2-proxy never connects to because of how it's configured).
+    # Mirrors pump-oauth2-proxy PR #11559.
+    # Upstream → jdownloader2.downloads:5800 is same-ns,
     # covered by baseline allow-intra-namespace.
-    #
-    # auth.${SECRET_DOMAIN} is canonical (no CNAME chain). Cilium 1.19
-    # matchPattern silently fails for canonical FQDNs through K8s DNS
-    # search-domain augmentation — per memory
-    # project_cilium_matchpattern_fqdn_limits.md. Use toEntities:world+443,
-    # matches the precedent in PRs #11498/#11512/#11517/#11533.
-    - toEntities: [world]
-      toPorts:
-        - ports:
-            - port: "443"
-              protocol: TCP
-    # OIDC token exchange — direct to authelia in-cluster Service
-    # (Pattern E). The Pattern A/B browser flow goes through envoy
-    # fine, but the server-side code exchange (oauth2-proxy callback
-    # → authelia after user login redirect back) needs this direct
-    # cross-ns allow. toEntities:[world]:443 and
-    # matchPattern:auth.${SECRET_DOMAIN} DO NOT work for the
-    # in-cluster path: split-horizon DNS returns the LB IP and
-    # Cilium socket-lb rewrites the connect() to the envoy pod IP +
-    # targetPort 10443 BEFORE policy check, so neither rule matches
-    # the rewritten destination. Authelia's CNP already permits
-    # fromEntities:cluster on 9091. Mirrors paperless PR #11525.
     - toEndpoints:
         - matchLabels:
-            io.kubernetes.pod.namespace: auth
-            app.kubernetes.io/name: authelia
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
       toPorts:
         - ports:
-            - port: "9091"
+            - port: "10443"
               protocol: TCP

--- a/kubernetes/apps/downloads/prowlarr-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/downloads/prowlarr-oauth2-proxy/app/cnp-allow.yaml
@@ -24,36 +24,24 @@ spec:
             - port: "4180"
               protocol: TCP
   egress:
-    # OIDC discovery + token exchange against Authelia, routed via the
-    # internal envoy gateway. Upstream → prowlarr.downloads:9696 is
+    # OIDC discovery + token exchange against Authelia at
+    # auth.${SECRET_DOMAIN}. oauth2-proxy is configured with the
+    # external issuer URL, so every OIDC request hits split-horizon DNS
+    # which returns the envoy LB IP (10.45.0.13). Cilium's socket-lb
+    # rewrites the connect() to the envoy pod IP + targetPort 10443
+    # BEFORE policy evaluation (per memory
+    # project_cilium_l4_port_targetport.md), so the policy must allow
+    # the envoy pod on its container port, NOT world:443 (which doesn't
+    # match cluster LB IPs) and NOT authelia:9091 directly (which
+    # oauth2-proxy never connects to because of how it's configured).
+    # Mirrors pump-oauth2-proxy PR #11559.
+    # Upstream → prowlarr.downloads:9696 is same-ns,
     # covered by baseline allow-intra-namespace.
-    #
-    # auth.${SECRET_DOMAIN} is canonical (no CNAME chain). Cilium 1.19
-    # matchPattern silently fails for canonical FQDNs through K8s DNS
-    # search-domain augmentation — per memory
-    # project_cilium_matchpattern_fqdn_limits.md. Use toEntities:world+443,
-    # matches the precedent in PRs #11498/#11512/#11517/#11533.
-    - toEntities: [world]
-      toPorts:
-        - ports:
-            - port: "443"
-              protocol: TCP
-    # OIDC token exchange — direct to authelia in-cluster Service
-    # (Pattern E). The Pattern A/B browser flow goes through envoy
-    # fine, but the server-side code exchange (oauth2-proxy callback
-    # → authelia after user login redirect back) needs this direct
-    # cross-ns allow. toEntities:[world]:443 and
-    # matchPattern:auth.${SECRET_DOMAIN} DO NOT work for the
-    # in-cluster path: split-horizon DNS returns the LB IP and
-    # Cilium socket-lb rewrites the connect() to the envoy pod IP +
-    # targetPort 10443 BEFORE policy check, so neither rule matches
-    # the rewritten destination. Authelia's CNP already permits
-    # fromEntities:cluster on 9091. Mirrors paperless PR #11525.
     - toEndpoints:
         - matchLabels:
-            io.kubernetes.pod.namespace: auth
-            app.kubernetes.io/name: authelia
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
       toPorts:
         - ports:
-            - port: "9091"
+            - port: "10443"
               protocol: TCP

--- a/kubernetes/apps/downloads/qbittorrent-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/downloads/qbittorrent-oauth2-proxy/app/cnp-allow.yaml
@@ -24,36 +24,24 @@ spec:
             - port: "4180"
               protocol: TCP
   egress:
-    # OIDC discovery + token exchange against Authelia, routed via the
-    # internal envoy gateway. Upstream → qbittorrent.downloads:8080 is
+    # OIDC discovery + token exchange against Authelia at
+    # auth.${SECRET_DOMAIN}. oauth2-proxy is configured with the
+    # external issuer URL, so every OIDC request hits split-horizon DNS
+    # which returns the envoy LB IP (10.45.0.13). Cilium's socket-lb
+    # rewrites the connect() to the envoy pod IP + targetPort 10443
+    # BEFORE policy evaluation (per memory
+    # project_cilium_l4_port_targetport.md), so the policy must allow
+    # the envoy pod on its container port, NOT world:443 (which doesn't
+    # match cluster LB IPs) and NOT authelia:9091 directly (which
+    # oauth2-proxy never connects to because of how it's configured).
+    # Mirrors pump-oauth2-proxy PR #11559.
+    # Upstream → qbittorrent.downloads:8080 is same-ns,
     # covered by baseline allow-intra-namespace.
-    #
-    # auth.${SECRET_DOMAIN} is canonical (no CNAME chain). Cilium 1.19
-    # matchPattern silently fails for canonical FQDNs through K8s DNS
-    # search-domain augmentation — per memory
-    # project_cilium_matchpattern_fqdn_limits.md. Use toEntities:world+443,
-    # matches the precedent in PRs #11498/#11512/#11517/#11533.
-    - toEntities: [world]
-      toPorts:
-        - ports:
-            - port: "443"
-              protocol: TCP
-    # OIDC token exchange — direct to authelia in-cluster Service
-    # (Pattern E). The Pattern A/B browser flow goes through envoy
-    # fine, but the server-side code exchange (oauth2-proxy callback
-    # → authelia after user login redirect back) needs this direct
-    # cross-ns allow. toEntities:[world]:443 and
-    # matchPattern:auth.${SECRET_DOMAIN} DO NOT work for the
-    # in-cluster path: split-horizon DNS returns the LB IP and
-    # Cilium socket-lb rewrites the connect() to the envoy pod IP +
-    # targetPort 10443 BEFORE policy check, so neither rule matches
-    # the rewritten destination. Authelia's CNP already permits
-    # fromEntities:cluster on 9091. Mirrors paperless PR #11525.
     - toEndpoints:
         - matchLabels:
-            io.kubernetes.pod.namespace: auth
-            app.kubernetes.io/name: authelia
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
       toPorts:
         - ports:
-            - port: "9091"
+            - port: "10443"
               protocol: TCP

--- a/kubernetes/apps/downloads/sabnzbd-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/downloads/sabnzbd-oauth2-proxy/app/cnp-allow.yaml
@@ -24,36 +24,24 @@ spec:
             - port: "4180"
               protocol: TCP
   egress:
-    # OIDC discovery + token exchange against Authelia, routed via the
-    # internal envoy gateway. Upstream → sabnzbd.downloads:8080 is
+    # OIDC discovery + token exchange against Authelia at
+    # auth.${SECRET_DOMAIN}. oauth2-proxy is configured with the
+    # external issuer URL, so every OIDC request hits split-horizon DNS
+    # which returns the envoy LB IP (10.45.0.13). Cilium's socket-lb
+    # rewrites the connect() to the envoy pod IP + targetPort 10443
+    # BEFORE policy evaluation (per memory
+    # project_cilium_l4_port_targetport.md), so the policy must allow
+    # the envoy pod on its container port, NOT world:443 (which doesn't
+    # match cluster LB IPs) and NOT authelia:9091 directly (which
+    # oauth2-proxy never connects to because of how it's configured).
+    # Mirrors pump-oauth2-proxy PR #11559.
+    # Upstream → sabnzbd.downloads:8080 is same-ns,
     # covered by baseline allow-intra-namespace.
-    #
-    # auth.${SECRET_DOMAIN} is canonical (no CNAME chain). Cilium 1.19
-    # matchPattern silently fails for canonical FQDNs through K8s DNS
-    # search-domain augmentation — per memory
-    # project_cilium_matchpattern_fqdn_limits.md. Use toEntities:world+443,
-    # matches the precedent in PRs #11498/#11512/#11517/#11533.
-    - toEntities: [world]
-      toPorts:
-        - ports:
-            - port: "443"
-              protocol: TCP
-    # OIDC token exchange — direct to authelia in-cluster Service
-    # (Pattern E). The Pattern A/B browser flow goes through envoy
-    # fine, but the server-side code exchange (oauth2-proxy callback
-    # → authelia after user login redirect back) needs this direct
-    # cross-ns allow. toEntities:[world]:443 and
-    # matchPattern:auth.${SECRET_DOMAIN} DO NOT work for the
-    # in-cluster path: split-horizon DNS returns the LB IP and
-    # Cilium socket-lb rewrites the connect() to the envoy pod IP +
-    # targetPort 10443 BEFORE policy check, so neither rule matches
-    # the rewritten destination. Authelia's CNP already permits
-    # fromEntities:cluster on 9091. Mirrors paperless PR #11525.
     - toEndpoints:
         - matchLabels:
-            io.kubernetes.pod.namespace: auth
-            app.kubernetes.io/name: authelia
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
       toPorts:
         - ports:
-            - port: "9091"
+            - port: "10443"
               protocol: TCP

--- a/kubernetes/apps/downloads/slskd-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/downloads/slskd-oauth2-proxy/app/cnp-allow.yaml
@@ -24,36 +24,24 @@ spec:
             - port: "4180"
               protocol: TCP
   egress:
-    # OIDC discovery + token exchange against Authelia, routed via the
-    # internal envoy gateway. Upstream → slskd.downloads:5030 is
+    # OIDC discovery + token exchange against Authelia at
+    # auth.${SECRET_DOMAIN}. oauth2-proxy is configured with the
+    # external issuer URL, so every OIDC request hits split-horizon DNS
+    # which returns the envoy LB IP (10.45.0.13). Cilium's socket-lb
+    # rewrites the connect() to the envoy pod IP + targetPort 10443
+    # BEFORE policy evaluation (per memory
+    # project_cilium_l4_port_targetport.md), so the policy must allow
+    # the envoy pod on its container port, NOT world:443 (which doesn't
+    # match cluster LB IPs) and NOT authelia:9091 directly (which
+    # oauth2-proxy never connects to because of how it's configured).
+    # Mirrors pump-oauth2-proxy PR #11559.
+    # Upstream → slskd.downloads:5030 is same-ns,
     # covered by baseline allow-intra-namespace.
-    #
-    # auth.${SECRET_DOMAIN} is canonical (no CNAME chain). Cilium 1.19
-    # matchPattern silently fails for canonical FQDNs through K8s DNS
-    # search-domain augmentation — per memory
-    # project_cilium_matchpattern_fqdn_limits.md. Use toEntities:world+443,
-    # matches the precedent in PRs #11498/#11512/#11517/#11533.
-    - toEntities: [world]
-      toPorts:
-        - ports:
-            - port: "443"
-              protocol: TCP
-    # OIDC token exchange — direct to authelia in-cluster Service
-    # (Pattern E). The Pattern A/B browser flow goes through envoy
-    # fine, but the server-side code exchange (oauth2-proxy callback
-    # → authelia after user login redirect back) needs this direct
-    # cross-ns allow. toEntities:[world]:443 and
-    # matchPattern:auth.${SECRET_DOMAIN} DO NOT work for the
-    # in-cluster path: split-horizon DNS returns the LB IP and
-    # Cilium socket-lb rewrites the connect() to the envoy pod IP +
-    # targetPort 10443 BEFORE policy check, so neither rule matches
-    # the rewritten destination. Authelia's CNP already permits
-    # fromEntities:cluster on 9091. Mirrors paperless PR #11525.
     - toEndpoints:
         - matchLabels:
-            io.kubernetes.pod.namespace: auth
-            app.kubernetes.io/name: authelia
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
       toPorts:
         - ports:
-            - port: "9091"
+            - port: "10443"
               protocol: TCP

--- a/kubernetes/apps/external-secrets/kustomization.yaml
+++ b/kubernetes/apps/external-secrets/kustomization.yaml
@@ -6,7 +6,6 @@ namespace: external-secrets
 components:
   - ../../components/alerts
   - ../../components/network-policy/baseline
-  - ../../components/network-policy/default-deny
 resources:
   - ./namespace.yaml
   - ./external-secrets/ks.yaml

--- a/kubernetes/apps/home/frigate-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/home/frigate-oauth2-proxy/app/cnp-allow.yaml
@@ -24,37 +24,24 @@ spec:
             - port: "4180"
               protocol: TCP
   egress:
-    # OIDC discovery + token exchange against Authelia.
-    # auth.${SECRET_DOMAIN} resolves to the internal Envoy gateway VIP,
-    # which then routes to the auth namespace. Upstream → frigate:5000
-    # is same-ns; baseline allow-intra-namespace covers that.
-    #
-    # auth.${SECRET_DOMAIN} is canonical (no CNAME chain). Cilium 1.19
-    # matchPattern silently fails for canonical FQDNs through K8s DNS
-    # search-domain augmentation — per memory
-    # project_cilium_matchpattern_fqdn_limits.md. Use toEntities:world+443,
-    # matches the precedent in PRs #11498/#11512/#11517/#11533.
-    - toEntities: [world]
-      toPorts:
-        - ports:
-            - port: "443"
-              protocol: TCP
-    # OIDC token exchange — direct to authelia in-cluster Service
-    # (Pattern E). The Pattern A/B browser flow goes through envoy
-    # fine, but the server-side code exchange (oauth2-proxy callback
-    # → authelia after user login redirect back) needs this direct
-    # cross-ns allow. toEntities:[world]:443 and
-    # matchPattern:auth.${SECRET_DOMAIN} DO NOT work for the
-    # in-cluster path: split-horizon DNS returns the LB IP and
-    # Cilium socket-lb rewrites the connect() to the envoy pod IP +
-    # targetPort 10443 BEFORE policy check, so neither rule matches
-    # the rewritten destination. Authelia's CNP already permits
-    # fromEntities:cluster on 9091. Mirrors paperless PR #11525.
+    # OIDC discovery + token exchange against Authelia at
+    # auth.${SECRET_DOMAIN}. oauth2-proxy is configured with the
+    # external issuer URL, so every OIDC request hits split-horizon DNS
+    # which returns the envoy LB IP (10.45.0.13). Cilium's socket-lb
+    # rewrites the connect() to the envoy pod IP + targetPort 10443
+    # BEFORE policy evaluation (per memory
+    # project_cilium_l4_port_targetport.md), so the policy must allow
+    # the envoy pod on its container port, NOT world:443 (which doesn't
+    # match cluster LB IPs) and NOT authelia:9091 directly (which
+    # oauth2-proxy never connects to because of how it's configured).
+    # Mirrors pump-oauth2-proxy PR #11559.
+    # Upstream → frigate.home:5000 is same-ns,
+    # covered by baseline allow-intra-namespace.
     - toEndpoints:
         - matchLabels:
-            io.kubernetes.pod.namespace: auth
-            app.kubernetes.io/name: authelia
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
       toPorts:
         - ports:
-            - port: "9091"
+            - port: "10443"
               protocol: TCP

--- a/kubernetes/apps/home/kustomization.yaml
+++ b/kubernetes/apps/home/kustomization.yaml
@@ -6,7 +6,6 @@ namespace: home
 components:
   - ../../components/alerts
   - ../../components/network-policy/baseline
-  - ../../components/network-policy/default-deny
 resources:
   - ./namespace.yaml
   - ./priority-class.yaml

--- a/kubernetes/apps/istio-system/kustomization.yaml
+++ b/kubernetes/apps/istio-system/kustomization.yaml
@@ -6,7 +6,6 @@ namespace: istio-system
 components:
   - ../../components/alerts
   - ../../components/network-policy/baseline
-  - ../../components/network-policy/default-deny
 resources:
   - ./namespace.yaml
   - ./istio/ks.yaml

--- a/kubernetes/apps/longhorn-system/kustomization.yaml
+++ b/kubernetes/apps/longhorn-system/kustomization.yaml
@@ -5,7 +5,6 @@ kind: Kustomization
 namespace: longhorn-system
 components:
   - ../../components/network-policy/baseline
-  - ../../components/network-policy/default-deny
 resources:
   - ./namespace.yaml
   - ./longhorn/ks.yaml

--- a/kubernetes/apps/mcp-system/kustomization.yaml
+++ b/kubernetes/apps/mcp-system/kustomization.yaml
@@ -5,7 +5,6 @@ kind: Kustomization
 namespace: mcp-system
 components:
   - ../../components/network-policy/baseline
-  - ../../components/network-policy/default-deny
 resources:
   - ./namespace.yaml
   - ./arr-mcp/ks.yaml

--- a/kubernetes/apps/media/av1corrector-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/av1corrector-oauth2-proxy/app/cnp-allow.yaml
@@ -24,36 +24,24 @@ spec:
             - port: "4180"
               protocol: TCP
   egress:
-    # OIDC discovery + token exchange against Authelia (auth.${SECRET_DOMAIN}
-    # resolves to the internal envoy gateway VIP).
-    # Upstream → av1corrector.media:8000 is same-ns (baseline covers).
-    #
-    # auth.${SECRET_DOMAIN} is canonical (no CNAME chain). Cilium 1.19
-    # matchPattern silently fails for canonical FQDNs through K8s DNS
-    # search-domain augmentation — per memory
-    # project_cilium_matchpattern_fqdn_limits.md. Use toEntities:world+443,
-    # matches the precedent in PRs #11498/#11512/#11517/#11533.
-    - toEntities: [world]
-      toPorts:
-        - ports:
-            - port: "443"
-              protocol: TCP
-    # OIDC token exchange — direct to authelia in-cluster Service
-    # (Pattern E). The Pattern A/B browser flow goes through envoy
-    # fine, but the server-side code exchange (oauth2-proxy callback
-    # → authelia after user login redirect back) needs this direct
-    # cross-ns allow. toEntities:[world]:443 and
-    # matchPattern:auth.${SECRET_DOMAIN} DO NOT work for the
-    # in-cluster path: split-horizon DNS returns the LB IP and
-    # Cilium socket-lb rewrites the connect() to the envoy pod IP +
-    # targetPort 10443 BEFORE policy check, so neither rule matches
-    # the rewritten destination. Authelia's CNP already permits
-    # fromEntities:cluster on 9091. Mirrors paperless PR #11525.
+    # OIDC discovery + token exchange against Authelia at
+    # auth.${SECRET_DOMAIN}. oauth2-proxy is configured with the
+    # external issuer URL, so every OIDC request hits split-horizon DNS
+    # which returns the envoy LB IP (10.45.0.13). Cilium's socket-lb
+    # rewrites the connect() to the envoy pod IP + targetPort 10443
+    # BEFORE policy evaluation (per memory
+    # project_cilium_l4_port_targetport.md), so the policy must allow
+    # the envoy pod on its container port, NOT world:443 (which doesn't
+    # match cluster LB IPs) and NOT authelia:9091 directly (which
+    # oauth2-proxy never connects to because of how it's configured).
+    # Mirrors pump-oauth2-proxy PR #11559.
+    # Upstream → av1corrector.media:8000 is same-ns,
+    # covered by baseline allow-intra-namespace.
     - toEndpoints:
         - matchLabels:
-            io.kubernetes.pod.namespace: auth
-            app.kubernetes.io/name: authelia
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
       toPorts:
         - ports:
-            - port: "9091"
+            - port: "10443"
               protocol: TCP

--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -6,7 +6,6 @@ namespace: media
 components:
   - ../../components/alerts
   - ../../components/network-policy/baseline
-  - ../../components/network-policy/default-deny
 resources:
   - ./namespace.yaml
   - ./priority-class.yaml

--- a/kubernetes/apps/media/lidarr-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/lidarr-oauth2-proxy/app/cnp-allow.yaml
@@ -24,36 +24,24 @@ spec:
             - port: "4180"
               protocol: TCP
   egress:
-    # OIDC discovery + token exchange against Authelia (auth.${SECRET_DOMAIN}
-    # resolves to the internal envoy gateway VIP).
-    # Upstream → lidarr.media:8686 is same-ns (baseline covers).
-    #
-    # auth.${SECRET_DOMAIN} is canonical (no CNAME chain). Cilium 1.19
-    # matchPattern silently fails for canonical FQDNs through K8s DNS
-    # search-domain augmentation — per memory
-    # project_cilium_matchpattern_fqdn_limits.md. Use toEntities:world+443,
-    # matches the precedent in PRs #11498/#11512/#11517/#11533.
-    - toEntities: [world]
-      toPorts:
-        - ports:
-            - port: "443"
-              protocol: TCP
-    # OIDC token exchange — direct to authelia in-cluster Service
-    # (Pattern E). The Pattern A/B browser flow goes through envoy
-    # fine, but the server-side code exchange (oauth2-proxy callback
-    # → authelia after user login redirect back) needs this direct
-    # cross-ns allow. toEntities:[world]:443 and
-    # matchPattern:auth.${SECRET_DOMAIN} DO NOT work for the
-    # in-cluster path: split-horizon DNS returns the LB IP and
-    # Cilium socket-lb rewrites the connect() to the envoy pod IP +
-    # targetPort 10443 BEFORE policy check, so neither rule matches
-    # the rewritten destination. Authelia's CNP already permits
-    # fromEntities:cluster on 9091. Mirrors paperless PR #11525.
+    # OIDC discovery + token exchange against Authelia at
+    # auth.${SECRET_DOMAIN}. oauth2-proxy is configured with the
+    # external issuer URL, so every OIDC request hits split-horizon DNS
+    # which returns the envoy LB IP (10.45.0.13). Cilium's socket-lb
+    # rewrites the connect() to the envoy pod IP + targetPort 10443
+    # BEFORE policy evaluation (per memory
+    # project_cilium_l4_port_targetport.md), so the policy must allow
+    # the envoy pod on its container port, NOT world:443 (which doesn't
+    # match cluster LB IPs) and NOT authelia:9091 directly (which
+    # oauth2-proxy never connects to because of how it's configured).
+    # Mirrors pump-oauth2-proxy PR #11559.
+    # Upstream → lidarr.media:8686 is same-ns,
+    # covered by baseline allow-intra-namespace.
     - toEndpoints:
         - matchLabels:
-            io.kubernetes.pod.namespace: auth
-            app.kubernetes.io/name: authelia
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
       toPorts:
         - ports:
-            - port: "9091"
+            - port: "10443"
               protocol: TCP

--- a/kubernetes/apps/media/medialyze-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/medialyze-oauth2-proxy/app/cnp-allow.yaml
@@ -24,36 +24,24 @@ spec:
             - port: "4180"
               protocol: TCP
   egress:
-    # OIDC discovery + token exchange against Authelia (auth.${SECRET_DOMAIN}
-    # resolves to the internal envoy gateway VIP).
-    # Upstream → medialyze.media:8080 is same-ns (baseline covers).
-    #
-    # auth.${SECRET_DOMAIN} is canonical (no CNAME chain). Cilium 1.19
-    # matchPattern silently fails for canonical FQDNs through K8s DNS
-    # search-domain augmentation — per memory
-    # project_cilium_matchpattern_fqdn_limits.md. Use toEntities:world+443,
-    # matches the precedent in PRs #11498/#11512/#11517/#11533.
-    - toEntities: [world]
-      toPorts:
-        - ports:
-            - port: "443"
-              protocol: TCP
-    # OIDC token exchange — direct to authelia in-cluster Service
-    # (Pattern E). The Pattern A/B browser flow goes through envoy
-    # fine, but the server-side code exchange (oauth2-proxy callback
-    # → authelia after user login redirect back) needs this direct
-    # cross-ns allow. toEntities:[world]:443 and
-    # matchPattern:auth.${SECRET_DOMAIN} DO NOT work for the
-    # in-cluster path: split-horizon DNS returns the LB IP and
-    # Cilium socket-lb rewrites the connect() to the envoy pod IP +
-    # targetPort 10443 BEFORE policy check, so neither rule matches
-    # the rewritten destination. Authelia's CNP already permits
-    # fromEntities:cluster on 9091. Mirrors paperless PR #11525.
+    # OIDC discovery + token exchange against Authelia at
+    # auth.${SECRET_DOMAIN}. oauth2-proxy is configured with the
+    # external issuer URL, so every OIDC request hits split-horizon DNS
+    # which returns the envoy LB IP (10.45.0.13). Cilium's socket-lb
+    # rewrites the connect() to the envoy pod IP + targetPort 10443
+    # BEFORE policy evaluation (per memory
+    # project_cilium_l4_port_targetport.md), so the policy must allow
+    # the envoy pod on its container port, NOT world:443 (which doesn't
+    # match cluster LB IPs) and NOT authelia:9091 directly (which
+    # oauth2-proxy never connects to because of how it's configured).
+    # Mirrors pump-oauth2-proxy PR #11559.
+    # Upstream → medialyze.media:8080 is same-ns,
+    # covered by baseline allow-intra-namespace.
     - toEndpoints:
         - matchLabels:
-            io.kubernetes.pod.namespace: auth
-            app.kubernetes.io/name: authelia
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
       toPorts:
         - ports:
-            - port: "9091"
+            - port: "10443"
               protocol: TCP

--- a/kubernetes/apps/media/music-assistant-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/music-assistant-oauth2-proxy/app/cnp-allow.yaml
@@ -24,36 +24,24 @@ spec:
             - port: "4180"
               protocol: TCP
   egress:
-    # OIDC discovery + token exchange against Authelia (auth.${SECRET_DOMAIN}
-    # resolves to the internal envoy gateway VIP).
-    # Upstream → music-assistant.media:8095 is same-ns (baseline covers).
-    #
-    # auth.${SECRET_DOMAIN} is canonical (no CNAME chain). Cilium 1.19
-    # matchPattern silently fails for canonical FQDNs through K8s DNS
-    # search-domain augmentation — per memory
-    # project_cilium_matchpattern_fqdn_limits.md. Use toEntities:world+443,
-    # matches the precedent in PRs #11498/#11512/#11517/#11533.
-    - toEntities: [world]
-      toPorts:
-        - ports:
-            - port: "443"
-              protocol: TCP
-    # OIDC token exchange — direct to authelia in-cluster Service
-    # (Pattern E). The Pattern A/B browser flow goes through envoy
-    # fine, but the server-side code exchange (oauth2-proxy callback
-    # → authelia after user login redirect back) needs this direct
-    # cross-ns allow. toEntities:[world]:443 and
-    # matchPattern:auth.${SECRET_DOMAIN} DO NOT work for the
-    # in-cluster path: split-horizon DNS returns the LB IP and
-    # Cilium socket-lb rewrites the connect() to the envoy pod IP +
-    # targetPort 10443 BEFORE policy check, so neither rule matches
-    # the rewritten destination. Authelia's CNP already permits
-    # fromEntities:cluster on 9091. Mirrors paperless PR #11525.
+    # OIDC discovery + token exchange against Authelia at
+    # auth.${SECRET_DOMAIN}. oauth2-proxy is configured with the
+    # external issuer URL, so every OIDC request hits split-horizon DNS
+    # which returns the envoy LB IP (10.45.0.13). Cilium's socket-lb
+    # rewrites the connect() to the envoy pod IP + targetPort 10443
+    # BEFORE policy evaluation (per memory
+    # project_cilium_l4_port_targetport.md), so the policy must allow
+    # the envoy pod on its container port, NOT world:443 (which doesn't
+    # match cluster LB IPs) and NOT authelia:9091 directly (which
+    # oauth2-proxy never connects to because of how it's configured).
+    # Mirrors pump-oauth2-proxy PR #11559.
+    # Upstream → music-assistant.media:8095 is same-ns,
+    # covered by baseline allow-intra-namespace.
     - toEndpoints:
         - matchLabels:
-            io.kubernetes.pod.namespace: auth
-            app.kubernetes.io/name: authelia
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
       toPorts:
         - ports:
-            - port: "9091"
+            - port: "10443"
               protocol: TCP

--- a/kubernetes/apps/media/radarr-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/radarr-oauth2-proxy/app/cnp-allow.yaml
@@ -24,36 +24,24 @@ spec:
             - port: "4180"
               protocol: TCP
   egress:
-    # OIDC discovery + token exchange against Authelia (auth.${SECRET_DOMAIN}
-    # resolves to the internal envoy gateway VIP).
-    # Upstream → radarr.media:7878 is same-ns (baseline covers).
-    #
-    # auth.${SECRET_DOMAIN} is canonical (no CNAME chain). Cilium 1.19
-    # matchPattern silently fails for canonical FQDNs through K8s DNS
-    # search-domain augmentation — per memory
-    # project_cilium_matchpattern_fqdn_limits.md. Use toEntities:world+443,
-    # matches the precedent in PRs #11498/#11512/#11517/#11533.
-    - toEntities: [world]
-      toPorts:
-        - ports:
-            - port: "443"
-              protocol: TCP
-    # OIDC token exchange — direct to authelia in-cluster Service
-    # (Pattern E). The Pattern A/B browser flow goes through envoy
-    # fine, but the server-side code exchange (oauth2-proxy callback
-    # → authelia after user login redirect back) needs this direct
-    # cross-ns allow. toEntities:[world]:443 and
-    # matchPattern:auth.${SECRET_DOMAIN} DO NOT work for the
-    # in-cluster path: split-horizon DNS returns the LB IP and
-    # Cilium socket-lb rewrites the connect() to the envoy pod IP +
-    # targetPort 10443 BEFORE policy check, so neither rule matches
-    # the rewritten destination. Authelia's CNP already permits
-    # fromEntities:cluster on 9091. Mirrors paperless PR #11525.
+    # OIDC discovery + token exchange against Authelia at
+    # auth.${SECRET_DOMAIN}. oauth2-proxy is configured with the
+    # external issuer URL, so every OIDC request hits split-horizon DNS
+    # which returns the envoy LB IP (10.45.0.13). Cilium's socket-lb
+    # rewrites the connect() to the envoy pod IP + targetPort 10443
+    # BEFORE policy evaluation (per memory
+    # project_cilium_l4_port_targetport.md), so the policy must allow
+    # the envoy pod on its container port, NOT world:443 (which doesn't
+    # match cluster LB IPs) and NOT authelia:9091 directly (which
+    # oauth2-proxy never connects to because of how it's configured).
+    # Mirrors pump-oauth2-proxy PR #11559.
+    # Upstream → radarr.media:7878 is same-ns,
+    # covered by baseline allow-intra-namespace.
     - toEndpoints:
         - matchLabels:
-            io.kubernetes.pod.namespace: auth
-            app.kubernetes.io/name: authelia
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
       toPorts:
         - ports:
-            - port: "9091"
+            - port: "10443"
               protocol: TCP

--- a/kubernetes/apps/media/sonarr-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/sonarr-oauth2-proxy/app/cnp-allow.yaml
@@ -24,36 +24,24 @@ spec:
             - port: "4180"
               protocol: TCP
   egress:
-    # OIDC discovery + token exchange against Authelia (auth.${SECRET_DOMAIN}
-    # resolves to the internal envoy gateway VIP).
-    # Upstream → sonarr.media:8989 is same-ns (baseline covers).
-    #
-    # auth.${SECRET_DOMAIN} is canonical (no CNAME chain). Cilium 1.19
-    # matchPattern silently fails for canonical FQDNs through K8s DNS
-    # search-domain augmentation — per memory
-    # project_cilium_matchpattern_fqdn_limits.md. Use toEntities:world+443,
-    # matches the precedent in PRs #11498/#11512/#11517/#11533.
-    - toEntities: [world]
-      toPorts:
-        - ports:
-            - port: "443"
-              protocol: TCP
-    # OIDC token exchange — direct to authelia in-cluster Service
-    # (Pattern E). The Pattern A/B browser flow goes through envoy
-    # fine, but the server-side code exchange (oauth2-proxy callback
-    # → authelia after user login redirect back) needs this direct
-    # cross-ns allow. toEntities:[world]:443 and
-    # matchPattern:auth.${SECRET_DOMAIN} DO NOT work for the
-    # in-cluster path: split-horizon DNS returns the LB IP and
-    # Cilium socket-lb rewrites the connect() to the envoy pod IP +
-    # targetPort 10443 BEFORE policy check, so neither rule matches
-    # the rewritten destination. Authelia's CNP already permits
-    # fromEntities:cluster on 9091. Mirrors paperless PR #11525.
+    # OIDC discovery + token exchange against Authelia at
+    # auth.${SECRET_DOMAIN}. oauth2-proxy is configured with the
+    # external issuer URL, so every OIDC request hits split-horizon DNS
+    # which returns the envoy LB IP (10.45.0.13). Cilium's socket-lb
+    # rewrites the connect() to the envoy pod IP + targetPort 10443
+    # BEFORE policy evaluation (per memory
+    # project_cilium_l4_port_targetport.md), so the policy must allow
+    # the envoy pod on its container port, NOT world:443 (which doesn't
+    # match cluster LB IPs) and NOT authelia:9091 directly (which
+    # oauth2-proxy never connects to because of how it's configured).
+    # Mirrors pump-oauth2-proxy PR #11559.
+    # Upstream → sonarr.media:8989 is same-ns,
+    # covered by baseline allow-intra-namespace.
     - toEndpoints:
         - matchLabels:
-            io.kubernetes.pod.namespace: auth
-            app.kubernetes.io/name: authelia
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
       toPorts:
         - ports:
-            - port: "9091"
+            - port: "10443"
               protocol: TCP

--- a/kubernetes/apps/media/soularr-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/soularr-oauth2-proxy/app/cnp-allow.yaml
@@ -24,36 +24,24 @@ spec:
             - port: "4180"
               protocol: TCP
   egress:
-    # OIDC discovery + token exchange against Authelia (auth.${SECRET_DOMAIN}
-    # resolves to the internal envoy gateway VIP).
-    # Upstream → soularr.media:1000 is same-ns (baseline covers).
-    #
-    # auth.${SECRET_DOMAIN} is canonical (no CNAME chain). Cilium 1.19
-    # matchPattern silently fails for canonical FQDNs through K8s DNS
-    # search-domain augmentation — per memory
-    # project_cilium_matchpattern_fqdn_limits.md. Use toEntities:world+443,
-    # matches the precedent in PRs #11498/#11512/#11517/#11533.
-    - toEntities: [world]
-      toPorts:
-        - ports:
-            - port: "443"
-              protocol: TCP
-    # OIDC token exchange — direct to authelia in-cluster Service
-    # (Pattern E). The Pattern A/B browser flow goes through envoy
-    # fine, but the server-side code exchange (oauth2-proxy callback
-    # → authelia after user login redirect back) needs this direct
-    # cross-ns allow. toEntities:[world]:443 and
-    # matchPattern:auth.${SECRET_DOMAIN} DO NOT work for the
-    # in-cluster path: split-horizon DNS returns the LB IP and
-    # Cilium socket-lb rewrites the connect() to the envoy pod IP +
-    # targetPort 10443 BEFORE policy check, so neither rule matches
-    # the rewritten destination. Authelia's CNP already permits
-    # fromEntities:cluster on 9091. Mirrors paperless PR #11525.
+    # OIDC discovery + token exchange against Authelia at
+    # auth.${SECRET_DOMAIN}. oauth2-proxy is configured with the
+    # external issuer URL, so every OIDC request hits split-horizon DNS
+    # which returns the envoy LB IP (10.45.0.13). Cilium's socket-lb
+    # rewrites the connect() to the envoy pod IP + targetPort 10443
+    # BEFORE policy evaluation (per memory
+    # project_cilium_l4_port_targetport.md), so the policy must allow
+    # the envoy pod on its container port, NOT world:443 (which doesn't
+    # match cluster LB IPs) and NOT authelia:9091 directly (which
+    # oauth2-proxy never connects to because of how it's configured).
+    # Mirrors pump-oauth2-proxy PR #11559.
+    # Upstream → soularr.media:1000 is same-ns,
+    # covered by baseline allow-intra-namespace.
     - toEndpoints:
         - matchLabels:
-            io.kubernetes.pod.namespace: auth
-            app.kubernetes.io/name: authelia
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
       toPorts:
         - ports:
-            - port: "9091"
+            - port: "10443"
               protocol: TCP

--- a/kubernetes/apps/media/suggestarr-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/suggestarr-oauth2-proxy/app/cnp-allow.yaml
@@ -24,36 +24,24 @@ spec:
             - port: "4180"
               protocol: TCP
   egress:
-    # OIDC discovery + token exchange against Authelia (auth.${SECRET_DOMAIN}
-    # resolves to the internal envoy gateway VIP).
-    # Upstream → suggestarr.media:5000 is same-ns (baseline covers).
-    #
-    # auth.${SECRET_DOMAIN} is canonical (no CNAME chain). Cilium 1.19
-    # matchPattern silently fails for canonical FQDNs through K8s DNS
-    # search-domain augmentation — per memory
-    # project_cilium_matchpattern_fqdn_limits.md. Use toEntities:world+443,
-    # matches the precedent in PRs #11498/#11512/#11517/#11533.
-    - toEntities: [world]
-      toPorts:
-        - ports:
-            - port: "443"
-              protocol: TCP
-    # OIDC token exchange — direct to authelia in-cluster Service
-    # (Pattern E). The Pattern A/B browser flow goes through envoy
-    # fine, but the server-side code exchange (oauth2-proxy callback
-    # → authelia after user login redirect back) needs this direct
-    # cross-ns allow. toEntities:[world]:443 and
-    # matchPattern:auth.${SECRET_DOMAIN} DO NOT work for the
-    # in-cluster path: split-horizon DNS returns the LB IP and
-    # Cilium socket-lb rewrites the connect() to the envoy pod IP +
-    # targetPort 10443 BEFORE policy check, so neither rule matches
-    # the rewritten destination. Authelia's CNP already permits
-    # fromEntities:cluster on 9091. Mirrors paperless PR #11525.
+    # OIDC discovery + token exchange against Authelia at
+    # auth.${SECRET_DOMAIN}. oauth2-proxy is configured with the
+    # external issuer URL, so every OIDC request hits split-horizon DNS
+    # which returns the envoy LB IP (10.45.0.13). Cilium's socket-lb
+    # rewrites the connect() to the envoy pod IP + targetPort 10443
+    # BEFORE policy evaluation (per memory
+    # project_cilium_l4_port_targetport.md), so the policy must allow
+    # the envoy pod on its container port, NOT world:443 (which doesn't
+    # match cluster LB IPs) and NOT authelia:9091 directly (which
+    # oauth2-proxy never connects to because of how it's configured).
+    # Mirrors pump-oauth2-proxy PR #11559.
+    # Upstream → suggestarr.media:5000 is same-ns,
+    # covered by baseline allow-intra-namespace.
     - toEndpoints:
         - matchLabels:
-            io.kubernetes.pod.namespace: auth
-            app.kubernetes.io/name: authelia
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
       toPorts:
         - ports:
-            - port: "9091"
+            - port: "10443"
               protocol: TCP

--- a/kubernetes/apps/network/kustomization.yaml
+++ b/kubernetes/apps/network/kustomization.yaml
@@ -6,7 +6,6 @@ namespace: network
 components:
   - ../../components/alerts
   - ../../components/network-policy/baseline
-  - ../../components/network-policy/default-deny
 resources:
   - ./namespace.yaml
   - ./cloudflare-ddns/ks.yaml

--- a/kubernetes/apps/observability/goldilocks-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/observability/goldilocks-oauth2-proxy/app/cnp-allow.yaml
@@ -22,35 +22,24 @@ spec:
             - port: "4180"
               protocol: TCP
   egress:
-    # OIDC discovery + token exchange against Authelia.
-    # Upstream → goldilocks-dashboard:80 is intra-ns; baseline covers.
-    #
-    # auth.${SECRET_DOMAIN} is canonical (no CNAME chain). Cilium 1.19
-    # matchPattern silently fails for canonical FQDNs through K8s DNS
-    # search-domain augmentation — per memory
-    # project_cilium_matchpattern_fqdn_limits.md. Use toEntities:world+443,
-    # matches the precedent in PRs #11498/#11512/#11517/#11533.
-    - toEntities: [world]
-      toPorts:
-        - ports:
-            - port: "443"
-              protocol: TCP
-    # OIDC token exchange — direct to authelia in-cluster Service
-    # (Pattern E). The Pattern A/B browser flow goes through envoy
-    # fine, but the server-side code exchange (oauth2-proxy callback
-    # → authelia after user login redirect back) needs this direct
-    # cross-ns allow. toEntities:[world]:443 and
-    # matchPattern:auth.${SECRET_DOMAIN} DO NOT work for the
-    # in-cluster path: split-horizon DNS returns the LB IP and
-    # Cilium socket-lb rewrites the connect() to the envoy pod IP +
-    # targetPort 10443 BEFORE policy check, so neither rule matches
-    # the rewritten destination. Authelia's CNP already permits
-    # fromEntities:cluster on 9091. Mirrors paperless PR #11525.
+    # OIDC discovery + token exchange against Authelia at
+    # auth.${SECRET_DOMAIN}. oauth2-proxy is configured with the
+    # external issuer URL, so every OIDC request hits split-horizon DNS
+    # which returns the envoy LB IP (10.45.0.13). Cilium's socket-lb
+    # rewrites the connect() to the envoy pod IP + targetPort 10443
+    # BEFORE policy evaluation (per memory
+    # project_cilium_l4_port_targetport.md), so the policy must allow
+    # the envoy pod on its container port, NOT world:443 (which doesn't
+    # match cluster LB IPs) and NOT authelia:9091 directly (which
+    # oauth2-proxy never connects to because of how it's configured).
+    # Mirrors pump-oauth2-proxy PR #11559.
+    # Upstream → goldilocks-dashboard.observability:80 is intra-ns,
+    # covered by baseline allow-intra-namespace.
     - toEndpoints:
         - matchLabels:
-            io.kubernetes.pod.namespace: auth
-            app.kubernetes.io/name: authelia
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
       toPorts:
         - ports:
-            - port: "9091"
+            - port: "10443"
               protocol: TCP

--- a/kubernetes/apps/observability/holmesgpt-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/observability/holmesgpt-oauth2-proxy/app/cnp-allow.yaml
@@ -22,38 +22,24 @@ spec:
             - port: "4180"
               protocol: TCP
   egress:
-    # OIDC discovery + token exchange against Authelia.
-    # auth.${SECRET_DOMAIN} resolves to the internal Envoy gateway VIP,
-    # which then routes to the auth namespace.
+    # OIDC discovery + token exchange against Authelia at
+    # auth.${SECRET_DOMAIN}. oauth2-proxy is configured with the
+    # external issuer URL, so every OIDC request hits split-horizon DNS
+    # which returns the envoy LB IP (10.45.0.13). Cilium's socket-lb
+    # rewrites the connect() to the envoy pod IP + targetPort 10443
+    # BEFORE policy evaluation (per memory
+    # project_cilium_l4_port_targetport.md), so the policy must allow
+    # the envoy pod on its container port, NOT world:443 (which doesn't
+    # match cluster LB IPs) and NOT authelia:9091 directly (which
+    # oauth2-proxy never connects to because of how it's configured).
+    # Mirrors pump-oauth2-proxy PR #11559.
     # Upstream → holmesgpt.observability.svc.cluster.local:8080 is
-    # intra-ns; baseline allow-intra-namespace covers that path.
-    #
-    # auth.${SECRET_DOMAIN} is canonical (no CNAME chain). Cilium 1.19
-    # matchPattern silently fails for canonical FQDNs through K8s DNS
-    # search-domain augmentation — per memory
-    # project_cilium_matchpattern_fqdn_limits.md. Use toEntities:world+443,
-    # matches the precedent in PRs #11498/#11512/#11517/#11533.
-    - toEntities: [world]
-      toPorts:
-        - ports:
-            - port: "443"
-              protocol: TCP
-    # OIDC token exchange — direct to authelia in-cluster Service
-    # (Pattern E). The Pattern A/B browser flow goes through envoy
-    # fine, but the server-side code exchange (oauth2-proxy callback
-    # → authelia after user login redirect back) needs this direct
-    # cross-ns allow. toEntities:[world]:443 and
-    # matchPattern:auth.${SECRET_DOMAIN} DO NOT work for the
-    # in-cluster path: split-horizon DNS returns the LB IP and
-    # Cilium socket-lb rewrites the connect() to the envoy pod IP +
-    # targetPort 10443 BEFORE policy check, so neither rule matches
-    # the rewritten destination. Authelia's CNP already permits
-    # fromEntities:cluster on 9091. Mirrors paperless PR #11525.
+    # intra-ns, covered by baseline allow-intra-namespace.
     - toEndpoints:
         - matchLabels:
-            io.kubernetes.pod.namespace: auth
-            app.kubernetes.io/name: authelia
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
       toPorts:
         - ports:
-            - port: "9091"
+            - port: "10443"
               protocol: TCP

--- a/kubernetes/apps/observability/kube-ops-view-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/observability/kube-ops-view-oauth2-proxy/app/cnp-allow.yaml
@@ -22,35 +22,24 @@ spec:
             - port: "4180"
               protocol: TCP
   egress:
-    # OIDC discovery + token exchange against Authelia.
-    # Upstream → kube-ops-view:8080 is intra-ns; baseline covers.
-    #
-    # auth.${SECRET_DOMAIN} is canonical (no CNAME chain). Cilium 1.19
-    # matchPattern silently fails for canonical FQDNs through K8s DNS
-    # search-domain augmentation — per memory
-    # project_cilium_matchpattern_fqdn_limits.md. Use toEntities:world+443,
-    # matches the precedent in PRs #11498/#11512/#11517/#11533.
-    - toEntities: [world]
-      toPorts:
-        - ports:
-            - port: "443"
-              protocol: TCP
-    # OIDC token exchange — direct to authelia in-cluster Service
-    # (Pattern E). The Pattern A/B browser flow goes through envoy
-    # fine, but the server-side code exchange (oauth2-proxy callback
-    # → authelia after user login redirect back) needs this direct
-    # cross-ns allow. toEntities:[world]:443 and
-    # matchPattern:auth.${SECRET_DOMAIN} DO NOT work for the
-    # in-cluster path: split-horizon DNS returns the LB IP and
-    # Cilium socket-lb rewrites the connect() to the envoy pod IP +
-    # targetPort 10443 BEFORE policy check, so neither rule matches
-    # the rewritten destination. Authelia's CNP already permits
-    # fromEntities:cluster on 9091. Mirrors paperless PR #11525.
+    # OIDC discovery + token exchange against Authelia at
+    # auth.${SECRET_DOMAIN}. oauth2-proxy is configured with the
+    # external issuer URL, so every OIDC request hits split-horizon DNS
+    # which returns the envoy LB IP (10.45.0.13). Cilium's socket-lb
+    # rewrites the connect() to the envoy pod IP + targetPort 10443
+    # BEFORE policy evaluation (per memory
+    # project_cilium_l4_port_targetport.md), so the policy must allow
+    # the envoy pod on its container port, NOT world:443 (which doesn't
+    # match cluster LB IPs) and NOT authelia:9091 directly (which
+    # oauth2-proxy never connects to because of how it's configured).
+    # Mirrors pump-oauth2-proxy PR #11559.
+    # Upstream → kube-ops-view.observability:8080 is intra-ns,
+    # covered by baseline allow-intra-namespace.
     - toEndpoints:
         - matchLabels:
-            io.kubernetes.pod.namespace: auth
-            app.kubernetes.io/name: authelia
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
       toPorts:
         - ports:
-            - port: "9091"
+            - port: "10443"
               protocol: TCP

--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -6,7 +6,6 @@ namespace: observability
 components:
   - ../../components/alerts
   - ../../components/network-policy/baseline
-  - ../../components/network-policy/default-deny
 resources:
   - ./namespace.yaml
   - ./exporters

--- a/kubernetes/apps/renovate/kustomization.yaml
+++ b/kubernetes/apps/renovate/kustomization.yaml
@@ -6,7 +6,6 @@ namespace: renovate
 components:
   - ../../components/alerts
   - ../../components/network-policy/baseline
-  - ../../components/network-policy/default-deny
 resources:
   - ./namespace.yaml
   - ./renovate-operator/ks.yaml

--- a/kubernetes/apps/rook-ceph/kustomization.yaml
+++ b/kubernetes/apps/rook-ceph/kustomization.yaml
@@ -6,7 +6,6 @@ namespace: rook-ceph
 components:
   - ../../components/alerts
   - ../../components/network-policy/baseline
-  - ../../components/network-policy/default-deny
 resources:
   - ./namespace.yaml
   - ./rook-ceph/ks.yaml

--- a/kubernetes/apps/selfhosted/kustomization.yaml
+++ b/kubernetes/apps/selfhosted/kustomization.yaml
@@ -6,7 +6,6 @@ namespace: selfhosted
 components:
   - ../../components/alerts
   - ../../components/network-policy/baseline
-  - ../../components/network-policy/default-deny
 resources:
   - ./namespace.yaml
   - ./webhook/ks.yaml

--- a/kubernetes/apps/storage/kustomization.yaml
+++ b/kubernetes/apps/storage/kustomization.yaml
@@ -5,7 +5,6 @@ kind: Kustomization
 namespace: storage
 components:
   - ../../components/network-policy/baseline
-  - ../../components/network-policy/default-deny
 resources:
   - ./namespace.yaml
   - ./garage/ks.yaml


### PR DESCRIPTION
## Summary

- Persist the 2026-05-18 mass-rollback in git so `cluster-apps` can be unsuspended without Flux reverting to the broken-lockdown state.
- Remove `network-policy/default-deny` component import from 19 namespace `kustomization.yaml` files. `baseline` (DNS, apiserver, intra-ns, monitoring scrape, host probes) remains — harmless without a default-deny.
- Correct 17 remaining oauth2-proxy CNPs cluster-wide to the `envoy:10443` egress pattern (was `toEntities:[world]:443` + direct `authelia:9091`, which doesn't match the socket-lb-rewritten destination — see memory `project_cilium_l4_port_targetport.md`). Mirrors PRs #11559 / #11560 / #11561 / #11562. Inert under current no-default-deny posture; correct when re-enabled.
- Document the 2026-05-18 full rollback in `docs/src/networkpolicy_rollout_plan.md` with the trigger (5+ broken apps in browser testing — pump/suggestarr/av1corrector/lidarr/medialyze/music-assistant OIDC + kube-ops-view/goldilocks/netdata/blackbox non-oauth gaps), the rationale for reset vs incremental fixes, and the re-rollout plan (one namespace at a time, smallest first, user browser-verification gates each step).

## Test plan

- [ ] `yamllint` passes on all 19 modified namespace kustomization.yaml files (verified locally, EXIT=0)
- [ ] `yamllint` passes on all 17 modified oauth2-proxy CNP files (verified locally, EXIT=0)
- [ ] `markdownlint-cli2 docs/src/networkpolicy_rollout_plan.md` passes (verified locally, 0 errors)
- [ ] flux-local CI renders cleanly across all 19 affected namespaces
- [ ] After merge: unsuspend `cluster-apps` and confirm Flux reconciles to the no-default-deny posture without re-applying the deleted CNPs

🤖 Generated with [Claude Code](https://claude.com/claude-code)