### PR TITLE
feat(netpol): re-enable default-deny in media (Phase 3)

### DIFF
--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -6,6 +6,11 @@ namespace: media
 components:
   - ../../components/alerts
   - ../../components/network-policy/baseline
+  # default-deny re-enabled 2026-05-18 (Phase 3, 7th user-facing ns).
+  # Pre-flight audit (PR #11585) added medialyze backend CNP. All 21
+  # HTTPRoute backends + 8 oauth2-proxy pairs covered. Hubble drop
+  # alerting (PR #11574) active.
+  - ../../components/network-policy/default-deny
 resources:
   - ./namespace.yaml
   - ./priority-class.yaml


### PR DESCRIPTION
21 HTTPRoute backends + 8 oauth2-proxy pairs pre-flight verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)