### PR TITLE
feat(netpol): storage pre-flight CNP gap for default-deny re-rollout

### DIFF
--- a/kubernetes/apps/storage/garage/webui/cnp-allow.yaml
+++ b/kubernetes/apps/storage/garage/webui/cnp-allow.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+#
+# No ingress rules needed: garage-webui-oauth2-proxy is the only
+# door, and the baseline allow-intra-namespace already permits
+# oauth2-proxy → garage-webui on :3909.
+#
+# Egress: garage-webui talks to garage admin/S3 in the same storage
+# ns (API_BASE_URL=garage.storage.svc:3903,
+# S3_ENDPOINT_URL=garage.storage.svc:3900) — covered by
+# allow-intra-namespace baseline.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: garage-webui-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: garage-webui
+  enableDefaultDeny:
+    egress: false
+    ingress: false

--- a/kubernetes/apps/storage/garage/webui/kustomization.yaml
+++ b/kubernetes/apps/storage/garage/webui/kustomization.yaml
@@ -5,4 +5,5 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./cnp-allow.yaml
   - ./helmrelease.yaml


### PR DESCRIPTION
## Summary

Pre-flight audit fix for re-enabling default-deny on `storage`. Single CNP gap: `garage-webui` had an oauth2-proxy CNP but no CNP for the backend pod. **Default-deny still OFF; ships as no-op.**

## Gap fixed

| App | Gap | Fix |
|---|---|---|
| `garage-webui` | No CNP for backend pod | New `garage-webui-allow` with no rules — intra-ns covers oauth2→backend and garage admin/S3 backend. |

## Test plan

- [ ] garage.${SECRET_DOMAIN} still loads
- [ ] flux-local renders storage cleanly
- [ ] Ready for separate PR to add default-deny to storage kustomization

🤖 Generated with [Claude Code](https://claude.com/claude-code)