### PR TITLE
feat(netpol): re-enable default-deny in collab (Phase 3)

### DIFF
--- a/kubernetes/apps/collab/kustomization.yaml
+++ b/kubernetes/apps/collab/kustomization.yaml
@@ -6,6 +6,12 @@ namespace: collab
 components:
   - ../../components/alerts
   - ../../components/network-policy/baseline
+  # default-deny re-enabled 2026-05-18 (Phase 3, 6th user-facing ns).
+  # Pre-flight audit confirmed all 14 HTTPRoute backends + oauth2-proxy
+  # pairs covered. zulip-memcached / rabbitmq covered by intra-ns. All
+  # oauth2-proxy CNPs use envoy:10443 (PRs #11559/11562/11563). Hubble
+  # drop alerting (PR #11574) active.
+  - ../../components/network-policy/default-deny
 resources:
   - ./namespace.yaml
   - ./atuin/ks.yaml


### PR DESCRIPTION
All 14 HTTPRoute backends + oauth2-proxy pairs pre-flight verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)