### PR TITLE
fix(pump-cv): canonical github.com FQDN -> toEntities:world

### DIFF
--- a/kubernetes/apps/collab/pump-cv/app/cnp-allow.yaml
+++ b/kubernetes/apps/collab/pump-cv/app/cnp-allow.yaml
@@ -30,12 +30,25 @@ spec:
               protocol: TCP
     # Ultralytics YOLOv8 model download from github releases on first
     # run (then cached to ceph-block under /cache). Subsequent restarts
-    # use the cached weights. Bare + `.*` matchPattern covers both
-    # un-augmented and search-domain-augmented FQDN forms (Cilium 1.19
-    # search-domain quirk — see PR #11492).
+    # use the cached weights.
+    #
+    # github.com is at its canonical DNS form (A-records only, no
+    # CNAME chain), so Cilium 1.19's toFQDNs.matchPattern silently
+    # fails — see project_cilium_matchpattern_fqdn_limits.md.
+    # Restore world:443.
+    #
+    # FQDNs covered by the world:443 rule below:
+    #   - github.com  (canonical, A-only)
+    #
+    # *.githubusercontent.com matchPattern retained per audit
+    # classification.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
     - toFQDNs:
-        - matchPattern: "github.com"
-        - matchPattern: "github.com.*"
         - matchPattern: "*.githubusercontent.com"
         - matchPattern: "*.githubusercontent.com.*"
       toPorts:


### PR DESCRIPTION
## Summary

- Predecessor audit found `github.com` matchPattern allow is silently inert in `collab/pump-cv/app/cnp-allow.yaml` — canonical (A-only, no CNAME).
- PR #11537 (collab namespace cleanup) explicitly excluded pump-cv as "CNAME-fronted, matchPattern works" — that classification was wrong for github.com itself.
- `*.githubusercontent.com` matchPattern retained per audit classification.

## Why latent

YOLOv8 weights are cached to ceph-block /cache after first run. Currently no DROPPED flows. Next image upgrade or cache-volume rebuild would fail.

## Test plan

- [ ] Flux reconciles `collab` Kustomization
- [ ] `kubectl get cnp -n collab pump-cv-allow` shows updated policy
- [ ] `kubectl -n kube-system exec ds/cilium -c cilium-agent -- hubble observe --pod collab/pump-cv --verdict DROPPED --since 5m` clean
- [ ] RTSP feeds from gym-front/gym-back continue uninterrupted (only egress is on different rule)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>