### PR TITLE
feat(netpol): tier 4 — Cilium policy-drop alerting

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -52,7 +52,11 @@ spec:
         serviceMonitor:
           enabled: true
 
+    # prometheus.enabled exposes the agent metrics port (9962); without
+    # it the chart skips the cilium-agent Service + ServiceMonitor even
+    # when serviceMonitor.enabled is true.
     prometheus:
+      enabled: true
       serviceMonitor:
         enabled: true
         trustCRDsExist: true

--- a/kubernetes/apps/kube-system/cilium/app/values.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/values.yaml
@@ -71,12 +71,17 @@ hubble:
   metrics:
     enabled:
       - dns:query;ignoreAAAA
-      - drop
+      - drop:labelsContext=source_namespace,destination_namespace
       - tcp
       - flow
       - port-distribution
       - icmp
       - http
+    # ServiceMonitor for the hubble-metrics service (port 9965).
+    # Without this the metrics are exposed by the agent but never
+    # scraped. Drives the network-policy drop alerts.
+    serviceMonitor:
+      enabled: true
 
   relay:
     enabled: true

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/kustomization.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/kustomization.yaml
@@ -8,4 +8,5 @@ resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
+  - ./prometheusrule-cilium-drops.yaml
   - ./prometheusrule-pv.yaml

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/prometheusrule-cilium-drops.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/prometheusrule-cilium-drops.yaml
@@ -1,0 +1,64 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: cilium-policy-drops
+spec:
+  groups:
+    # Network-policy drop visibility. Without these, a CiliumNetworkPolicy
+    # gap is silent — drops show up only when a user notices an app is
+    # broken. The 2026-05-17 netpol rollout left 5+ apps broken for ~14h
+    # before discovery; these alerts close that loop.
+    #
+    # Metric: `hubble_drop_total{reason="POLICY_DENIED"}` is emitted by
+    # the cilium-agent hubble-metrics server (port 9965) and carries the
+    # `source_namespace` + `destination_namespace` labels added via
+    # `hubble.metrics.enabled[drop]:labelsContext=...` in
+    # kubernetes/apps/kube-system/cilium/app/values.yaml.
+    #
+    # A correctly-configured cluster has 0 sustained policy drops. Brief
+    # spikes during pod startup races and netpol reconciles are normal;
+    # thresholds below tolerate those while catching real breakage.
+    - name: cilium-policy-drops
+      rules:
+        - alert: CiliumPolicyDropsSustained
+          annotations:
+            description: >-
+              CiliumNetworkPolicy is dropping {{ $value | humanize }} pkt/s
+              destined for namespace {{ $labels.destination_namespace }}
+              (sustained 10m+). An app in this namespace likely cannot reach
+              a dependency it needs; check recent netpol changes and Hubble
+              flows for the offending source/destination pair.
+            summary: Sustained CiliumNetworkPolicy drops into {{ $labels.destination_namespace }}.
+          # >5 drops/min (0.083 pkt/s) sustained for 10m = real policy gap,
+          # not a transient reconcile race. Drops with no destination_namespace
+          # label (host-network or unmapped) get aggregated into the empty
+          # bucket but still alert.
+          expr: |
+            sum by (destination_namespace) (
+              rate(hubble_drop_total{reason="POLICY_DENIED"}[5m])
+            ) > 0.083
+          for: 10m
+          labels:
+            severity: warning
+        - alert: CiliumPolicyDropBurst
+          annotations:
+            description: >-
+              {{ $value | humanize }} CiliumNetworkPolicy drops in the last
+              2m destined for namespace {{ $labels.destination_namespace }}.
+              This burst pattern typically follows a netpol PR regression —
+              check the most recent merge touching CiliumNetworkPolicy or
+              CNP-equivalent resources in this namespace.
+            summary: CiliumNetworkPolicy drop burst into {{ $labels.destination_namespace }}.
+          # 200 drops in 2m = ~1.7 pkt/s sustained, the signature of an app
+          # whose connectivity just broke (e.g. a netpol PR landed and an
+          # egress rule went missing). Critical → routes through HolmesGPT
+          # investigation + Pushover.
+          expr: |
+            sum by (destination_namespace) (
+              increase(hubble_drop_total{reason="POLICY_DENIED"}[2m])
+            ) > 200
+          for: 2m
+          labels:
+            severity: critical


### PR DESCRIPTION
## Summary

- Closes the silent-drop gap from the 2026-05-17 netpol rollout (5+ apps broken ~14h before user noticed) by enabling Cilium agent + Hubble metrics scrape and adding two PrometheusRules on `hubble_drop_total{reason=\"POLICY_DENIED\"}`.
- Cilium chart needs both `prometheus.enabled` (exposes agent port 9962 + Service) and `serviceMonitor.enabled` — only the latter was set, so the agent SM was never created. Hubble metrics on port 9965 had no SM either.
- `drop` metric gains `labelsContext=source_namespace,destination_namespace` for per-namespace attribution; alerts aggregate `sum by (destination_namespace)`.

## Alerts

| Alert | Threshold | Severity | Rationale |
|---|---|---|---|
| `CiliumPolicyDropsSustained` | >5 drops/min for 10m | warning | Real policy gap; tolerates pod-startup reconcile races |
| `CiliumPolicyDropBurst` | >200 drops in 2m | critical | Post-PR regression signature; routes through HolmesGPT + Pushover |

No dashboard panel shipped separately — `hubble.dashboards.enabled` was already true, so chart-shipped Hubble dashboards activate automatically once the SM scrapes the metrics.

## Test plan

- [ ] flux-local CI passes
- [ ] After merge: `kubectl -n kube-system get servicemonitor` shows `cilium-agent` and `hubble` in addition to `cilium-operator`
- [ ] Prometheus `up{job=~\"cilium-agent|hubble\"}` returns 1 per node
- [ ] `hubble_drop_total{reason=\"POLICY_DENIED\"}` series visible (zero counts is fine)
- [ ] Trigger a synthetic drop (e.g. exec a no-egress pod, hit external IP) and confirm `CiliumPolicyDropsSustained` fires after 10m

🤖 Generated with [Claude Code](https://claude.com/claude-code)