### PR TITLE
fix(khoj): canonical huggingface.co FQDN -> toEntities:world

### DIFF
--- a/kubernetes/apps/ai/khoj/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/khoj/app/cnp-allow.yaml
@@ -38,20 +38,31 @@ spec:
     # HuggingFace model downloads (embedding/search models cached to
     # khoj-models PVC on first run + on model config changes).
     #
-    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
-    # pod DNS search-domain augmentation (pod queries
-    # `huggingface.co.ai.svc.cluster.local.` and the FQDN cache stores
-    # the augmented name; matchName misses it). The bare + `.*`
-    # dual-form matchPattern covers both un-augmented and
-    # search-domain-augmented forms — see PR #11492 for the canonical
-    # example.
+    # huggingface.co is at its canonical DNS form (A-records only, no
+    # CNAME chain), so Cilium 1.19's toFQDNs.matchPattern silently
+    # fails — see project_cilium_matchpattern_fqdn_limits.md. PR
+    # #11494 originally moved these to toEntities:world; PR #11499
+    # reverted to matchPattern based on PR #11492's pattern; that
+    # revert was wrong for canonical FQDNs. Restore world:443.
+    #
+    # FQDNs covered by the world:443 rule below:
+    #   - huggingface.co  (canonical, A-only)
+    #
+    # cdn-lfs.huggingface.co matchPattern REMOVED — NXDOMAIN, dead
+    # rule. The actual LFS endpoint is e.g. cdn-lfs-us-1.hf.co (also
+    # canonical, also covered by world:443 above).
+    #
+    # *.huggingface.co, *.hf.co matchPattern entries retained per
+    # audit classification.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
     - toFQDNs:
-        - matchPattern: "huggingface.co"
-        - matchPattern: "huggingface.co.*"
         - matchPattern: "*.huggingface.co"
         - matchPattern: "*.huggingface.co.*"
-        - matchPattern: "cdn-lfs.huggingface.co"
-        - matchPattern: "cdn-lfs.huggingface.co.*"
         - matchPattern: "*.hf.co"
         - matchPattern: "*.hf.co.*"
       toPorts:


### PR DESCRIPTION
## Summary

- Predecessor audit found `huggingface.co` matchPattern allow is silently inert in `ai/khoj/app/cnp-allow.yaml` — canonical (A-only, no CNAME).
- Same bug PR #11494 originally fixed; PR #11499 reverted; that revert was wrong for canonical FQDNs.
- Removes dead-rule `cdn-lfs.huggingface.co` (NXDOMAIN).
- `*.huggingface.co`, `*.hf.co` matchPattern entries retained per audit (likely also inert for `*.hf.co` subdomains — flagged for follow-up audit).

## Why latent

khoj has its embedding model already cached to the khoj-models PVC, so isn't currently exercising the HF code path. Next model rotation or fresh install would fail.

## Test plan

- [ ] Flux reconciles `ai` Kustomization
- [ ] `kubectl get cnp -n ai khoj-allow` shows updated policy
- [ ] `kubectl -n kube-system exec ds/cilium -c cilium-agent -- hubble observe --pod ai/khoj --verdict DROPPED --since 5m` clean
- [ ] Next HF model download attempt succeeds (if/when triggered)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>