### PR TITLE
fix(langgraph-agents): bump image 0.2.6 → 0.2.7

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/langgraph-agents
-              tag: 0.2.6  # versioned release; Renovate tracks subsequent bumps
+              tag: 0.2.7  # versioned release; Renovate tracks subsequent bumps
 
             env:
               # --- vault ---


### PR DESCRIPTION
Picks up langgraph-agents #10 — POST /inbox no longer 500s on the AsyncPostgresSaver state-snapshot step.