### PR TITLE
security(oauth2-proxy): add baseline securityContext to media non-*arr apps

### DIFF
--- a/kubernetes/apps/media/av1corrector-oauth2-proxy/app/helmrelease.yaml
+++ b/kubernetes/apps/media/av1corrector-oauth2-proxy/app/helmrelease.yaml
@@ -20,6 +20,14 @@ spec:
   values:
     controllers:
       av1corrector-oauth2-proxy:
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 2000
+            runAsGroup: 2000
+            fsGroup: 2000
+            fsGroupChangePolicy: OnRootMismatch
+
         annotations:
           reloader.stakater.com/auto: "true"
 
@@ -28,6 +36,15 @@ spec:
             image:
               repository: quay.io/oauth2-proxy/oauth2-proxy
               tag: v7.15.2
+
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+              seccompProfile:
+                type: RuntimeDefault
 
             args:
               - --provider=oidc

--- a/kubernetes/apps/media/batocera-webdashboard-pro-oauth2-proxy/app/helmrelease.yaml
+++ b/kubernetes/apps/media/batocera-webdashboard-pro-oauth2-proxy/app/helmrelease.yaml
@@ -20,6 +20,14 @@ spec:
   values:
     controllers:
       batocera-webdashboard-pro-oauth2-proxy:
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 2000
+            runAsGroup: 2000
+            fsGroup: 2000
+            fsGroupChangePolicy: OnRootMismatch
+
         annotations:
           reloader.stakater.com/auto: "true"
 
@@ -28,6 +36,15 @@ spec:
             image:
               repository: quay.io/oauth2-proxy/oauth2-proxy
               tag: v7.15.2
+
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+              seccompProfile:
+                type: RuntimeDefault
 
             args:
               - --provider=oidc

--- a/kubernetes/apps/media/medialyze-oauth2-proxy/app/helmrelease.yaml
+++ b/kubernetes/apps/media/medialyze-oauth2-proxy/app/helmrelease.yaml
@@ -20,6 +20,14 @@ spec:
   values:
     controllers:
       medialyze-oauth2-proxy:
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 2000
+            runAsGroup: 2000
+            fsGroup: 2000
+            fsGroupChangePolicy: OnRootMismatch
+
         annotations:
           reloader.stakater.com/auto: "true"
 
@@ -28,6 +36,15 @@ spec:
             image:
               repository: quay.io/oauth2-proxy/oauth2-proxy
               tag: v7.15.2
+
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+              seccompProfile:
+                type: RuntimeDefault
 
             args:
               - --provider=oidc

--- a/kubernetes/apps/media/music-assistant-oauth2-proxy/app/helmrelease.yaml
+++ b/kubernetes/apps/media/music-assistant-oauth2-proxy/app/helmrelease.yaml
@@ -20,6 +20,14 @@ spec:
   values:
     controllers:
       music-assistant-oauth2-proxy:
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 2000
+            runAsGroup: 2000
+            fsGroup: 2000
+            fsGroupChangePolicy: OnRootMismatch
+
         annotations:
           reloader.stakater.com/auto: "true"
 
@@ -28,6 +36,15 @@ spec:
             image:
               repository: quay.io/oauth2-proxy/oauth2-proxy
               tag: v7.15.2
+
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+              seccompProfile:
+                type: RuntimeDefault
 
             args:
               - --provider=oidc


### PR DESCRIPTION
## Summary

PSA audit (PR #11584) follow-up — **final (8th)** of 8 per-namespace PRs.

**media namespace, non-*arr (4 HRs)**: av1corrector, batocera-webdashboard-pro, medialyze, music-assistant.

Apply baseline pod-level + container-level hardening from `.agents/instructions/helmrelease.security.md`:

- `pod.securityContext`: `runAsNonRoot: true`, `runAsUser/Group: 2000`, `fsGroup: 2000`, `fsGroupChangePolicy: OnRootMismatch`
- `containers.app.securityContext`: `allowPrivilegeEscalation: false`, `readOnlyRootFilesystem: true`, `capabilities.drop: [ALL]`, `seccompProfile.type: RuntimeDefault`

Completes the 24-HR oauth2-proxy hardening series (collab #11600, ai #11604, home #11606, storage #11607, observability #11608, downloads #11609, media-*arr #11611, this PR).

## Test plan

- [ ] Flux reconciles each HelmRelease without rollback
- [ ] `kubectl get pods -n media -l 'app.kubernetes.io/name in (av1corrector-oauth2-proxy,batocera-webdashboard-pro-oauth2-proxy,medialyze-oauth2-proxy,music-assistant-oauth2-proxy)'` shows 1/1 Running, 0 restarts post-rollout
- [ ] OIDC login flow still works for av1corrector, batocera, medialyze, music-assistant web UIs

🤖 Generated with [Claude Code](https://claude.com/claude-code)