### PR TITLE
feat(netpol): re-enable default-deny in external-secrets (Phase 2)

### DIFF
--- a/kubernetes/apps/external-secrets/kustomization.yaml
+++ b/kubernetes/apps/external-secrets/kustomization.yaml
@@ -6,6 +6,13 @@ namespace: external-secrets
 components:
   - ../../components/alerts
   - ../../components/network-policy/baseline
+  # default-deny re-enabled 2026-05-18 (Phase 2 of re-rollout, after
+  # selfhosted + cert-manager validated). onepassword-connect-allow
+  # covers Connect → 1Password Cloud (world:443). external-secrets-
+  # webhook-allow covers kube-apiserver → webhook (10250). Controller
+  # relies on baseline (apiserver + DNS + intra-ns). Validate via
+  # `kubectl get externalsecrets -A` staying READY=True post-merge.
+  - ../../components/network-policy/default-deny
 resources:
   - ./namespace.yaml
   - ./external-secrets/ks.yaml


### PR DESCRIPTION
## Summary

Third namespace in the careful re-rollout after the 2026-05-18 mass-rollback (after selfhosted PR #11565 and cert-manager Phase 2).

## Pre-flight verified

- `onepassword-connect-allow` -> world:443 (1Password Cloud)
- `external-secrets-webhook-allow` <- kube-apiserver:10250
- baseline covers apiserver, DNS, intra-ns, monitoring scrape, host probes
- all ExternalSecrets currently READY=True

## Test plan

- [ ] Flux reconciles cleanly
- [ ] `kubectl get externalsecrets -A | grep -v True` returns nothing
- [ ] `hubble observe --namespace external-secrets --verdict DROPPED --since 2m` shows no/expected drops

🤖 Generated with [Claude Code](https://claude.com/claude-code)