### PR TITLE
feat(netpol): drop L7 DNS proxy in auth namespace

### DIFF
--- a/kubernetes/apps/auth/kustomization.yaml
+++ b/kubernetes/apps/auth/kustomization.yaml
@@ -9,3 +9,18 @@ resources:
   - ./namespace.yaml
   - ./authelia/ks.yaml
   - ./lldap/ks.yaml
+# Strip Cilium's L7 DNS proxy rule from baseline allow-dns in this
+# namespace. The L7 `rules.dns.matchPattern: "*"` proxies every DNS
+# query through cilium-agent to populate the FQDN cache for later
+# toFQDNs: rules — but no policy in `auth` uses toFQDNs, and the
+# added latency previously broke authelia → LLDAP timing (soulseek
+# 403). L4 DNS (UDP/TCP 53 to kube-dns) remains allowed.
+patches:
+  - target:
+      group: cilium.io
+      version: v2
+      kind: CiliumNetworkPolicy
+      name: allow-dns
+    patch: |
+      - op: remove
+        path: /spec/egress/0/toPorts/0/rules

--- a/kubernetes/components/network-policy/baseline/README.md
+++ b/kubernetes/components/network-policy/baseline/README.md
@@ -92,6 +92,38 @@ patches:
         path: /metadata/annotations/policy.cilium.io~1audit-mode
 ```
 
+## Dropping the L7 DNS proxy per-namespace
+
+`allow-dns` ships with an L7 `dns.matchPattern: "*"` rule that proxies
+every DNS query through cilium-agent. This is required for `toFQDNs:`
+egress rules in app overlays to work — Cilium populates the FQDN cache
+from observed proxied queries.
+
+The proxy adds latency (one extra hop per query, plus per-query policy
+evaluation). For latency-sensitive auth flows it can be enough to break
+things — see `auth/kustomization.yaml` where it broke authelia → LLDAP
+during a prior rollout. **If a namespace uses no `toFQDNs:` rules at
+all, the L7 proxy is dead weight.**
+
+To opt out per-namespace, strip the `rules:` block via a kustomize JSON
+patch in the namespace's `kustomization.yaml`:
+
+```yaml
+patches:
+  - target:
+      group: cilium.io
+      version: v2
+      kind: CiliumNetworkPolicy
+      name: allow-dns
+    patch: |
+      - op: remove
+        path: /spec/egress/0/toPorts/0/rules
+```
+
+The L4 DNS allow (UDP/TCP 53 to `kube-dns`) remains in effect. Adding a
+`toFQDNs:` rule to any policy in the namespace later will silently fail
+to match anything — re-add the L7 proxy first.
+
 ## The `default-deny` companion
 
 `default-deny` is intentionally **not** in this component. Bundling


### PR DESCRIPTION
## Summary

- Audited `toFQDNs` usage: 12 files in `kubernetes/apps/**` rely on
  Cilium's L7 DNS proxy. Above the 10-file threshold for cluster-wide
  removal — **keep L7 as cluster default.**
- Auth namespace uses zero `toFQDNs:` rules, so the L7 proxy adds only
  latency. Prior rollout broke authelia → LLDAP timing (soulseek 403).
- Per-namespace kustomize patch in `kubernetes/apps/auth/kustomization.yaml`
  strips the `rules:` block from baseline `allow-dns`; L4 DNS allow
  (UDP/TCP 53 to kube-dns) remains in effect.
- README documents the opt-out pattern for future namespaces.

## Rendered diff (auth `allow-dns`)

Before:
```yaml
toPorts:
  - ports: [...]
    rules:
      dns:
        - matchPattern: "*"
```

After:
```yaml
toPorts:
  - ports: [...]
```

## Follow-up

- 12 apps still use `toFQDNs:` (cluster-wide L7 remains). No action
  needed unless we revisit per-app conversion to `toEntities: world` /
  `toCIDR` to allow full L7 removal.
- If a new `toFQDNs:` rule is ever added to a policy in `auth`, the
  patch must be removed first or the rule will silently match nothing.
  README calls this out.

## Test plan

- [ ] `kubectl kustomize kubernetes/apps/auth/` shows `allow-dns`
      without `rules:` (verified locally)
- [ ] After merge + Flux reconcile, `kubectl -n auth get cnp allow-dns
      -o yaml` shows no `rules:` block
- [ ] authelia login flow against LLDAP completes without DNS-induced
      latency
- [ ] Other namespaces (which keep L7) continue to resolve external
      FQDNs gated by `toFQDNs:` rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)