### PR TITLE
fix(kubeclaw): canonical HF + github FQDNs -> toEntities:world

### DIFF
--- a/kubernetes/apps/ai/kubeclaw/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/kubeclaw/app/cnp-allow.yaml
@@ -54,24 +54,37 @@ spec:
     # downloads on first run + on model rotation) and qmd-update
     # (GitHub skill-repo updates).
     #
-    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
-    # pod DNS search-domain augmentation (pod queries e.g.
-    # `huggingface.co.ai.svc.cluster.local.` and the FQDN cache stores
-    # the augmented name; matchName misses it). The bare + `.*`
-    # dual-form matchPattern covers both un-augmented and
-    # search-domain-augmented forms — see PR #11492 for the canonical
-    # example.
+    # huggingface.co, hf.co, github.com are at their canonical DNS
+    # form (A-records only, no CNAME chain), so Cilium 1.19's
+    # toFQDNs.matchPattern silently fails — see
+    # project_cilium_matchpattern_fqdn_limits.md. PR #11494 originally
+    # moved these to toEntities:world; PR #11499 reverted to
+    # matchPattern based on PR #11492's pattern; that revert was
+    # wrong for canonical FQDNs. Restore world:443.
+    #
+    # FQDNs covered by the world:443 rule below:
+    #   - huggingface.co      (canonical, A-only)
+    #   - hf.co               (canonical, A-only)
+    #   - github.com          (canonical, A-only)
+    #
+    # cdn-lfs.huggingface.co matchPattern REMOVED — NXDOMAIN, dead
+    # rule. The actual LFS endpoint is e.g. cdn-lfs-us-1.hf.co (also
+    # canonical, also covered by world:443 above).
+    #
+    # *.hf.co, *.huggingface.co, *.githubusercontent.com,
+    # codeload.github.com, raw.githubusercontent.com matchPattern
+    # entries retained per audit classification.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
     - toFQDNs:
-        - matchPattern: "huggingface.co"
-        - matchPattern: "huggingface.co.*"
         - matchPattern: "*.huggingface.co"
         - matchPattern: "*.huggingface.co.*"
-        - matchPattern: "cdn-lfs.huggingface.co"
-        - matchPattern: "cdn-lfs.huggingface.co.*"
         - matchPattern: "*.hf.co"
         - matchPattern: "*.hf.co.*"
-        - matchPattern: "github.com"
-        - matchPattern: "github.com.*"
         - matchPattern: "codeload.github.com"
         - matchPattern: "codeload.github.com.*"
         - matchPattern: "raw.githubusercontent.com"


### PR DESCRIPTION
## Summary

- Predecessor audit found `huggingface.co`, `hf.co`, `github.com` matchPattern allows are silently inert in `ai/kubeclaw/app/cnp-allow.yaml` — all three are canonical (A-records only, no CNAME chain). Cilium 1.19's matchPattern fails for the K8s search-domain-augmented queried form.
- This is the same bug PR #11494 originally fixed; PR #11499 reverted; that revert was wrong for canonical FQDNs.
- Predecessor confirmed Hubble drops against hf.co (qmd-embed model-download path) — this rule is actually firing somewhere.
- Removes dead-rule `cdn-lfs.huggingface.co` (NXDOMAIN — real LFS endpoint is e.g. cdn-lfs-us-1.hf.co, also canonical, also covered by world:443).
- `*.hf.co`, `*.huggingface.co`, `*.githubusercontent.com`, `codeload.github.com`, `raw.githubusercontent.com` matchPattern entries retained per audit classification.

## Note

I verified with `dig` that `*.hf.co` subdomains (e.g. `cdn-lfs-us-1.hf.co`, `cas-bridge.xethub.hf.co`) are also A-only with no CNAME — so the kept `*.hf.co` matchPattern is likely also inert. But predecessor classified these as keep, and the new `toEntities:world` rule is functionally a superset, so no traffic is blocked either way. Flagging for the next audit pass.

## Test plan

- [ ] Flux reconciles `ai` Kustomization
- [ ] `kubectl get cnp -n ai kubeclaw-allow` shows updated policy
- [ ] `kubectl -n kube-system exec ds/cilium -c cilium-agent -- hubble observe --pod ai/kubeclaw --verdict DROPPED --since 5m` clean
- [ ] Next qmd-embed Job run can download from HuggingFace
- [ ] Next qmd-update Job run can clone from github.com

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>