### PR TITLE
feat(home/windmill): Phase 1a deploy — native auth, CNPG-backed

### DIFF
--- a/kubernetes/apps/databases/cloudnative-pg/config/windmill/cluster.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/windmill/cluster.yaml
@@ -1,0 +1,67 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/cluster_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgres-windmill
+spec:
+  instances: 3
+
+  imageName: ghcr.io/cloudnative-pg/postgresql:17.7
+
+  primaryUpdateStrategy: unsupervised
+
+  failoverDelay: 30
+
+  replicationSlots:
+    highAvailability:
+      enabled: true
+
+  postgresql:
+    parameters:
+      timezone: "America/New_York"
+
+  storage:
+    size: 8Gi
+    storageClass: ceph-block
+
+  walStorage:
+    size: 8Gi
+    storageClass: ceph-block
+
+  resources:
+    requests:
+      cpu: 50m
+      memory: 256Mi
+    limits:
+      memory: 512Mi
+
+  enableSuperuserAccess: true
+  superuserSecret:
+    name: cloudnative-pg
+
+  bootstrap:
+    initdb:
+      database: windmill
+      owner: windmill
+
+  monitoring:
+    enablePodMonitor: true
+
+  plugins:
+    - enabled: true
+      isWALArchiver: true
+      name: barman-cloud.cloudnative-pg.io
+      parameters:
+        barmanObjectName: garage-windmill
+        serverName: postgres-windmill-backup
+
+  externalClusters:
+    - name: postgres-windmill-backup
+      plugin:
+        enabled: true
+        isWALArchiver: false
+        name: barman-cloud.cloudnative-pg.io
+        parameters:
+          barmanObjectName: garage-windmill
+          serverName: postgres-windmill-backup

--- a/kubernetes/apps/databases/cloudnative-pg/config/windmill/kustomization.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/windmill/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../../components/cnpg-app-database
+resources:
+  - ./cluster.yaml

--- a/kubernetes/apps/databases/cloudnative-pg/ks.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/ks.yaml
@@ -963,3 +963,41 @@ spec:
     - apiVersion: postgresql.cnpg.io/v1
       kind: Cluster
       current: status.phase in ['Cluster in healthy state']
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app windmill
+  labels:
+    substitution.flux.home.arpa/enabled: "true"
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: databases
+  path: ./kubernetes/apps/databases/cloudnative-pg/config/windmill
+  interval: 30m
+  timeout: 5m
+  prune: true
+  wait: true
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: cloudnative-pg
+      namespace: databases
+    - name: cloudnative-pg-plugin-barman-cloud
+      namespace: databases
+    - name: garage
+      namespace: storage
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  postBuild:
+    substitute:
+      APP: *app
+  healthCheckExprs:
+    - apiVersion: postgresql.cnpg.io/v1
+      kind: Cluster
+      current: status.phase in ['Cluster in healthy state']

--- a/kubernetes/apps/home/kustomization.yaml
+++ b/kubernetes/apps/home/kustomization.yaml
@@ -27,6 +27,7 @@ resources:
   - ./netbox/ks.yaml
   - ./node-red/ks.yaml
   - ./smtp-relay/ks.yaml
+  - ./windmill/ks.yaml
   - ./wyoming-services/ks.yaml
   - ./zigbee2mqtt/ks.yaml
   - ./zwave-js-ui/ks.yaml

