### PR TITLE
feat(ai): add ollama-spark for arm64 Blackwell (concurrent w/ P40 ollama)

### DIFF
--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
   - ./kubeclaw/ks.yaml
   - ./langgraph-agents/ks.yaml
   - ./ollama/ks.yaml
+  - ./ollama-spark/ks.yaml
   - ./paperless-ai/ks.yaml
   - ./sync-receiver/ks.yaml
   - ./khoj/ks.yaml

--- a/kubernetes/apps/ai/ollama-spark/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/ollama-spark/app/cnp-allow.yaml
@@ -1,0 +1,54 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: ollama-spark-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: ollama-spark
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal gateway → ollama-spark:11434 (ollama-spark.${SECRET_DOMAIN}
+    # for direct user access).
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "11434"
+              protocol: TCP
+    # Cross-ns callers (mirrors the existing ollama CNP; both Services
+    # serve the same surface of consumers post-Phase-2 factory cutover).
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: home
+            app.kubernetes.io/name: home-assistant
+        - matchLabels:
+            io.kubernetes.pod.namespace: media
+            app.kubernetes.io/name: suggestarr
+        - matchLabels:
+            io.kubernetes.pod.namespace: collab
+            app.kubernetes.io/name: open-webui
+        - matchLabels:
+            io.kubernetes.pod.namespace: mcp-system
+      toPorts:
+        - ports:
+            - port: "11434"
+              protocol: TCP
+  egress:
+    # Model registry — ollama pulls model blobs on first invocation
+    # (`ollama pull <model>`) and on Modelfile changes.
+    # See sibling ollama CNP for the canonical-FQDN limitation rationale;
+    # toEntities:world+443 covers ollama.com / registry.ollama.ai / HF / R2.
+    - toEntities: [world]
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/ai/ollama-spark/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/ollama-spark/app/helmrelease.yaml
@@ -1,0 +1,104 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: ollama-spark
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 30m
+  values:
+    controllers:
+      backend:
+        pod:
+          nodeSelector:
+            node-role.kubernetes.io/gpu: blackwell
+
+          tolerations:
+            - key: nvidia.com/gpu
+              operator: Equal
+              value: "true"
+              effect: NoSchedule
+
+          priorityClassName: ai-gpu-critical
+
+        annotations:
+          reloader.stakater.com/auto: "true"
+
+        type: statefulset
+
+        containers:
+          main:
+            image:
+              repository: docker.io/ollama/ollama
+              tag: 0.24.0@sha256:a6149234667efc71d37766d61c1a16f24c33e4cd7a0bf4125c44a7e47e2419c4
+
+            env:
+              OLLAMA_HOST: 0.0.0.0
+              OLLAMA_ORIGINS: "*"
+              OLLAMA_LOG_LEVEL: info
+              OLLAMA_MODELS: &pvc /models
+              OLLAMA_LOAD_TIMEOUT: 10m
+              OLLAMA_KV_CACHE_TYPE: q8_0
+              OLLAMA_FLASH_ATTENTION: 1
+              OLLAMA_CONTEXT_LENGTH: 16384
+              OLLAMA_NUM_PARALLEL: 4
+              # Spark's 128 GB unified memory comfortably runs 30b-class
+              # models concurrently. P40-era cap of 1 lifted.
+              OLLAMA_MAX_LOADED_MODELS: 2
+
+            resources:
+              requests:
+                memory: 32Gi
+                cpu: 2000m
+                nvidia.com/gpu: 1
+              limits:
+                memory: 64Gi
+                nvidia.com/gpu: 1
+
+            securityContext:
+              privileged: true
+
+    service:
+      backend:
+        controller: backend
+        ports:
+          http:
+            port: &httpPort 11434
+
+    route:
+      main:
+        hostnames:
+          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: backend
+                port: *httpPort
+
+    persistence:
+      data:
+        existingClaim: ollama-spark-data-pvc
+        advancedMounts:
+          backend:
+            main:
+              - path: /.ollama
+
+      models:
+        existingClaim: ollama-spark-models-pvc
+        advancedMounts:
+          backend:
+            main:
+              - path: *pvc
+
+      tmp:
+        type: emptyDir
+        enabled: true
+        medium: Memory
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/ai/ollama-spark/app/kustomization.yaml
+++ b/kubernetes/apps/ai/ollama-spark/app/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../components/repos/app-template
+
+resources:
+  - ./cnp-allow.yaml
+  - ./helmrelease.yaml
+  - ./pvc.yaml

--- a/kubernetes/apps/ai/ollama-spark/app/pvc.yaml
+++ b/kubernetes/apps/ai/ollama-spark/app/pvc.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ollama-spark-data-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: ceph-block
+  resources:
+    requests:
+      storage: 2Gi
+
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ollama-spark-models-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: ceph-block
+  resources:
+    requests:
+      storage: 100Gi

--- a/kubernetes/apps/ai/ollama-spark/ks.yaml
+++ b/kubernetes/apps/ai/ollama-spark/ks.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app ollama-spark
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: ai
+  path: "./kubernetes/apps/ai/ollama-spark/app"
+  interval: 30m
+  timeout: 5m
+  prune: true
+  wait: true
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: onepassword-connect
+      namespace: external-secrets
+    - name: gpu-operator
+      namespace: kube-system
+    - name: rook-ceph-cluster
+      namespace: rook-ceph


### PR DESCRIPTION
## Summary

- New `ollama-spark` HelmRelease pinned to the DGX Spark (arm64, Blackwell GB10) via `node-role.kubernetes.io/gpu: blackwell` nodeSelector + `nvidia.com/gpu` toleration
- 32Gi req / 64Gi limit memory (Spark has 128Gi unified — comfortably runs `qwen2.5:32b` plus a 2nd 30b-class model concurrently)
- `OLLAMA_MAX_LOADED_MODELS=2` — lifts the P40-era cap of 1
- Ceph-block PVCs (2Gi data + 100Gi models)
- CiliumNetworkPolicy mirrors the existing `ollama-allow` ingress/egress shape

## Design rationale

Per the post-Spark roadmap (plan v48): both Spark and P40 serve concurrently rather than relocating Ollama. Light agents (triager, classifiers) will use P40 `qwen2.5:7b`; heavy specialists (coder, reviewer, operators) will use Spark `qwen2.5:32b`. Spark failure → factory falls back to P40 (degraded model quality, no Claude spend).

Existing `ollama` HR (worker8/P40, qwen2.5:7b) stays unchanged in this PR — no consumer breakage. The rename `ollama` → `ollama-p40` is deferred to the Phase 2 factory cutover, when langgraph-agents starts routing per-agent via the new `llm()` factory and the hardcoded `OLLAMA_BASE_URL` env disappears.

## Post-merge manual step

```bash
kubectl -n ai exec sts/ollama-spark -- ollama pull qwen2.5:32b
# ~3 min at 1GbE
```

## Test plan

- [ ] Flux reconciles `ai/ollama-spark` Kustomization → Ready
- [ ] `ollama-spark` StatefulSet schedules onto `spark.thesteamedcrab.com` (only node matching the nodeSelector)
- [ ] Pod reaches Running; `nvidia.com/gpu: 1` resource allocated
- [ ] `kubectl run -i --rm test --image=curlimages/curl:8.10.1 --restart=Never -- curl -sf http://ollama-spark.ai.svc.cluster.local:11434/api/tags` returns 200
- [ ] Existing `ollama` HR (P40) unaffected: `kubectl -n ai get sts ollama` still Running on worker8
- [ ] After `ollama pull qwen2.5:32b`: `/api/tags` lists `qwen2.5:32b`

🤖 Generated with [Claude Code](https://claude.com/claude-code)