### PR TITLE
fix(zot): require auth for push, keep pulls anonymous

### DIFF
--- a/kubernetes/apps/kube-system/zot/app/externalsecret.yaml
+++ b/kubernetes/apps/kube-system/zot/app/externalsecret.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: zot
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: zot-secret
+    template:
+      engineVersion: v2
+      data:
+        # htpasswd file consumed by ZOT at /etc/zot/htpasswd. One bcrypt
+        # line per user. Anonymous pulls are still allowed (accessControl
+        # anonymousPolicy=read in config.json); this gates push only.
+        htpasswd: "{{ .HTPASSWD_ENTRY }}"
+  dataFrom:
+    - extract:
+        key: zot

--- a/kubernetes/apps/kube-system/zot/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/zot/app/helmrelease.yaml
@@ -85,6 +85,14 @@ spec:
             subPath: config.json
             readOnly: true
 
+      htpasswd:
+        type: secret
+        name: zot-secret
+        globalMounts:
+          - path: /etc/zot/htpasswd
+            subPath: htpasswd
+            readOnly: true
+
       data:
         existingClaim: zot-data-ceph
         globalMounts:

--- a/kubernetes/apps/kube-system/zot/app/kustomization.yaml
+++ b/kubernetes/apps/kube-system/zot/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./pvc.yaml
 configMapGenerator:

--- a/kubernetes/apps/kube-system/zot/app/resources/config.json
+++ b/kubernetes/apps/kube-system/zot/app/resources/config.json
@@ -28,7 +28,25 @@
   },
   "http": {
     "address": "0.0.0.0",
-    "port": "5000"
+    "port": "5000",
+    "auth": {
+      "htpasswd": {
+        "path": "/etc/zot/htpasswd"
+      },
+      "failDelay": 1
+    },
+    "accessControl": {
+      "repositories": {
+        "**": {
+          "anonymousPolicy": ["read"],
+          "defaultPolicy": []
+        }
+      },
+      "adminPolicy": {
+        "users": ["zot-admin"],
+        "actions": ["read", "create", "update", "delete"]
+      }
+    }
   },
   "log": {
     "level": "info"


### PR DESCRIPTION
## Summary

ZOT at `zot.thesteamedcrab.com` was accepting anonymous push from any internet client. Discovered today while probing for chart-mirror viability — pushed a probe chart with no credentials. A malicious push of e.g. `ghcr.io/bjw-s-labs/helm/app-template:5.0.1` would be served back through pull-through to 14 namespaces of HelmReleases — one-curl supply-chain attack.

- Adds `http.auth.htpasswd` pointing at a Secret-mounted file
- `accessControl`: `anonymousPolicy=[read]`, `defaultPolicy=[]`
- `adminPolicy` grants full write to user `zot-admin`
- `ExternalSecret` pulls `HTPASSWD_ENTRY` from 1P `Kubernetes/zot`

Pull-through stays anonymous (it's a public mirror of public images). Sync extension writes bypass HTTP auth — they go directly to local storage, so all 41 OCIRepositories keep flowing.

## Rollout risk

Low. ExternalSecret reconciles faster than helm-controller upgrade path, so `zot-secret` exists before the new ZOT pod tries to mount it. Worst case: new pod stays `ContainerCreating` waiting for Secret; old pod stays Ready (statefulset rolling update), so pull-through keeps working through the rollout. ZOT internal sync writes bypass HTTP auth, so OCIRepository fetches keep flowing during and after.

## Test plan

- [ ] CI green
- [ ] After merge: `kubectl get externalsecret -n kube-system zot` → SecretSynced
- [ ] `kubectl get secret -n kube-system zot-secret` → exists, key=`htpasswd`
- [ ] `kubectl rollout status -n kube-system sts/zot` → Ready
- [ ] Anon GET works: `curl -fsS https://zot.thesteamedcrab.com/v2/ghcr.io/bjw-s-labs/helm/app-template/tags/list | jq .name`
- [ ] Anon push rejected: `helm push probe-0.1.0.tgz oci://zot.thesteamedcrab.com/charts-mirror` returns 401
- [ ] Auth push works: `helm registry login -u zot-admin -p '<pw>' zot.thesteamedcrab.com` then push succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)