### PR TITLE
docs(claude-runner): activation state — image done, 1P partial, suspend pending

### DIFF
--- a/kubernetes/apps/automation/claude-runner/README.md
+++ b/kubernetes/apps/automation/claude-runner/README.md
@@ -2,83 +2,50 @@
 
 Phase 4 scaffold for the [post-Spark roadmap](../../../../docs/src/audit/post-spark-tool-call-leakage-2026-05-18.md).
 
-The Flux Kustomization ships with `spec.suspend: true` so the manifests
-live in git as the staging point but Flux doesn't try to apply them
-until the three gating items below are done.
+## Activation status (2026-05-19)
 
-## Gating: things that must land before unsuspending
+| Gating item | State |
+|---|---|
+| 1. Container image at `rwlove/containers` | ✅ **DONE** — `ghcr.io/rwlove/claude-runner:0.1.1` (rwlove/containers PR #16 + #17) |
+| 2. 1P item `claude-runner` in vault `Kubernetes` | 🟡 **PARTIAL** — created with `gh_token` + `zulip_bot_*` reused from existing items; `anthropic_api_key` is a **placeholder** the user must replace |
+| 3. Unsuspend the Flux Kustomization | ⏳ pending (one-line `ks.yaml` edit) |
 
-### 1. Container image at `rwlove/containers`
+**To activate**: do step 2 (replace placeholder) + step 3 (remove the `spec.suspend: true` line). After Flux reconciles, the namespace gets RBAC + CronJobs + CNP and the next scheduled run fires.
 
-Need a `claude-runner` image baked with the Claude Code CLI + an
-opinionated MCP allowlist. Per `project_rwlove_containers_upstream_tarball`
-this lives in the [`rwlove/containers`](https://github.com/rwlove/containers)
-repo. Approximate Dockerfile:
+## Step 2 detail — fill the placeholder
 
-```dockerfile
-FROM node:20-alpine
-RUN apk add --no-cache git curl jq && \
-    npm install -g @anthropic-ai/claude-code
+The 1P item `claude-runner` exists with all five expected fields:
 
-# Default per-workflow settings file — overridden by per-CronJob mount.
-COPY settings.json /root/.claude/settings.json
-COPY settings.json /workspace/.claude/settings.json
+- `anthropic_api_key` — **PLACEHOLDER** (`sk-ant-PLACEHOLDER-REPLACE-WITH-REAL-KEY`). Generate from <https://console.anthropic.com/settings/keys> and replace via `op item edit "claude-runner" --vault Kubernetes anthropic_api_key=sk-ant-…` (or via the 1P desktop app).
+- `gh_token` — **REUSED** from `github` item's `github_notification_token` field. Long-term, rotate to a dedicated PAT scoped to the home-ops repo (PR read only).
+- `zulip_bot_email` — **REUSED** from `zulip-bots-langgraph.ZULIP_REPORTER_EMAIL` (the `reporter` bot).
+- `zulip_bot_token` — **REUSED** from `zulip-bots-langgraph.ZULIP_REPORTER_API_KEY`.
+- `zulip_site` — `https://chat.thesteamedcrab.com`.
 
-WORKDIR /workspace
-ENTRYPOINT ["claude"]
-```
+**Implications of reusing the reporter bot**: cron-runner Zulip messages will appear under the same bot identity as the langgraph reporter agent (when that activates). For Phase 4 alone this is fine — both are "report on the world" workflows. If you want a dedicated `claude-runner` bot, create it in the Zulip admin UI and update the 1P fields.
 
-The `settings.json` declares the MCP allowlist (gh, kubectl, loki, the
-lovenet-gateway subset each workflow needs). Per-workflow overrides are
-mounted via a ConfigMap at `/workspace/.claude/settings.json`.
+## Step 3 — unsuspend
 
-Tag + push to `ghcr.io/rwlove/claude-runner:<sha>`; Renovate tracks.
+Edit `ks.yaml`, drop the `suspend: true` line, commit, push. The next Flux source-controller poll (≤1 min) pulls the change; helm-controller / kustomize-controller reconciles within the HR `interval: 30m` OR sooner via `flux reconcile kustomization claude-runner -n automation --force`.
 
-### 2. 1Password items
-
-Each workflow needs its own ExternalSecret. The shared 1P item
-`claude-runner` (vault `Kubernetes`) should hold:
-
-- `anthropic_api_key` — Anthropic API key for the Claude Code runtime
-- `gh_token` — fine-grained PAT (repo:read for home-ops PRs, no write)
-- `zulip_bot_token` — bot token for the `ops` stream
-- `zulip_bot_email` — bot email
-- `zulip_site` — `https://chat.${SECRET_DOMAIN}`
-
-Plus per-workflow scope-narrowed alternates if needed (e.g., a separate
-`gh_token` with broader perms for cost-cap workflows that read across
-repos).
-
-### 3. Unsuspend the Flux Kustomization
-
-Edit `ks.yaml` to remove the `suspend: true` line. Commit + push. Flux
-picks up the manifests on next reconcile, creates the namespace + RBAC
-+ CronJobs.
-
-## Workflows shipped in this scaffold
-
-Two starter CronJobs per the Phase 4 plan recommendation (highest
-signal, lowest noise):
+## Workflows shipped
 
 | Workflow | Schedule (UTC) | What |
 |---|---|---|
 | `pr-triage` | `0 13 * * *` (= 09:00 EDT / 08:00 EST) | Read open PRs at rwlove/home-ops via gh MCP, summarize each Renovate change in one paragraph, post one Zulip card per PR to `ops/pr-triage`. |
 | `cost-cap-commentary` | `0 22 * * *` (= 18:00 EDT / 17:00 EST) | Read `langgraph-agents /admin/costs/today` + Prometheus, project monthly Claude spend, post Zulip card. Flag if trending > $30/mo. |
 
-Two more from the Outcomes table (`Daily HA log skim` + `Weekly Frigate
-clip review`) are intentionally left for after a week of observation —
-ship + watch the first two before adding more noise.
+Two more from the Outcomes table (`Daily HA log skim` + `Weekly Frigate clip review`) are intentionally left for after a week of observation — ship + watch these two before adding more noise.
 
-## Per-workflow kill criterion
+## Kill criterion (per Phase 4 plan body)
 
-Per Phase 4 plan body: kill any workflow if (a) useful-card rate < 30%
-after 2 weeks, OR (b) zero acted-upon cards in 14 days, OR (c) > 5
-unintended noise reactions in any 7-day window. Document the decision
-in the plan's v-changelog and remove the CronJob from this dir.
+Kill any workflow if:
+- useful-card rate < 30% after 2 weeks, OR
+- zero acted-upon cards in 14 days, OR
+- > 5 unintended noise reactions in any 7-day window.
 
-## Container-image rebuild trigger
+Document the kill in the plan's v-changelog and remove the CronJob from this dir.
 
-The image baked at step 1 above is a one-shot. To pick up a Claude Code
-CLI bump or MCP-allowlist change, re-run the build at
-`rwlove/containers` and bump the tag in each CronJob (or wait for
-Renovate). The manifests here use the explicit tag for reproducibility.
+## Container-image rebuild
+
+The image at `rwlove/containers/claude-runner` is tag-driven. To pick up a Claude Code CLI bump or MCP-allowlist change, edit the `CLAUDE_CODE_VERSION` ARG in `claude-runner/Dockerfile`, push, tag `claude-runner-v<new>`, then bump the image tag in each CronJob here (or wait for Renovate).


### PR DESCRIPTION
Updates the README to reflect what autonomous Claude got done (image build + 1P item with reused tokens) and what user-side work remains (replace placeholder anthropic_api_key + remove `suspend: true`).