### PR TITLE
feat(netpol): re-enable default-deny in istio-system (Phase 2)

### DIFF
--- a/kubernetes/apps/istio-system/kustomization.yaml
+++ b/kubernetes/apps/istio-system/kustomization.yaml
@@ -6,6 +6,14 @@ namespace: istio-system
 components:
   - ../../components/alerts
   - ../../components/network-policy/baseline
+  # default-deny re-enabled 2026-05-18 (Phase 2 of re-rollout, after
+  # rook-ceph PR #11579 validated). istiod-allow covers ingress: XDS
+  # mTLS (15012) + legacy plaintext (15010) from cluster, plus webhooks
+  # from kube-apiserver (443). Egress to kube-apiserver covered by
+  # baseline allow-apiserver. EXTRA CAUTION: istiod backs mcp-system
+  # sidecar mTLS and the apiserver-invoked mutating webhook; an outage
+  # blocks sidecar injection cluster-wide.
+  - ../../components/network-policy/default-deny
 resources:
   - ./namespace.yaml
   - ./istio/ks.yaml


### PR DESCRIPTION
## Summary
- Phase 2 of careful default-deny re-rollout (after rook-ceph PR #11579 validated)
- Adds `default-deny` component to `istio-system` namespace
- istiod is the only workload; istiod-allow already in place covering required ingress paths

## Risk
EXTRA CAUTION: istiod backs mcp-system sidecar mTLS and the apiserver-invoked mutating webhook; an outage blocks sidecar injection cluster-wide.

Coverage verified:
- istiod-allow ingress: XDS 15012 (mTLS) + 15010 (plaintext) from cluster; 443 from kube-apiserver (webhooks)
- baseline allow-apiserver covers istiod -> kube-apiserver egress
- baseline allow-dns covers DNS

## Test plan
- [ ] istiod pods Running post-merge
- [ ] mcp-system pods still functional (sidecar injection healthy)
- [ ] `hubble observe --namespace istio-system --verdict DROPPED --since 3m` -> no drops

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>