### PR TITLE
fix(home/windmill): remove non-functional bootstrap-admin envs

### DIFF
--- a/kubernetes/apps/home/windmill/README.md
+++ b/kubernetes/apps/home/windmill/README.md
@@ -6,19 +6,54 @@ FOSS workflow automation tool, replacing n8n. See the migration plan in
 
 ## Activation (Phase 1a — no SSO yet)
 
-This is the initial deploy with Windmill's native admin auth. Authelia
-OIDC SSO via oauth2-proxy is deferred to Phase 1b (separate PR) to
-avoid editing the cluster's 24-OIDC-client Authelia config under
-autonomy.
+Initial deploy uses Windmill's native admin auth. Authelia OIDC SSO via
+oauth2-proxy is deferred to Phase 1b (separate PR) to avoid editing
+the cluster's 24-OIDC-client Authelia config under autonomy.
+
+### Bootstrap admin
+
+Windmill's binary hard-codes the initial admin at:
+
+- **email**: `admin@windmill.dev` (NOT `admin@windmill.local` — chart
+  has no admin-email override)
+- **password**: `changeme` (default)
+
+The chart does NOT expose `WM_USER_*` env vars. Setting them via
+`extraEnv` is silently ignored. The official Windmill bootstrap flow
+is: deploy → log in as `admin@windmill.dev` / `changeme` → rotate
+password via UI or API.
+
+### Post-deploy: rotate the bootstrap password
+
+The default `changeme` is exposed on the LAN until rotated. The
+`windmill` 1P item (vault `Kubernetes`) stores the rotated password
+in field `admin_password`. To rotate (or re-rotate after a cluster
+rebuild):
+
+```sh
+ADMIN_PW=$(op item get "windmill" --vault Kubernetes --reveal \
+  --format json | jq -r '.fields[] | select(.label=="admin_password") | .value')
+
+TOKEN=$(curl -sk -X POST https://windmill.${SECRET_DOMAIN}/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email": "admin@windmill.dev", "password": "changeme"}')
+
+curl -sk -X POST https://windmill.${SECRET_DOMAIN}/api/users/setpassword \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{\"password\": \"$ADMIN_PW\"}"
+```
 
 ### 1P item `windmill` (vault `Kubernetes`) — required fields
 
 | Field | What |
 |---|---|
-| `admin_password` | Initial admin password for `WM_USER_USERNAME=admin`. Generate with `openssl rand -base64 32` and store. |
-| `encryption_key` | Reserved for future Windmill-side cookie/JWT encryption — not currently consumed by this manifest. Generate with `openssl rand -hex 32` and store. |
+| `admin_password` | Rotated admin password (replaces `changeme`). Generate with `openssl rand -base64 32` and store. |
+| `encryption_key` | Reserved for future Windmill-side cookie/JWT encryption — not currently consumed. Generate with `openssl rand -hex 32`. |
+| `GARAGE_AWS_ACCESS_KEY_ID` | Garage S3 access key for Barman/Postgres backups. From `garage key info windmill-key`. |
+| `GARAGE_AWS_SECRET_ACCESS_KEY` | Matching secret. |
 
-Creation recipe:
+Creation recipe (initial deploy):
 
 ```sh
 ADMIN_PW=$(openssl rand -base64 32)
@@ -29,16 +64,25 @@ op item create \
     --title "windmill" \
     "admin_password[password]=${ADMIN_PW}" \
     "encryption_key[password]=${ENC_KEY}"
+# Then provision Garage key/bucket per
+# project_garage_cnpg_provisioning_playbook and edit the item to add
+# the GARAGE_* fields.
 ```
 
 ### Database
 
