### PR TITLE
feat(n8n): enable Public API for programmatic workflow management

### DIFF
--- a/kubernetes/apps/home/n8n/app/helmrelease.yaml
+++ b/kubernetes/apps/home/n8n/app/helmrelease.yaml
@@ -51,6 +51,11 @@ spec:
               N8N_HOST: &host n8n.${SECRET_DOMAIN}
               N8N_LOG_LEVEL: info
               N8N_LOG_OUTPUT: console
+              # Public API is needed for the documented workflow-import
+              # procedure at workflows/README.md (X-N8N-API-KEY auth still
+              # required). Default in n8n 2.x is disabled; explicit "false"
+              # opens /api/v1/* for credential-gated programmatic management.
+              N8N_PUBLIC_API_DISABLED: "false"
               WEBHOOK_URL: https://n8n.${SECRET_DOMAIN}/
             envFrom: *envFrom
             resources:


### PR DESCRIPTION
Public API was off by default in n8n 2.x — the documented `X-N8N-API-KEY` recipe at workflows/README.md couldn't reach `/api/v1/*`. Enabling so workflow-management automation works.