### PR TITLE
fix(rbac): scope longhorn-support-bundle CRB to view, not cluster-admin

### DIFF
--- a/kubernetes/apps/longhorn-system/longhorn/app/helmrelease.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn/app/helmrelease.yaml
@@ -47,3 +47,21 @@ spec:
     preUpgradeChecker:
       jobEnabled: false
       upgradeVersionCheck: false
+  # Scope the chart-shipped `longhorn-support-bundle` ClusterRoleBinding
+  # from `cluster-admin` down to `view`. The chart hardcodes the binding
+  # with no values knob to disable it (clusterrolebinding.yaml lines
+  # 15-27 in longhorn-1.11.2), so we patch it post-render. The SA is
+  # only consumed when a support bundle is being collected; if a bundle
+  # fails because of insufficient permissions, drop this patch and file
+  # an upstream issue.
+  # See docs/src/rbac_audit.md §2.1.
+  postRenderers:
+    - kustomize:
+        patches:
+          - patch: |-
+              - op: replace
+                path: /roleRef/name
+                value: view
+            target:
+              kind: ClusterRoleBinding
+              name: longhorn-support-bundle


### PR DESCRIPTION
## Summary

- Longhorn chart ships `longhorn-support-bundle` SA + CRB bound to `cluster-admin` with no values knob to disable.
- No pod consumes the SA at steady state (only during bundle collection), but the binding persists between collections — a leaked token → full cluster takeover.
- Patch the CRB post-render to point at `view` instead.

Addresses RBAC audit Tier 1 finding (docs/src/rbac_audit.md §2.1).

## Test plan

- [ ] Flux reconciles the HelmRelease successfully
- [ ] `kubectl get clusterrolebinding longhorn-support-bundle -o yaml` shows `roleRef.name: view`
- [ ] Trigger a support-bundle collection from the Longhorn UI; verify it still completes (or drop this patch if it fails)
- [ ] Existing longhorn-manager / longhorn-ui pods continue to function (they use `longhorn-service-account`, unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)