### PR TITLE
fix(mcp-system/chrome-mcp): set --allowed-hosts=* so broker can connect

### DIFF
--- a/kubernetes/apps/mcp-system/chrome-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/chrome-mcp/app/helmrelease.yaml
@@ -34,10 +34,15 @@ spec:
             #   node /app/cli.js --headless --browser chromium --no-sandbox
             # We append HTTP transport flags. --no-sandbox is acceptable
             # because the gateway gates all callers via Authelia JWT.
+            # --allowed-hosts=* disables Playwright MCP's built-in DNS
+            # rebinding protection; safe here because (a) the CNP blocks
+            # ingress from outside the cluster and (b) the mcp-gateway
+            # gates every caller via JWT before traffic reaches us.
             args:
               - --port=8931
               - --host=0.0.0.0
               - --isolated
+              - --allowed-hosts=*
             resources:
               requests:
                 cpu: 100m


### PR DESCRIPTION
## Summary

Follow-up to #11665. Playwright MCP enforces a Host-header allowlist independent of the bind interface; with the default, every request whose `Host` isn't `localhost:8931` gets a 403 — including the in-cluster broker. `chrome-tools` registration was `Ready=False: failed to connect to upstream mcp` because of this.

Setting `--allowed-hosts=*` disables the check. Safe here because:
- CNP blocks external ingress to the chrome-mcp pod
- `mcp-gateway` already authenticates every caller via Authelia JWT before traffic ever reaches this backend

## Repro

```
$ curl -s -X POST http://chrome-mcp.mcp-system.svc.cluster.local:8931/mcp \
    -H 'Content-Type: application/json' \
    -H 'Accept: application/json, text/event-stream' \
    -d '{"jsonrpc":"2.0","id":1,"method":"initialize",...}'
Access is only allowed at localhost:8931
```

## Test plan

- [ ] Flux reconciles, chrome-mcp pod restarts with new args
- [ ] `kubectl -n mcp-system get mcpserverregistration chrome-tools` shows Ready=True
- [ ] Broker log: `totalServers=14 healthyServers=N+1 unhealthyServers=...`
- [ ] `tools/list` against `mcp.\${SECRET_DOMAIN}` includes `chrome_browser_*` tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)