### PR TITLE
feat(netpol): re-enable default-deny in renovate (phase 2)

### DIFF
--- a/kubernetes/apps/renovate/kustomization.yaml
+++ b/kubernetes/apps/renovate/kustomization.yaml
@@ -6,6 +6,12 @@ namespace: renovate
 components:
   - ../../components/alerts
   - ../../components/network-policy/baseline
+  # default-deny re-enabled 2026-05-18 as phase 2 of careful re-rollout
+  # after the mass-rollback (precedent: selfhosted PR #11565). Per-app
+  # CNPs in renovate-operator/app and renovate-operator/jobs cover both
+  # operator (envoy ingress + GitHub API egress) and Job pods (Dragonfly
+  # + wildcard FQDN egress for registry/repo scanning).
+  - ../../components/network-policy/default-deny
 resources:
   - ./namespace.yaml
   - ./renovate-operator/ks.yaml


### PR DESCRIPTION
## Summary

Phase 2 of careful default-deny re-rollout after the 2026-05-18 mass-rollback (precedent: selfhosted PR #11565).

Renovate ns already has 2 per-app CNPs covering both controllers:

- **renovate-operator-allow**: envoy → :8081 ingress + `toEntities:[world]:443` egress for `api.github.com`. FQDN matching is unreliable through K8s search-domain augmentation (per PR #11492), so this is broadened to world:443.
- **renovate-jobs-allow**: Dragonfly (databases ns) egress for the shared repo cache + `toFQDNs: matchPattern: "*"` on :443/:80 for repo cloning and the open-ended set of upstream registries renovate touches (ghcr.io, registry.k8s.io, docker.io, quay.io, gcr.io, npm/pypi/crates/maven/helm). TODO captured in the CNP comment to tighten once a registry mirror or HTTP forward proxy mediates all renovate egress.

Pre-existing "Failed to discover projects" error in operator logs is operator-side log parsing, unrelated to netpol — the latest 08:00 schedule fired clean and the discovery + executor pods completed 16m ago.

## Test plan

- [ ] Wait for Flux reconcile
- [ ] `kubectl get pods -n renovate` — operator Running, no crashloops
- [ ] `kubectl logs -n renovate -l app=renovate-operator --tail=20` — no new errors beyond the pre-existing parse one
- [ ] Watch next hourly schedule trigger discovery + executor Jobs successfully (Completed, not Failed)
- [ ] Hubble drops for 2 min: `kubectl -n kube-system exec ds/cilium -- hubble observe --namespace renovate --verdict DROPPED --since 5m`

Only add default-deny to the next namespace once this is confirmed working per `feedback_netpol_rollout_needs_per_app_browser_test.md`.

Generated with [Claude Code](https://claude.com/claude-code)