### PR TITLE
security(psa): audit-only Pod Security Admission labels per namespace

### DIFF
--- a/docs/src/pod_security_audit.md
+++ b/docs/src/pod_security_audit.md
@@ -1,6 +1,6 @@
 # Pod Security Baseline Audit
 
-Status: **Audit only — no remediation in this PR.** Next step is per-namespace remediation PRs; enforcement via Kyverno/PSA is a separate later step.
+Status: **PSA audit labels applied per-namespace (audit-mode only, no warn/enforce).** Group A remediation in flight (PRs #11600/#11604/#11606/#11607/#11608/#11609/#11611/#11612). Enforcement ramp is per-namespace and gated on log observation.
 Owner: home-ops
 Last updated: 2026-05-18
 
@@ -227,17 +227,115 @@ namespace. This is inherent to the CSI architecture.
    UID 0 on sidecars). Pod-gateway architecture; sidecars need to
    manipulate the netns. Already isolated to one namespace.
 
+## PSA enforcement plan
+
+### Decision: built-in PSA labels, not Kyverno
+
+Choices considered for new-workload enforcement:
+
+| Option | Pros | Cons |
+|---|---|---|
+| **Built-in PSA** (`pod-security.kubernetes.io/<mode>` labels) | No new component; zero CRDs; built into apiserver since v1.25; one label-line per namespace | Three modes only (privileged/baseline/restricted); no per-pod exception model; cluster-wide policy not expressible as code |
+| **Kyverno** | Full policy DSL, per-workload exceptions, mutation, image-signature checks | Another operator to upgrade; webhook in admission path adds latency + a failure mode; CRDs to learn |
+
+For a 1-operator / ~400-pod home lab, the PSA labels are the right
+size. Decision: ship PSA labels, revisit Kyverno only if we hit a
+policy expressiveness limit (e.g. per-workload exception inside an
+otherwise-restricted namespace).
+
+### Per-namespace audit level
+
+Applied as `pod-security.kubernetes.io/audit: <level>` +
+`pod-security.kubernetes.io/audit-version: latest`. No `warn` or
+`enforce` yet — audit-only logs violations into the apiserver's pod
+log without admitting/rejecting. Out-of-scope namespaces (`kube-system`,
+`flux-system`, `cilium-secrets`, `kuadrant` (empty/dormant)) carry no
+PSA labels — same boundary as the netpol rollout.
+
+| Namespace | Audit level | Rationale |
+|---|---|---|
+| `actions-runner-system` | `baseline` | ARC runners spawn user-defined workloads |
+| `ai` | `restricted` | App-template HRs; partially hardened |
+| `auth` | `restricted` | Authelia + LLDAP already meet baseline |
+| `cert-manager` | `restricted` | Upstream pods are clean |
+| `collab` | `restricted` | oauth2-proxy hardened; zulip will fire |
+| `databases` | `baseline` | CNPG operator-managed; tighten later |
+| `downloads` | `baseline` | pod-gateway-sidecar root + NET_ADMIN |
+| `external-secrets` | `restricted` | ESO controller is clean |
+| `home` | `baseline` | frigate/z2m/zwave-js need privileged USB |
+| `istio-system` | `baseline` | istio CNI installer needs privileged init |
+| `longhorn-system` | `privileged` | CSI architecture (audit doc C1) |
+| `mcp-system` | `restricted` | Stateless services |
+| `media` | `baseline` | Rootfs writes (jellyfin/gonic/romm) |
+| `network` | `baseline` | multus/wg-easy need NET_ADMIN |
+| `observability` | `privileged` | node-exporter/smartctl/vector hostPID |
+| `renovate` | `restricted` | Stateless workers |
+| `rook-ceph` | `privileged` | CSI + OSDs (audit doc C1) |
+| `selfhosted` | `restricted` | Small stateless set |
+| `storage` | `baseline` | Garage is near-clean |
+| `vpn` | `privileged` | Already enforce-privileged; audit aligned |
+
+### Reading PSA audit-mode violations
+
+PSA violations land in the kube-apiserver pod's stdout (each control-plane
+node) as warnings. Vector-agent scrapes them into Loki. From Grafana
+Explore:
+
+```text
+{namespace="kube-system", pod=~"kube-apiserver-.*"}
+  |~ "would violate PodSecurity"
+  | json
+  | line_format `{{.violations}} ns={{.namespace}} pod={{.name}}`
+```
+
+Each violation line includes the failing field (`runAsNonRoot`,
+`seccompProfile`, etc.), the offending namespace, and the requesting
+user/serviceAccount. For a focused look at a single ns:
+
+```text
+{namespace="kube-system", pod=~"kube-apiserver-.*"}
+  |~ "would violate PodSecurity"
+  |~ `ns=\"observability\"`
+```
+
+The same data is also emitted as a `policy_violation` annotation on
+`Events` in the namespace of the rejected workload, queryable with:
+
+```bash
+kubectl get events -A --field-selector reason=FailedCreate -o yaml \
+  | grep -B1 -A5 'would violate PodSecurity'
+```
+
+### Ramp criteria: audit → warn → enforce
+
+Per-namespace, advance one step at a time once the prior step has been
+stable for the window:
+
+- **`audit` → `warn`**: ≥7 days of audit logs with zero unexplained
+  violations (i.e. every violation maps to a known accepted-deviation
+  pod from this audit doc, or to a Group A/B remediation TODO). Adding
+  `warn` surfaces violations to the user creating the workload at
+  apply-time, which is where you want them.
+- **`warn` → `enforce`**: ≥14 days of `warn` with zero new violation
+  classes (operators have learned the rule; the noise has settled to
+  steady-state). Flip via `pod-security.kubernetes.io/enforce: <level>`
+  in the same namespace.yaml — the level should match `audit`. After
+  enforce lands, the audit + warn labels become belt-and-suspenders;
+  leave them in place so version bumps continue logging.
+
+Per-namespace tracking lives in this section's table as the levels are
+ramped.
+
 ## What this audit doesn't do
 
-- **No remediation in this PR.** Every "easy" finding still needs a
-  PR. Don't auto-apply.
-- **No Kyverno / PSA admission enforcement.** That's a followup
-  decision: once we've remediated the easy + medium tiers, decide
-  whether to enforce `restricted` or `baseline` PSA at the
-  namespace label level. Until then, ad-hoc compliance only.
-- **No drift detection.** Static snapshot. New apps can ship below
-  baseline without a check. Enforcement is the answer; this audit
-  is the prerequisite for it.
+- **No drift detection beyond audit-mode logs.** Group A/B remediation
+  PRs still have to be authored by hand. PSA admission catches *new*
+  workloads that violate the level; it doesn't migrate the existing
+  fleet.
+- **Doesn't replace HelmRelease defaults.** PSA is the floor;
+  `helmrelease.security.md` is the ceiling. New HRs should still meet
+  the helmrelease.security baseline even if the namespace's PSA level
+  doesn't require it (defense in depth + makes future ramps free).
 
 ## Methodology
 

--- a/kubernetes/apps/actions-runner-system/namespace.yaml
+++ b/kubernetes/apps/actions-runner-system/namespace.yaml
@@ -6,3 +6,8 @@ metadata:
   name: actions-runner-system
   labels:
     kustomize.toolkit.fluxcd.io/prune: disabled
+    # PSA: audit-only baseline (see docs/src/pod_security_audit.md).
+    # ARC runners spawn user-defined workloads; start at baseline (not
+    # restricted) until we have a known-good runner spec.
+    pod-security.kubernetes.io/audit: baseline
+    pod-security.kubernetes.io/audit-version: latest

--- a/kubernetes/apps/ai/namespace.yaml
+++ b/kubernetes/apps/ai/namespace.yaml
@@ -7,3 +7,8 @@ metadata:
   labels:
     goldilocks.fairwinds.com/enabled: "true"
     kustomize.toolkit.fluxcd.io/prune: disabled
+    # PSA: audit-only baseline (see docs/src/pod_security_audit.md).
+    # Mostly stateless app-template HRs (khoj, paperless-ai, comfyui);
+    # already partially hardened (PR #11604). Ramp: audit -> warn -> enforce.
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest

--- a/kubernetes/apps/auth/namespace.yaml
+++ b/kubernetes/apps/auth/namespace.yaml
@@ -7,3 +7,8 @@ metadata:
   labels:
     goldilocks.fairwinds.com/enabled: "true"
     kustomize.toolkit.fluxcd.io/prune: disabled
+    # PSA: audit-only restricted (see docs/src/pod_security_audit.md).
+    # Authelia is non-root + fsGroup; LLDAP + oauth2-proxy stack already
+    # hardened. Should be close to clean at audit-restricted.
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest

--- a/kubernetes/apps/cert-manager/namespace.yaml
+++ b/kubernetes/apps/cert-manager/namespace.yaml
@@ -7,3 +7,7 @@ metadata:
   labels:
     goldilocks.fairwinds.com/enabled: "true"
     kustomize.toolkit.fluxcd.io/prune: disabled
+    # PSA: audit-only restricted (see docs/src/pod_security_audit.md).
+    # Upstream cert-manager pods are non-root, no privileged, no caps.
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest

--- a/kubernetes/apps/collab/namespace.yaml
+++ b/kubernetes/apps/collab/namespace.yaml
@@ -7,3 +7,8 @@ metadata:
   labels:
     goldilocks.fairwinds.com/enabled: "true"
     kustomize.toolkit.fluxcd.io/prune: disabled
+    # PSA: audit-only restricted (see docs/src/pod_security_audit.md).
+    # Post PR #11600/#11607: oauth2-proxy fleet hardened. Zulip still
+    # starts root-then-drops; will fire under restricted (expected).
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest

--- a/kubernetes/apps/databases/namespace.yaml
+++ b/kubernetes/apps/databases/namespace.yaml
@@ -7,3 +7,8 @@ metadata:
   labels:
     goldilocks.fairwinds.com/enabled: "true"
     kustomize.toolkit.fluxcd.io/prune: disabled
+    # PSA: audit-only baseline (see docs/src/pod_security_audit.md).
+    # CNPG operator-managed pods may need looser fields; start at
+    # baseline and tighten once we know per-pod what fires.
+    pod-security.kubernetes.io/audit: baseline
+    pod-security.kubernetes.io/audit-version: latest

--- a/kubernetes/apps/downloads/namespace.yaml
+++ b/kubernetes/apps/downloads/namespace.yaml
@@ -8,5 +8,13 @@ metadata:
     kustomize.toolkit.fluxcd.io/prune: disabled
     goldilocks.fairwinds.com/enabled: "true"
     routed-gateway: "true"
+    # PSA: audit-only baseline (see docs/src/pod_security_audit.md).
+    # pod-gateway-sidecar in every *arr pod runs as UID 0 with NET_ADMIN
+    # (audit doc C2). restricted would fire on every pod; baseline is
+    # the realistic ceiling here.
+    pod-security.kubernetes.io/audit: baseline
+    pod-security.kubernetes.io/audit-version: latest
+    # Pre-existing commented enforce: privileged. Leave as marker —
+    # only set if we ever have to escape baseline.
     # pod-security.kubernetes.io/enforce: privileged
     # pod-security.kubernetes.io/enforce-version: latest

--- a/kubernetes/apps/external-secrets/namespace.yaml
+++ b/kubernetes/apps/external-secrets/namespace.yaml
@@ -6,3 +6,8 @@ metadata:
   name: external-secrets
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
+  labels:
+    # PSA: audit-only restricted (see docs/src/pod_security_audit.md).
+    # ESO controller + cert-controller + webhook are upstream-clean.
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest

--- a/kubernetes/apps/home/namespace.yaml
+++ b/kubernetes/apps/home/namespace.yaml
@@ -7,3 +7,8 @@ metadata:
   labels:
     goldilocks.fairwinds.com/enabled: "true"
     kustomize.toolkit.fluxcd.io/prune: disabled
+    # PSA: audit-only baseline (see docs/src/pod_security_audit.md).
+    # frigate, zigbee2mqtt, zwave-js-ui need privileged USB passthrough
+    # (audit doc C3). esphome/node-red want NET_RAW for IoT discovery.
+    pod-security.kubernetes.io/audit: baseline
+    pod-security.kubernetes.io/audit-version: latest

--- a/kubernetes/apps/istio-system/namespace.yaml
+++ b/kubernetes/apps/istio-system/namespace.yaml
@@ -7,3 +7,8 @@ metadata:
   labels:
     goldilocks.fairwinds.com/enabled: "true"
     kustomize.toolkit.fluxcd.io/prune: disabled
+    # PSA: audit-only baseline (see docs/src/pod_security_audit.md).
+    # istio CNI installer needs privileged + hostPath; istiod itself is
+    # non-root. Baseline tolerates the installer; restricted would not.
+    pod-security.kubernetes.io/audit: baseline
+    pod-security.kubernetes.io/audit-version: latest

--- a/kubernetes/apps/longhorn-system/namespace.yaml
+++ b/kubernetes/apps/longhorn-system/namespace.yaml
@@ -7,3 +7,9 @@ metadata:
   labels:
     goldilocks.fairwinds.com/enabled: "true"
     kustomize.toolkit.fluxcd.io/prune: disabled
+    # PSA: audit-only privileged (see docs/src/pod_security_audit.md).
+    # CSI architecture requires privileged + hostPath bind-mounts on
+    # longhorn-manager, instance-manager, share-manager, csi-plugin
+    # (audit doc C1, accepted deviation).
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/audit-version: latest

--- a/kubernetes/apps/mcp-system/namespace.yaml
+++ b/kubernetes/apps/mcp-system/namespace.yaml
@@ -7,3 +7,8 @@ metadata:
   labels:
     goldilocks.fairwinds.com/enabled: "true"
     kustomize.toolkit.fluxcd.io/prune: disabled
+    # PSA: audit-only restricted (see docs/src/pod_security_audit.md).
+    # mcp-gateway, jwt-rotator, immich-mcp are stateless services;
+    # should be reachable at audit-restricted with light hardening.
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest

--- a/kubernetes/apps/media/namespace.yaml
+++ b/kubernetes/apps/media/namespace.yaml
@@ -7,3 +7,9 @@ metadata:
   labels:
     goldilocks.fairwinds.com/enabled: "true"
     kustomize.toolkit.fluxcd.io/prune: disabled
+    # PSA: audit-only baseline (see docs/src/pod_security_audit.md).
+    # Jellyfin transcode cache, gonic scans, romm scan state all need
+    # writable rootfs paths; restricted enforcement is premature until
+    # user-app rootfs writes are remediated (audit doc B1).
+    pod-security.kubernetes.io/audit: baseline
+    pod-security.kubernetes.io/audit-version: latest

--- a/kubernetes/apps/network/namespace.yaml
+++ b/kubernetes/apps/network/namespace.yaml
@@ -7,3 +7,9 @@ metadata:
   labels:
     goldilocks.fairwinds.com/enabled: "true"
     kustomize.toolkit.fluxcd.io/prune: disabled
+    # PSA: audit-only baseline (see docs/src/pod_security_audit.md).
+    # multus + wg-easy need NET_ADMIN; wg-easy is currently privileged
+    # (audit doc C2) — privileged would mask that. Baseline forces it
+    # to surface in audit logs.
+    pod-security.kubernetes.io/audit: baseline
+    pod-security.kubernetes.io/audit-version: latest

--- a/kubernetes/apps/observability/namespace.yaml
+++ b/kubernetes/apps/observability/namespace.yaml
@@ -7,3 +7,10 @@ metadata:
   labels:
     goldilocks.fairwinds.com/enabled: "true"
     kustomize.toolkit.fluxcd.io/prune: disabled
+    # PSA: audit-only privileged (see docs/src/pod_security_audit.md).
+    # node-exporter (RAPL, runAsUser:0) + smartctl-exporter (ioctls) +
+    # vector-agent (host log scrape) all require privileged/hostPID
+    # (audit doc C3 keep). Privileged audit level prevents noisy
+    # false-positives on accepted deviations.
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/audit-version: latest

--- a/kubernetes/apps/renovate/namespace.yaml
+++ b/kubernetes/apps/renovate/namespace.yaml
@@ -10,3 +10,8 @@ metadata:
   name: _
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
+  labels:
+    # PSA: audit-only restricted (see docs/src/pod_security_audit.md).
+    # renovate-operator + RenovateJob pods are stateless workers.
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest

--- a/kubernetes/apps/rook-ceph/namespace.yaml
+++ b/kubernetes/apps/rook-ceph/namespace.yaml
@@ -7,3 +7,9 @@ metadata:
   labels:
     goldilocks.fairwinds.com/enabled: "true"
     kustomize.toolkit.fluxcd.io/prune: disabled
+    # PSA: audit-only privileged (see docs/src/pod_security_audit.md).
+    # OSDs, csi-rbdplugin, csi-cephfsplugin all need privileged +
+    # SYS_ADMIN to bind-mount in the host namespace (audit doc C1,
+    # accepted CSI-architectural deviation).
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/audit-version: latest

--- a/kubernetes/apps/selfhosted/namespace.yaml
+++ b/kubernetes/apps/selfhosted/namespace.yaml
@@ -6,3 +6,8 @@ metadata:
   name: _
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
+  labels:
+    # PSA: audit-only restricted (see docs/src/pod_security_audit.md).
+    # Small set of stateless apps; should be reachable at restricted.
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest

--- a/kubernetes/apps/storage/namespace.yaml
+++ b/kubernetes/apps/storage/namespace.yaml
@@ -7,3 +7,8 @@ metadata:
   labels:
     goldilocks.fairwinds.com/enabled: "true"
     kustomize.toolkit.fluxcd.io/prune: disabled
+    # PSA: audit-only baseline (see docs/src/pod_security_audit.md).
+    # Garage runs as a fixed UID + writes to PVC; should be near-clean
+    # but garage-webui + ZOT may surface fields under restricted.
+    pod-security.kubernetes.io/audit: baseline
+    pod-security.kubernetes.io/audit-version: latest

--- a/kubernetes/apps/vpn/namespace.yaml
+++ b/kubernetes/apps/vpn/namespace.yaml
@@ -7,5 +7,10 @@ metadata:
   labels:
     goldilocks.fairwinds.com/enabled: "true"
     kustomize.toolkit.fluxcd.io/prune: disabled
+    # PSA: enforce-privileged already set (pod-gateway needs root +
+    # NET_ADMIN — audit doc C2). Audit label matches so the level
+    # appears in admission events alongside the enforce check.
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/audit-version: latest
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/enforce-version: latest


### PR DESCRIPTION
## Summary

Apply `pod-security.kubernetes.io/audit: <level>` + `audit-version: latest` to every in-scope namespace. Audit-mode only — no `warn` or `enforce` yet — so violations log to the apiserver pod without blocking any pod creation.

Per-ns level chosen from the findings in `docs/src/pod_security_audit.md`:

- `restricted` (9 ns): ai, auth, cert-manager, collab, external-secrets, mcp-system, renovate, selfhosted, (workload tier already close to clean)
- `baseline` (8 ns): actions-runner-system, databases, downloads, home, istio-system, media, network, storage (structural elevation: NET_ADMIN sidecars, USB passthrough, rootfs writes, CSI installers)
- `privileged` (4 ns): longhorn-system, observability, rook-ceph, vpn (CSI architecture + hostPID, accepted deviations from audit doc C1/C3)

`vpn` already enforces `privileged`; audit added so admission events carry the level alongside the enforce check.

Out of scope (no labels): `kube-system`, `flux-system`, `cilium-secrets`, `kuadrant` (empty/dormant). Same boundary as the netpol rollout.

## Why built-in PSA, not Kyverno

For 1 operator + ~400 pods, PSA labels are the right size:

- No new component, no CRDs, no admission webhook latency
- One label line per `namespace.yaml`
- Revisit Kyverno only if we hit an expressiveness limit (per-workload exception inside a restricted namespace)

Tradeoff captured in the doc.

## Doc update

`docs/src/pod_security_audit.md`:

- PSA-vs-Kyverno decision + tradeoff table
- Per-namespace audit level table with rationale
- Loki query for reading violations from kube-apiserver pod logs
- audit → warn → enforce ramp criteria (per-ns, 7-day + 14-day soak)

## What this does NOT do

- No `warn` or `enforce` yet — audit-only
- Doesn't remediate existing fleet; Group A/B PRs are ongoing in parallel
- Doesn't replace `helmrelease.security.md` defaults (PSA is the floor)

## Test plan

- [ ] Flux reconciles the namespaces (no apiserver rejection — audit-mode is non-blocking)
- [ ] Apiserver pod logs (or Loki `{pod=~"kube-apiserver-.*"} \|~ "would violate PodSecurity"`) start showing per-violation lines within an hour
- [ ] No pods rejected, no rollouts blocked
- [ ] Wait ≥7 days, then per-namespace flip audit → warn (separate PR per ns)

Generated with [Claude Code](https://claude.com/claude-code)