### PR TITLE
fix(ai): disableWait on ollama-spark HelmRelease

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/kustomization.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./pvc.yaml
+  - ./servicemonitor.yaml

--- a/kubernetes/apps/ai/langgraph-agents/app/servicemonitor.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/servicemonitor.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/servicemonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: langgraph-agents
+  labels:
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/instance: langgraph-agents
+    app.kubernetes.io/name: langgraph-agents
+    prometheus: kube-prometheus
+spec:
+  endpoints:
+    - interval: 30s
+      path: /metrics
+      port: http
+      scheme: http
+      scrapeTimeout: 10s
+  namespaceSelector:
+    matchNames:
+      - ai
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: langgraph-agents

--- a/kubernetes/apps/ai/ollama-spark/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/ollama-spark/app/helmrelease.yaml
@@ -17,6 +17,15 @@ spec:
             node-role.kubernetes.io/gpu: blackwell
 
           tolerations:
+            # Spark is tainted kubernetes.io/arch=arm64:NoSchedule to keep
+            # amd64-only workloads off it (the scheduler doesn't validate
+            # image arch pre-binding; the kubelet only catches mismatches at
+            # pull time — too late). This HR is arm64-native (ollama image
+            # is multi-arch), so we tolerate it explicitly.
+            - key: kubernetes.io/arch
+              operator: Equal
+              value: arm64
+              effect: NoSchedule
             - key: nvidia.com/gpu
               operator: Equal
               value: "true"

--- a/kubernetes/apps/ai/ollama-spark/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/ollama-spark/app/helmrelease.yaml
@@ -9,6 +9,10 @@ spec:
     kind: OCIRepository
     name: app-template
   interval: 30m
+  install:
+    disableWait: true
+  upgrade:
+    disableWait: true
   values:
     controllers:
       backend:

--- a/kubernetes/apps/collab/glance/app/resources/glance.yml
+++ b/kubernetes/apps/collab/glance/app/resources/glance.yml
@@ -29,7 +29,7 @@ pages:
             title: AI
             url: http://glance-k8s-extension:8080/extension/apps
             allow-potentially-dangerous-html: true
-            cache: 1h
+            cache: 5m
             parameters:
               show-if: |
                 namespace != "kube-system" and
@@ -137,7 +137,7 @@ pages:
           - type: extension
             url: http://glance-k8s-extension:8080/extension/nodes
             allow-potentially-dangerous-html: true
-            cache: 1h
+            cache: 5m
 
           - type: bookmarks
             groups:

--- a/kubernetes/apps/observability/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/grafana/app/helmrelease.yaml
@@ -110,7 +110,19 @@ spec:
               path: /var/lib/grafana/dashboards/hardware
             orgId: 1
             type: file
+          - disableDeletion: false
+            editable: true
+            folder: AI
+            name: AI
+            options:
+              path: /var/lib/grafana/dashboards/ai
+            orgId: 1
+            type: file
     dashboards:
+      ai:
+        langgraph-agents:
+          datasource: Prometheus
+          url: https://raw.githubusercontent.com/rwlove/home-ops/main/kubernetes/apps/observability/grafana/dashboards/langgraph-agents.json
       cert-manager:
         overview:
           url: https://raw.githubusercontent.com/monitoring-mixins/website/refs/heads/master/assets/cert-manager/dashboards/cert-manager-overview.json

