### PR TITLE
feat(netpol): re-enable default-deny in mcp-system (Phase 3)

### DIFF
--- a/kubernetes/apps/mcp-system/kustomization.yaml
+++ b/kubernetes/apps/mcp-system/kustomization.yaml
@@ -5,6 +5,12 @@ kind: Kustomization
 namespace: mcp-system
 components:
   - ../../components/network-policy/baseline
+  # default-deny re-enabled 2026-05-18 (Phase 3, 4th user-facing ns).
+  # Pre-flight audit confirmed per-server MCPs attach to istio gateway
+  # (mcp-gateway-istio-allow); n8n-mcp has its own envoy ingress for
+  # the public n8n-mcp.${SECRET_DOMAIN} route. intra-ns covers all
+  # broker → server flows. Hubble alerting (PR #11574) active.
+  - ../../components/network-policy/default-deny
 resources:
   - ./namespace.yaml
   - ./arr-mcp/ks.yaml


### PR DESCRIPTION
Per-flight verified: per-server MCPs use istio gateway, n8n-mcp has envoy ingress. Hubble alerting active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)