### PR TITLE
feat(netpol): re-enable default-deny in selfhosted (smallest ns first)

### DIFF
--- a/kubernetes/apps/selfhosted/kustomization.yaml
+++ b/kubernetes/apps/selfhosted/kustomization.yaml
@@ -6,6 +6,11 @@ namespace: selfhosted
 components:
   - ../../components/alerts
   - ../../components/network-policy/baseline
+  # default-deny re-enabled 2026-05-18 as first ns in careful re-rollout
+  # after the mass-rollback. Selfhosted = smallest surface (1 app, 1
+  # HTTPRoute). webhook-allow-from-gateway already covers envoy → webhook.
+  # Validate renovate-webhook.${SECRET_DOMAIN} in browser before next ns.
+  - ../../components/network-policy/default-deny
 resources:
   - ./namespace.yaml
   - ./webhook/ks.yaml


### PR DESCRIPTION
## Summary

First step in the careful re-rollout after the 2026-05-18 mass-rollback.

- Re-adds `network-policy/default-deny` component to selfhosted ns kustomization
- Selfhosted = smallest test surface (1 app, 1 HTTPRoute)
- `webhook-allow-from-gateway` CNP already in place
- baseline (DNS, apiserver, intra-ns, host probes, monitoring scrape) already present

## Test plan

- [ ] After merge: wait for Flux reconcile (~1 min)
- [ ] Open https://renovate-webhook.thesteamedcrab.com in browser
- [ ] Verify renovate UI loads + can submit a test webhook
- [ ] Hubble check: `kubectl -n kube-system exec ds/cilium -- hubble observe --namespace selfhosted --verdict DROPPED --since 5m`

Only proceed to next namespace (cert-manager, external-secrets, etc.) once browser verification passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)