### PR TITLE
feat(netpol): re-enable default-deny in cilium-secrets (Phase 2, v2)

### DIFF
--- a/kubernetes/apps/cilium-secrets/kustomization.yaml
+++ b/kubernetes/apps/cilium-secrets/kustomization.yaml
@@ -13,3 +13,4 @@ kind: Kustomization
 namespace: cilium-secrets
 components:
   - ../../components/network-policy/baseline
+  - ../../components/network-policy/default-deny


### PR DESCRIPTION
## Summary

- Phase 2 of the careful netpol re-rollout following the 2026-05-18 mass rollback (#11563).
- Re-adds `network-policy/default-deny` component to `kubernetes/apps/cilium-secrets/kustomization.yaml`.
- Restores the posture originally landed in #11523 (commit 8abbc2d56a) and rolled back in #11563.

## Why cilium-secrets first

cilium-secrets is a Helm-chart-managed namespace (the cilium chart creates it as the holding namespace for Gateway/Ingress TLS Secrets consumed by `cilium-secrets-sync`). It contains zero pods — the CNPs are documentation-by-default. No traffic to block, no app to break. Safest possible re-enable.

## Test plan

- [ ] Flux reconciles cilium-secrets Kustomization
- [ ] `kubectl get cnp -n cilium-secrets` shows `default-deny` (plus the 5 baseline `allow-*` CNPs)
- [ ] No pods present in namespace (expected; chart-owned Secret holder)

🤖 Generated with [Claude Code](https://claude.com/claude-code)