### PR TITLE
fix(romm): bump config PVC 5Gi → 10Gi

### DIFF
--- a/kubernetes/apps/media/romm/app/longhorn-pvc.yaml
+++ b/kubernetes/apps/media/romm/app/longhorn-pvc.yaml
@@ -12,7 +12,7 @@ spec:
   volumeMode: Filesystem
   resources:
     requests:
-      storage: 5Gi
+      storage: 10Gi
   volumeName: romm-config-pv
   storageClassName: romm-config-storage-class
 ---
@@ -27,7 +27,7 @@ metadata:
     recurring-job-group.longhorn.io/weekly-backup: enabled
 spec:
   capacity:
-    storage: 5Gi
+    storage: 10Gi
   volumeMode: Filesystem
   accessModes:
     - ReadWriteOnce


### PR DESCRIPTION
## Summary

- RomM config volume hit 90% (4.5G used / 491M free) mid-scan, tripping `HostOutOfDiskSpace` (5x firing) on worker8. RomM accumulates metadata art during the 10-source scan of ~10k ROMs.
- Online-expanded live: Longhorn Volume CR → PVC → PV → `xfs_growfs` against the engine on worker8. No restart, no detach. In-pod `df` now shows **9.9G / 5.4G free / 46%** used.
- Hand-applied the missing `romm-config-storage-class` StorageClass (Longhorn validating webhook refused the resize until the per-app SC existed). Same pattern as `wg-easy-config-storage-class` and `obsidian-data-storage-class`.

## Why git was breaking Flux

Without this merge, `media/romm` Flux reconciliation fails:

```
PersistentVolumeClaim "romm-config-pvc" is invalid:
spec.resources.requests.storage: Forbidden: field can not be less than status.capacity
```

…because git is 5Gi and live is 10Gi. The merge re-aligns desired with actual.

## Notes / gap captured

The per-app Longhorn StorageClasses (`*-config-storage-class`) are all hand-applied — no git source. Separate cleanup, not in scope here.

## Test plan

- [x] PVC `spec.requests.storage` = 10Gi (live)
- [x] PVC `status.capacity` = 10Gi (live)
- [x] PV `spec.capacity.storage` = 10Gi (live)
- [x] Longhorn Volume `spec.size` = 10737418240 (live)
- [x] In-pod `df -h /romm/resources` shows 9.9G total
- [x] `HostOutOfDiskSpace` cleared from Alertmanager
- [ ] Post-merge: `flux get ks -n media romm` reports `True`

🤖 Generated with [Claude Code](https://claude.com/claude-code)