### PR TITLE
feat(observability): langgraph-agents ServiceMonitor + Grafana dashboard

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/kustomization.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./pvc.yaml
+  - ./servicemonitor.yaml

--- a/kubernetes/apps/ai/langgraph-agents/app/servicemonitor.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/servicemonitor.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/servicemonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: langgraph-agents
+  labels:
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/instance: langgraph-agents
+    app.kubernetes.io/name: langgraph-agents
+    prometheus: kube-prometheus
+spec:
+  endpoints:
+    - interval: 30s
+      path: /metrics
+      port: http
+      scheme: http
+      scrapeTimeout: 10s
+  namespaceSelector:
+    matchNames:
+      - ai
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: langgraph-agents

--- a/kubernetes/apps/observability/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/grafana/app/helmrelease.yaml
@@ -110,7 +110,19 @@ spec:
               path: /var/lib/grafana/dashboards/hardware
             orgId: 1
             type: file
+          - disableDeletion: false
+            editable: true
+            folder: AI
+            name: AI
+            options:
+              path: /var/lib/grafana/dashboards/ai
+            orgId: 1
+            type: file
     dashboards:
+      ai:
+        langgraph-agents:
+          datasource: Prometheus
+          url: https://raw.githubusercontent.com/rwlove/home-ops/main/kubernetes/apps/observability/grafana/dashboards/langgraph-agents.json
       cert-manager:
         overview:
           url: https://raw.githubusercontent.com/monitoring-mixins/website/refs/heads/master/assets/cert-manager/dashboards/cert-manager-overview.json

--- a/kubernetes/apps/observability/grafana/dashboards/langgraph-agents.json
+++ b/kubernetes/apps/observability/grafana/dashboards/langgraph-agents.json
@@ -1,0 +1,347 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "calls/min",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "normal" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "unit": "cps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "right", "showLegend": true, "calcs": ["sum"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "sum by (agent) (rate(langgraph_calls_total{agent=~\"$agent\",group=~\"$group\",outcome=~\"$outcome\"}[5m]))",
+          "legendFormat": "{{agent}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "LLM calls/sec by agent",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 3 }
+            ]
+          },
+          "unit": "currencyUSD"
+        }
+      },
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 0 },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "sum(increase(langgraph_cost_usd_total{agent=~\"$agent\",group=~\"$group\"}[24h]))",
+          "legendFormat": "spend today",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Claude spend (24h)",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [
+            { "type": "value", "value": "NaN", "options": { "0": { "text": "—" } } }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 0.9 },
+              { "color": "green", "value": 0.99 }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        }
+      },
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 0 },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "sum(rate(langgraph_calls_total{outcome=\"success\",agent=~\"$agent\",group=~\"$group\"}[5m])) / sum(rate(langgraph_calls_total{agent=~\"$agent\",group=~\"$group\"}[5m]))",
+          "legendFormat": "success",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Success rate (5m)",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisLabel": "tokens/s",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "stacking": { "group": "A", "mode": "normal" }
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "id": 4,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "right", "showLegend": true, "calcs": ["sum"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "sum by (direction) (rate(langgraph_tokens_total{agent=~\"$agent\",group=~\"$group\"}[5m]))",
+          "legendFormat": "{{direction}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Token rate (in/out)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "continuous-BlYlRd" },
+          "custom": {
+            "axisLabel": "p95 (s)",
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "unit": "s"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "id": 5,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "right", "showLegend": true, "calcs": ["mean", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (agent, le) (rate(langgraph_llm_duration_seconds_bucket{agent=~\"$agent\",group=~\"$group\"}[5m])))",
+          "legendFormat": "{{agent}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "LLM duration p95 by agent",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisLabel": "calls",
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": { "group": "A", "mode": "normal" }
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "id": 6,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "right", "showLegend": true, "calcs": ["sum"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "sum by (group) (increase(langgraph_calls_total{agent=~\"$agent\"}[1h]))",
+          "legendFormat": "{{group}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Calls per hour by group (Spark / P40 / Claude split)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisLabel": "calls",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "id": 7,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "right", "showLegend": true, "calcs": ["sum"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "sum by (trigger) (rate(langgraph_calls_total{group=\"claude\"}[5m]))",
+          "legendFormat": "{{trigger}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Claude escalations by trigger (degraded_mode / requires_cloud)",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": ["langgraph-agents", "ai"],
+  "templating": {
+    "list": [
+      {
+        "current": { "selected": false, "text": "All", "value": "$__all" },
+        "datasource": "Prometheus",
+        "definition": "label_values(langgraph_calls_total, agent)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "agent",
+        "multi": true,
+        "name": "agent",
+        "options": [],
+        "query": { "query": "label_values(langgraph_calls_total, agent)", "refId": "StandardVariableQuery" },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": { "selected": false, "text": "All", "value": "$__all" },
+        "datasource": "Prometheus",
+        "definition": "label_values(langgraph_calls_total, group)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "group",
+        "multi": true,
+        "name": "group",
+        "options": [],
+        "query": { "query": "label_values(langgraph_calls_total, group)", "refId": "StandardVariableQuery" },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": { "selected": false, "text": "All", "value": "$__all" },
+        "datasource": "Prometheus",
+        "definition": "label_values(langgraph_calls_total, outcome)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "outcome",
+        "multi": true,
+        "name": "outcome",
+        "options": [],
+        "query": { "query": "label_values(langgraph_calls_total, outcome)", "refId": "StandardVariableQuery" },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "America/New_York",
+  "title": "LangGraph Agents",
+  "uid": "langgraph-agents",
+  "version": 1,
+  "weekStart": ""
+}


### PR DESCRIPTION
## Summary
- Phase 1a (home-ops side) of the [langgraph-agents observability plan](/home/rwlove/.claude-personal/plans/i-want-you-to-steady-marshmallow.md). Pairs with langgraph-agents PR #7 which exposes \`/metrics\` + structlog JSON.
- New ServiceMonitor at \`kubernetes/apps/ai/langgraph-agents/app/servicemonitor.yaml\` — scrapes the existing \`http\` Service port at \`/metrics\` every 30s. Ingress permission is already granted by the baseline \`allow-monitoring-scrape\` CNP, so no per-app CNP edit.
- New Grafana dashboard at \`kubernetes/apps/observability/grafana/dashboards/langgraph-agents.json\` — 7 panels backed by the 4 \`langgraph_*\` metrics from the v20 schema. Three multi-select template vars (\`agent\`, \`group\`, \`outcome\`).
- Grafana \`helmrelease.yaml\`: register the new \`AI\` dashboard folder + \`ai.langgraph-agents\` provider entry pointing at this repo's dashboard JSON.

The dashboard renders no-data until langgraph-agents Phase 2 (LLM factory) attaches the \`LangGraphMetricsCallback\` handler. ServiceMonitor will scrape immediately on next Flux reconcile + Prometheus discovery.

## Test plan
- [x] \`kustomize build kubernetes/apps/ai/langgraph-agents/app\` renders ServiceMonitor with \`path: /metrics\` and the correct selector.
- [ ] After merge: \`kubectl -n observability get servicemonitor langgraph-agents -n ai\` shows the SM picked up by kube-prometheus-stack.
- [ ] After merge: \`kubectl -n observability port-forward svc/kube-prometheus-stack-prometheus 9090:9090\` → http://localhost:9090/targets shows the langgraph-agents target as \`UP\`.
- [ ] After merge: dashboard \`LangGraph Agents\` appears in Grafana under the new \`AI\` folder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)