### PR TITLE
fix(observability): wire prometheusrule-pod-pending into kustomization

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/kustomization.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/kustomization.yaml
@@ -10,4 +10,5 @@ resources:
   - ./ocirepository.yaml
   - ./prometheusrule-cilium-drops.yaml
   - ./prometheusrule-egress-detection.yaml
+  - ./prometheusrule-pod-pending.yaml
   - ./prometheusrule-pv.yaml


### PR DESCRIPTION
Companion to #11652 — file landed but wasn't in the resources list, so Flux ignored it.