### PR TITLE
feat(netpol): re-enable default-deny in observability (Phase 3)

### DIFF
--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -6,6 +6,14 @@ namespace: observability
 components:
   - ../../components/alerts
   - ../../components/network-policy/baseline
+  # default-deny re-enabled 2026-05-18 (Phase 3, 2nd user-facing ns).
+  # Pre-flight audit (PR #11583) added the 4 backend CNPs that were
+  # missing during the 2026-05-18 rollback: netdata, blackbox-exporter,
+  # kube-ops-view, goldilocks. Hubble drop alerting (PR #11574) is
+  # active — any new gaps trigger Pushover within minutes via HolmesGPT
+  # routing. Validate grafana, netdata, blackbox, kube-ops-view,
+  # goldilocks URLs in browser after merge.
+  - ../../components/network-policy/default-deny
 resources:
   - ./namespace.yaml
   - ./exporters


### PR DESCRIPTION
Phase 3 of careful re-rollout: 2nd user-facing ns.

## Pre-flight checks done
- 4 missing CNPs added in PR #11583 (netdata, blackbox-exporter, kube-ops-view, goldilocks) — exact apps that broke last time
- Hubble drop alerting active (PR #11574)

## Test plan (post-merge)
- [ ] grafana.thesteamedcrab.com loads, shows dashboards
- [ ] netdata.thesteamedcrab.com loads
- [ ] blackbox.thesteamedcrab.com loads
- [ ] kube-ops-view.thesteamedcrab.com loads
- [ ] goldilocks.thesteamedcrab.com loads
- [ ] Drops check: `kubectl -n kube-system exec ds/cilium -- hubble observe --namespace observability --verdict DROPPED --since 3m`

🤖 Generated with [Claude Code](https://claude.com/claude-code)