### PR TITLE
feat(netpol): re-enable default-deny in ai (Phase 3)

### DIFF
--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -5,6 +5,12 @@ kind: Kustomization
 namespace: ai
 components:
   - ../../components/network-policy/baseline
+  # default-deny re-enabled 2026-05-18 (Phase 3, 3rd user-facing ns).
+  # Pre-flight audit confirmed all 5 HTTPRoute backends have envoy
+  # ingress CNPs; khoj-oauth2-proxy already corrected to envoy:10443.
+  # Cross-ns egress (postgres, searxng, HuggingFace) explicit in
+  # per-app CNPs. Hubble drop alerting active (PR #11574).
+  - ../../components/network-policy/default-deny
 resources:
   - ./namespace.yaml
   - ./priority-class.yaml


### PR DESCRIPTION
All 5 HTTPRoute backends pre-flight verified. Hubble alerting (PR #11574) active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)