### PR TITLE
fix(home/windmill): cover lsp pods (chart label inconsistency)

### DIFF
--- a/kubernetes/apps/home/windmill/app/cnp-allow.yaml
+++ b/kubernetes/apps/home/windmill/app/cnp-allow.yaml
@@ -5,13 +5,18 @@ kind: CiliumNetworkPolicy
 metadata:
   name: windmill-allow
 spec:
-  # The official Windmill chart labels pods with release=windmill plus
-  # per-component app=<windmill-app|windmill-lsp|windmill-workers>. We
-  # select all four with `release=windmill` so this single policy
-  # covers app + workers + lsp + indexer.
+  # The chart labels are inconsistent: app + workers carry
+  # `release=windmill`, but `windmill-lsp` does NOT. Cover all three
+  # via matchExpressions across the chart-set
+  # `app.kubernetes.io/name` field.
   endpointSelector:
-    matchLabels:
-      release: windmill
+    matchExpressions:
+      - key: app.kubernetes.io/name
+        operator: In
+        values:
+          - windmill-app
+          - windmill-lsp
+          - windmill-workers
   enableDefaultDeny:
     egress: false
     ingress: false
@@ -44,8 +49,13 @@ spec:
               protocol: TCP
     # windmill-app → windmill-lsp:3001 (in-browser code-completion LSP).
     - fromEndpoints:
-        - matchLabels:
-            release: windmill
+        - matchExpressions:
+            - key: app.kubernetes.io/name
+              operator: In
+              values:
+                - windmill-app
+                - windmill-lsp
+                - windmill-workers
       toPorts:
         - ports:
             - port: "3001"
@@ -74,8 +84,13 @@ spec:
     # Workers → app (job pickup is via Postgres but workers also call
     # /api/* on the app server for token refresh, log shipping, etc).
     - toEndpoints:
-        - matchLabels:
-            release: windmill
+        - matchExpressions:
+            - key: app.kubernetes.io/name
+              operator: In
+              values:
+                - windmill-app
+                - windmill-lsp
+                - windmill-workers
       toPorts:
         - ports:
             - port: "8000"


### PR DESCRIPTION
## Summary

- Chart labels windmill-lsp pods without \`release=windmill\` (app + workers have it; lsp does not).
- PR #11662's selector left LSPs uncovered under home ns default-deny → in-browser code completion broken.
- Switch to matchExpressions \`app.kubernetes.io/name In [windmill-app, windmill-lsp, windmill-workers]\` which all three pod families set consistently.

## Test plan

- [x] Confirmed labels via \`kubectl get pod -o jsonpath='{.metadata.labels}'\` — only LSP missing release label.
- [ ] After merge: code completion in the Windmill UI works (typing in a TS script suggests completions).