--- a/kubernetes/apps/observability/grafana/dashboards/langgraph-agents.json
+++ b/kubernetes/apps/observability/grafana/dashboards/langgraph-agents.json
@@ -1,0 +1,347 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "calls/min",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "normal" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "unit": "cps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "right", "showLegend": true, "calcs": ["sum"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "sum by (agent) (rate(langgraph_calls_total{agent=~\"$agent\",group=~\"$group\",outcome=~\"$outcome\"}[5m]))",
+          "legendFormat": "{{agent}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "LLM calls/sec by agent",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 3 }
+            ]
+          },
+          "unit": "currencyUSD"
+        }
+      },
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 0 },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "sum(increase(langgraph_cost_usd_total{agent=~\"$agent\",group=~\"$group\"}[24h]))",
+          "legendFormat": "spend today",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Claude spend (24h)",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [
+            { "type": "value", "value": "NaN", "options": { "0": { "text": "—" } } }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 0.9 },
+              { "color": "green", "value": 0.99 }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        }
+      },
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 0 },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "sum(rate(langgraph_calls_total{outcome=\"success\",agent=~\"$agent\",group=~\"$group\"}[5m])) / sum(rate(langgraph_calls_total{agent=~\"$agent\",group=~\"$group\"}[5m]))",
+          "legendFormat": "success",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Success rate (5m)",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisLabel": "tokens/s",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "stacking": { "group": "A", "mode": "normal" }
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "id": 4,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "right", "showLegend": true, "calcs": ["sum"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "sum by (direction) (rate(langgraph_tokens_total{agent=~\"$agent\",group=~\"$group\"}[5m]))",
+          "legendFormat": "{{direction}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Token rate (in/out)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "continuous-BlYlRd" },
+          "custom": {
+            "axisLabel": "p95 (s)",
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "unit": "s"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "id": 5,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "right", "showLegend": true, "calcs": ["mean", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (agent, le) (rate(langgraph_llm_duration_seconds_bucket{agent=~\"$agent\",group=~\"$group\"}[5m])))",
+          "legendFormat": "{{agent}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "LLM duration p95 by agent",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisLabel": "calls",
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": { "group": "A", "mode": "normal" }
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "id": 6,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "right", "showLegend": true, "calcs": ["sum"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "sum by (group) (increase(langgraph_calls_total{agent=~\"$agent\"}[1h]))",
+          "legendFormat": "{{group}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Calls per hour by group (Spark / P40 / Claude split)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisLabel": "calls",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "id": 7,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "right", "showLegend": true, "calcs": ["sum"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "sum by (trigger) (rate(langgraph_calls_total{group=\"claude\"}[5m]))",
+          "legendFormat": "{{trigger}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Claude escalations by trigger (degraded_mode / requires_cloud)",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": ["langgraph-agents", "ai"],
+  "templating": {
+    "list": [
+      {
+        "current": { "selected": false, "text": "All", "value": "$__all" },
+        "datasource": "Prometheus",
+        "definition": "label_values(langgraph_calls_total, agent)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "agent",
+        "multi": true,
+        "name": "agent",
+        "options": [],
+        "query": { "query": "label_values(langgraph_calls_total, agent)", "refId": "StandardVariableQuery" },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": { "selected": false, "text": "All", "value": "$__all" },
+        "datasource": "Prometheus",
+        "definition": "label_values(langgraph_calls_total, group)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "group",
+        "multi": true,
+        "name": "group",
+        "options": [],
+        "query": { "query": "label_values(langgraph_calls_total, group)", "refId": "StandardVariableQuery" },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": { "selected": false, "text": "All", "value": "$__all" },
+        "datasource": "Prometheus",
+        "definition": "label_values(langgraph_calls_total, outcome)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "outcome",
+        "multi": true,
+        "name": "outcome",
+        "options": [],
+        "query": { "query": "label_values(langgraph_calls_total, outcome)", "refId": "StandardVariableQuery" },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "America/New_York",
+  "title": "LangGraph Agents",
+  "uid": "langgraph-agents",
+  "version": 1,
+  "weekStart": ""
+}


### PR DESCRIPTION
## Summary
- ollama-spark HR is in \`UpgradeFailed\` state — helm-controller's 5-min wait timed out on the Pending pod (race after the arm64-toleration fix in #11637), then **rolled back** to the prior revision, silently dropping the toleration. New pods spawn from the reverted template; loop.
- Per memory \`project_helmrelease_disablewait\`: canonical fix for this exact symptom is \`install.disableWait: true\` + \`upgrade.disableWait: true\`. Adding them.

## After merge
- \`flux reconcile helmrelease -n ai ollama-spark --force\` to clear the UpgradeFailed state and let it re-apply with disableWait in scope.
- StatefulSet template should pick up arm64 toleration (from PR #11637) AND not get rolled back this time.
- Existing Pending \`ollama-spark-0\` pod needs \`kubectl delete\` to pick up the new template (StatefulSet doesn't auto-recreate Pending pods on template change).

## Test plan
- [ ] After merge + reconcile: \`kubectl get hr -n ai ollama-spark\` shows Ready=True.
- [ ] \`kubectl get sts -n ai ollama-spark -o jsonpath='{.spec.template.spec.tolerations}'\` shows BOTH \`kubernetes.io/arch=arm64\` AND \`nvidia.com/gpu=true\`.
- [ ] After pod delete: \`ollama-spark-0\` Running on spark.thesteamedcrab.com.

## Follow-up (not in this PR)
- Apply same disableWait pattern to \`kubernetes/apps/ai/ollama/app/helmrelease.yaml\` (P40 ollama) — same latent risk, but it's been Running 2+ days so no acute incident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)