### PR TITLE
fix(rbac): scope renovate-operator to its own namespace

### DIFF
--- a/kubernetes/apps/renovate/renovate-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/app/helmrelease.yaml
@@ -11,6 +11,14 @@ spec:
   interval: 30m
   values:
     fullnameOverride: renovate-operator
+    # All RenovateJob CRs in this cluster live in the `renovate`
+    # namespace; the operator only reconciles + reads secrets within
+    # its own namespace. Scope its RBAC from cluster-wide to namespace-
+    # local (Role + RoleBinding) so a compromised operator pod cannot
+    # mint / read secrets across the cluster. See docs/src/rbac_audit.md
+    # §4 (renovate-operator row).
+    rbac:
+      ownNamespaceOnly: true
     route:
       enabled: true
       hostnames:


### PR DESCRIPTION
## Summary

- Set `rbac.ownNamespaceOnly: true` so the chart renders a `Role` + `RoleBinding` in the `renovate` namespace instead of a cluster-wide `ClusterRole` granting `secrets create/get/list/watch/update/delete`.
- All RenovateJob CRs in this cluster live in the `renovate` ns (`kubernetes/apps/renovate/renovate-operator/jobs/*.yaml`); operator logs only show `namespace:\"renovate\"` work. Cluster-wide secret write was unused attack surface.

Addresses RBAC audit Tier 2/3 finding (docs/src/rbac_audit.md §4 renovate-operator row).

## Test plan

- [ ] Flux reconciles HelmRelease
- [ ] `kubectl get clusterrole renovate-operator` returns NotFound; `kubectl get role -n renovate renovate-operator` exists
- [ ] Manually trigger a RenovateJob (e.g. `rwlove-home-ops`); verify the operator still creates pods/jobs/secrets in the renovate ns
- [ ] Renovate PRs continue to appear on schedule (next run already cron'd hourly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)