### PR TITLE
security(oauth2-proxy): add baseline securityContext to collab namespace

### DIFF
--- a/kubernetes/apps/collab/glance-oauth2-proxy/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/glance-oauth2-proxy/app/helmrelease.yaml
@@ -20,6 +20,14 @@ spec:
   values:
     controllers:
       glance-oauth2-proxy:
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 2000
+            runAsGroup: 2000
+            fsGroup: 2000
+            fsGroupChangePolicy: OnRootMismatch
+
         annotations:
           reloader.stakater.com/auto: "true"
 
@@ -28,6 +36,15 @@ spec:
             image:
               repository: quay.io/oauth2-proxy/oauth2-proxy
               tag: v7.15.2
+
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+              seccompProfile:
+                type: RuntimeDefault
 
             args:
               - --provider=oidc

--- a/kubernetes/apps/collab/glance-user-oauth2-proxy/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/glance-user-oauth2-proxy/app/helmrelease.yaml
@@ -20,6 +20,14 @@ spec:
   values:
     controllers:
       glance-user-oauth2-proxy:
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 2000
+            runAsGroup: 2000
+            fsGroup: 2000
+            fsGroupChangePolicy: OnRootMismatch
+
         annotations:
           reloader.stakater.com/auto: "true"
 
@@ -28,6 +36,15 @@ spec:
             image:
               repository: quay.io/oauth2-proxy/oauth2-proxy
               tag: v7.15.2
+
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+              seccompProfile:
+                type: RuntimeDefault
 
             args:
               - --provider=oidc

--- a/kubernetes/apps/collab/pump-oauth2-proxy/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump-oauth2-proxy/app/helmrelease.yaml
@@ -20,6 +20,14 @@ spec:
   values:
     controllers:
       pump-oauth2-proxy:
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 2000
+            runAsGroup: 2000
+            fsGroup: 2000
+            fsGroupChangePolicy: OnRootMismatch
+
         annotations:
           reloader.stakater.com/auto: "true"
 
@@ -28,6 +36,15 @@ spec:
             image:
               repository: quay.io/oauth2-proxy/oauth2-proxy
               tag: v7.15.2
+
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+              seccompProfile:
+                type: RuntimeDefault
 
             args:
               - --provider=oidc

--- a/kubernetes/apps/collab/startpunkt-oauth2-proxy/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/startpunkt-oauth2-proxy/app/helmrelease.yaml
@@ -20,6 +20,14 @@ spec:
   values:
     controllers:
       startpunkt-oauth2-proxy:
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 2000
+            runAsGroup: 2000
+            fsGroup: 2000
+            fsGroupChangePolicy: OnRootMismatch
+
         annotations:
           reloader.stakater.com/auto: "true"
 
@@ -28,6 +36,15 @@ spec:
             image:
               repository: quay.io/oauth2-proxy/oauth2-proxy
               tag: v7.15.2
+
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+              seccompProfile:
+                type: RuntimeDefault
 
             args:
               - --provider=oidc


### PR DESCRIPTION
## Summary

PSA audit (PR #11584) found 24 oauth2-proxy HelmReleases shipping with empty `securityContext`. This is the first of 8 per-namespace PRs adding the baseline pod-level + container-level hardening from `.agents/instructions/helmrelease.security.md`.

**collab namespace (4 HRs)**: glance, glance-user, pump, startpunkt.

### Baseline applied

- `pod.securityContext`: `runAsNonRoot: true`, `runAsUser/Group: 2000`, `fsGroup: 2000`, `fsGroupChangePolicy: OnRootMismatch`
- `containers.app.securityContext`: `allowPrivilegeEscalation: false`, `readOnlyRootFilesystem: true`, `capabilities.drop: [ALL]`, `seccompProfile.type: RuntimeDefault`

UID 2000 picked to avoid clashing with the default UID 1000 used by most app pods. oauth2-proxy runs as non-root cleanly and does not write to rootfs.

## Test plan

- [ ] Flux reconciles each HelmRelease without rollback
- [ ] `kubectl get pods -n collab -l 'app.kubernetes.io/name in (glance-oauth2-proxy,glance-user-oauth2-proxy,pump-oauth2-proxy,startpunkt-oauth2-proxy)'` shows 1/1 Running, 0 restarts post-rollout
- [ ] OIDC login flow still works for glance, pump, startpunkt landing pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)