### PR TITLE
security(oauth2-proxy): add baseline securityContext to observability namespace

### DIFF
--- a/kubernetes/apps/observability/goldilocks-oauth2-proxy/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/goldilocks-oauth2-proxy/app/helmrelease.yaml
@@ -20,6 +20,14 @@ spec:
   values:
     controllers:
       goldilocks-oauth2-proxy:
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 2000
+            runAsGroup: 2000
+            fsGroup: 2000
+            fsGroupChangePolicy: OnRootMismatch
+
         annotations:
           reloader.stakater.com/auto: "true"
 
@@ -28,6 +36,15 @@ spec:
             image:
               repository: quay.io/oauth2-proxy/oauth2-proxy
               tag: v7.15.2
+
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+              seccompProfile:
+                type: RuntimeDefault
 
             args:
               - --provider=oidc

--- a/kubernetes/apps/observability/holmesgpt-oauth2-proxy/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/holmesgpt-oauth2-proxy/app/helmrelease.yaml
@@ -20,6 +20,14 @@ spec:
   values:
     controllers:
       holmesgpt-oauth2-proxy:
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 2000
+            runAsGroup: 2000
+            fsGroup: 2000
+            fsGroupChangePolicy: OnRootMismatch
+
         annotations:
           reloader.stakater.com/auto: "true"
 
@@ -28,6 +36,15 @@ spec:
             image:
               repository: quay.io/oauth2-proxy/oauth2-proxy
               tag: v7.15.2
+
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+              seccompProfile:
+                type: RuntimeDefault
 
             args:
               - --provider=oidc

--- a/kubernetes/apps/observability/kube-ops-view-oauth2-proxy/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-ops-view-oauth2-proxy/app/helmrelease.yaml
@@ -20,6 +20,14 @@ spec:
   values:
     controllers:
       kube-ops-view-oauth2-proxy:
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 2000
+            runAsGroup: 2000
+            fsGroup: 2000
+            fsGroupChangePolicy: OnRootMismatch
+
         annotations:
           reloader.stakater.com/auto: "true"
 
@@ -28,6 +36,15 @@ spec:
             image:
               repository: quay.io/oauth2-proxy/oauth2-proxy
               tag: v7.15.2
+
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+              seccompProfile:
+                type: RuntimeDefault
 
             args:
               - --provider=oidc


### PR DESCRIPTION
## Summary

PSA audit (PR #11584) follow-up — 5th of 8 per-namespace PRs.

**observability namespace (3 HRs)**: goldilocks, holmesgpt, kube-ops-view.

Apply baseline pod-level + container-level hardening from `.agents/instructions/helmrelease.security.md`:

- `pod.securityContext`: `runAsNonRoot: true`, `runAsUser/Group: 2000`, `fsGroup: 2000`, `fsGroupChangePolicy: OnRootMismatch`
- `containers.app.securityContext`: `allowPrivilegeEscalation: false`, `readOnlyRootFilesystem: true`, `capabilities.drop: [ALL]`, `seccompProfile.type: RuntimeDefault`

## Test plan

- [ ] Flux reconciles each HelmRelease without rollback
- [ ] `kubectl get pods -n observability -l 'app.kubernetes.io/name in (goldilocks-oauth2-proxy,holmesgpt-oauth2-proxy,kube-ops-view-oauth2-proxy)'` shows 1/1 Running, 0 restarts post-rollout
- [ ] OIDC login flow still works for goldilocks, holmesgpt, kube-ops-view dashboards

🤖 Generated with [Claude Code](https://claude.com/claude-code)