### PR TITLE
fix(auth): disableWait on Authelia HelmRelease — recover rolled-back upgrade from #11587

### DIFF
--- a/kubernetes/apps/auth/authelia/app/helmrelease.yaml
+++ b/kubernetes/apps/auth/authelia/app/helmrelease.yaml
@@ -9,6 +9,10 @@ spec:
     kind: OCIRepository
     name: app-template
   interval: 1h
+  install:
+    disableWait: true
+  upgrade:
+    disableWait: true
   values:
     defaultPodOptions:
       enableServiceLinks: false


### PR DESCRIPTION
## Summary

PR #11587 landed the move of OIDC client hashes into a 1P-backed `clients.yml`, but **helm-controller rolled back the Deployment** during the slow pod startup window — the new pod was crashlooping while ESO finished its first force-sync, and the 5-minute Helm upgrade wait timed out.

After the rollback, the cluster is in a mixed state:
- ConfigMap: **new** (clients block removed) — kustomize-applied, sticks
- Secret: **new** (`clients.yml` = 24,541 bytes) — ESO-managed, sticks
- Deployment: **old** (no `clients.yml` mount, `--config` without it) — Helm-rolled-back

So Authelia loads only the (now-clientsless) ConfigMap and crashes. The reverted state is `args/volumeMounts` from before PR #11587.

## Fix

Add `install.disableWait` + `upgrade.disableWait` to the HelmRelease. Helm applies the spec without waiting for the pod to become Ready and does not roll back on failed startup. The Deployment ends up correctly configured (new mount + new `--config`); the next pod creation mounts the already-correct Secret and starts normally.

Same pattern is used elsewhere in this cluster for slow-startup HRs (immich-ml, prowlarr, etc.) per the known-good convention.

## Test plan

- [ ] Flux reconciles, Helm upgrade lands without rollback
- [ ] Deployment spec shows `--config /config/configuration.yml,/secrets/jwks.yml,/secrets/clients.yml`
- [ ] Pod has `/secrets/clients.yml` mount, file is 24,541 bytes
- [ ] Authelia logs show "Startup complete"
- [ ] One OIDC login (e.g. open-webui) succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)