### PR TITLE
chore(cnp): remove inert matchPattern wildcards from canonical-FQDN CNPs

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/operator/cnp-allow.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/operator/cnp-allow.yaml
@@ -18,28 +18,17 @@ spec:
     # GitHub API: the operator authenticates as a GitHub App, polls for
     # the registration token, and reconciles runner-scale-set state.
     #
-    # api.github.com and github.com are at their canonical form (A-only,
-    # no CNAME chain), so Cilium 1.19's toFQDNs.matchPattern silently
-    # fails — see project_cilium_matchpattern_fqdn_limits.md.
-    # PR #11495 originally moved these to toEntities:world; PR #11499
-    # reverted to matchPattern based on PR #11492's pattern; that
-    # revert was wrong for canonical FQDNs. Restore world:443.
+    # api.github.com, github.com, and *.githubusercontent.com subdomains
+    # all resolve to A-records only (no CNAME chain). Cilium 1.19's
+    # toFQDNs.matchPattern only walks one label per `.*` and follows
+    # CNAME canonical names — so wildcards against these A-only zones
+    # are inert. Coverage is provided by the toEntities: [world]:443
+    # rule below.
     #
-    # FQDNs covered by the world:443 rule below:
-    #   - api.github.com (canonical, A-only — observed 140.82.113.5)
-    #   - github.com    (canonical, A-only — observed 140.82.114.3)
-    #
-    # *.githubusercontent.com matchPattern retained per audit
-    # classification.
+    # See project_cilium_matchpattern_fqdn_limits.md for the cluster-
+    # wide audit.
     - toEntities:
         - world
-      toPorts:
-        - ports:
-            - port: "443"
-              protocol: TCP
-    - toFQDNs:
-        - matchPattern: "*.githubusercontent.com"
-        - matchPattern: "*.githubusercontent.com.*"
       toPorts:
         - ports:
             - port: "443"

--- a/kubernetes/apps/ai/khoj/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/khoj/app/cnp-allow.yaml
@@ -38,33 +38,18 @@ spec:
     # HuggingFace model downloads (embedding/search models cached to
     # khoj-models PVC on first run + on model config changes).
     #
-    # huggingface.co is at its canonical DNS form (A-records only, no
-    # CNAME chain), so Cilium 1.19's toFQDNs.matchPattern silently
-    # fails — see project_cilium_matchpattern_fqdn_limits.md. PR
-    # #11494 originally moved these to toEntities:world; PR #11499
-    # reverted to matchPattern based on PR #11492's pattern; that
-    # revert was wrong for canonical FQDNs. Restore world:443.
+    # huggingface.co, hf.co, and their subdomains (cdn-lfs-*.hf.co,
+    # cas-bridge.xethub.hf.co, cdn-thumbnails.huggingface.co, etc.) all
+    # resolve to A-records only (no CNAME chain). Cilium 1.19's
+    # toFQDNs.matchPattern only walks one label per `.*` and follows
+    # CNAME canonical names — so `*.huggingface.co` / `*.hf.co` are
+    # inert against A-only FQDNs. Coverage is provided by the
+    # toEntities: [world]:443 rule below.
     #
-    # FQDNs covered by the world:443 rule below:
-    #   - huggingface.co  (canonical, A-only)
-    #
-    # cdn-lfs.huggingface.co matchPattern REMOVED — NXDOMAIN, dead
-    # rule. The actual LFS endpoint is e.g. cdn-lfs-us-1.hf.co (also
-    # canonical, also covered by world:443 above).
-    #
-    # *.huggingface.co, *.hf.co matchPattern entries retained per
-    # audit classification.
+    # See project_cilium_matchpattern_fqdn_limits.md for the cluster-
+    # wide audit.
     - toEntities:
         - world
-      toPorts:
-        - ports:
-            - port: "443"
-              protocol: TCP
-    - toFQDNs:
-        - matchPattern: "*.huggingface.co"
-        - matchPattern: "*.huggingface.co.*"
-        - matchPattern: "*.hf.co"
-        - matchPattern: "*.hf.co.*"
       toPorts:
         - ports:
             - port: "443"

--- a/kubernetes/apps/ai/kubeclaw/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/kubeclaw/app/cnp-allow.yaml
@@ -54,43 +54,18 @@ spec:
     # downloads on first run + on model rotation) and qmd-update
     # (GitHub skill-repo updates).
     #
-    # huggingface.co, hf.co, github.com are at their canonical DNS
-    # form (A-records only, no CNAME chain), so Cilium 1.19's
-    # toFQDNs.matchPattern silently fails — see
-    # project_cilium_matchpattern_fqdn_limits.md. PR #11494 originally
-    # moved these to toEntities:world; PR #11499 reverted to
-    # matchPattern based on PR #11492's pattern; that revert was
-    # wrong for canonical FQDNs. Restore world:443.
+    # huggingface.co, hf.co, github.com and their subdomains
+    # (raw./codeload./*.githubusercontent.com, cdn-lfs-*.hf.co, etc.)
+    # all resolve to A-records only (no CNAME chain). Cilium 1.19's
+    # toFQDNs.matchPattern only walks one label per `.*` and follows
+    # CNAME canonical names — so wildcards and bare matchPatterns
+    # against these A-only zones are inert. Coverage is provided by
+    # the toEntities: [world]:443 rule below.
     #
