### PR TITLE
fix(netpol): make 3 backend CNPs valid (batch — same bug as PR #11597)

### DIFF
--- a/kubernetes/apps/media/medialyze/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/medialyze/app/cnp-allow.yaml
@@ -1,14 +1,10 @@
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
 #
-# No ingress rules needed: medialyze-oauth2-proxy is the only door,
-# and the baseline allow-intra-namespace already permits
-# oauth2-proxy → medialyze on :8080.
-#
-# Egress: medialyze consumes *arr APIs (sonarr/radarr/lidarr) in the
-# same media ns — covered by allow-intra-namespace baseline. No
-# external API calls observed in the helmrelease env. Add specific
-# allows here if medialyze later needs cross-ns or external access.
+# Cilium 1.19 requires at least one ingress or egress rule when
+# endpointSelector is set — empty rules with enableDefaultDeny:false
+# failed schema validation and never applied. Same bug class as the
+# goldilocks-allow fix (PR #11597).
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -20,3 +16,12 @@ spec:
   enableDefaultDeny:
     egress: false
     ingress: false
+  ingress:
+    # oauth2-proxy → medialyze backend
+    - fromEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: medialyze-oauth2-proxy
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP

--- a/kubernetes/apps/observability/kube-ops-view/app/cnp-allow.yaml
+++ b/kubernetes/apps/observability/kube-ops-view/app/cnp-allow.yaml
@@ -1,14 +1,10 @@
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
 #
-# No ingress rules needed: kube-ops-view-oauth2-proxy is the only
-# door, and the baseline allow-intra-namespace already permits
-# oauth2-proxy → kube-ops-view on :8080. Surfaced as a broken app
-# during the 2026-05-18 lockdown rollback retrospective.
-#
-# apiserver egress is covered by the baseline allow-apiserver rule;
-# kube-ops-view uses an in-cluster client (--in-cluster) to enumerate
-# nodes and pods.
+# Cilium 1.19 requires at least one ingress or egress rule when
+# endpointSelector is set — empty rules with enableDefaultDeny:false
+# failed schema validation and never applied. Same bug class as the
+# goldilocks-allow fix (PR #11597).
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -20,3 +16,12 @@ spec:
   enableDefaultDeny:
     egress: false
     ingress: false
+  ingress:
+    # oauth2-proxy → kube-ops-view backend (default chart port 8080)
+    - fromEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: kube-ops-view-oauth2-proxy
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP

--- a/kubernetes/apps/storage/garage/webui/cnp-allow.yaml
+++ b/kubernetes/apps/storage/garage/webui/cnp-allow.yaml
@@ -1,14 +1,10 @@
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
 #
-# No ingress rules needed: garage-webui-oauth2-proxy is the only
-# door, and the baseline allow-intra-namespace already permits
-# oauth2-proxy → garage-webui on :3909.
-#
-# Egress: garage-webui talks to garage admin/S3 in the same storage
-# ns (API_BASE_URL=garage.storage.svc:3903,
-# S3_ENDPOINT_URL=garage.storage.svc:3900) — covered by
-# allow-intra-namespace baseline.
+# Cilium 1.19 requires at least one ingress or egress rule when
+# endpointSelector is set — empty rules with enableDefaultDeny:false
+# failed schema validation and never applied. Same bug class as the
+# goldilocks-allow fix (PR #11597).
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -20,3 +16,12 @@ spec:
   enableDefaultDeny:
     egress: false
     ingress: false
+  ingress:
+    # oauth2-proxy → garage-webui backend
+    - fromEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: garage-webui-oauth2-proxy
+      toPorts:
+        - ports:
+            - port: "3909"
+              protocol: TCP


### PR DESCRIPTION
medialyze, kube-ops-view, garage-webui backend CNPs were silently failing Cilium schema validation (empty rules + enableDefaultDeny:false). Same fix shape as goldilocks PR #11597.

🤖 Generated with [Claude Code](https://claude.com/claude-code)