### PR TITLE
feat(netpol): re-enable default-deny in home (Phase 3)

### DIFF
--- a/kubernetes/apps/home/kustomization.yaml
+++ b/kubernetes/apps/home/kustomization.yaml
@@ -6,6 +6,14 @@ namespace: home
 components:
   - ../../components/alerts
   - ../../components/network-policy/baseline
+  # default-deny re-enabled 2026-05-18 (Phase 3, 5th user-facing ns).
+  # Pre-flight audit confirmed all 12 HTTPRoute backends have envoy
+  # ingress CNPs. EMQX brokers handle world/host/remote-node for MQTT
+  # LAN clients. NOTE: HA + frigate + esphome use Multus net1/net2 for
+  # IoT VLAN access — Cilium policy doesn't apply to secondary
+  # interfaces, so LAN device reachability via net1 is unaffected.
+  # Hubble drop alerting (PR #11574) active.
+  - ../../components/network-policy/default-deny
 resources:
   - ./namespace.yaml
   - ./priority-class.yaml


### PR DESCRIPTION
Pre-flight verified all 12 HTTPRoute backends. HA + frigate + esphome bypass Cilium policy via Multus net1/net2. Hubble alerting active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)