### PR TITLE
feat(netpol): re-enable default-deny in databases (Phase 2)

### DIFF
--- a/kubernetes/apps/databases/kustomization.yaml
+++ b/kubernetes/apps/databases/kustomization.yaml
@@ -5,6 +5,19 @@ kind: Kustomization
 namespace: databases
 components:
   - ../../components/network-policy/baseline
+  # default-deny re-enabled 2026-05-18 (Phase 2 of re-rollout, after
+  # selfhosted PR #11565 + cert-manager PR #11571 validated). databases
+  # uses a label-selector model rather than per-cluster CNPs:
+  # postgres-instances-allow selects all `cnpg.io/podRole: instance` pods
+  # (24 clusters × 3 instances = 72 pods covered by one policy) with
+  # ingress `fromEntities: cluster` :5432 + egress to storage/garage:3900
+  # for Barman backups. plugin-barman-cloud-allow handles operator-side
+  # Garage egress; cloudnative-pg-allow opens 9443 to kube-apiserver for
+  # the webhook. baseline (apiserver + DNS + intra-namespace) handles
+  # operator egress to k8s API. dragonfly/pgadmin/qdrant each have their
+  # own allow CNP. No browser UI to test; validate via Cluster health +
+  # cross-ns consumer connectivity post-merge.
+  - ../../components/network-policy/default-deny
 resources:
   - ./namespace.yaml
   - ./priority-class.yaml


### PR DESCRIPTION
## Summary

Phase 2 of careful default-deny re-rollout after the mass-rollback in #11563. Selfhosted (#11565) and cert-manager (#11571) validated; databases next.

## Coverage audit

24 CNPG clusters, all `Cluster in healthy state`. The namespace uses a **label-selector model** rather than per-cluster CNPs:

- `postgres-instances-allow` selects `cnpg.io/podRole=instance` (72 pods across 24 clusters). Ingress `fromEntities: cluster` :5432, egress to `storage/garage:3900` for Barman.
- `cloudnative-pg-allow` opens :9443 to `kube-apiserver` (webhook).
- `plugin-barman-cloud-allow` operator egress to `storage/garage:3900`.
- `dragonfly-allow` / `pgadmin-allow` / `qdrant-allow` — own per-app CNPs.
- `baseline` component: apiserver + DNS + intra-ns + host-probes + monitoring-scrape.

No per-cluster gaps — label selector matches all 24/24.

## Test plan

- [ ] All 24 `Cluster` resources stay healthy: `kubectl get cluster -n databases -o wide`
- [ ] Spot-check 3 random cluster pods stay Running
- [ ] `hubble observe --namespace databases --verdict DROPPED --since 3m` empty
- [ ] Consumer connectivity: exec into an authelia pod, `nc -zv postgres-authelia-rw.databases.svc.cluster.local 5432`
- [ ] Revert via `git revert` + fast PR if anything breaks

Generated with [Claude Code](https://claude.com/claude-code)