### PR TITLE
Revert "fix(auth): move Authelia OIDC client hashes out of git into 1P-backed Secret (#11570)"

### DIFF
--- a/kubernetes/apps/auth/authelia/app/configmap.yaml
+++ b/kubernetes/apps/auth/authelia/app/configmap.yaml
@@ -123,9 +123,674 @@ data:
             # rotator; rotation cadence is 6d (overlap window with 7d TTL).
             mcp-gateway:
               access_token: '7d'
-        # OIDC clients (including argon2id client_secret hashes) live in
-        # /secrets/clients.yml, rendered by ExternalSecret from the
-        # OIDC_CLIENTS_YAML field of the `authelia` 1P item. See
-        # externalsecret.yaml and the --config arg in helmrelease.yaml.
-        # Authelia merges per-file configs; the clients array is contributed
-        # entirely by clients.yml.
+        clients:
+          - client_id: 'open-webui'
+            client_name: 'Open WebUI'
+            client_secret: '$argon2id$v=19$m=65536,t=3,p=4$ghwUPb4pg8xFt6HRoR+Wcg$Aob+gT6YMASp+pRZKbLwm/CTcd2dgMh+lOsMEPzBBnw'
+            public: false
+            authorization_policy: 'one_factor'
+            consent_mode: 'implicit'
+            require_pkce: false
+            redirect_uris:
+              - 'https://open-webui.${SECRET_DOMAIN}/oauth/oidc/callback'
+            scopes:
+              - 'openid'
+              - 'profile'
+              - 'email'
+              - 'groups'
+            grant_types:
+              - 'authorization_code'
+            response_types:
+              - 'code'
+            userinfo_signed_response_alg: 'none'
+            token_endpoint_auth_method: 'client_secret_basic'
+          - client_id: 'stash'
+            client_name: 'Stash'
+            client_secret: '$argon2id$v=19$m=65536,t=3,p=4$o+TbtKjSQPNtjXJgyy+7gw$LrfWn9QXaWa0L+K62wr2suKCN7ISTK3F3vG4Uy5Muew'
+            public: false
+            authorization_policy: 'admin_only'
+            consent_mode: 'implicit'
+            require_pkce: false
+            redirect_uris:
+              - 'https://stash.${SECRET_DOMAIN}/login/callback'
+            scopes:
+              - 'openid'
+              - 'profile'
+              - 'email'
+              - 'groups'
+            grant_types:
+              - 'authorization_code'
+            response_types:
+              - 'code'
+            userinfo_signed_response_alg: 'none'
+            token_endpoint_auth_method: 'client_secret_basic'
+          - client_id: 'netbox'
+            client_name: 'NetBox'
+            client_secret: '$argon2id$v=19$m=65536,t=3,p=4$6ms1MartYljP8LojIW73HA$aTGmdOSjgbKZaoRL7zbhSOKOXcqBSnBKTGwFZoFHckc'
+            public: false
+            authorization_policy: 'admin_only'
+            consent_mode: 'implicit'
+            require_pkce: true
+            pkce_challenge_method: 'S256'
+            redirect_uris:
+              - 'https://netbox.${SECRET_DOMAIN}/oauth/complete/oidc/'
+            scopes:
+              - 'openid'
+              - 'profile'
+              - 'email'
+              - 'groups'
+            grant_types:
+              - 'authorization_code'
+            response_types:
+              - 'code'
+            userinfo_signed_response_alg: 'none'
+            token_endpoint_auth_method: 'client_secret_basic'
+          - client_id: 'paperless'
+            client_name: 'Paperless'
+            client_secret: '$argon2id$v=19$m=65536,t=3,p=4$H5ybGtXh/xPZBe1moOoaTA$OtTI5RLl91Oc3HK5kjMLTC76oQnXQcdoknVJQDx9Fx8'
+            public: false
+            authorization_policy: 'one_factor'
+            consent_mode: 'implicit'
+            require_pkce: true
+            pkce_challenge_method: 'S256'
+            redirect_uris:
+              - 'https://paperless.${SECRET_DOMAIN}/accounts/oidc/authelia/login/callback/'
+            scopes:
+              - 'openid'
+              - 'profile'
+              - 'email'
+              - 'groups'
+            grant_types:
+              - 'authorization_code'
+            response_types:
+              - 'code'
+            userinfo_signed_response_alg: 'none'
+            token_endpoint_auth_method: 'client_secret_basic'
+          - client_id: 'kitchenowl'
+            client_name: 'KitchenOwl'
+            client_secret: '$argon2id$v=19$m=65536,t=3,p=4$gUFeX/wqVRM/+M7Itz8ZcQ$p6nWP/YCwP3mSBzW3H1Ly2EY4piIRG3YlXgMjeGKcVo'
+            public: false
+            authorization_policy: 'one_factor'
+            consent_mode: 'implicit'
+            # KitchenOwl's OIDC client does not send code_challenge; PKCE
+            # would block the authorize call with invalid_request.
+            require_pkce: false
+            redirect_uris:
+              - 'https://kitchenowl.${SECRET_DOMAIN}/signin/redirect'
+              - 'kitchenowl:/signin/redirect'
+            scopes:
+              - 'openid'
+              - 'profile'
+              - 'email'
+            grant_types:
+              - 'authorization_code'
+            response_types:
+              - 'code'
+            userinfo_signed_response_alg: 'none'
+            token_endpoint_auth_method: 'client_secret_post'
+          - client_id: 'immich'
+            client_name: 'Immich'
+            client_secret: '$argon2id$v=19$m=65536,t=3,p=4$tEi+f53DmSl1AOcx5HL4oA$9ARNNb3pJUSt/GymcQoOwvHYKQ+lRZGwDFArNACAnz4'
+            public: false
+            authorization_policy: 'one_factor'
+            consent_mode: 'implicit'
+            require_pkce: true
+            pkce_challenge_method: 'S256'
+            redirect_uris:
+              - 'https://photos.${SECRET_DOMAIN}/auth/login'
+              - 'https://photos.${SECRET_DOMAIN}/user-settings'
+              - 'app.immich:///oauth-callback'
+            scopes:
+              - 'openid'
+              - 'profile'
+              - 'email'
+              - 'groups'
+              - 'offline_access'
+            grant_types:
+              - 'authorization_code'
+              - 'refresh_token'
+            response_types:
+              - 'code'
+            userinfo_signed_response_alg: 'none'
+            token_endpoint_auth_method: 'client_secret_post'
+          - client_id: 'av1corrector-oauth2-proxy'
+            client_name: 'AV1 Corrector (oauth2-proxy)'
+            client_secret: '$argon2id$v=19$m=65536,t=3,p=4$lefMbdj3u1h9ZR7Z/Ph/pg$byHKBOplo5rkhZrW4JE6dJU9Z1V1U4FUYW/gdgXFK+8'
+            public: false
+            authorization_policy: 'one_factor'
+            consent_mode: 'implicit'
+            require_pkce: true
+            pkce_challenge_method: 'S256'
+            redirect_uris:
+              - 'https://av1corrector.${SECRET_DOMAIN}/oauth2/callback'
+            scopes:
+              - 'openid'
+              - 'profile'
+              - 'email'
+              - 'groups'
+            grant_types:
+              - 'authorization_code'
+            response_types:
+              - 'code'
+            userinfo_signed_response_alg: 'none'
+            token_endpoint_auth_method: 'client_secret_basic'
+          - client_id: 'frigate-oauth2-proxy'
+            client_name: 'Frigate (oauth2-proxy)'
+            client_secret: '$argon2id$v=19$m=65536,t=3,p=4$CxGhmQ1ufAJrxoznbbs08w$q+/SQ/11JjeeQGtH3SykIZj4XZgt1Cgx7W+OoCI97Q0'
+            public: false
+            authorization_policy: 'one_factor'
+            consent_mode: 'implicit'
+            require_pkce: true
+            pkce_challenge_method: 'S256'
+            redirect_uris:
+              - 'https://frigate.${SECRET_DOMAIN}/oauth2/callback'
+            scopes:
+              - 'openid'
+              - 'profile'
+              - 'email'
+              - 'groups'
+            grant_types:
+              - 'authorization_code'
+            response_types:
+              - 'code'
+            userinfo_signed_response_alg: 'none'
+            token_endpoint_auth_method: 'client_secret_basic'
+          - client_id: 'prowlarr-oauth2-proxy'
+            client_name: 'Prowlarr (oauth2-proxy)'
+            client_secret: '$argon2id$v=19$m=65536,t=3,p=4$ggdK4gWog9pN9Zf4tvK5ow$gEdS6WrUnYPblS0XJpCiUFpfkexbwo7hqOzbSRCFmT4'
+            public: false
+            authorization_policy: 'admin_only'
+            consent_mode: 'implicit'
+            require_pkce: true
+            pkce_challenge_method: 'S256'
+            redirect_uris:
+              - 'https://prowlarr.${SECRET_DOMAIN}/oauth2/callback'
+            scopes:
+              - 'openid'
+              - 'profile'
+              - 'email'
+              - 'groups'
+            grant_types:
+              - 'authorization_code'
+            response_types:
+              - 'code'
+            userinfo_signed_response_alg: 'none'
+            token_endpoint_auth_method: 'client_secret_basic'
+          - client_id: 'qbittorrent-oauth2-proxy'
+            client_name: 'qBittorrent (oauth2-proxy)'
+            client_secret: '$argon2id$v=19$m=65536,t=3,p=4$KhMuCH71XZwLvFoifqgXAA$davjI6dihjxGbK9m4EOJeC4XWV9d2lVGYNTUaEoKr38'
+            public: false
+            authorization_policy: 'admin_only'
+            consent_mode: 'implicit'
+            require_pkce: true
+            pkce_challenge_method: 'S256'
+            redirect_uris:
+              - 'https://bt.${SECRET_DOMAIN}/oauth2/callback'
+            scopes:
+              - 'openid'
+              - 'profile'
+              - 'email'
+              - 'groups'
+            grant_types:
+              - 'authorization_code'
+            response_types:
+              - 'code'
+            userinfo_signed_response_alg: 'none'
+            token_endpoint_auth_method: 'client_secret_basic'
+          - client_id: 'jdownloader2-oauth2-proxy'
+            client_name: 'JDownloader2 (oauth2-proxy)'
+            client_secret: '$argon2id$v=19$m=65536,t=3,p=4$G8rBJLQMaSFcQyRXv4Qwzg$xVJPyPxU2LlmYEuQjW+KnbxMHeV44UmI5jpmKMmGCD8'
+            public: false
+            authorization_policy: 'admin_only'
+            consent_mode: 'implicit'
+            require_pkce: true
+            pkce_challenge_method: 'S256'
+            redirect_uris:
+              - 'https://downloader.${SECRET_DOMAIN}/oauth2/callback'
+            scopes:
+              - 'openid'
+              - 'profile'
+              - 'email'
+              - 'groups'
+            grant_types:
+              - 'authorization_code'
+            response_types:
+              - 'code'
+            userinfo_signed_response_alg: 'none'
+            token_endpoint_auth_method: 'client_secret_basic'
+          - client_id: 'sabnzbd-oauth2-proxy'
+            client_name: 'SABnzbd (oauth2-proxy)'
+            client_secret: '$argon2id$v=19$m=65536,t=3,p=4$galaZvJ2kGqu2gnoEihaCw$IAdbdKHWd2oVVfkD9jskpFF51GZCUDEZZHIDpHsLclc'
+            public: false
+            authorization_policy: 'admin_only'
+            consent_mode: 'implicit'
+            require_pkce: true
+            pkce_challenge_method: 'S256'
+            redirect_uris:
+              - 'https://sabnzbd.${SECRET_DOMAIN}/oauth2/callback'
+            scopes:
+              - 'openid'
+              - 'profile'
+              - 'email'
+              - 'groups'
+            grant_types:
+              - 'authorization_code'
+            response_types:
+              - 'code'
+            userinfo_signed_response_alg: 'none'
+            token_endpoint_auth_method: 'client_secret_basic'
+          - client_id: 'slskd-oauth2-proxy'
+            client_name: 'slskd (oauth2-proxy)'
+            client_secret: '$argon2id$v=19$m=65536,t=3,p=4$eke9ctQJOkpctOsiw+fkdw$0ymA+6Re6YeHaI7QdM6LB5s/edMsbYZ6weUzkJXr8YQ'
+            public: false
+            authorization_policy: 'admin_only'
+            consent_mode: 'implicit'
+            require_pkce: true
+            pkce_challenge_method: 'S256'
+            redirect_uris:
+              - 'https://soulseek.${SECRET_DOMAIN}/oauth2/callback'
+            scopes:
+              - 'openid'
+              - 'profile'
+              - 'email'
+              - 'groups'
+            grant_types:
+              - 'authorization_code'
+            response_types:
+              - 'code'
+            userinfo_signed_response_alg: 'none'
+            token_endpoint_auth_method: 'client_secret_basic'
+          - client_id: 'kube-ops-view-oauth2-proxy'
+            client_name: 'kube-ops-view (oauth2-proxy)'
+            client_secret: '$argon2id$v=19$m=65536,t=3,p=4$lmfRDZjIcamC3nPvMGitKA$78l5Tkp2YohT2u9xD7W8uJUKEOEsaBMn7+rhvVaIN6E'
+            public: false
+            authorization_policy: 'admin_only'
+            consent_mode: 'implicit'
+            require_pkce: true
+            pkce_challenge_method: 'S256'
+            redirect_uris:
+              - 'https://kube-ops-view.${SECRET_DOMAIN}/oauth2/callback'
+            scopes:
+              - 'openid'
+              - 'profile'
+              - 'email'
+              - 'groups'
+            grant_types:
+              - 'authorization_code'
+            response_types:
+              - 'code'
+            userinfo_signed_response_alg: 'none'
+            token_endpoint_auth_method: 'client_secret_basic'
+          - client_id: 'goldilocks-oauth2-proxy'
+            client_name: 'Goldilocks (oauth2-proxy)'
+            client_secret: '$argon2id$v=19$m=65536,t=3,p=4$DI/KcMpLHtijw/ws6/9IwA$KnOsrfztJ5lpDzs4NAQTCQ9tuOGaUQEnAPpJ4sLSMAU'
+            public: false
+            authorization_policy: 'admin_only'
+            consent_mode: 'implicit'
+            require_pkce: true
+            pkce_challenge_method: 'S256'
+            redirect_uris:
+              - 'https://goldilocks.${SECRET_DOMAIN}/oauth2/callback'
+            scopes:
+              - 'openid'
+              - 'profile'
+              - 'email'
+              - 'groups'
+            grant_types:
+              - 'authorization_code'
+            response_types:
+              - 'code'
+            userinfo_signed_response_alg: 'none'
+            token_endpoint_auth_method: 'client_secret_basic'
+          - client_id: 'garage-webui-oauth2-proxy'
+            client_name: 'Garage WebUI (oauth2-proxy)'
+            client_secret: '$argon2id$v=19$m=65536,t=3,p=4$sHlzY5r1i5O/GK7k13S02w$IS8FQqHXu/ZgcBfDRL9o/R3Bq2x10P4JS7MT3AM81Bw'
+            public: false
+            authorization_policy: 'admin_only'
+            consent_mode: 'implicit'
+            require_pkce: true
+            pkce_challenge_method: 'S256'
+            redirect_uris:
+              - 'https://garage.${SECRET_DOMAIN}/oauth2/callback'
+            scopes:
+              - 'openid'
+              - 'profile'
+              - 'email'
+              - 'groups'
+            grant_types:
+              - 'authorization_code'
+            response_types:
+              - 'code'
+            userinfo_signed_response_alg: 'none'
+            token_endpoint_auth_method: 'client_secret_basic'
+          - client_id: 'sonarr-oauth2-proxy'
+            client_name: 'Sonarr (oauth2-proxy)'
+            client_secret: '$argon2id$v=19$m=65536,t=3,p=4$d9reMTh68M20vjROIJKH0g$eD9LCng4fOxS5LI61f0R0KW15LiqCP0c/5F3kIF8QQw'
+            public: false
+            authorization_policy: 'one_factor'
+            consent_mode: 'implicit'
+            require_pkce: true
+            pkce_challenge_method: 'S256'
+            redirect_uris:
+              - 'https://sonarr.${SECRET_DOMAIN}/oauth2/callback'
+            scopes:
+              - 'openid'
+              - 'profile'
+              - 'email'
+              - 'groups'
+            grant_types:
+              - 'authorization_code'
+            response_types:
+              - 'code'
+            userinfo_signed_response_alg: 'none'
+            token_endpoint_auth_method: 'client_secret_basic'
+          - client_id: 'radarr-oauth2-proxy'
+            client_name: 'Radarr (oauth2-proxy)'
+            client_secret: '$argon2id$v=19$m=65536,t=3,p=4$1hGWuCcyPXhq0JkZXb6ncA$Zxmtv/pNCLyczl+EPk+RhUaZwb00JGtgMwAeCT2IWM4'
+            public: false
+            authorization_policy: 'one_factor'
+            consent_mode: 'implicit'
+            require_pkce: true
+            pkce_challenge_method: 'S256'
+            redirect_uris:
+              - 'https://radarr.${SECRET_DOMAIN}/oauth2/callback'
+            scopes:
+              - 'openid'
+              - 'profile'
+              - 'email'
+              - 'groups'
+            grant_types:
+              - 'authorization_code'
+            response_types:
+              - 'code'
+            userinfo_signed_response_alg: 'none'
+            token_endpoint_auth_method: 'client_secret_basic'
+          - client_id: 'lidarr-oauth2-proxy'
+            client_name: 'Lidarr (oauth2-proxy)'
+            client_secret: '$argon2id$v=19$m=65536,t=3,p=4$DmjJsDTXHuZho/wLmbVP6g$iY6DzZaeHNsqGD74J20l5YGITY49GkuL3sNqMQsQUZI'
+            public: false
+            authorization_policy: 'one_factor'
+            consent_mode: 'implicit'
+            require_pkce: true
+            pkce_challenge_method: 'S256'
+            redirect_uris:
+              - 'https://lidarr.${SECRET_DOMAIN}/oauth2/callback'
+            scopes:
+              - 'openid'
+              - 'profile'
+              - 'email'
+              - 'groups'
+            grant_types:
+              - 'authorization_code'
+            response_types:
+              - 'code'
+            userinfo_signed_response_alg: 'none'
+            token_endpoint_auth_method: 'client_secret_basic'
+          - client_id: 'music-assistant-oauth2-proxy'
+            client_name: 'Music Assistant (oauth2-proxy)'
+            client_secret: '$argon2id$v=19$m=65536,t=3,p=4$mhJKit5XFdGbv7gdx/unUA$7E08hQtsCLbjkOFfzENlmsrIM1Ho1tg0JQQVHXujg+I'
+            public: false
+            authorization_policy: 'one_factor'
+            consent_mode: 'implicit'
+            require_pkce: true
+            pkce_challenge_method: 'S256'
+            redirect_uris:
+              - 'https://music-assistant.${SECRET_DOMAIN}/oauth2/callback'
+            scopes:
+              - 'openid'
+              - 'profile'
+              - 'email'
+              - 'groups'
+            grant_types:
+              - 'authorization_code'
+            response_types:
+              - 'code'
+            userinfo_signed_response_alg: 'none'
+            token_endpoint_auth_method: 'client_secret_basic'
+          - client_id: 'suggestarr-oauth2-proxy'
+            client_name: 'Suggestarr (oauth2-proxy)'
+            client_secret: '$argon2id$v=19$m=65536,t=3,p=4$IDjZs2rgFeLOCQp8d66cew$Vik4Y2bDkBFO5wYiuvqSBT/hiTNUUsy8a4iD58s/Jks'
+            public: false
+            authorization_policy: 'one_factor'
+            consent_mode: 'implicit'
+            require_pkce: true
+            pkce_challenge_method: 'S256'
+            redirect_uris:
+              - 'https://suggestarr.${SECRET_DOMAIN}/oauth2/callback'
+            scopes:
+              - 'openid'
+              - 'profile'
+              - 'email'
+              - 'groups'
+            grant_types:
+              - 'authorization_code'
+            response_types:
+              - 'code'
+            userinfo_signed_response_alg: 'none'
+            token_endpoint_auth_method: 'client_secret_basic'
+          - client_id: 'soularr-oauth2-proxy'
+            client_name: 'Soularr (oauth2-proxy)'
+            client_secret: '$argon2id$v=19$m=65536,t=3,p=4$ltBrpbUBk4fLQEM3teCTuw$U7X8z72lbFyn09LPa27Nd+1fRuuV2dOqy19sIWEGwOk'
+            public: false
+            authorization_policy: 'one_factor'
+            consent_mode: 'implicit'
+            require_pkce: true
+            pkce_challenge_method: 'S256'
+            redirect_uris:
+              - 'https://soularr.${SECRET_DOMAIN}/oauth2/callback'
+            scopes:
+              - 'openid'
+              - 'profile'
+              - 'email'
+              - 'groups'
+            grant_types:
+              - 'authorization_code'
+            response_types:
+              - 'code'
+            userinfo_signed_response_alg: 'none'
+            token_endpoint_auth_method: 'client_secret_basic'
+          - client_id: 'medialyze-oauth2-proxy'
+            client_name: 'MediaLyze (oauth2-proxy)'
+            client_secret: '$argon2id$v=19$m=65536,t=3,p=4$LENJXJF2ZaCcJ2nObgiU5Q$VL7WCNAhbS9tKi866xsUtMgFhCxb2aZZQyCsWcZsiDA'
+            public: false
+            authorization_policy: 'one_factor'
+            consent_mode: 'implicit'
+            require_pkce: true
+            pkce_challenge_method: 'S256'
+            redirect_uris:
+              - 'https://medialyze.${SECRET_DOMAIN}/oauth2/callback'
+            scopes:
+              - 'openid'
+              - 'profile'
+              - 'email'
+              - 'groups'
+            grant_types:
+              - 'authorization_code'
+            response_types:
+              - 'code'
+            userinfo_signed_response_alg: 'none'
+            token_endpoint_auth_method: 'client_secret_basic'
+          - client_id: 'glance-user-oauth2-proxy'
+            client_name: 'Glance (Renee, oauth2-proxy)'
+            client_secret: '$argon2id$v=19$m=65536,t=3,p=4$AdfV258HDW+g/297gI/FlQ$dxr9p8b1+QfJdaqQgAPG3yICArQLDi82NeSM5AKREhA'
+            public: false
+            authorization_policy: 'one_factor'
+            consent_mode: 'implicit'
+            require_pkce: true
+            pkce_challenge_method: 'S256'
+            redirect_uris:
+              - 'https://start-preview.${SECRET_DOMAIN}/oauth2/callback'
+              - 'https://start.${SECRET_DOMAIN}/oauth2/callback'
+            scopes:
+              - 'openid'
+              - 'profile'
+              - 'email'
+              - 'groups'
+            grant_types:
+              - 'authorization_code'
+            response_types:
+              - 'code'
+            userinfo_signed_response_alg: 'none'
+            token_endpoint_auth_method: 'client_secret_basic'
+          - client_id: 'glance-oauth2-proxy'
+            client_name: 'Glance (oauth2-proxy)'
+            client_secret: '$argon2id$v=19$m=65536,t=3,p=4$zGULDknsrkF+zva1by6tBQ$y/9Nq/y93osw9T4jv2rPfenRH81JVUrnpPHvkYEYsXE'
+            public: false
+            authorization_policy: 'admin_only'
+            consent_mode: 'implicit'
+            require_pkce: true
+            pkce_challenge_method: 'S256'
+            redirect_uris:
+              - 'https://glance.${SECRET_DOMAIN}/oauth2/callback'
+            scopes:
+              - 'openid'
+              - 'profile'
+              - 'email'
+              - 'groups'
+            grant_types:
+              - 'authorization_code'
+            response_types:
+              - 'code'
+            userinfo_signed_response_alg: 'none'
+            token_endpoint_auth_method: 'client_secret_basic'
+          - client_id: 'startpunkt-oauth2-proxy'
+            client_name: 'Startpunkt (oauth2-proxy)'
+            client_secret: '$argon2id$v=19$m=65536,t=3,p=4$nYrXI/Q6c9bstYynvKNKLA$6Zx4wE0+rY/8y+U2zEOkX95Qhwlxr8QSl68HuEAFiks'
+            public: false
+            authorization_policy: 'one_factor'
+            consent_mode: 'implicit'
+            require_pkce: true
+            pkce_challenge_method: 'S256'
+            redirect_uris:
+              - 'https://start.${SECRET_DOMAIN}/oauth2/callback'
+            scopes:
+              - 'openid'
+              - 'profile'
+              - 'email'
+              - 'groups'
+            grant_types:
+              - 'authorization_code'
+            response_types:
+              - 'code'
+            userinfo_signed_response_alg: 'none'
+            token_endpoint_auth_method: 'client_secret_basic'
+          - client_id: 'holmesgpt-oauth2-proxy'
+            client_name: 'HolmesGPT (oauth2-proxy)'
+            client_secret: '$argon2id$v=19$m=65536,t=3,p=4$2onhDCsJ7uUqrw29TSqPEg$2zwFf+s8zbuoi60WUbueukj/fk++NjIGHeySLaJ6OiQ'
+            public: false
+            authorization_policy: 'admin_only'
+            consent_mode: 'implicit'
+            require_pkce: true
+            pkce_challenge_method: 'S256'
+            redirect_uris:
+              - 'https://holmesgpt.${SECRET_DOMAIN}/oauth2/callback'
+            scopes:
+              - 'openid'
+              - 'profile'
+              - 'email'
+              - 'groups'
+            grant_types:
+              - 'authorization_code'
+            response_types:
+              - 'code'
+            userinfo_signed_response_alg: 'none'
+            token_endpoint_auth_method: 'client_secret_basic'
+          - client_id: 'pump-oauth2-proxy'
+            client_name: 'PUMP (oauth2-proxy)'
+            client_secret: '$argon2id$v=19$m=65536,t=3,p=4$p/ozuAhwtZWvL6hs3OJrkQ$6o5pXt7fM5wiGWosD2l/j8HjMZhrEv6QcpZbmNw4M8k'
+            public: false
+            authorization_policy: 'admin_only'
+            consent_mode: 'implicit'
+            require_pkce: true
+            pkce_challenge_method: 'S256'
+            redirect_uris:
+              - 'https://pump.${SECRET_DOMAIN}/oauth2/callback'
+            scopes:
+              - 'openid'
+              - 'profile'
+              - 'email'
+              - 'groups'
+            grant_types:
+              - 'authorization_code'
+            response_types:
+              - 'code'
+            userinfo_signed_response_alg: 'none'
+            token_endpoint_auth_method: 'client_secret_basic'
+          - client_id: 'romm'
+            client_name: 'RomM'
+            client_secret: '$argon2id$v=19$m=65536,t=3,p=4$7m9Vtu4TLNNNpWl7ccSp1w$5DxHbpKWsQ6Lo7rmS11Ws6Lbz5NmfwswYJeb6Pb/2dk'
+            public: false
+            authorization_policy: 'one_factor'
+            consent_mode: 'implicit'
+            require_pkce: false
+            claims_policy: 'default'
+            redirect_uris:
+              - 'https://romm.${SECRET_DOMAIN}/api/oauth/openid'
+            scopes:
+              - 'openid'
+              - 'profile'
+              - 'email'
+              - 'groups'
+            grant_types:
+              - 'authorization_code'
+            response_types:
+              - 'code'
+            userinfo_signed_response_alg: 'none'
+            token_endpoint_auth_method: 'client_secret_basic'
+          - client_id: 'batocera-webdashboard-pro-oauth2-proxy'
+            client_name: 'Batocera WebDashboard (oauth2-proxy)'
+            client_secret: '$argon2id$v=19$m=65536,t=3,p=4$Zq9aoDt3wlb6Xkug0PdGTw$ORfQTtSz/SpVIljCegyBOqIlUjJLUmUYVpwNH/D+F6M'
+            public: false
+            authorization_policy: 'one_factor'
+            consent_mode: 'implicit'
+            require_pkce: true
+            pkce_challenge_method: 'S256'
+            redirect_uris:
+              - 'https://batocera.${SECRET_DOMAIN}/oauth2/callback'
+            scopes:
+              - 'openid'
+              - 'profile'
+              - 'email'
+              - 'groups'
+            grant_types:
+              - 'authorization_code'
+            response_types:
+              - 'code'
+            userinfo_signed_response_alg: 'none'
+            token_endpoint_auth_method: 'client_secret_basic'
+          - client_id: 'khoj-oauth2-proxy'
+            client_name: 'Khoj (oauth2-proxy)'
+            client_secret: '$argon2id$v=19$m=65536,t=3,p=4$cfK5bGWeh2k0bfkAuViuVg$6KNEkqwGGKxyA/ujRtjEDoUA12iYFS+xiwsMIY4QONk'
+            public: false
+            authorization_policy: 'admin_only'
+            consent_mode: 'implicit'
+            require_pkce: true
+            pkce_challenge_method: 'S256'
+            redirect_uris:
+              - 'https://khoj.${SECRET_DOMAIN}/oauth2/callback'
+            scopes:
+              - 'openid'
+              - 'profile'
+              - 'email'
+              - 'groups'
+            grant_types:
+              - 'authorization_code'
+            response_types:
+              - 'code'
+            userinfo_signed_response_alg: 'none'
+            token_endpoint_auth_method: 'client_secret_basic'
+          - client_id: 'mcp-gateway'
+            client_name: 'MCP Gateway (rotator client_credentials)'
+            client_secret: '$argon2id$v=19$m=65536,t=3,p=4$bIo242+S+lfKQ9PaagNEQw$F6m6UtzA95x2X6k5X92itQ+v/71zYCylOhtYdwUxXUs'
+            public: false
+            audience:
+              - 'mcp-gateway'
+            scopes:
+              - 'mcp-gateway'
+            grant_types:
+              - 'client_credentials'
+            lifespan: 'mcp-gateway'
+            token_endpoint_auth_method: 'client_secret_post'
+            # Issue signed JWT access tokens (not opaque) so Envoy
+            # SecurityPolicy can validate against Authelia's JWKS.
+            access_token_signed_response_alg: 'RS256'