--- a/kubernetes/apps/home/windmill/README.md
+++ b/kubernetes/apps/home/windmill/README.md
@@ -1,0 +1,71 @@
+# Windmill
+
+FOSS workflow automation tool, replacing n8n. See the migration plan in
+`docs/src/audit/` and the steady-marshmallow plan at
+`~/.claude-personal/plans/i-want-you-to-steady-marshmallow.md`.
+
+## Activation (Phase 1a — no SSO yet)
+
+This is the initial deploy with Windmill's native admin auth. Authelia
+OIDC SSO via oauth2-proxy is deferred to Phase 1b (separate PR) to
+avoid editing the cluster's 24-OIDC-client Authelia config under
+autonomy.
+
+### 1P item `windmill` (vault `Kubernetes`) — required fields
+
+| Field | What |
+|---|---|
+| `admin_password` | Initial admin password for `WM_USER_USERNAME=admin`. Generate with `openssl rand -base64 32` and store. |
+| `encryption_key` | Reserved for future Windmill-side cookie/JWT encryption — not currently consumed by this manifest. Generate with `openssl rand -hex 32` and store. |
+
+Creation recipe:
+
+```sh
+ADMIN_PW=$(openssl rand -base64 32)
+ENC_KEY=$(openssl rand -hex 32)
+op item create \
+    --vault Kubernetes \
+    --category "Login" \
+    --title "windmill" \
+    "admin_password[password]=${ADMIN_PW}" \
+    "encryption_key[password]=${ENC_KEY}"
+```
+
+### Database
+
+A 3-instance CNPG cluster `postgres-windmill` is provisioned in the
+`databases` namespace via the cnpg-app-database component. Connection
+parameters land in the `postgres-windmill-app` Secret (created by CNPG)
+with a ready-to-use `uri` field. The Windmill HR's
+`windmill.databaseUrlSecretName` + `databaseUrlSecretKey` point at that
+secret + the `uri` field.
+
+### Verify
+
+After Flux reconciles:
+
+```sh
+kubectl -n databases get cluster postgres-windmill
+kubectl -n home get pod -l app.kubernetes.io/name=windmill -o wide
+kubectl -n home get httproute windmill -o yaml | grep -i hostname
+curl -k https://windmill.${SECRET_DOMAIN}  # → 200 + Windmill UI
+```
+
+Log in via the UI with `admin@windmill.local` + the password from the
+1P item.
+
+## Phase 1b — Authelia SSO via oauth2-proxy (future)
+
+When ready, follow the av1corrector-oauth2-proxy pattern at
+`kubernetes/apps/media/av1corrector-oauth2-proxy/` for the manifest
+shape, plus register a new OIDC client in Authelia's `OIDC_CLIENTS_YAML`
+1P field (`token_endpoint_auth_method: client_secret_post` per memory
+`project_authelia_oauth2_proxy_token_endpoint_auth`). Re-point the
+HTTPRoute at the oauth2-proxy Service instead of `windmill-app:8000`.
+
+## Phase 2 — Author 7 workflows
+
+Per the migration plan. Workflows checked into git under
+`./workflows/<name>.yaml` (Windmill flow format). Tools to use:
+`windmill sync` CLI from inside the pod, or the Windmill UI's "Save +
+Deploy" + git-sync feature.

--- a/kubernetes/apps/home/windmill/app/cnp-allow.yaml
+++ b/kubernetes/apps/home/windmill/app/cnp-allow.yaml
@@ -1,0 +1,88 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: windmill-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: windmill
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # Internal Envoy gateway → windmill-app:8000.
+    # Open WebUI / n8n-style direct in-cluster Service calls also
+    # land here (e.g., when langgraph-agents posts to a Windmill
+    # webhook URL).
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+        - matchLabels:
+            io.kubernetes.pod.namespace: ai
+            app.kubernetes.io/name: langgraph-agents
+        - matchLabels:
+            io.kubernetes.pod.namespace: observability
+            app.kubernetes.io/name: alertmanager
+      toPorts:
+        - ports:
+            - port: "8000"
+              protocol: TCP
+  egress:
+    # CNPG postgres-windmill cluster in `databases` ns.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
+            cnpg.io/cluster: postgres-windmill
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+    # In-cluster Services Windmill workflows POST to:
+    # langgraph-agents (replaces n8n's role in the LangGraph flows)
+    # HolmesGPT (replaces n8n's role for the AlertManager flow)
+    # Zulip (chat notifications + approval reactions)
+    # MCP gateway (future flows may call MCP backends)
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: ai
+            app.kubernetes.io/name: langgraph-agents
+      toPorts:
+        - ports:
+            - port: "8765"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: observability
+            app.kubernetes.io/name: holmesgpt
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: collab
+            app.kubernetes.io/name: zulip
+      toPorts:
+        - ports:
+            - port: "80"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: mcp-system
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+    # External APIs Windmill workflows hit: Pushover + Anthropic + GitHub.
+    # Canonical FQDNs via toEntities:world+443 per memory
+    # project_cilium_matchpattern_fqdn_limits (matchPattern silently
+    # fails for canonical FQDNs queried via K8s DNS search-domain
+    # augmentation).
+    - toEntities: [world]
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/home/windmill/app/externalsecret.yaml
+++ b/kubernetes/apps/home/windmill/app/externalsecret.yaml
@@ -1,0 +1,35 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: windmill
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: windmill-secret
+    template:
+      engineVersion: v2
+      data:
+        # Windmill expects DATABASE_URL — the chart reads from
+        # the secret pointed to by databaseUrlSecretName + key.
+        # We synthesize the URL from CNPG's per-database app secret
+        # (postgres-windmill-app), which has connection-string parts
+        # but no full URL in the format Windmill wants. Use the
+        # superuser instead — CNPG creates a postgres-windmill-superuser
+        # secret with a `uri` field that's directly usable. Simpler.
+        # NOTE: in this template the actual DATABASE_URL is built in the
+        # HelmRelease via env.value referencing CNPG secrets directly.
+        # This ExternalSecret only carries Windmill's own secrets.
+        WM_BASE_INTERNAL_URL: "http://windmill-app.home.svc.cluster.local:8000"
+  dataFrom:
+    - extract:
+        # 1P item `windmill` in vault `Kubernetes`. Required fields:
+        # - admin_password: Windmill bootstrap admin password
+        # - encryption_key: Windmill cookie/secret encryption key
+        # See `kubernetes/apps/home/windmill/README.md` for the item
+        # creation recipe.
+        key: windmill