-A 3-instance CNPG cluster `postgres-windmill` is provisioned in the
-`databases` namespace via the cnpg-app-database component. Connection
-parameters land in the `postgres-windmill-app` Secret (created by CNPG)
-with a ready-to-use `uri` field. The Windmill HR's
-`windmill.databaseUrlSecretName` + `databaseUrlSecretKey` point at that
-secret + the `uri` field.
+A 3-instance CNPG cluster `postgres-windmill` lives in the `databases`
+namespace via the `cnpg-app-database` component.
+
+Two cluster-specific quirks (codified — survive rebuild):
+
+- **`postInitApplicationSQL`** in `bootstrap.initdb` creates the
+  `windmill_admin` + `windmill_user` NOLOGIN roles Windmill's first
+  migration expects. Without them the app crash-loops with
+  `role "windmill_admin" does not exist`.
+- **`inheritedMetadata.annotations`** propagates emberstack reflector
+  annotations to the `postgres-windmill-app` Secret so the Windmill
+  HR (in `home` ns) can consume the DB URI cross-namespace.
 
 ### Verify
 
@@ -46,13 +90,12 @@ After Flux reconciles:
 
 ```sh
 kubectl -n databases get cluster postgres-windmill
-kubectl -n home get pod -l app.kubernetes.io/name=windmill -o wide
+kubectl -n home get pod -l release=windmill -o wide
 kubectl -n home get httproute windmill -o yaml | grep -i hostname
 curl -k https://windmill.${SECRET_DOMAIN}  # → 200 + Windmill UI
 ```
 
-Log in via the UI with `admin@windmill.local` + the password from the
-1P item.
+First image pull is **~5 minutes** — the image is 4 GiB.
 
 ## Phase 1b — Authelia SSO via oauth2-proxy (future)
 
@@ -67,5 +110,11 @@ HTTPRoute at the oauth2-proxy Service instead of `windmill-app:8000`.
 
 Per the migration plan. Workflows checked into git under
 `./workflows/<name>.yaml` (Windmill flow format). Tools to use:
-`windmill sync` CLI from inside the pod, or the Windmill UI's "Save +
-Deploy" + git-sync feature.
+`wmill sync` CLI from inside the pod, or the Windmill UI's "Save +
+Deploy" + workspace git-sync feature.
+
+Workspace `lovenet` already created via API for this purpose.
+
+Source-of-truth n8n workflows (to be migrated) live at
+`../n8n/workflows/*.json`. After cutover, that directory + the n8n
+namespace go away (Phase 3).

--- a/kubernetes/apps/home/windmill/app/helmrelease.yaml
+++ b/kubernetes/apps/home/windmill/app/helmrelease.yaml
@@ -78,19 +78,13 @@ spec:
         # Forward the actual client IP via the headers Envoy sets.
         enabled: true
 
-      # Bootstrap admin credentials (Windmill's first-run setup expects
-      # to either land at /user/setup or accept these from env).
-      # Reference the ExternalSecret-materialized windmill-secret.
-      extraEnv:
-        - name: WM_USER_USERNAME
-          value: admin
-        - name: WM_USER_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: windmill-secret
-              key: admin_password
-        - name: WM_USER_EMAIL
-          value: admin@windmill.local
+      # NOTE: Windmill's bootstrap admin is hardcoded by the binary to
+      # `admin@windmill.dev` with default password `changeme`. The
+      # chart does NOT expose an admin-password override (the
+      # `windmill.extraEnv` block has no analog in the chart). Operators
+      # must rotate the password immediately after first deploy via:
+      #   curl -X POST https://windmill.${SECRET_DOMAIN}/api/users/setpassword
+      # See ../README.md for the full bootstrap recipe.
 
     indexer:
       enabled: true


### PR DESCRIPTION
## Summary

- The \`windmill.extraEnv\` block from PR #11661 is silently ignored by the chart (chart only accepts \`app.extraEnv\` / \`workerGroups[].extraEnv\` / \`lsp.extraEnv\` — no \`windmill.extraEnv\` key exists).
- Worse: the chart has no admin-password override. Windmill's binary hardcodes the initial admin to \`admin@windmill.dev\` / \`changeme\` regardless of env vars.
- README updated with the documented rotation flow (\`POST /api/users/setpassword\`) plus the 1P item shape including the GARAGE_* fields actually used.

Verified live: password rotated 2026-05-19 via the documented API call; \`changeme\` no longer accepted.

## Test plan

- [x] Helm template renders cleanly without the dead block
- [x] Live test: rotation API call works against the running deploy
- [ ] Next deploy (cluster rebuild) should reproduce the flow without manual intervention beyond the documented rotation step