### PR TITLE
feat(langgraph-agents): bump image 0.2.7 → 0.2.8 (metrics callback)

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/langgraph-agents
-              tag: 0.2.7  # versioned release; Renovate tracks subsequent bumps
+              tag: 0.2.8  # versioned release; Renovate tracks subsequent bumps
 
             env:
               # --- vault ---


### PR DESCRIPTION
Phase 2 metrics callback wiring (langgraph-agents PR #11). Factory now binds `LangGraphMetricsCallback` + `{agent,group,model}` metadata at construction; Prometheus counters will populate per LLM call.