--- a/kubernetes/apps/home/windmill/app/helmrelease.yaml
+++ b/kubernetes/apps/home/windmill/app/helmrelease.yaml
@@ -1,0 +1,109 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: windmill
+spec:
+  chart:
+    spec:
+      chart: windmill
+      sourceRef:
+        kind: HelmRepository
+        name: windmill
+      version: 2.x  # TODO: pin to a concrete version after first install
+  install:
+    disableWait: true
+  interval: 30m
+  upgrade:
+    disableWait: true
+  values:
+    # No bundled postgres — we use the CNPG cluster `postgres-windmill`.
+    postgresql:
+      enabled: false
+    # No bundled minio either.
+    minio:
+      enabled: false
+    enterprise:
+      enabled: false
+    hub:
+      enabled: false
+
+    windmill:
+      baseDomain: "windmill.${SECRET_DOMAIN}"
+      baseProtocol: https
+
+      # CNPG provisions a per-app `<cluster>-app` Secret with full DB
+      # credentials. The Secret has fields: username, password, host,
+      # port, dbname, and a ready-to-use `uri`. Point Windmill at that
+      # secret's uri field.
+      databaseUrlSecretName: postgres-windmill-app
+      databaseUrlSecretKey: uri
+
+      # Replica count — single instance is fine for a homelab.
+      appReplicas: 1
+
+      # Default worker group.
+      workerGroups:
+        - name: default
+          replicas: 1
+          tolerations: []
+          nodeSelector: {}
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              memory: 1Gi
+        # Native worker — runs Bash/PowerShell/etc. without nsjail.
+        - name: native
+          replicas: 1
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              memory: 512Mi
+
+      # App pod resources.
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          memory: 1Gi
+
+      # Tell Windmill it's behind a TLS-terminating proxy (Envoy).
+      proxy:
+        # Forward the actual client IP via the headers Envoy sets.
+        enabled: true
+
+      # Bootstrap admin credentials (Windmill's first-run setup expects
+      # to either land at /user/setup or accept these from env).
+      # Reference the ExternalSecret-materialized windmill-secret.
+      extraEnv:
+        - name: WM_USER_USERNAME
+          value: admin
+        - name: WM_USER_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: windmill-secret
+              key: admin_password
+        - name: WM_USER_EMAIL
+          value: admin@windmill.local
+
+    indexer:
+      enabled: true
+
+    "windmill-extra":
+      lsp:
+        enabled: true
+      multiplayer:
+        enabled: false  # Enterprise-only
+
+    # Disable the chart's bundled ingress — we use Gateway API HTTPRoute
+    # (see route.yaml in the same dir).
+    ingress:
+      enabled: false
+    httproute:
+      enabled: false

--- a/kubernetes/apps/home/windmill/app/kustomization.yaml
+++ b/kubernetes/apps/home/windmill/app/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../components/repos/windmill
+resources:
+  - ./cnp-allow.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./route.yaml

--- a/kubernetes/apps/home/windmill/app/route.yaml
+++ b/kubernetes/apps/home/windmill/app/route.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: windmill
+  annotations:
+    glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/windmill.png"
+    glance/id: "Automation"
+    glance/name: "Windmill"
+    glance/show: "true"
+spec:
+  hostnames:
+    - "windmill.${SECRET_DOMAIN}"
+  parentRefs:
+    - name: internal
+      namespace: network
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: windmill-app
+          port: 8000

--- a/kubernetes/apps/home/windmill/ks.yaml
+++ b/kubernetes/apps/home/windmill/ks.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app windmill
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: home
+  path: ./kubernetes/apps/home/windmill/app
+  interval: 30m
+  timeout: 10m
+  prune: true
+  wait: true
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: onepassword-connect
+      namespace: external-secrets
+    - name: windmill
+      namespace: databases

--- a/kubernetes/components/repos/windmill/helmrepository.yaml
+++ b/kubernetes/components/repos/windmill/helmrepository.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/refs/heads/main/helmrepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: windmill
+spec:
+  interval: 1h
+  url: https://windmill-labs.github.io/windmill-helm-charts
+  timeout: 3m

--- a/kubernetes/components/repos/windmill/kustomization.yaml
+++ b/kubernetes/components/repos/windmill/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - ./helmrepository.yaml


### PR DESCRIPTION
First step of the n8n → Windmill migration per the steady-marshmallow plan. Native auth only (Authelia SSO in Phase 1b). See `kubernetes/apps/home/windmill/README.md` for activation + verification steps.