### PR TITLE
fix(github-mcp): canonical github FQDNs -> toEntities:world

### DIFF
--- a/kubernetes/apps/mcp-system/github-mcp/app/cnp-allow.yaml
+++ b/kubernetes/apps/mcp-system/github-mcp/app/cnp-allow.yaml
@@ -14,27 +14,38 @@ spec:
     ingress: false
   egress:
     # GitHub API surface. The github-mcp-server proxies REST + GraphQL
-    # tools to api.github.com (and graphql.github.com for v4); also
-    # touches uploads.github.com for release artifact uploads when an
-    # agent invokes the release tools. raw.githubusercontent.com and
-    # codeload.github.com cover repo content access.
+    # tools to api.github.com (and the v4 GraphQL endpoint lives at
+    # api.github.com/graphql, not a separate hostname). Also touches
+    # uploads.github.com for release artifact uploads and
+    # codeload.github.com / raw.githubusercontent.com for repo content.
     #
-    # Cilium 1.19's toFQDNs.matchName doesn't match through Kubernetes
-    # pod DNS search-domain augmentation (pod queries
-    # `api.github.com.mcp-system.svc.cluster.local.`; the FQDN cache
-    # stores the augmented name; matchName misses it). The bare +
-    # `.*` dual-form matchPattern covers both un-augmented and
-    # search-domain-augmented forms — see PR #11492 for the canonical
-    # example.
+    # api.github.com and codeload.github.com are at their canonical
+    # DNS form (A-records only, no CNAME chain), so Cilium 1.19's
+    # toFQDNs.matchPattern silently fails — see
+    # project_cilium_matchpattern_fqdn_limits.md. PR #11498 originally
+    # moved these to toEntities:world; PR #11499 reverted to
+    # matchPattern based on PR #11492's pattern; that revert was
+    # wrong for canonical FQDNs. Restore world:443.
+    #
+    # FQDNs covered by the world:443 rule below:
+    #   - api.github.com       (canonical, A-only)
+    #   - codeload.github.com  (canonical, A-only)
+    #
+    # graphql.github.com REMOVED — NXDOMAIN, dead rule (GraphQL is
+    # actually served from api.github.com/graphql, already covered).
+    #
+    # uploads.github.com (CNAME → alambic-origin.githubusercontent.com)
+    # and *.githubusercontent.com matchPattern entries retained per
+    # audit classification (CDN-fronted, CNAME-walk works).
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
     - toFQDNs:
-        - matchPattern: "api.github.com"
-        - matchPattern: "api.github.com.*"
-        - matchPattern: "graphql.github.com"
-        - matchPattern: "graphql.github.com.*"
         - matchPattern: "uploads.github.com"
         - matchPattern: "uploads.github.com.*"
-        - matchPattern: "codeload.github.com"
-        - matchPattern: "codeload.github.com.*"
         - matchPattern: "*.githubusercontent.com"
         - matchPattern: "*.githubusercontent.com.*"
       toPorts:


### PR DESCRIPTION
## Summary

- Predecessor audit found `api.github.com` and `codeload.github.com` matchPattern allows are silently inert in `mcp-system/github-mcp/app/cnp-allow.yaml` — both canonical (A-only, no CNAME).
- Same bug PR #11498 originally fixed; PR #11499 reverted; that revert was wrong for canonical FQDNs.
- Removes dead-rule `graphql.github.com` (NXDOMAIN — GitHub GraphQL actually lives at api.github.com/graphql, already covered).
- `uploads.github.com` (real CNAME → alambic-origin.githubusercontent.com) and `*.githubusercontent.com` matchPattern entries retained per audit classification.

## Why latent

`hubble observe --pod mcp-system/github-mcp --verdict DROPPED --since 24h` is clean. The server's long-lived HTTPS sessions to api.github.com were opened under prior world rule; FQDN cache extends them. Next pod restart could break the GitHub App auth path.

## Test plan

- [ ] Flux reconciles `mcp-system` Kustomization
- [ ] `kubectl get cnp -n mcp-system github-mcp-allow` shows updated policy
- [ ] `kubectl -n kube-system exec ds/cilium -c cilium-agent -- hubble observe --pod mcp-system/github-mcp --verdict DROPPED --since 5m` clean
- [ ] github-mcp tool invocations from agent sessions succeed end-to-end

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>