### PR TITLE
fix(holmesgpt): bump LITELLM timeout 600 → 1500s

### DIFF
--- a/kubernetes/apps/observability/holmesgpt/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/holmesgpt/app/helmrelease.yaml
@@ -46,6 +46,14 @@ spec:
               OLLAMA_API_BASE: http://ollama.ai.svc.cluster.local:11434
               OVERRIDE_MAX_CONTENT_SIZE: "16384"
               OVERRIDE_MAX_OUTPUT_TOKEN: "4096"
+              # Default litellm timeout is 600s — tool-calling investigations
+              # against qwen2.5:7b on P40 frequently exceed it (verified
+              # 2026-05-19 via direct /api/chat probe; investigation timed out
+              # at 600s with `litellm.Timeout: Connection timed out`). Align
+              # with the n8n outer-timeout of 1500s per
+              # `project_n8n_holmesgpt_timeout_workaround` memory.
+              LITELLM_REQUEST_TIMEOUT: "1500"
+              LITELLM_TIMEOUT: "1500"
               HOLMES_HOST: 0.0.0.0
               HOLMES_PORT: "8080"
             resources:


### PR DESCRIPTION
Aligns the inner litellm timeout with the n8n outer-timeout so tool-call investigation chains on P40 qwen2.5:7b don't race-fail at the 600s default.