### PR TITLE
security(oauth2-proxy): add pod-level securityContext to ai/khoj

### DIFF
--- a/kubernetes/apps/ai/khoj-oauth2-proxy/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/khoj-oauth2-proxy/app/helmrelease.yaml
@@ -20,6 +20,13 @@ spec:
   values:
     controllers:
       khoj-oauth2-proxy:
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 2000
+            runAsGroup: 2000
+            fsGroup: 2000
+            fsGroupChangePolicy: OnRootMismatch
         annotations:
           reloader.stakater.com/auto: "true"
         containers:


### PR DESCRIPTION
## Summary

PSA audit (PR #11584) follow-up — 2nd of 8 per-namespace PRs.

`khoj-oauth2-proxy` already had container-level securityContext from a prior pass (allowPrivilegeEscalation/capabilities/readOnlyRootFilesystem/seccompProfile). This adds the missing **pod-level** baseline from `.agents/instructions/helmrelease.security.md`:

- `pod.securityContext`: `runAsNonRoot: true`, `runAsUser/Group: 2000`, `fsGroup: 2000`, `fsGroupChangePolicy: OnRootMismatch`

UID 2000 matches the other oauth2-proxy hardening commits in this series.

## Test plan

- [ ] Flux reconciles without rollback
- [ ] `kubectl get pods -n ai -l app.kubernetes.io/name=khoj-oauth2-proxy` shows 1/1 Running, 0 restarts post-rollout
- [ ] khoj OIDC login flow still works; `/api/` bearer-token carve-out still bypasses auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)