### PR TITLE
feat(netpol): re-enable default-deny in storage (Phase 3 — first user-facing ns)

### DIFF
--- a/kubernetes/apps/storage/kustomization.yaml
+++ b/kubernetes/apps/storage/kustomization.yaml
@@ -5,6 +5,11 @@ kind: Kustomization
 namespace: storage
 components:
   - ../../components/network-policy/baseline
+  # default-deny re-enabled 2026-05-18 (Phase 3: user-facing ns, first
+  # of 9). Pre-flight audit (PR #11586) added garage-webui backend CNP.
+  # Validate s3.${SECRET_DOMAIN} (garage direct) + garage.${SECRET_DOMAIN}
+  # (garage-webui via oauth2-proxy) in browser before next ns.
+  - ../../components/network-policy/default-deny
 resources:
   - ./namespace.yaml
   - ./garage/ks.yaml


### PR DESCRIPTION
Phase 3 of careful netpol re-rollout: first user-facing ns.

## Pre-flight checks done
- garage-webui backend CNP added in PR #11586
- All other storage app CNPs already in place

## Test plan
- [ ] User opens https://garage.thesteamedcrab.com (garage-webui) — should auth via oauth2-proxy and show UI
- [ ] User opens https://s3.thesteamedcrab.com — should return a Garage S3 response (404 for /, but TCP layer works)
- [ ] Drops check: `kubectl -n kube-system exec ds/cilium -- hubble observe --namespace storage --verdict DROPPED --since 3m`

## If broken
PR #11574 Hubble alerting will surface drops. Roll back by removing the default-deny line + redo PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)