### PR TITLE
security(oauth2-proxy): add baseline securityContext to downloads namespace

### DIFF
--- a/kubernetes/apps/downloads/jdownloader2-oauth2-proxy/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/jdownloader2-oauth2-proxy/app/helmrelease.yaml
@@ -26,12 +26,27 @@ spec:
         pod:
           labels:
             setGateway: "false"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 2000
+            runAsGroup: 2000
+            fsGroup: 2000
+            fsGroupChangePolicy: OnRootMismatch
 
         containers:
           app:
             image:
               repository: quay.io/oauth2-proxy/oauth2-proxy
               tag: v7.15.2
+
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+              seccompProfile:
+                type: RuntimeDefault
 
             args:
               - --provider=oidc

--- a/kubernetes/apps/downloads/prowlarr-oauth2-proxy/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/prowlarr-oauth2-proxy/app/helmrelease.yaml
@@ -29,12 +29,27 @@ spec:
           # (kubernetes/apps/vpn/downloads-gateway) reads "setGateway".
           labels:
             setGateway: "false"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 2000
+            runAsGroup: 2000
+            fsGroup: 2000
+            fsGroupChangePolicy: OnRootMismatch
 
         containers:
           app:
             image:
               repository: quay.io/oauth2-proxy/oauth2-proxy
               tag: v7.15.2
+
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+              seccompProfile:
+                type: RuntimeDefault
 
             args:
               - --provider=oidc

--- a/kubernetes/apps/downloads/qbittorrent-oauth2-proxy/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/qbittorrent-oauth2-proxy/app/helmrelease.yaml
@@ -26,12 +26,27 @@ spec:
         pod:
           labels:
             setGateway: "false"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 2000
+            runAsGroup: 2000
+            fsGroup: 2000
+            fsGroupChangePolicy: OnRootMismatch
 
         containers:
           app:
             image:
               repository: quay.io/oauth2-proxy/oauth2-proxy
               tag: v7.15.2
+
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+              seccompProfile:
+                type: RuntimeDefault
 
             args:
               - --provider=oidc

--- a/kubernetes/apps/downloads/sabnzbd-oauth2-proxy/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/sabnzbd-oauth2-proxy/app/helmrelease.yaml
@@ -26,12 +26,27 @@ spec:
         pod:
           labels:
             setGateway: "false"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 2000
+            runAsGroup: 2000
+            fsGroup: 2000
+            fsGroupChangePolicy: OnRootMismatch
 
         containers:
           app:
             image:
               repository: quay.io/oauth2-proxy/oauth2-proxy
               tag: v7.15.2
+
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+              seccompProfile:
+                type: RuntimeDefault
 
             args:
               - --provider=oidc

--- a/kubernetes/apps/downloads/slskd-oauth2-proxy/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/slskd-oauth2-proxy/app/helmrelease.yaml
@@ -26,12 +26,27 @@ spec:
         pod:
           labels:
             setGateway: "false"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 2000
+            runAsGroup: 2000
+            fsGroup: 2000
+            fsGroupChangePolicy: OnRootMismatch
 
         containers:
           app:
             image:
               repository: quay.io/oauth2-proxy/oauth2-proxy
               tag: v7.15.2
+
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+              seccompProfile:
+                type: RuntimeDefault
 
             args:
               - --provider=oidc


### PR DESCRIPTION
## Summary

PSA audit (PR #11584) follow-up — 6th of 8 per-namespace PRs.

**downloads namespace (5 HRs)**: jdownloader2, prowlarr, qbittorrent, sabnzbd, slskd.

Apply baseline pod-level + container-level hardening from `.agents/instructions/helmrelease.security.md`, augmenting the existing `pod:` block (which already carries the `setGateway=false` label opting out of the downloads-ns VPN sidecar injection):

- `pod.securityContext`: `runAsNonRoot: true`, `runAsUser/Group: 2000`, `fsGroup: 2000`, `fsGroupChangePolicy: OnRootMismatch`
- `containers.app.securityContext`: `allowPrivilegeEscalation: false`, `readOnlyRootFilesystem: true`, `capabilities.drop: [ALL]`, `seccompProfile.type: RuntimeDefault`

The slskd memory entry's `readOnlyRootFilesystem: false` exception is for the slskd main app (its entrypoint quirks), not its oauth2-proxy sidecar HR, which runs the vanilla `quay.io/oauth2-proxy/oauth2-proxy` image and is unaffected.

## Test plan

- [ ] Flux reconciles each HelmRelease without rollback
- [ ] `kubectl get pods -n downloads -l 'app.kubernetes.io/name in (jdownloader2-oauth2-proxy,prowlarr-oauth2-proxy,qbittorrent-oauth2-proxy,sabnzbd-oauth2-proxy,slskd-oauth2-proxy)'` shows 1/1 Running, 0 restarts post-rollout
- [ ] OIDC login flow still works for downloader, prowlarr, bt, sabnzbd, soulseek
- [ ] qBittorrent `--skip-auth-route=^/api/` still bypasses auth for CLI clients

🤖 Generated with [Claude Code](https://claude.com/claude-code)