### PR TITLE
feat(netpol): media pre-flight CNP gap for default-deny re-rollout

### DIFF
--- a/kubernetes/apps/media/medialyze/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/medialyze/app/cnp-allow.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+#
+# No ingress rules needed: medialyze-oauth2-proxy is the only door,
+# and the baseline allow-intra-namespace already permits
+# oauth2-proxy → medialyze on :8080.
+#
+# Egress: medialyze consumes *arr APIs (sonarr/radarr/lidarr) in the
+# same media ns — covered by allow-intra-namespace baseline. No
+# external API calls observed in the helmrelease env. Add specific
+# allows here if medialyze later needs cross-ns or external access.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: medialyze-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: medialyze
+  enableDefaultDeny:
+    egress: false
+    ingress: false

--- a/kubernetes/apps/media/medialyze/app/kustomization.yaml
+++ b/kubernetes/apps/media/medialyze/app/kustomization.yaml
@@ -7,6 +7,7 @@ components:
   - ../../../../components/repos/app-template
 
 resources:
+  - ./cnp-allow.yaml
   - ./helmrelease.yaml
   - ./longhorn-pvc.yaml
   - ./nfs-pvc.yaml


### PR DESCRIPTION
## Summary

Pre-flight audit fix for re-enabling default-deny on `media`. Single CNP gap: `medialyze` had an oauth2-proxy CNP but no CNP for the backend pod itself. **Default-deny still OFF; ships as no-op.**

## Gap fixed

| App | Gap | Fix |
|---|---|---|
| `medialyze` | No CNP for backend pod (oauth2-proxy CNP exists) | New `medialyze-allow` with no rules — intra-ns covers oauth2→backend and *arr consumers. |

## Test plan

- [ ] medialyze.${SECRET_DOMAIN} still loads
- [ ] flux-local renders media cleanly
- [ ] Ready for separate PR to add default-deny to media kustomization

🤖 Generated with [Claude Code](https://claude.com/claude-code)