### PR TITLE
feat(netpol): egress detection — FQDN baseline + novel-dest + volume anomaly alerts

### DIFF
--- a/docs/src/egress_restriction_design.md
+++ b/docs/src/egress_restriction_design.md
@@ -1,9 +1,34 @@
 # Egress Restriction Design Proposal
 
-Status: **Proposal — not implemented.** Tier 3 of the network security
-roadmap.
+Status: **Phases 1–3 implemented 2026-05-18.** Detection-first hybrid
+(approach E) live; per-app narrowing (approach F) is opportunistic and
+ongoing. Tier 3 of the network security roadmap.
 Owner: home-ops
 Last updated: 2026-05-18
+
+## Implementation notes (2026-05-18)
+
+The Hubble metrics in this cluster don't expose what the original
+design assumed:
+
+- `hubble_dns_queries_total` has a `query` label but no source-pod
+  attribution out of the box — only the cilium-agent pod observing the
+  query. Fixed by adding `labelsContext=source_namespace,source_pod`
+  to the `dns:` metric in
+  `kubernetes/apps/kube-system/cilium/app/values.yaml`.
+- `hubble_flows_processed_total` has no `destination_fqdn` label at
+  all in Cilium 1.19 — that pairing exists in the flow logs but not
+  in the Prometheus export. For Phase 3 (egress-volume anomaly) we
+  use `container_network_transmit_bytes_total` from cAdvisor instead,
+  since byte counts aren't in any Hubble metric.
+
+The shipped recording rules + alerts live in
+`kubernetes/apps/observability/kube-prometheus-stack/app/prometheusrule-egress-detection.yaml`.
+The Phase-0 "baseline JSON exported to git" step is deferred — the
+detection alert fires on novel destinations relative to a live 24h
+window rather than a frozen baseline file, which trades some signal
+quality for not needing to commit and refresh a per-app FQDN
+manifest.
 
 ## Problem statement
 

--- a/kubernetes/apps/kube-system/cilium/app/values.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/values.yaml
@@ -70,7 +70,13 @@ hubble:
 
   metrics:
     enabled:
-      - dns:query;ignoreAAAA
+      # `labelsContext=source_namespace,source_pod` attributes each DNS
+      # query to the pod that asked. Without this the `query` label is
+      # there but unattributable (the only pod label is the cilium-agent
+      # observing pod). Drives the per-app egress-FQDN baselining +
+      # novel-destination alerting from
+      # docs/src/egress_restriction_design.md (approach E).
+      - dns:query;ignoreAAAA;labelsContext=source_namespace,source_pod
       - drop:labelsContext=source_namespace,destination_namespace
       - tcp
       - flow

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/kustomization.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/kustomization.yaml
@@ -9,4 +9,5 @@ resources:
   - ./helmrelease.yaml
   - ./ocirepository.yaml
   - ./prometheusrule-cilium-drops.yaml