-    # FQDNs covered by the world:443 rule below:
-    #   - huggingface.co      (canonical, A-only)
-    #   - hf.co               (canonical, A-only)
-    #   - github.com          (canonical, A-only)
-    #
-    # cdn-lfs.huggingface.co matchPattern REMOVED — NXDOMAIN, dead
-    # rule. The actual LFS endpoint is e.g. cdn-lfs-us-1.hf.co (also
-    # canonical, also covered by world:443 above).
-    #
-    # *.hf.co, *.huggingface.co, *.githubusercontent.com,
-    # codeload.github.com, raw.githubusercontent.com matchPattern
-    # entries retained per audit classification.
+    # See project_cilium_matchpattern_fqdn_limits.md for the cluster-
+    # wide audit.
     - toEntities:
         - world
-      toPorts:
-        - ports:
-            - port: "443"
-              protocol: TCP
-    - toFQDNs:
-        - matchPattern: "*.huggingface.co"
-        - matchPattern: "*.huggingface.co.*"
-        - matchPattern: "*.hf.co"
-        - matchPattern: "*.hf.co.*"
-        - matchPattern: "codeload.github.com"
-        - matchPattern: "codeload.github.com.*"
-        - matchPattern: "raw.githubusercontent.com"
-        - matchPattern: "raw.githubusercontent.com.*"
-        - matchPattern: "*.githubusercontent.com"
-        - matchPattern: "*.githubusercontent.com.*"
       toPorts:
         - ports:
             - port: "443"

--- a/kubernetes/apps/collab/pump-cv/app/cnp-allow.yaml
+++ b/kubernetes/apps/collab/pump-cv/app/cnp-allow.yaml
@@ -32,25 +32,16 @@ spec:
     # run (then cached to ceph-block under /cache). Subsequent restarts
     # use the cached weights.
     #
-    # github.com is at its canonical DNS form (A-records only, no
-    # CNAME chain), so Cilium 1.19's toFQDNs.matchPattern silently
-    # fails — see project_cilium_matchpattern_fqdn_limits.md.
-    # Restore world:443.
+    # github.com and *.githubusercontent.com subdomains all resolve to
+    # A-records only (no CNAME chain). Cilium 1.19's toFQDNs.matchPattern
+    # only walks one label per `.*` and follows CNAME canonical names —
+    # so wildcards against these A-only zones are inert. Coverage is
+    # provided by the toEntities: [world]:443 rule below.
     #
-    # FQDNs covered by the world:443 rule below:
-    #   - github.com  (canonical, A-only)
-    #
-    # *.githubusercontent.com matchPattern retained per audit
-    # classification.
+    # See project_cilium_matchpattern_fqdn_limits.md for the cluster-
+    # wide audit.
     - toEntities:
         - world
-      toPorts:
-        - ports:
-            - port: "443"
-              protocol: TCP
-    - toFQDNs:
-        - matchPattern: "*.githubusercontent.com"
-        - matchPattern: "*.githubusercontent.com.*"
       toPorts:
         - ports:
             - port: "443"

--- a/kubernetes/apps/media/recyclarr/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/recyclarr/app/cnp-allow.yaml
@@ -15,36 +15,20 @@ spec:
     ingress: false
   egress:
     # External: clones github.com/recyclarr/config-templates (trash-guides
-    # JSON snapshots) at the start of each `recyclarr sync` run.
+    # JSON snapshots) at the start of each `recyclarr sync` run; also
+    # fetches raw content from raw./codeload./objects.githubusercontent.com.
     #
-    # github.com is at its canonical form (no CNAME chain in DNS
-    # response), so Cilium 1.19's toFQDNs.matchPattern silently fails —
-    # see project_cilium_matchpattern_fqdn_limits.md and PRs #11540 /
-    # #11536 / #11537 / #11495 / #11498 for the cluster-wide audit.
-    # Replace canonical-FQDN matchPattern with toEntities: [world]:443.
+    # github.com, *.github.com subdomains, and *.githubusercontent.com
+    # subdomains all resolve to A-records only (no CNAME chain). Cilium
+    # 1.19's toFQDNs.matchPattern only walks one label per `.*` and
+    # follows CNAME canonical names — so wildcards and bare
+    # matchPatterns against these A-only zones are inert. Coverage is
+    # provided by the toEntities: [world]:443 rule below.
     #
