### PR TITLE
feat(ai): bump langgraph-agents 0.2.2 → 0.2.5

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/langgraph-agents
-              tag: 0.2.2  # versioned release; Renovate tracks subsequent bumps
+              tag: 0.2.5  # versioned release; Renovate tracks subsequent bumps
 
             env:
               # --- vault ---


### PR DESCRIPTION
## Summary

- Bumps `kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml` image tag 0.2.2 → 0.2.5
- v0.2.5 image published to GHCR (`sha-2c862cb`, also tagged `0.2`, `latest`)

## What's in v0.2.5 (vs. running 0.2.2)

Lands two release cycles of operator-class specialist work:

- **v0.2.3**: `network-operator` port (Pylon 🛰️) — VLANs / ACLs / BGP / Omada / DNS
- **v0.2.4**: `storage-operator` net-new (Granary 🌾); `smart-home-engineer` → `smart-home-operator` (Sentinel 👁️); `ml-tuner` → `ml-operator` (Cortex 🧠). Engineer/tuner → operator-class promotion with prime directive + 8-clause execution gate + safety-gate-fielded Pydantic schemas.
- **v0.2.5**: `observability-operator` net-new (Beacon 🔦). Prime directive: *you cannot bury a real alert under flap*. `ObservabilityFinding` schema makes both `flood_mode` AND `mute_mode` mandatory.

`ALL_AGENT_IDS`: 13 → 17.

## Pre-flight

- [x] v0.2.5 image confirmed on GHCR (build workflow succeeded on `v0.2.5` tag push)
- [x] Vault content already pushed to `langgraph-vault` PVC via sync-receiver. All 17 workspace dirs present; obsolete `smart-home-engineer` / `ml-tuner` dirs removed
- [x] 5 new Zulip bot identities created (Pylon was also pending) — `scripts/zulip-bootstrap.py --apply` run; bot creds in 1P `zulip-bots-langgraph` (Kubernetes vault)
- [x] Tests 94/94 pass in langgraph-agents on rebased branch (rwlove/langgraph-agents#5 merged via squash)
- [x] Drift-check (`scripts/check-operator-drift.py`) 5/5 operators have `.md` ↔ vault parity

## Activation safety

Activation stays gated on Spark: `ENABLE_CLAUDE_API: "false"` in this helmrelease per `project_langgraph_activation_gated_on_spark`. This bump loads new agent code + personas but doesn't fire them at production scale.

## Test plan

- [ ] Flux reconciles → pod restarts on v0.2.5 → all 17 `/v1/models` agents listed
- [ ] `personas.py` loads each workspace cleanly (look for FileNotFoundError in logs — would indicate a vault sync gap)
- [ ] `mcp-allowlist` test passes against live `mcp-gateway` (each new operator's allowlist matches actual gateway tool surface)
- [ ] Old `Spark ⚡` and `Tuner 🎛️` bot identities still in Zulip (lingering; manually deactivate via Zulip admin UI when ready)

🤖 Generated with [Claude Code](https://claude.com/claude-code)