### PR TITLE
feat(mcp-system): add chrome-mcp (Playwright MCP behind lovenet-gateway)

### DIFF
--- a/kubernetes/apps/mcp-system/chrome-mcp/app/cnp-allow.yaml
+++ b/kubernetes/apps/mcp-system/chrome-mcp/app/cnp-allow.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: chrome-mcp-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: chrome-mcp
+  # Additive — default-deny is what triggers the lockdown.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  egress:
+    # Chromium browses public-facing apps (immich.${SECRET_DOMAIN} etc.)
+    # via the Cloudflared tunnel — the realistic user-side path, not
+    # a curl-pod shortcut.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/mcp-system/chrome-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/chrome-mcp/app/helmrelease.yaml
@@ -1,0 +1,96 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: chrome-mcp
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 1h
+  values:
+    defaultPodOptions:
+      securityContext:
+        # Image runs as `node` user (UID 1000) per its baked-in USER directive.
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+    controllers:
+      chrome-mcp:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        pod:
+          annotations:
+            sidecar.istio.io/inject: "true"
+        containers:
+          app:
+            image:
+              repository: mcr.microsoft.com/playwright/mcp
+              tag: v0.0.75@sha256:d238ec7bc98cc4e22df0696d6031dad5b8a4b46781f4f0abaa3bfadeedb43b9a
+            # Image entrypoint is:
+            #   node /app/cli.js --headless --browser chromium --no-sandbox
+            # We append HTTP transport flags. --no-sandbox is acceptable
+            # because the gateway gates all callers via Authelia JWT.
+            args:
+              - --port=8931
+              - --host=0.0.0.0
+              - --isolated
+            resources:
+              requests:
+                cpu: 100m
+                memory: 512Mi
+              limits:
+                memory: 2Gi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - ALL
+              readOnlyRootFilesystem: true
+              seccompProfile:
+                type: RuntimeDefault
+    persistence:
+      # Chromium scratch space and Playwright cache directories. --isolated
+      # keeps the browser profile in memory, but the runtime still touches
+      # /tmp and the user's home dir.
+      tmp:
+        type: emptyDir
+        advancedMounts:
+          chrome-mcp:
+            app:
+              - path: /tmp
+                subPath: tmp
+              - path: /home/node
+                subPath: home
+      # Chromium uses /dev/shm heavily for IPC; default 64Mi is too small.
+      dev-shm:
+        type: emptyDir
+        medium: Memory
+        sizeLimit: 1Gi
+        globalMounts:
+          - path: /dev/shm
+    service:
+      app:
+        controller: chrome-mcp
+        ports:
+          http:
+            port: 8931
+    route:
+      app:
+        hostnames:
+          - "chrome-mcp.mcp.local"
+        parentRefs:
+          - name: mcp-gateway
+            namespace: mcp-system
+            sectionName: mcps
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /mcp
+            backendRefs:
+              - identifier: app
+                port: 8931

--- a/kubernetes/apps/mcp-system/chrome-mcp/app/kustomization.yaml
+++ b/kubernetes/apps/mcp-system/chrome-mcp/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../components/repos/app-template
+resources:
+  - ./helmrelease.yaml
+  - ./cnp-allow.yaml

--- a/kubernetes/apps/mcp-system/chrome-mcp/ks.yaml
+++ b/kubernetes/apps/mcp-system/chrome-mcp/ks.yaml
@@ -1,0 +1,48 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app chrome-mcp
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: mcp-system
+  path: ./kubernetes/apps/mcp-system/chrome-mcp/app
+  interval: 1h
+  timeout: 5m
+  prune: true
+  wait: false
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: mcp-gateway
+      namespace: mcp-system
+  retryInterval: 2m
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app chrome-mcp-mcpserverregistration
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: mcp-system
+  path: ./kubernetes/apps/mcp-system/chrome-mcp/mcp
+  interval: 1h
+  timeout: 5m
+  prune: true
+  wait: false
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: chrome-mcp
+      namespace: mcp-system
+  retryInterval: 2m

--- a/kubernetes/apps/mcp-system/chrome-mcp/mcp/kustomization.yaml
+++ b/kubernetes/apps/mcp-system/chrome-mcp/mcp/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./mcpserverregistration.yaml

--- a/kubernetes/apps/mcp-system/chrome-mcp/mcp/mcpserverregistration.yaml
+++ b/kubernetes/apps/mcp-system/chrome-mcp/mcp/mcpserverregistration.yaml
@@ -1,0 +1,14 @@
+---
+# TODO: apply schema
+apiVersion: mcp.kuadrant.io/v1alpha1
+kind: MCPServerRegistration
+metadata:
+  name: chrome-tools
+  labels:
+    mcp.kuadrant.io/managed: "true"
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: chrome-mcp
+  toolPrefix: chrome_

--- a/kubernetes/apps/mcp-system/kustomization.yaml
+++ b/kubernetes/apps/mcp-system/kustomization.yaml
@@ -14,6 +14,7 @@ components:
 resources:
   - ./namespace.yaml
   - ./arr-mcp/ks.yaml
+  - ./chrome-mcp/ks.yaml
   - ./github-mcp/ks.yaml
   - ./grafana-mcp/ks.yaml
   - ./ha-mcp/ks.yaml


### PR DESCRIPTION
## Summary

- Adds `chrome-mcp` to `mcp-system` — an agent-driveable browser via `mcr.microsoft.com/playwright/mcp`, registered behind the existing JWT-authed mcp-gateway.
- Chose Playwright over `ChromeDevTools/chrome-devtools-mcp` because the latter is stdio-only and upstream rejected HTTP transport (PR #459) until multi-session lands — would have re-introduced the stdio→SHTTP bridge pattern `time-mcp` was rebuilt to escape.
- Tradeoff: no Lighthouse / Core Web Vitals (revisit if it becomes load-bearing). Covers smoke tests, OIDC E2E, network-tab debugging, dashboard checks, screenshots.

## Implementation notes

- Image: `mcr.microsoft.com/playwright/mcp:v0.0.75@sha256:d238ec7b…`. Entrypoint already runs `--headless --browser chromium --no-sandbox`; HelmRelease only adds `--port=8931 --host=0.0.0.0 --isolated`.
- `--no-sandbox` is acceptable because the gateway gates every caller via Authelia JWT (trusted-caller context).
- `--isolated` = ephemeral profile per session; no persistent cookies, clean state every navigation.
- `/dev/shm` tmpfs sized to 1Gi (Chromium IPC); `/tmp` + `/home/node` emptyDir mounts to satisfy read-only rootfs.
- Egress CNP allows `world:443` only — Cloudflared tunnel is the realistic user-side path.
- Tool prefix `chrome_` (avoids `browser_browser_*` double-prefix collision; telegraphs intent regardless of Playwright being the implementation).
- `mcr.microsoft.com` not yet in ZOT pull-through sync — direct pulls for now (follow-up).

## Test plan

- [ ] Flux reconciles `chrome-mcp` HelmRelease + MCPServerRegistration cleanly
- [ ] Pod Ready, no Chromium crash loop, no `/dev/shm` exhaustion in logs
- [ ] `kubectl -n mcp-system get mcpserverregistration chrome-tools` shows READY
- [ ] JWT + `tools/list` against `mcp.${SECRET_DOMAIN}` returns `chrome_browser_*` tools
- [ ] `chrome_browser_navigate https://auth.${SECRET_DOMAIN}` → `chrome_browser_snapshot` returns the Authelia login accessibility tree
- [ ] `kubectl top pod` after 2–3 navigations stays under 2Gi limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)