### PR TITLE
fix(node-exporter): exclude kubelet pod bind-mounts from filesystem collector

### DIFF
--- a/kubernetes/apps/observability/exporters/node-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/exporters/node-exporter/app/helmrelease.yaml
@@ -17,6 +17,17 @@ spec:
   values:
     fullnameOverride: node-exporter
 
+    # The node-exporter binary's built-in default for mount-points-exclude
+    # is narrow (dev|proc|run/credentials/.+|sys|var/lib/docker/.+|var/lib/containers/storage/.+).
+    # It does NOT cover /var/lib/kubelet/pods/.+, so every pod's bind-mounts
+    # (k8tz /etc/localtime subpath, local-volume bind-mounts) appear as
+    # separate filesystems with the host's fill rate, triggering false
+    # CephNodeDiskspaceWarning + HostOutOfDiskSpace alerts per pod.
+    # Match the kube-prometheus-stack upstream default to suppress those.
+    extraArgs:
+      - --collector.filesystem.mount-points-exclude=^/(dev|proc|run/credentials/.+|sys|var/lib/docker/.+|var/lib/containers/storage/.+|var/lib/kubelet/pods/.+)($|/)
+      - --collector.filesystem.fs-types-exclude=^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|erofs|sysfs|tracefs)$
+
     hostNetwork: false
     image:
       registry: quay.io


### PR DESCRIPTION
## Summary

Adds `extraArgs` to the node-exporter HelmRelease to set `--collector.filesystem.mount-points-exclude` and `--collector.filesystem.fs-types-exclude` to match the kube-prometheus-stack upstream defaults.

## Why

The node-exporter binary's built-in default for `mount-points-exclude` is:

```
^/(dev|proc|run/credentials/.+|sys|var/lib/docker/.+|var/lib/containers/storage/.+)($|/)
```

That regex does **not** cover `/var/lib/kubelet/pods/.+`, so every pod's bind-mounts are reported as separate filesystems with the host's fill rate. With k8tz injecting `/etc/localtime` into every pod via a subpath, plus per-pod local-volume mounts, a moderately-loaded node generates dozens of duplicate `node_filesystem_*` series per real filesystem.

Observed impact: 18× `CephNodeDiskspaceWarning` + 5× `HostOutOfDiskSpace` firing simultaneously when the underlying issue was a single PVC at 90% (RomM config, resolved in #11564). The volume of false positives drowns real signal in pushover.

## Effect

- ~18 `CephNodeDiskspaceWarning` instances clear once Flux + Helm roll the DaemonSet (likely 1–2 reconcile cycles).
- Real fill-rate alerts on actual block devices still fire normally.
- Node-exporter scrape volume drops (every kubelet bind-mount is a series-per-mount today; this consolidates them).
- Aligns with kube-prometheus-stack's built-in default — we lose nothing the upstream chart users have.

## Test plan

- [ ] Post-merge: `kubectl get ds -n observability node-exporter -o jsonpath='{.spec.template.spec.containers[0].args}'` shows the two new flags
- [ ] `node_filesystem_avail_bytes{mountpoint=~"/var/lib/kubelet/pods/.*"}` returns 0 series (was: 100+)
- [ ] `CephNodeDiskspaceWarning` count drops sharply
- [ ] No real-disk alerts disappear (sanity-check `HostOutOfDiskSpace` against actual block devices)

🤖 Generated with [Claude Code](https://claude.com/claude-code)