+  - ./prometheusrule-egress-detection.yaml
   - ./prometheusrule-pv.yaml

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/prometheusrule-egress-detection.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/prometheusrule-egress-detection.yaml
@@ -1,0 +1,184 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: egress-detection
+spec:
+  groups:
+    # Egress detection-first hardening per
+    # docs/src/egress_restriction_design.md (approach E + F).
+    #
+    # The cluster's CNP posture is `toEntities: [world]` on ~50 of 51
+    # rules — every workload that needs any outbound HTTPS today can
+    # exfiltrate anywhere on 443. The design recommends detection
+    # rather than prevention because Cilium 1.19's matchPattern
+    # silently fails on canonical FQDNs (memory:
+    # project_cilium_matchpattern_fqdn_limits.md), and the 2026-05-18
+    # rollback established that any control that fails silently is
+    # operationally unacceptable.
+    #
+    # Source metric for Phase 1+2: `hubble_dns_queries_total` enriched
+    # with `labelsContext=source_namespace,source_pod` (added in
+    # kubernetes/apps/kube-system/cilium/app/values.yaml). The
+    # `query` label carries the FQDN as the pod asked it — which
+    # includes K8s DNS search-suffix augmentation (e.g.
+    # `api.cloudflare.com.network.svc.cluster.local.`). Filtering
+    # on canonical suffixes is the cleanest way to isolate
+    # external lookups from intra-cluster service lookups.
+    #
+    # Source metric for Phase 3: `container_network_transmit_bytes_total`
+    # from cAdvisor. Hubble doesn't expose byte counts on flows, so
+    # cAdvisor's per-pod tx counter is the simplest signal.
+    - name: egress-fqdn-baseline
+      interval: 1m
+      rules:
+        # Phase 1: per-(namespace, pod, fqdn) DNS-query rate over 5m.
+        # Materialized as a recording rule so the novel-destination
+        # alert below can ask "was this tuple seen in the last 24h?"
+        # cheaply via `offset`, instead of fanning the raw counter
+        # out at alert-eval time.
+        #
+        # Filters strip non-egress queries:
+        #   - `.cluster.local.` — intra-cluster service resolution.
+        #   - `.thesteamedcrab.com.` — LAN-internal hosts via bind9
+        #     split-horizon; not external egress.
+        #   - `.in-addr.arpa.` / `.ip6.arpa.` — reverse DNS, not egress.
+        - record: namespace_pod_fqdn:hubble_dns_queries:rate5m
+          expr: |
+            sum by (source_namespace, source_pod, query) (
+              rate(hubble_dns_queries_total{
+                query!~".*\\.cluster\\.local\\.$",
+                query!~".*\\.thesteamedcrab\\.com\\.$",
+                query!~".*\\.in-addr\\.arpa\\.$",
+                query!~".*\\.ip6\\.arpa\\.$",
+                source_namespace!="",
+                source_pod!=""
+              }[5m])
+            )
+        # Phase 3 substrate: per-(namespace, pod) egress bytes rate
+        # restricted to the "inherently unbounded" pod population from
+        # the design doc. Materializing this rate as a recording rule
+        # lets the volume-anomaly alert below avoid re-evaluating the
+        # same cAdvisor subquery five times.
+        #
+        # Regex covers home-assistant, n8n, node-red, searxng,
+        # open-webui, glance (incl glance-user), esphome (incl
+        # esphome-code), and self-hosted runners. Narrow on purpose —
+        # broadening this catches infrastructure pods (backup jobs,
+        # image pulls) whose egress is bursty by design and would
+        # generate noise.
+        - record: namespace_pod:broad_egress_bytes:rate1h
+          expr: |
+            sum by (namespace, pod) (
+              rate(container_network_transmit_bytes_total{
+                namespace=~"home|automation|actions-runner-system|ai",
+                pod=~"home-assistant.*|n8n.*|node-red.*|searxng.*|open-webui.*|glance.*|esphome.*|.*-runner-.*",
+                pod!=""
+              }[1h])
+            )
+    - name: egress-fqdn-novel-destination
+      rules:
+        # Phase 2: a `(namespace, pod, query)` tuple shows up in the
+        # last 15m that did NOT exist in the past 24h. `absent_over_time`
+        # is the idiom for "this series didn't exist over the
+        # lookback window."
+        #
+        # The 24h window is the design's recommended starting point.
+        # Once a real soak exists (design Phase 0 calls for 7d), widen
+        # to `[7d]` — but 24h means the alert is useful immediately
+        # rather than waiting a week. Cost: it fires on legitimately
+        # new destinations during the soak; that surfaces alert-tuning
+        # work before silence does.
+        #
+        # `for: 15m` dampens single-query bursts (a curl from a debug
+        # exec, a DNS retry on packet loss). 15 minutes of repeated
+        # lookups means the pod is actually using the destination,
+        # not a one-shot probe.
+        - alert: PodEgressNovelDestination
+          annotations:
+            description: >-
+              Pod {{ $labels.source_namespace }}/{{ $labels.source_pod }}
+              is querying DNS for `{{ $labels.query }}` — a destination
+              not seen from this pod in the past 24h. Investigate whether
+              this is a legitimate config change or an exfiltration
+              attempt. See docs/src/egress_restriction_design.md.
+            summary: >-
+              Pod {{ $labels.source_namespace }}/{{ $labels.source_pod }}
+              hit novel egress destination {{ $labels.query }}.
+          expr: |
+            (
+              namespace_pod_fqdn:hubble_dns_queries:rate5m > 0
+            )
+            and
+            (
+              absent_over_time(
+                namespace_pod_fqdn:hubble_dns_queries:rate5m[24h] offset 15m
+              )
+            )
+          for: 15m
+          labels:
+            severity: warning
+    - name: egress-volume-anomaly
+      rules:
+        # Phase 3: egress-bytes anomaly for inherently-broad pods.
+        # The design's unbounded population is structurally allowed
+        # to talk anywhere — FQDN baselining would churn constantly.
+        # Volume anomaly catches the bulk-exfil scenario without
+        # needing an FQDN allowlist.
+        #
+        # Comparison: current 1h rate vs 7d baseline of the same
+        # recording rule (avg ± 3σ). Subquery `[7d:5m]` samples the
+        # recording rule every 5m over 7d for the avg/stddev.
+        #
+        # Guards (all required to fire):
+        #   - `> 1e6` floor (1 MB/s) avoids firing on apps whose
+        #     baseline rate is so low that 3σ is meaningless (idle
+        #     node-red with a 100 B/s baseline would alert on a 1KB
+        #     burst otherwise).
+        #   - `stddev_over_time > 0` avoids div-by-zero on pods with
+        #     perfectly constant rates.
+        #   - `unless absent_over_time([7d:5m])` prevents firing on
+        #     cold baselines (pod first deployed <7d ago, fresh
+        #     Prometheus, recording rule not yet present). The
+        #     design explicitly calls out "don't fire on empty/cold
+        #     data."
+        - alert: PodEgressVolumeAnomaly
+          annotations:
+            description: >-
+              Pod {{ $labels.namespace }}/{{ $labels.pod }} has sustained
+              egress of {{ $value | humanize }}B/s over the last hour —
+              more than 3 standard deviations above its 7-day baseline.
+              This pod is on the broad-egress allowlist (home-assistant,
+              n8n, node-red, searxng, open-webui, glance, esphome,
+              runners) where an FQDN baseline isn't tractable; volume
+              anomaly is the catch for bulk-exfil patterns. Investigate
+              via Hubble flow logs in Grafana.
+            summary: >-
+              Egress-bytes anomaly on broad-egress pod
+              {{ $labels.namespace }}/{{ $labels.pod }}.
+          expr: |
+            (
+              namespace_pod:broad_egress_bytes:rate1h
+              >
+              (
+                avg_over_time(namespace_pod:broad_egress_bytes:rate1h[7d:5m])
+                +
+                3 * stddev_over_time(namespace_pod:broad_egress_bytes:rate1h[7d:5m])
+              )
+            )
+            and
+            (
+              namespace_pod:broad_egress_bytes:rate1h > 1e6
+            )
+            and
+            (
+              stddev_over_time(namespace_pod:broad_egress_bytes:rate1h[7d:5m]) > 0
+            )
+            unless
+            (
+              absent_over_time(namespace_pod:broad_egress_bytes:rate1h[7d:5m])
+            )
+          for: 30m
+          labels:
+            severity: warning


