### PR TITLE
feat(claude-runner): unsuspend

### DIFF
--- a/kubernetes/apps/automation/claude-runner/ks.yaml
+++ b/kubernetes/apps/automation/claude-runner/ks.yaml
@@ -13,10 +13,6 @@ spec:
   interval: 30m
   timeout: 5m
   prune: true
-  # Suspended until Phase 4's three gating items land — see
-  # ./README.md. Unsuspend by removing this line OR via
-  # `flux resume kustomization claude-runner -n flux-system`.
-  suspend: true
   wait: true
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
Anthropic key landed in 1P. Drops `suspend: true` so Flux reconciles. Next pr-triage fires at 09:00 EDT, cost-cap-commentary at 18:00 EDT.