### PR TITLE
fix(external-secrets): allow controller egress to world:443 (api.github.com)

### DIFF
--- a/kubernetes/apps/external-secrets/external-secrets/app/cnp-allow-controller.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/app/cnp-allow-controller.yaml
@@ -1,0 +1,33 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: external-secrets-controller-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: external-secrets
+      app.kubernetes.io/instance: external-secrets
+  # Additive — default-deny is what triggers the lockdown; this rule
+  # punches a hole through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  egress:
+    # GithubAccessToken generator (renovate/github-auth-token ES) runs
+    # IN the controller process and POSTs to api.github.com for App
+    # installation token minting. Without this, ExternalSecrets using
+    # GithubAccessToken fail with "context deadline exceeded" — surfaced
+    # 2026-05-18 as renovate/github-auth-token failing for ~90min after
+    # the external-secrets ns default-deny landed (PR #11572).
+    #
+    # api.github.com is canonical FQDN (no CNAME chain) — matchPattern
+    # silently fails per memory cilium-matchpattern-fqdn-limits, so use
+    # toEntities:[world]:443. The 1Password Connect path is already
+    # covered by onepassword-connect-allow on a separate pod.
+    - toEntities: [world]
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/external-secrets/external-secrets/app/kustomization.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/app/kustomization.yaml
@@ -3,6 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./cnp-allow-controller.yaml
   - ./cnp-allow-webhook.yaml
   - ./helmrelease.yaml
 configMapGenerator:


### PR DESCRIPTION
renovate/github-auth-token ES failing ~90min with context deadline exceeded. Controller pod has no CNP, GithubAccessToken generator runs in-process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)