### PR TITLE
fix(langgraph-agents): bump 0.2.8 → 0.2.9 (metrics callback)

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/langgraph-agents
-              tag: 0.2.8  # versioned release; Renovate tracks subsequent bumps
+              tag: 0.2.9  # versioned release; Renovate tracks subsequent bumps
 
             env:
               # --- vault ---


### PR DESCRIPTION
Picks up langgraph-agents PR #12. v0.2.8's metrics-callback wiring via `with_config` was empirically broken; v0.2.9 uses intrinsic ChatOllama callbacks instead, which survive `.with_structured_output()` chain wrapping.