### PR TITLE
feat(netpol): re-enable default-deny in cert-manager (v2)

### DIFF
--- a/kubernetes/apps/cert-manager/kustomization.yaml
+++ b/kubernetes/apps/cert-manager/kustomization.yaml
@@ -6,6 +6,13 @@ namespace: cert-manager
 components:
   - ../../components/alerts
   - ../../components/network-policy/baseline
+  # default-deny re-enabled 2026-05-18 (Phase 2 of re-rollout, after
+  # selfhosted PR #11565 validated). cert-manager-allow covers controller
+  # egress to ACME/CF (world:443). cert-manager-webhook-allow covers
+  # kube-apiserver ingress. cainjector relies on baseline (apiserver +
+  # DNS). No user-facing UI to browser-test; verify via Certificate
+  # reconciliation health post-merge.
+  - ../../components/network-policy/default-deny
 resources:
   - ./namespace.yaml
   - ./cert-manager/ks.yaml


### PR DESCRIPTION
Original PR #11566 was overwritten by a parallel agent's branch (its content became langgraph-agents instead of cert-manager). This is the actual cert-manager re-enable.

After Flux reconciles, verify cert-manager pods stay 1/1 Running and Certificates remain Ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)