### PR TITLE
fix(databases/postgres-windmill): codify migration unblockers

### DIFF
--- a/kubernetes/apps/databases/cloudnative-pg/config/windmill/cluster.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/windmill/cluster.yaml
@@ -44,6 +44,29 @@ spec:
     initdb:
       database: windmill
       owner: windmill
+      # Windmill's migration 20221211192539 grants USAGE on the schema to
+      # windmill_admin + windmill_user (NOLOGIN roles it expects to exist).
+      # Without these, migrations fail mid-run and the app crash-loops.
+      postInitApplicationSQL:
+        - CREATE ROLE windmill_admin WITH NOLOGIN
+        - CREATE ROLE windmill_user WITH NOLOGIN
+        - GRANT windmill_admin TO windmill
+        - GRANT windmill_user TO windmill
+        - GRANT ALL ON SCHEMA public TO windmill_admin
+        - GRANT ALL ON SCHEMA public TO windmill_user
+
+  # CNPG generates the `postgres-windmill-app` Secret with the connection
+  # URI in this namespace. The Windmill HR consumes it cross-namespace
+  # via emberstack reflector — these annotations are propagated to the
+  # generated Secret via inheritedMetadata so a future cluster rebuild
+  # automatically re-establishes the mirror.
+  # Pattern: project_cnpg_cross_namespace_reflector.
+  inheritedMetadata:
+    annotations:
+      reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: home
+      reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: home
 
   monitoring:
     enablePodMonitor: true


### PR DESCRIPTION
## Summary

- Codifies two manual one-time fixes applied during Phase 1a Windmill deploy so future cluster rebuilds reproduce them.
- 1: `postInitApplicationSQL` creates the \`windmill_admin\` + \`windmill_user\` NOLOGIN roles that Windmill's first migration expects.
- 2: \`inheritedMetadata.annotations\` propagates emberstack reflector annotations to the \`postgres-windmill-app\` Secret so the home ns HR can consume it.

Without (1) the Windmill app crash-loops on first run. Without (2) the chart fails with \`secret "postgres-windmill-app" not found\` since CNPG only creates that Secret in the databases ns by default.

## Test plan

- [x] Verified live: roles created via \`kubectl exec ... psql -c "CREATE ROLE ..."\`; reflector annotations applied via \`kubectl annotate\`; Windmill app + workers Running 5/5; UI returns 200.
- [ ] For a clean repro on future rebuild: delete \`postgres-windmill\` cluster + the home ns secret + windmill pods, then reconcile — pods should come up green without manual intervention.