### PR TITLE
chore(ci): add gitleaks workflow + config

### DIFF
--- a/.github/workflows/gitleaks.yaml
+++ b/.github/workflows/gitleaks.yaml
@@ -1,0 +1,63 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Gitleaks
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: Scan for inline secrets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          # PR scans need base-branch history for --log-opts; push scans
+          # don't, but full-depth checkout is cheap on this repo and keeps
+          # the two branches symmetric.
+          fetch-depth: 0
+
+      - name: Install gitleaks
+        env:
+          GITLEAKS_VERSION: 8.30.1
+        run: |
+          set -euo pipefail
+          curl -fsSL \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | tar -xz -C "${RUNNER_TEMP}" gitleaks
+          echo "${RUNNER_TEMP}" >> "${GITHUB_PATH}"
+
+      - name: Scan PR commits
+        if: github.event_name == 'pull_request'
+        # Only the commits this PR adds. Historical leaks on other refs
+        # (e.g. bc7dddb1, remediated in PR #11587) do not break CI here.
+        run: |
+          gitleaks detect \
+            --no-banner \
+            --config=.gitleaks.toml \
+            --log-opts="origin/${{ github.base_ref }}..HEAD" \
+            --verbose --redact
+
+      - name: Scan working tree
+        if: github.event_name == 'push'
+        # Direct-to-main push: validate the tree as it is, ignore history.
+        run: |
+          gitleaks detect \
+            --no-banner \
+            --config=.gitleaks.toml \
+            --no-git \
+            --verbose --redact

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,42 @@
+title = "home-ops gitleaks config"
+
+# Inherit every gitleaks built-in rule (generic-api-key, jwt, aws,
+# private-key, etc.) and add repo-specific ones below.
+[extend]
+useDefault = true
+
+# Authelia OIDC client_secret values are stored as argon2id PHC strings.
+# These are the shape Red Hat InfoSec's scanner flagged on bc7dddb1 — fix
+# landed in PR #11587, this rule prevents regression with a clearer id
+# than the default "generic-api-key".
+[[rules]]
+id = "argon2id-phc-string"
+description = "Argon2id PHC password hash (e.g. Authelia client_secret)"
+regex = '''\$argon2id\$v=\d+\$m=\d+,t=\d+,p=\d+\$[A-Za-z0-9+/=]+\$[A-Za-z0-9+/=]+'''
+tags = ["password", "hash", "authelia"]
+
+[allowlist]
+description = "Paths and patterns that are not real secrets"
+paths = [
+  # Local Claude Code worktree artifacts (in .gitignore; absent in CI).
+  '''^\.claude/''',
+  # Archived configs — kept for reference, not deployed.
+  '''^\.archive/''',
+  # kubeadm bootstrap token expires 24h after `kubeadm init`; the
+  # token in this file is a long-expired one-shot artifact from cluster
+  # bring-up, not a live credential.
+  '''^init/clusterconfiguration\.yaml$''',
+]
+regexes = [
+  # ExternalSecret Go-template substitutions like {{ .OIDC_HMAC_SECRET }}
+  # — the actual value lives in 1Password, never in git.
+  '''\{\{\s*\.\w+\s*\}\}''',
+  # Flux postBuild substitution vars like ${SECRET_DOMAIN} and the
+  # default-form ${VAR:-fallback} used in flux-local rendering.
+  '''\$\{[A-Z_][A-Z0-9_]*(?::-[^}]*)?\}''',
+  # Repo convention: comments documenting env-sourced Authelia fields.
+  '''#\s*from\s+env:\s*AUTHELIA_''',
+  # Grafana panel/query refIDs in dashboard JSON, shaped like
+  # `Q-<uuid>-<n>` — auto-generated, not credentials.
+  '''Q-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}-\d+''',
+]


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/gitleaks.yaml` — gitleaks v8.30.1 scan on PRs (commits the PR adds, via `--log-opts`) and direct-to-main pushes (working-tree, via `--no-git`).
- Adds `.gitleaks.toml` extending the default ruleset with an explicit `argon2id-phc-string` rule and an allowlist for the patterns we use legitimately.

## Context

Red Hat Information Security flagged 32 "Generic Secret" findings in `kubernetes/apps/auth/authelia/app/configmap.yaml` at commit `bc7dddb1`. That code was already migrated to a 1P-backed `clients.yml` in #11587 (commit `b8cb8b4805`); the alert was citing stale unmerged feature branches that still hold the pre-fix file.

User-approved scope was minimal:

- No secret rotation — argon2id hashes, home-lab tier
- No branch cleanup — accept that future alerts cite stale refs until they age out
- No history rewrite — destructive on a Flux/Renovate repo with 254 branches
- No reply to Red Hat — `no-reply@` sender

The durable lever is this CI guard so no future commit can reintroduce inline secrets.

## Local verification

```
gitleaks v8.30.1
$ gitleaks detect --no-git --config=.gitleaks.toml
→ 0 leaks (working tree clean)

$ git show bc7dddb1:kubernetes/apps/auth/authelia/app/configmap.yaml \
    | gitleaks detect --no-git --config=.gitleaks.toml --source=-
→ 32 findings, all argon2id-phc-string (matches Red Hat's alert count exactly)

$ gitleaks detect --log-opts='origin/main..HEAD' --config=.gitleaks.toml
→ 1 commit scanned, 0 leaks (PR-scan path)
```

## Allowlist rationale

| Path/Pattern | Why |
|---|---|
| `^\.archive/` | Reference-only, not deployed |
| `^\.claude/` | Local Claude Code worktree artifacts (gitignored; absent in CI) |
| `^init/clusterconfiguration\.yaml$` | kubeadm bootstrap token, `ttl: 24h0m0s` — expired |
| `\{\{\s*\.\w+\s*\}\}` | ExternalSecret Go-template vars |
| `\$\{[A-Z_][A-Z0-9_]*(?::-[^}]*)?\}` | Flux postBuild substitution vars |
| `#\s*from\s+env:\s*AUTHELIA_` | Repo convention for env-source comments |
| `Q-[hex-uuid]-\d+` | Grafana panel/query refIDs in dashboard JSON |

The Authelia `configmap.yaml` is **not** path-allowlisted — the regex doesn't match the comment that mentions argon2id, and an explicit allowlist there would mask a regression if anyone reverted the migration.

## Test plan

- [ ] PR-scan job runs against the diff (two new files) → expect 0 leaks
- [ ] After merge, push-scan job runs against `main` working tree → expect 0 leaks
- [ ] Optional regression sanity: throwaway PR that adds an `\$argon2id\$v=19\$...` string to a new yaml under `kubernetes/` is blocked. Close without merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)