### PR TITLE
feat(network-policy): actions-runner-system default-deny re-enable (Phase 2)

### DIFF
--- a/kubernetes/apps/actions-runner-system/kustomization.yaml
+++ b/kubernetes/apps/actions-runner-system/kustomization.yaml
@@ -6,6 +6,12 @@ namespace: actions-runner-system
 components:
   - ../../components/alerts
   - ../../components/network-policy/baseline
+  # default-deny re-enabled 2026-05-18 as Phase 2 of the careful re-rollout
+  # after the mass-rollback (PR #11563). Phase 1 was selfhosted (PR #11565).
+  # Per-app CNPs already exist: actions-runner-controller-allow (operator →
+  # GitHub API + githubusercontent), arc-runner-set-home-ops-allow (runners
+  # wildcard 80/443 — trust boundary is GitHub App scoping, not network).
+  - ../../components/network-policy/default-deny
 resources:
   - ./namespace.yaml
   - ./actions-runner-controller/ks.yaml


### PR DESCRIPTION
## Summary

Phase 2 of the careful netpol re-rollout after the mass-rollback (PR #11563).

- Re-enables `default-deny` on `actions-runner-system` namespace via the existing component.
- Per-app CNPs already in tree from the original rollout (PRs #11485 / #11492 / #11495 / #11499):
  - `actions-runner-controller-allow`: operator → GitHub API + `*.githubusercontent.com` (matchPattern dual-form for Cilium 1.19 search-domain augmentation).
  - `arc-runner-set-home-ops-allow`: runner pods wildcard 80/443. Trust boundary is the GitHub App scoping, not the network — workflows pull arbitrary registries/URLs.

Follows the precedent set by selfhosted in PR #11565.

## Test plan

- [ ] Flux reconciles `cluster-apps -> actions-runner-system` cleanly
- [ ] `kubectl get pods -n actions-runner-system` — controller + listener + any in-flight runner all `Running`
- [ ] `kubectl logs -n actions-runner-system -l app.kubernetes.io/name=actions-runner-controller --tail=50` — no auth/connection errors to GitHub
- [ ] Hubble drops for ~2 min — no unexpected drops past pod restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)