### PR TITLE
fix(ai): drop langgraph-agents external HTTPRoute (unauthenticated)

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
@@ -128,23 +128,13 @@ spec:
           http:
             port: *httpPort
 
-    route:
-      app:
-        annotations:
-          glance/name: "LangGraph Agents"
-          glance/show: "true"
-          glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/langchain.png"
-          glance/id: "AI"
-        hostnames:
-          - "agents.${SECRET_DOMAIN}"
-        parentRefs:
-          - name: internal
-            namespace: network
-            sectionName: https
-        rules:
-          - backendRefs:
-              - identifier: app
-                port: *httpPort
+    # No external HTTPRoute. langgraph-agents is a webhook/MCP backend
+    # consumed exclusively via the in-cluster Service
+    # (langgraph-agents.ai.svc.cluster.local:8765) by open-webui and the
+    # n8n langgraph-* workflows. Exposing /docs, /openapi.json, /healthz
+    # at agents.${SECRET_DOMAIN} without auth leaked the full FastAPI
+    # schema to anyone on LAN. Use `kubectl -n ai port-forward
+    # svc/langgraph-agents 8765` for one-off /docs access.
 
     persistence:
       # Vault content is split into two PVCs (pvc.yaml).


### PR DESCRIPTION
## Summary

- agents.thesteamedcrab.com was an unauthenticated HTTPRoute on the internal Gateway. /docs, /openapi.json, /healthz returned 200 to any LAN client, leaking the full FastAPI schema.
- All legitimate consumers reach langgraph-agents over the in-cluster Service (langgraph-agents.ai.svc.cluster.local:8765): open-webui's OPENAI_API_BASE_URLS, and five n8n workflows (langgraph-daily-digest, langgraph-inbox, langgraph-approval-receive, langgraph-awaiting-user-sweep, langgraph-cost-cap-watcher).
- Nothing in the repo references agents.\${SECRET_DOMAIN}, so removing the HTTPRoute is non-breaking. Ad-hoc /docs access is recoverable via kubectl port-forward.

## Test plan

- [ ] flux-local renders cleanly with the route block removed.
- [ ] After merge, confirm the HTTPRoute is pruned in the ai namespace (no langgraph-agents HTTPRoute listed by kubectl).
- [ ] Confirm open-webui still resolves langgraph models (OPENAI_API_BASE_URLS uses the cluster-internal SVC, so unaffected).
- [ ] Confirm n8n langgraph-* workflows still post successfully (they use the cluster-internal SVC).
- [ ] curl agents.thesteamedcrab.com from LAN returns 404 from the gateway (no matching route).