--- a/kubernetes/apps/auth/authelia/app/externalsecret.yaml
+++ b/kubernetes/apps/auth/authelia/app/externalsecret.yaml
@@ -37,11 +37,6 @@ spec:
                   use: 'sig'
                   key: |
                     {{ .OIDC_ISSUER_PRIVATE_KEY | nindent 20 }}
-        # OIDC clients block — pulled from 1P as a single multi-line field so
-        # client_secret argon2id hashes don't sit in git. Mounted as
-        # /secrets/clients.yml and merged into the main config via --config.
-        # SECRET_DOMAIN is pre-substituted in 1P (no flux postBuild reach here).
-        clients.yml: '{{ .OIDC_CLIENTS_YAML }}'
         # Postgres init container needs these
         INIT_POSTGRES_DBNAME: "authelia"
         INIT_POSTGRES_HOST: "postgres-authelia-rw.databases.svc.cluster.local"

--- a/kubernetes/apps/auth/authelia/app/helmrelease.yaml
+++ b/kubernetes/apps/auth/authelia/app/helmrelease.yaml
@@ -40,7 +40,7 @@ spec:
               tag: 4.39.19@sha256:0c824dcab1ae97c56bf673c5e77fe8cc6bcd400564555140cc8002a12c6b6463
             args:
               - "--config"
-              - "/config/configuration.yml,/secrets/jwks.yml,/secrets/clients.yml"
+              - "/config/configuration.yml,/secrets/jwks.yml"
             envFrom: *envFrom
             probes:
               liveness: &probes
@@ -109,8 +109,6 @@ spec:
         globalMounts:
           - path: /secrets/jwks.yml
             subPath: jwks.yml
-          - path: /secrets/clients.yml
-            subPath: clients.yml
       tmp:
         type: emptyDir
         globalMounts:


### PR DESCRIPTION
Reverts #11570 — Authelia entered CrashLoopBackOff after merge with `option 'clients' must have one or more clients configured`, despite:

- Secret `authelia-secret` having `clients.yml` key with correct 24,541 bytes / 32 clients
- Pod having correct `--config /config/configuration.yml,/secrets/jwks.yml,/secrets/clients.yml` arg + correct subPath mount
- `authelia config validate` succeeding in a fresh test pod with the exact same configmap+secret mounts

Root cause not yet identified. Reverting to restore OIDC; will investigate offline and re-attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)