### PR TITLE
feat(netpol): observability pre-flight CNP gaps for default-deny re-rollout

### DIFF
--- a/kubernetes/apps/observability/exporters/blackbox-exporter/app/cnp-allow.yaml
+++ b/kubernetes/apps/observability/exporters/blackbox-exporter/app/cnp-allow.yaml
@@ -11,10 +11,21 @@ spec:
   enableDefaultDeny:
     egress: false
     ingress: false
-  # No additional ingress: Prometheus scrapes blackbox at /metrics
-  # via the baseline allow-monitoring-scrape rule, and probe results
-  # are pulled from Prometheus (which calls /probe?target=… on the
-  # same port).
+  # Prometheus scrapes blackbox at /metrics via the baseline
+  # allow-monitoring-scrape rule, and probe results are pulled from
+  # Prometheus (which calls /probe?target=… on the same port).
+  ingress:
+    # HTTPRoute on internal gateway (blackbox.${SECRET_DOMAIN}) →
+    # blackbox-exporter:9115. Surfaced as a broken app during the
+    # 2026-05-18 lockdown rollback retrospective.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "9115"
+              protocol: TCP
   egress:
     # Blackbox probes LAN hosts (~60 devices: cameras, UPSes, iDRAC,
     # ESPHome devices, WLED, Roborock, Kodi, voice satellites, NFS

--- a/kubernetes/apps/observability/goldilocks/app/cnp-allow.yaml
+++ b/kubernetes/apps/observability/goldilocks/app/cnp-allow.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+#
+# Covers both goldilocks-controller and goldilocks-dashboard
+# Deployments; they share `app.kubernetes.io/name: goldilocks`
+# (distinguished by `app.kubernetes.io/component`).
+#
+# No ingress rules needed: goldilocks-oauth2-proxy is the only door
+# to the dashboard, and the baseline allow-intra-namespace already
+# permits oauth2-proxy → goldilocks-dashboard on :8080. The
+# controller doesn't accept inbound traffic. Surfaced as a broken
+# app during the 2026-05-18 lockdown rollback retrospective.
+#
+# apiserver egress (for VPA recommendations + workload enumeration)
+# is covered by the baseline allow-apiserver rule.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: goldilocks-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: goldilocks
+  enableDefaultDeny:
+    egress: false
+    ingress: false

--- a/kubernetes/apps/observability/goldilocks/app/kustomization.yaml
+++ b/kubernetes/apps/observability/goldilocks/app/kustomization.yaml
@@ -7,5 +7,6 @@ components:
   - ../../../../components/repos/fairwinds-harts
 
 resources:
+  - ./cnp-allow.yaml
   - ./helmrelease.yaml
   - ./httproute.yaml

--- a/kubernetes/apps/observability/kube-ops-view/app/cnp-allow.yaml
+++ b/kubernetes/apps/observability/kube-ops-view/app/cnp-allow.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+#
+# No ingress rules needed: kube-ops-view-oauth2-proxy is the only
+# door, and the baseline allow-intra-namespace already permits
+# oauth2-proxy → kube-ops-view on :8080. Surfaced as a broken app
+# during the 2026-05-18 lockdown rollback retrospective.
+#
+# apiserver egress is covered by the baseline allow-apiserver rule;
+# kube-ops-view uses an in-cluster client (--in-cluster) to enumerate
+# nodes and pods.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: kube-ops-view-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: kube-ops-view
+  enableDefaultDeny:
+    egress: false
+    ingress: false

--- a/kubernetes/apps/observability/kube-ops-view/app/kustomization.yaml
+++ b/kubernetes/apps/observability/kube-ops-view/app/kustomization.yaml
@@ -5,5 +5,6 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./helmrelease.yaml
   - ./rbac.yaml

--- a/kubernetes/apps/observability/netdata/app/cnp-allow.yaml
+++ b/kubernetes/apps/observability/netdata/app/cnp-allow.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: netdata-allow
+spec:
+  # netdata's parent pod uses the chart's legacy `app: netdata` label
+  # rather than `app.kubernetes.io/name`. Select by both `app` and
+  # `role: parent` to avoid catching helper pods.
+  endpointSelector:
+    matchLabels:
+      app: netdata
+      role: parent
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal gateway (netdata.${SECRET_DOMAIN}) →
+    # netdata:19999 (no oauth2-proxy fronting; auth is on the parent
+    # itself). Surfaced as a broken app during the 2026-05-18 lockdown
+    # rollback retrospective.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "19999"
+              protocol: TCP

--- a/kubernetes/apps/observability/netdata/app/kustomization.yaml
+++ b/kubernetes/apps/observability/netdata/app/kustomization.yaml
@@ -3,6 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./cnp-allow.yaml
   - ./helmrelease.yaml
   - ./helmrepository.yaml
   - ./httproute.yaml


### PR DESCRIPTION
## Summary

Pre-flight audit fix for re-enabling default-deny on `observability`. Adds the four CNP gaps that were surfaced by the 2026-05-18 lockdown rollback retrospective. **Default-deny is still OFF; these ship as no-ops until re-rollout.**

## Gaps fixed

| App | Gap | Fix |
|---|---|---|
| `netdata` | No CNP at all; HTTPRoute → :19999 direct (no oauth2-proxy) | New `netdata-allow` with envoy:19999 ingress. Pod uses legacy `app: netdata` + `role: parent` labels. |
| `blackbox-exporter` | CNP exists but no envoy ingress; HTTPRoute → :9115 direct | Add envoy:9115 ingress rule. |
| `kube-ops-view` | No CNP; oauth2-proxy fronted but backend pod left bare | New `kube-ops-view-allow` (no rules — intra-ns covers oauth2→backend, baseline covers apiserver). |
| `goldilocks` | No CNP; covers both controller + dashboard | New `goldilocks-allow` (no rules — same reasoning). |

## Test plan

- [ ] flux-local renders observability cleanly
- [ ] After merge, `kubectl get cnp -n observability` shows all four allow CNPs
- [ ] netdata, blackbox, kube-ops-view, goldilocks URLs continue to work (no regression with default-deny still OFF)
- [ ] Ready for separate PR to add `default-deny` component to observability kustomization

🤖 Generated with [Claude Code](https://claude.com/claude-code)