### PR TITLE
fix(arc): canonical api.github.com/github.com FQDNs -> toEntities:world

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/operator/cnp-allow.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/operator/cnp-allow.yaml
@@ -18,20 +18,26 @@ spec:
     # GitHub API: the operator authenticates as a GitHub App, polls for
     # the registration token, and reconciles runner-scale-set state.
     #
-    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
-    # pod DNS search-domain augmentation (pod queries e.g.
-    # `api.github.com.actions-runner-system.svc.cluster.local.`; the
-    # FQDN cache stores the augmented name; matchName misses it). The
-    # bare + `.*` dual-form matchPattern covers both un-augmented and
-    # search-domain-augmented forms — see PR #11492 for the canonical
-    # example.
-    # api.github.com resolves to Azure / GitHub IPs (140.82.112.0/20
-    # observed 140.82.112/113/114 .5/.6 in cilium-dbg fqdn cache).
+    # api.github.com and github.com are at their canonical form (A-only,
+    # no CNAME chain), so Cilium 1.19's toFQDNs.matchPattern silently
+    # fails — see project_cilium_matchpattern_fqdn_limits.md.
+    # PR #11495 originally moved these to toEntities:world; PR #11499
+    # reverted to matchPattern based on PR #11492's pattern; that
+    # revert was wrong for canonical FQDNs. Restore world:443.
+    #
+    # FQDNs covered by the world:443 rule below:
+    #   - api.github.com (canonical, A-only — observed 140.82.113.5)
+    #   - github.com    (canonical, A-only — observed 140.82.114.3)
+    #
+    # *.githubusercontent.com matchPattern retained per audit
+    # classification.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
     - toFQDNs:
-        - matchPattern: "api.github.com"
-        - matchPattern: "api.github.com.*"
-        - matchPattern: "github.com"
-        - matchPattern: "github.com.*"
         - matchPattern: "*.githubusercontent.com"
         - matchPattern: "*.githubusercontent.com.*"
       toPorts:


### PR DESCRIPTION
## Summary

- Predecessor audit found `api.github.com` and `github.com` matchPattern allows are silently inert in `actions-runner-controller/operator/cnp-allow.yaml` — both are canonical (A-records only, no CNAME chain), so Cilium 1.19's matchPattern fails to match the K8s search-domain-augmented queried name.
- This is the same bug PR #11495 originally fixed (toEntities:world); PR #11499 reverted to matchPattern; that revert was correct for CNAME-fronted FQDNs but wrong for these two canonical ones.
- `*.githubusercontent.com` matchPattern retained per audit (predecessor classified as CDN-fronted).

## Why this is a latent bug, not currently firing

`hubble observe --pod actions-runner-system/actions-runner-controller --verdict DROPPED --since 24h` is clean. The operator opened its long-lived gRPC-over-HTTPS session to GitHub under a prior toEntities:world rule and the FQDN cache may be keeping it alive. Next pod restart + Cilium TTL expiry combination is one event away from breaking GitHub App registration.

## Test plan

- [ ] Flux reconciles `actions-runner-system` Kustomization
- [ ] `kubectl get cnp -n actions-runner-system actions-runner-controller-allow` shows updated policy
- [ ] `kubectl -n kube-system exec ds/cilium -c cilium-agent -- hubble observe --pod actions-runner-system/actions-runner-controller --verdict DROPPED --since 5m` clean
- [ ] Operator still reconciles AutoscalingRunnerSet on next interval
- [ ] New CI job successfully registers a runner

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>