### PR TITLE
feat(netpol): re-enable default-deny in rook-ceph (Phase 2)

### DIFF
--- a/kubernetes/apps/rook-ceph/kustomization.yaml
+++ b/kubernetes/apps/rook-ceph/kustomization.yaml
@@ -6,6 +6,16 @@ namespace: rook-ceph
 components:
   - ../../components/alerts
   - ../../components/network-policy/baseline
+  # default-deny re-enabled 2026-05-18 (Phase 2 of re-rollout, after
+  # cert-manager PR #11571 validated). ceph-broad-allow covers all
+  # rook-managed daemons (rook_cluster label: mon, mgr, osd, mds, rgw,
+  # exporter, crashcollector). ceph-operator-allow covers the operator.
+  # ceph-csi-allow covers cephfs+rbd ctrl/node plugins. ceph-csi-
+  # controller-manager-allow covers the helm-managed CSI ctrl mgr.
+  # Node-plugin DaemonSets run hostNetwork and are outside Cilium per-pod
+  # policy scope. EXTRA CAUTION: ceph data plane underlies most
+  # ceph-block PVCs cluster-wide.
+  - ../../components/network-policy/default-deny
 resources:
   - ./namespace.yaml
   - ./rook-ceph/ks.yaml


### PR DESCRIPTION
## Summary
- Phase 2 of careful default-deny re-rollout (after cert-manager PR #11571 validated)
- Adds `default-deny` component to `rook-ceph` namespace
- All Ceph daemons + operator + CSI plugins have allow CNPs in place; verified pre-merge

## Risk
EXTRA CAUTION: Ceph data plane underlies most ceph-block PVCs cluster-wide. Misconfigured netpol = data plane down.

Coverage verified:
- `ceph-broad-allow` (rook_cluster label) → mon, mgr, osd, mds, rgw, exporter, crashcollector
- `ceph-operator-allow` → operator pod
- `ceph-csi-allow` → cephfs + rbd ctrl/node plugins
- `ceph-csi-controller-manager-allow` → helm-managed ceph-csi ctrl mgr
- Node-plugin DaemonSets run hostNetwork (outside Cilium per-pod policy scope)

## Test plan
- [ ] `kubectl exec -n rook-ceph deploy/rook-ceph-operator -- ceph -s` → HEALTH_OK
- [ ] `ceph osd tree` → all OSDs up + in
- [ ] `hubble observe --namespace rook-ceph --verdict DROPPED --since 3m` → no drops
- [ ] Spot-check a ceph-block PVC consumer still functional

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>