### PR TITLE
fix(recyclarr): canonical github.com FQDN -> toEntities:world

### DIFF
--- a/kubernetes/apps/media/recyclarr/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/recyclarr/app/cnp-allow.yaml
@@ -16,10 +16,27 @@ spec:
   egress:
     # External: clones github.com/recyclarr/config-templates (trash-guides
     # JSON snapshots) at the start of each `recyclarr sync` run.
-    # github.com FQDN cache + .* augmentation per PR #11492.
+    #
+    # github.com is at its canonical form (no CNAME chain in DNS
+    # response), so Cilium 1.19's toFQDNs.matchPattern silently fails —
+    # see project_cilium_matchpattern_fqdn_limits.md and PRs #11540 /
+    # #11536 / #11537 / #11495 / #11498 for the cluster-wide audit.
+    # Replace canonical-FQDN matchPattern with toEntities: [world]:443.
+    #
+    # FQDNs covered by the world:443 rule below:
+    #   - github.com (canonical, A-only)
+    #
+    # *.githubusercontent.com / raw.githubusercontent.com /
+    # codeload.github.com / objects.githubusercontent.com kept as
+    # matchPattern below — predecessor classification (see audit
+    # report).
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
     - toFQDNs:
-        - matchPattern: "github.com"
-        - matchPattern: "github.com.*"
         - matchPattern: "*.github.com"
         - matchPattern: "*.github.com.*"
         - matchPattern: "raw.githubusercontent.com"


### PR DESCRIPTION
## Summary

- Predecessor audit found `github.com` matchPattern is silently inert in `recyclarr/cnp-allow.yaml` — github.com is at its canonical form (A-records only, no CNAME chain), so Cilium 1.19's toFQDNs.matchPattern doesn't match through the K8s search-domain-augmented queried name. See `project_cilium_matchpattern_fqdn_limits.md`.
- This is a **latent bug**: 24h of `hubble observe --pod media/recyclarr --verdict DROPPED` is clean. Recyclarr isn't currently failing, but the rule providing github.com access doesn't actually work.
- Adds explicit `toEntities: [world]:443` rule covering github.com.
- `*.githubusercontent.com`, `raw.githubusercontent.com`, `codeload.github.com`, `objects.githubusercontent.com` matchPattern entries are RETAINED — predecessor classification (see audit report).

## Why this is the right call

Same pattern as PRs #11540, #11536, #11537, #11495, #11498 (cluster-wide audit) — recyclarr was explicitly skipped in #11540 ("CNAME-fronted, matchPattern works") but predecessor audit confirms github.com itself is canonical, not CNAME-fronted.

## Test plan

- [ ] Flux reconciles `media` Kustomization (≤60s)
- [ ] `kubectl get cnp -n media recyclarr-allow` shows updated policy
- [ ] No new DROPPED flows: `kubectl -n kube-system exec ds/cilium -c cilium-agent -- hubble observe --pod media/recyclarr --verdict DROPPED --since 5m`
- [ ] Next recyclarr sync (cron daily) reaches github.com successfully

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>