### PR TITLE
security(oauth2-proxy): add baseline securityContext to home/frigate

### DIFF
--- a/kubernetes/apps/home/frigate-oauth2-proxy/app/helmrelease.yaml
+++ b/kubernetes/apps/home/frigate-oauth2-proxy/app/helmrelease.yaml
@@ -20,6 +20,14 @@ spec:
   values:
     controllers:
       frigate-oauth2-proxy:
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 2000
+            runAsGroup: 2000
+            fsGroup: 2000
+            fsGroupChangePolicy: OnRootMismatch
+
         annotations:
           reloader.stakater.com/auto: "true"
 
@@ -28,6 +36,15 @@ spec:
             image:
               repository: quay.io/oauth2-proxy/oauth2-proxy
               tag: v7.15.2
+
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+              seccompProfile:
+                type: RuntimeDefault
 
             args:
               - --provider=oidc


### PR DESCRIPTION
## Summary

PSA audit (PR #11584) follow-up — 3rd of 8 per-namespace PRs.

**home namespace (1 HR)**: frigate-oauth2-proxy.

Apply baseline pod-level + container-level hardening from `.agents/instructions/helmrelease.security.md`:

- `pod.securityContext`: `runAsNonRoot: true`, `runAsUser/Group: 2000`, `fsGroup: 2000`, `fsGroupChangePolicy: OnRootMismatch`
- `containers.app.securityContext`: `allowPrivilegeEscalation: false`, `readOnlyRootFilesystem: true`, `capabilities.drop: [ALL]`, `seccompProfile.type: RuntimeDefault`

## Test plan

- [ ] Flux reconciles without rollback
- [ ] `kubectl get pods -n home -l app.kubernetes.io/name=frigate-oauth2-proxy` shows 1/1 Running, 0 restarts post-rollout
- [ ] Frigate OIDC login flow still works (`frigate.${SECRET_DOMAIN}`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)