### PR TITLE
fix(auth): split jwks/clients into separate persistence — secret items projection

### DIFF
--- a/kubernetes/apps/auth/authelia/app/helmrelease.yaml
+++ b/kubernetes/apps/auth/authelia/app/helmrelease.yaml
@@ -113,6 +113,16 @@ spec:
         globalMounts:
           - path: /secrets/jwks.yml
             subPath: jwks.yml
+      # Separate persistence entry so the chart generates a Secret volume
+      # projecting `clients.yml` as its own item. With both subPaths sharing
+      # one `jwks` persistence the chart only puts jwks.yml in `items:` and
+      # /secrets/clients.yml ends up as an empty directory (subPath of a
+      # missing key) — see PRs #11587/#11594 and the post-mortem in commit
+      # message.
+      clients:
+        type: secret
+        name: authelia-secret
+        globalMounts:
           - path: /secrets/clients.yml
             subPath: clients.yml
       tmp:


### PR DESCRIPTION
## Summary

Final fix to the Authelia OIDC client hashes move (started in #11570, then #11587, then #11594 disableWait).

PRs #11587 and #11594 put both `/secrets/jwks.yml` and `/secrets/clients.yml` under the existing `jwks` persistence block as two `globalMounts` entries. But the bjw-s app-template generated the underlying Secret volume with `items: [{key: jwks.yml, path: jwks.yml}]` — only the first subPath made it into the projection. `clients.yml` was never projected, so kubelet's `subPath: clients.yml` lookup found no file and created an empty directory at `/secrets/clients.yml`. Authelia parsed 0 clients and crashlooped.

Visible directly on the live Deployment after #11594:

```
volumes:
- name: jwks
  secret:
    secretName: authelia-secret
    items:
      - key: jwks.yml
        path: jwks.yml    # <-- clients.yml not in items!
```

## Fix

Split into two `persistence` entries — each generates its own Secret volume with the matching item, both backed by `authelia-secret`. Same Secret, two projections.

```yaml
persistence:
  jwks:
    type: secret
    name: authelia-secret
    globalMounts:
      - path: /secrets/jwks.yml
        subPath: jwks.yml
  clients:
    type: secret
    name: authelia-secret
    globalMounts:
      - path: /secrets/clients.yml
        subPath: clients.yml
```

## Test plan

- [ ] Flux reconciles, Helm upgrade applies new Deployment spec
- [ ] Deploy spec shows two Secret volumes (jwks + clients), each with correct items
- [ ] New pod's `/secrets/clients.yml` is a 24,541-byte file (not a directory)
- [ ] Authelia logs show "Startup complete"
- [ ] OIDC login works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)