-    # FQDNs covered by the world:443 rule below:
-    #   - github.com (canonical, A-only)
-    #
-    # *.githubusercontent.com / raw.githubusercontent.com /
-    # codeload.github.com / objects.githubusercontent.com kept as
-    # matchPattern below — predecessor classification (see audit
-    # report).
+    # See project_cilium_matchpattern_fqdn_limits.md for the cluster-
+    # wide audit.
     - toEntities:
         - world
-      toPorts:
-        - ports:
-            - port: "443"
-              protocol: TCP
-    - toFQDNs:
-        - matchPattern: "*.github.com"
-        - matchPattern: "*.github.com.*"
-        - matchPattern: "raw.githubusercontent.com"
-        - matchPattern: "raw.githubusercontent.com.*"
-        - matchPattern: "codeload.github.com"
-        - matchPattern: "codeload.github.com.*"
-        - matchPattern: "objects.githubusercontent.com"
-        - matchPattern: "objects.githubusercontent.com.*"
       toPorts:
         - ports:
             - port: "443"


### PR DESCRIPTION
## Summary

Hygiene cleanup. Per the `project_cilium_matchpattern_fqdn_limits` audit, `matchPattern` against A-only zones (no CNAME chain) is silently inert in Cilium 1.19 — `.*` walks only one label, and the canonical-name follow only fires when the queried FQDN has a CNAME chain to walk. Removed wildcards/bare patterns that the audit confirmed are A-only; coverage stays via the existing `toEntities: [world]:443` rule already present in each CNP.

## Verification

Verified A-only via `dig @1.1.1.1`:

| FQDN | CNAME | A-only? |
|------|-------|---------|
| `raw.githubusercontent.com` | none | yes |
| `objects.githubusercontent.com` | none | yes |
| `camo.githubusercontent.com` | none | yes |
| `avatars.githubusercontent.com` | none | yes |
| `codeload.github.com` | none | yes |
| `api.github.com` | none | yes |
| `huggingface.co` | none | yes |
| `cdn-thumbnails.huggingface.co` | none | yes |
| `cdn-lfs-us-1.hf.co` | none | yes |
| `cas-bridge.xethub.hf.co` | none | yes |
| `api.hf.co` | none | yes |
| `uploads.github.com` | `→ alambic-origin.githubusercontent.com` | NO (kept in github-mcp) |

## Wildcards removed

| File | Patterns dropped |
|------|------------------|
| `kubernetes/apps/ai/khoj/app/cnp-allow.yaml` | `*.huggingface.co`, `*.huggingface.co.*`, `*.hf.co`, `*.hf.co.*` |
| `kubernetes/apps/ai/kubeclaw/app/cnp-allow.yaml` | `*.huggingface.co{,.*}`, `*.hf.co{,.*}`, `codeload.github.com{,.*}`, `raw.githubusercontent.com{,.*}`, `*.githubusercontent.com{,.*}` |
| `kubernetes/apps/media/recyclarr/app/cnp-allow.yaml` | `*.github.com{,.*}`, `raw.githubusercontent.com{,.*}`, `codeload.github.com{,.*}`, `objects.githubusercontent.com{,.*}` |
| `kubernetes/apps/collab/pump-cv/app/cnp-allow.yaml` | `*.githubusercontent.com{,.*}` |
| `kubernetes/apps/actions-runner-system/actions-runner-controller/operator/cnp-allow.yaml` | `*.githubusercontent.com{,.*}` |

Each CNP retains its `toEntities: [world]:443` rule which already covered these.

## Left alone (with rationale)

- `mcp-system/github-mcp/app/cnp-allow.yaml` — PR #11622 already cleaned this; the surviving `uploads.github.com` matchPattern works via CNAME-walk to `alambic-origin.githubusercontent.com`, and `*.githubusercontent.com` covers that walk target. Not inert.
- `actions-runner-system/actions-runner-controller/runners/cnp-allow.yaml` — intentional broad-allow `matchPattern: "*"` so runner pods can clone, pull, fetch from arbitrary URLs in user-authored workflows. Trust boundary is the GitHub-App scoping, not the network.
- Other CNPs containing `matchPattern: "*"` tokens (rook-ceph, etc.) — intentional broad-allow per task constraint.

## Surfaced

Nothing surprising. The audit's A-only classification held for every host I checked. The only CNAME-chain hit was `uploads.github.com` (in the github-mcp CNP, already handled by PR #11622).

## Test plan

- [ ] After merge, watch `khoj` qmd-embed model downloads still work (next embed run).
- [ ] After merge, watch `kubeclaw` qmd-embed + qmd-update Jobs still complete.
- [ ] After merge, watch `recyclarr` next sync (clones trash-guides repo).
- [ ] After merge, watch `pump-cv` model download cache hit on restart (cached, no redownload expected).
- [ ] After merge, ARC operator continues authenticating + reconciling.
- [ ] Behavior should be identical to before — these wildcards were already inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)