### PR DESCRIPTION
## Summary

Implements phases 1–3 of `docs/src/egress_restriction_design.md` — detection-first egress hardening (approach E).

Reality check on Hubble metrics in 1.19: `hubble_dns_queries_total` carries the FQDN as a `query` label but no source-pod attribution out of the box (only the observing cilium-agent pod). `hubble_flows_processed_total` has no `destination_fqdn` label at all in Cilium 1.19, and no byte counter. So this PR:

- Adds `labelsContext=source_namespace,source_pod` to the `dns:` Hubble metric in `cilium/app/values.yaml`.
- Uses cAdvisor's `container_network_transmit_bytes_total` for Phase 3 byte-volume anomaly (since no Hubble metric exposes bytes).

## Recording rules (Phase 1 + Phase 3 substrate)

| Rule | Source | Purpose |
|---|---|---|
| `namespace_pod_fqdn:hubble_dns_queries:rate5m` | `hubble_dns_queries_total` (enriched) | Per-(ns, pod, fqdn) DNS-query rate, external destinations only |
| `namespace_pod:broad_egress_bytes:rate1h` | `container_network_transmit_bytes_total` | Per-(ns, pod) egress rate for "inherently unbounded" pods |

## Alerts

| Alert | Trigger | Severity |
|---|---|---|
| `PodEgressNovelDestination` | Pod hits a DNS name not seen from it in 24h; `for: 15m` dampens single-query bursts | warning |
| `PodEgressVolumeAnomaly` | Sustained 1h egress >3σ above 7d baseline, ≥1 MB/s floor, `absent_over_time` guard against cold data; `for: 30m` | warning |

Both route via the existing pushover receiver pattern from `alertmanagerconfig.yaml` (`severity=warning` lands on the default route).

## Validated

- `yamllint` clean on all changed files
- `markdownlint` clean on the design doc
- All four expressions parse against live Prometheus
- Phase 3 recording-rule expr returns 16 valid series live (cAdvisor side already populated)
- Backslash escaping verified: `\\.` in YAML → `\.` to PromQL regex engine

## Test plan

- [ ] flux-local CI passes
- [ ] After merge + cilium HelmRelease reconciles: `hubble_dns_queries_total` carries `source_namespace` + `source_pod` labels
- [ ] After ~5m: `namespace_pod_fqdn:hubble_dns_queries:rate5m` recording rule appears in Prometheus and has series
- [ ] After 24h: `PodEgressNovelDestination` may fire as the 24h baseline window starts populating — expected during soak; tune `for:` or expand to `[7d]` if alert volume is too high
- [ ] After 7d: `PodEgressVolumeAnomaly` becomes meaningfully scoped (won't fire until baseline exists due to `absent_over_time` guard)

## Notes

- Phase 0 from the design (baseline JSON exported to git) is deferred — the detection alert fires on novel destinations relative to a live 24h window rather than a frozen baseline file, which trades some signal quality for not needing to commit and refresh a per-app FQDN manifest.
- Phase 4 (Cilium 1.21 upgrade convergence) is unchanged — separate workstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)