### PR TITLE
feat(home/windmill): author 7 workflow scripts + secret injection (Phase 2A)

### DIFF
--- a/kubernetes/apps/home/windmill/app/externalsecret-workflows.yaml
+++ b/kubernetes/apps/home/windmill/app/externalsecret-workflows.yaml
@@ -1,0 +1,35 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: windmill-workflows
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: windmill-workflows-secret
+    creationPolicy: Owner
+    template:
+      data:
+        # HMAC key for signing approval tokens sent to langgraph-agents.
+        # Single source of truth: the langgraph-agents 1P item.
+        LANGGRAPH_APPROVAL_SIGNING_KEY: "{{ .LANGGRAPH_APPROVAL_SIGNING_KEY }}"
+        # Pushover creds — used by 5 of the 7 flows.
+        PUSHOVER_APP_TOKEN: "{{ .PUSHOVER_APP_TOKEN }}"
+        PUSHOVER_USER_KEY: "{{ .PUSHOVER_USER_KEY }}"
+        # Zulip bot creds — used by approval-post, approval-receive
+        # (for the user_id check), inbox (pause forwarding), and
+        # daily-digest.
+        ZULIP_BOT_EMAIL: "{{ .ZULIP_BOT_EMAIL }}"
+        ZULIP_BOT_API_KEY: "{{ .ZULIP_BOT_API_KEY }}"
+        ROB_ZULIP_USER_ID: "{{ .ROB_ZULIP_USER_ID }}"
+  dataFrom:
+    # LANGGRAPH_APPROVAL_SIGNING_KEY + PUSHOVER_*
+    - extract:
+        key: langgraph-agents
+    # ZULIP_BOT_* + ROB_ZULIP_USER_ID
+    - extract:
+        key: zulip-n8n-bot

--- a/kubernetes/apps/home/windmill/app/helmrelease.yaml
+++ b/kubernetes/apps/home/windmill/app/helmrelease.yaml
@@ -55,6 +55,40 @@ spec:
               memory: 256Mi
             limits:
               memory: 1Gi
+          # Workflow secrets — single 1P source materialized by the
+          # windmill-workflows ExternalSecret. Scripts read via
+          # Deno.env.get("…").
+          extraEnv: &workflow_secrets
+            - name: LANGGRAPH_APPROVAL_SIGNING_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: windmill-workflows-secret
+                  key: LANGGRAPH_APPROVAL_SIGNING_KEY
+            - name: PUSHOVER_APP_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: windmill-workflows-secret
+                  key: PUSHOVER_APP_TOKEN
+            - name: PUSHOVER_USER_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: windmill-workflows-secret
+                  key: PUSHOVER_USER_KEY
+            - name: ZULIP_BOT_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  name: windmill-workflows-secret
+                  key: ZULIP_BOT_EMAIL
+            - name: ZULIP_BOT_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: windmill-workflows-secret
+                  key: ZULIP_BOT_API_KEY
+            - name: ROB_ZULIP_USER_ID
+              valueFrom:
+                secretKeyRef:
+                  name: windmill-workflows-secret
+                  key: ROB_ZULIP_USER_ID
         # Native worker — runs Bash/PowerShell/etc. without nsjail.
         - name: native
           replicas: 1
@@ -64,6 +98,13 @@ spec:
               memory: 128Mi
             limits:
               memory: 512Mi
+          extraEnv: *workflow_secrets
+
+      # app pod — also receives workflow secrets so scripts triggered
+      # via `/api/w/.../run_wait_result` from inside the app pod see
+      # the same env (Windmill execs scripts inline for short flows).
+      app:
+        extraEnv: *workflow_secrets
 
       # App pod resources.
       resources:

--- a/kubernetes/apps/home/windmill/app/kustomization.yaml
+++ b/kubernetes/apps/home/windmill/app/kustomization.yaml
@@ -7,5 +7,6 @@ components:
 resources:
   - ./cnp-allow.yaml
   - ./externalsecret.yaml
+  - ./externalsecret-workflows.yaml
   - ./helmrelease.yaml
   - ./route.yaml

--- a/kubernetes/apps/home/windmill/workflows/README.md
+++ b/kubernetes/apps/home/windmill/workflows/README.md
@@ -1,0 +1,31 @@
+# Windmill workflow source
+
+These TypeScript scripts are the source-of-truth for the 7 Windmill
+flows that replaced n8n in the `lovenet` workspace.
+
+Runtime lives in the Windmill DB; this directory is the *checked-in
+canonical text*. Push to Windmill via the API (see `tools/wmill-sync.sh`
+or the inline curl in the README two levels up).
+
+## Convention
+
+- One `.ts` file per workflow.
+- Filename matches the Windmill script path basename — e.g.
+  `langgraph-cost-cap-watcher.ts` → `f/lovenet/langgraph-cost-cap-watcher`.
+- Each file is self-contained: no shared modules. Windmill's "trigger
+  the script via webhook" model expects each script to be standalone.
+- Secrets are read from environment variables that the worker pod
+  has via `secretKeyRef` → `windmill-workflows-secret` (k8s Secret
+  materialized by ExternalSecret from 1P). Do not embed secrets
+  inline.
+
+## Secrets the workers consume (via env)
+
+| env | source 1P item / field |
+|---|---|
+| `LANGGRAPH_APPROVAL_SIGNING_KEY` | `langgraph-agents.LANGGRAPH_APPROVAL_SIGNING_KEY` |
+| `PUSHOVER_USER_KEY` | `langgraph-agents.PUSHOVER_USER_KEY` |
+| `PUSHOVER_APP_TOKEN` | `langgraph-agents.PUSHOVER_APP_TOKEN` |
+| `ZULIP_BOT_EMAIL` | `zulip-n8n-bot.ZULIP_BOT_EMAIL` |
+| `ZULIP_BOT_API_KEY` | `zulip-n8n-bot.ZULIP_BOT_API_KEY` |
+| `ROB_ZULIP_USER_ID` | `zulip-n8n-bot.ROB_ZULIP_USER_ID` |

--- a/kubernetes/apps/home/windmill/workflows/alertmanager-holmesgpt-pushover.ts
+++ b/kubernetes/apps/home/windmill/workflows/alertmanager-holmesgpt-pushover.ts
@@ -1,0 +1,100 @@
+// Triggered by Alertmanager webhook receiver.
+//
+// Receives a critical alert, asks HolmesGPT to investigate (≤2 tool
+// calls, <500 chars), then forwards the summary to Pushover.
+//
+// Replaces the n8n flow "AlertManager → HolmesGPT → Pushover".
+
+type AlertmanagerPayload = {
+    alerts: Array<{
+        labels: { alertname: string; severity?: string; namespace?: string; pod?: string };
+        annotations: { summary?: string; description?: string };
+    }>;
+};
+
+export async function main(body: AlertmanagerPayload) {
+    const a = body.alerts?.[0];
+    if (!a) {
+        return { skip: true, reason: "no alerts in payload" };
+    }
+
+    const ask = [
+        "IMPORTANT: Be concise. Investigate this alert in <=2 tool calls",
+        "(kubectl_get_events on the namespace plus one other). Then answer",
+        "in <500 chars total: 1 sentence root cause + 1 sentence remediation.",
+        "Do not iterate further.",
+        "",
+        `Alert: ${a.labels.alertname}`,
+        `Severity: ${a.labels.severity ?? "unknown"}`,
+        `Namespace: ${a.labels.namespace ?? "unknown"}`,
+        `Pod: ${a.labels.pod ?? "n/a"}`,
+        `Summary: ${a.annotations.summary ?? "(none)"}`,
+        `Description: ${a.annotations.description ?? "(none)"}`,
+    ].join("\n");
+
+    // HolmesGPT REST: POST /api/chat
+    const hg = await fetch(
+        "http://holmesgpt.observability.svc.cluster.local:8080/api/chat",
+        {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ ask }),
+            signal: AbortSignal.timeout(600_000),
+        },
+    );
+    const data = await hg.json().catch(() => ({}));
+    const raw = String(data.analysis ?? data.response ?? "").trim();
+
+    let message: string;
+    if (!raw) {
+        message = "⚠️ HolmesGPT returned no analysis. Check the Windmill execution.";
+    } else if (
+        /^[:\s]*\{/.test(raw) &&
+        /"(suggested_prefixes|tool_call_id|function)"\s*:/.test(raw.slice(0, 200))
+    ) {
+        message = `⚠️ HolmesGPT model returned a tool-call instead of a summary.`;
+    } else if (raw.length <= 1000) {
+        message = raw;
+    } else {
+        const cut = raw.slice(0, 997);
+        const m = cut.match(/^[\s\S]*[.!?\n](?=[^.!?\n]*$)/);
+        message = ((m && m[0].length > 600) ? m[0] : cut).trimEnd() + "…";
+    }
+
+    // Pushover REST: POST /1/messages.json
+    const pushoverResp = await sendPushover({
+        title: `🔍 ${a.labels.alertname}`,
+        message,
+        priority: 0,
+        sound: "intermission",
+    });
+
+    return { alertname: a.labels.alertname, holmes_chars: raw.length, pushover: pushoverResp };
+}
+
+async function sendPushover(args: {
+    title: string;
+    message: string;
+    priority: number;
+    sound?: string;
+}) {
+    const token = Deno.env.get("PUSHOVER_APP_TOKEN");
+    const user = Deno.env.get("PUSHOVER_USER_KEY");
+    if (!token || !user) {
+        throw new Error("PUSHOVER_APP_TOKEN / PUSHOVER_USER_KEY env not set");
+    }
+    const form = new URLSearchParams({
+        token,
+        user,
+        title: args.title,
+        message: args.message,
+        priority: String(args.priority),
+    });
+    if (args.sound) form.set("sound", args.sound);
+    const r = await fetch("https://api.pushover.net/1/messages.json", {
+        method: "POST",
+        body: form,
+        signal: AbortSignal.timeout(30_000),
+    });
+    return { status: r.status };
+}

--- a/kubernetes/apps/home/windmill/workflows/langgraph-approval-post.ts
+++ b/kubernetes/apps/home/windmill/workflows/langgraph-approval-post.ts
@@ -1,0 +1,100 @@
+// Triggered by langgraph-agents when a task pauses for approval.
+//
+// Posts a formatted message into Zulip stream #approvals (so Rob can
+// react with 👍 / 👎 / ⏸️), plus a tier-1 Pushover for attention.
+//
+// Replaces the n8n flow "LangGraph → Approval post to Zulip".
+
+type ApprovalRequest = {
+    task_id: string;
+    paused_for: {
+        approval_request: {
+            proposed_by: string;
+            action_class: string;
+            target: string;
+            payload_summary: string;
+            undo_path?: string;
+            cost_estimate_usd?: number;
+        };
+    };
+};
+
+export async function main(body: ApprovalRequest) {
+    const r = body.paused_for.approval_request;
+    const topic = `${body.task_id} — Class ${r.action_class}: ${r.target}`;
+    const content = [
+        `**Task:** \`${body.task_id}\``,
+        `**Proposed by:** ${r.proposed_by}`,
+        `**Action class:** ${r.action_class}`,
+        `**Target:** \`${r.target}\``,
+        `**Summary:** ${r.payload_summary}`,
+        `**Undo path:** ${r.undo_path ?? "_(none — will escalate to Class D)_"}`,
+        `**Cost estimate:** $${r.cost_estimate_usd ?? 0}`,
+        "",
+        "React: 👍 approve / 👎 reject / ⏸️ defer 4h",
+    ].join("\n");
+
+    // Post to Zulip via REST as the n8n-bot user.
+    const email = Deno.env.get("ZULIP_BOT_EMAIL");
+    const apiKey = Deno.env.get("ZULIP_BOT_API_KEY");
+    if (!email || !apiKey) {
+        throw new Error("ZULIP_BOT_EMAIL / ZULIP_BOT_API_KEY env not set");
+    }
+    const auth = "Basic " + btoa(`${email}:${apiKey}`);
+    const zulipHost = Deno.env.get("ZULIP_HOST") ?? "chat.thesteamedcrab.com";
+    const form = new URLSearchParams({
+        type: "stream",
+        to: "approvals",
+        topic,
+        content,
+    });
+    const zr = await fetch(`https://${zulipHost}/api/v1/messages`, {
+        method: "POST",
+        headers: {
+            Authorization: auth,
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: form,
+        signal: AbortSignal.timeout(30_000),
+    });
+    const zResult = await zr.json().catch(() => ({}));
+
+    // Tier-1 Pushover.
+    const pushoverResp = await sendPushover({
+        title: `🔔 Approval needed: Class ${r.action_class}`,
+        message: `${r.target}\n${r.payload_summary}\n\nReact in Zulip: chat.${
+            Deno.env.get("ZULIP_HOST")?.replace(/^chat\./, "") ?? "thesteamedcrab.com"
+        }`,
+        priority: 1,
+        sound: "gamelan",
+    });
+
+    return { task_id: body.task_id, topic, zulip: zResult.result ?? zResult, pushover: pushoverResp };
+}
+
+async function sendPushover(args: {
+    title: string;
+    message: string;
+    priority: number;
+    sound?: string;
+}) {
+    const token = Deno.env.get("PUSHOVER_APP_TOKEN");
+    const user = Deno.env.get("PUSHOVER_USER_KEY");
+    if (!token || !user) {
+        throw new Error("PUSHOVER_APP_TOKEN / PUSHOVER_USER_KEY env not set");
+    }
+    const form = new URLSearchParams({
+        token,
+        user,
+        title: args.title,
+        message: args.message,
+        priority: String(args.priority),
+    });
+    if (args.sound) form.set("sound", args.sound);
+    const r = await fetch("https://api.pushover.net/1/messages.json", {
+        method: "POST",
+        body: form,
+        signal: AbortSignal.timeout(30_000),
+    });
+    return { status: r.status };
+}

--- a/kubernetes/apps/home/windmill/workflows/langgraph-approval-receive.ts
+++ b/kubernetes/apps/home/windmill/workflows/langgraph-approval-receive.ts
@@ -1,0 +1,80 @@
+// Triggered by Zulip outgoing-webhook on emoji reactions in #approvals.
+//
+// Verifies the reactor is Rob, maps the emoji → approve/reject/defer,
+// parses task_id from the topic, signs an HMAC-SHA256 approval token,
+// and POSTs it to langgraph-agents /approval.
+//
+// Replaces the n8n flow "LangGraph → Approval receive (Zulip reaction)".
+
+import { crypto } from "https://deno.land/std@0.224.0/crypto/mod.ts";
+
+type ZulipReactionEvent = {
+    user_id?: number;
+    emoji_name?: string;
+    topic?: string;
+    message?: { topic?: string };
+};
+
+export async function main(body: ZulipReactionEvent) {
+    const robId = parseInt(Deno.env.get("ROB_ZULIP_USER_ID") ?? "0", 10);
+    if (body.user_id !== robId) {
+        return { skip: true, reason: "reactor is not Rob", user_id: body.user_id };
+    }
+
+    const emoji = body.emoji_name ?? "";
+    let reaction: "approve" | "reject" | "defer" | undefined;
+    if (emoji === "thumbs_up" || emoji === "+1") reaction = "approve";
+    else if (emoji === "thumbs_down" || emoji === "-1") reaction = "reject";
+    else if (emoji === "pause" || emoji === "pause_button") reaction = "defer";
+    else return { skip: true, reason: "irrelevant emoji", emoji };
+
+    // Topic format: "<task_id> — Class <C/D>: <action>"
+    const topic = body.message?.topic ?? body.topic ?? "";
+    const taskMatch = topic.match(/^([\w-]+)\s/);
+    if (!taskMatch) return { skip: true, reason: "no task_id in topic", topic };
+    const task_id = taskMatch[1];
+
+    const classMatch = topic.match(/Class\s+([ABCD]):/);
+    const targetMatch = topic.match(/Class\s+[ABCD]:\s*(\S+)/);
+    if (!classMatch || !targetMatch) {
+        return { skip: true, reason: "malformed topic", topic };
+    }
+    const action_class = classMatch[1];
+    const target = targetMatch[1];
+    const [server, ...rest] = target.split(".");
+    const method = rest.join(".");
+
+    // Sign approval token.
+    const secret = Deno.env.get("LANGGRAPH_APPROVAL_SIGNING_KEY");
+    if (!secret) throw new Error("LANGGRAPH_APPROVAL_SIGNING_KEY env not set");
+
+    const nonceBytes = new Uint8Array(8);
+    crypto.getRandomValues(nonceBytes);
+    const nonce = Array.from(nonceBytes).map((b) => b.toString(16).padStart(2, "0")).join("");
+    const payload = `${task_id}|${action_class}|${server}|${method}|${nonce}`;
+    const sig = await hmacSha256Hex(secret, payload);
+    const approval_token = `${payload}:${sig}`;
+
+    // POST to langgraph-agents.
+    const r = await fetch("http://langgraph-agents.ai.svc.cluster.local:8765/approval", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ task_id, reaction, approval_token, actor: "rob" }),
+        signal: AbortSignal.timeout(300_000),
+    });
+    const lgResult = await r.json().catch(() => ({}));
+    return { status: lgResult.status ?? "completed", task_id, reaction };
+}
+
+async function hmacSha256Hex(secret: string, msg: string): Promise<string> {
+    const enc = new TextEncoder();
+    const key = await crypto.subtle.importKey(
+        "raw",
+        enc.encode(secret),
+        { name: "HMAC", hash: "SHA-256" },
+        false,
+        ["sign"],
+    );
+    const sig = await crypto.subtle.sign("HMAC", key, enc.encode(msg));
+    return Array.from(new Uint8Array(sig)).map((b) => b.toString(16).padStart(2, "0")).join("");
+}

--- a/kubernetes/apps/home/windmill/workflows/langgraph-awaiting-user-sweep.ts
+++ b/kubernetes/apps/home/windmill/workflows/langgraph-awaiting-user-sweep.ts
@@ -1,0 +1,117 @@
+// Cron: every 5 minutes.
+//
+// Buckets interrupted (paused-for-user) tasks by age and acts:
+//   30 min  → tier-1 Pushover escalation
+//   4 hr    → POST /admin/tasks/<id>/timeout-tier {tier: "4h"} (mark cold)
+//   7 day   → POST /admin/tasks/<id>/cancel (auto-cancel)
+//
+// Replaces the n8n flow "LangGraph → Awaiting-user sweep".
+
+type Task = {
+    task_id: string;
+    interrupts?: unknown[];
+    awaiting_user_since?: string | null;
+    target_agent?: string;
+};
+
+const MIN_30 = 30 * 60 * 1000;
+const HR_4 = 4 * 60 * 60 * 1000;
+const DAY_7 = 7 * 24 * 60 * 60 * 1000;
+
+export async function main() {
+    const r = await fetch(
+        "http://langgraph-agents.ai.svc.cluster.local:8765/admin/tasks",
+        { signal: AbortSignal.timeout(30_000) },
+    );
+    if (!r.ok) {
+        return { skip: true, reason: `GET /admin/tasks → ${r.status}` };
+    }
+    const tasks: Task[] = (await r.json().catch(() => [])) as Task[];
+    const paused = (Array.isArray(tasks) ? tasks : []).filter(
+        (t) => t.interrupts && t.interrupts.length > 0,
+    );
+
+    const now = Date.now();
+    const results: Array<{ task_id: string; tier: string; action: string; ok: boolean }> = [];
+    for (const t of paused) {
+        const since = t.awaiting_user_since ? new Date(t.awaiting_user_since).getTime() : null;
+        if (!since) continue;
+        const age = now - since;
+        let tier: "30min" | "4h" | "7d" | null = null;
+        if (age > DAY_7) tier = "7d";
+        else if (age > HR_4) tier = "4h";
+        else if (age > MIN_30) tier = "30min";
+        if (!tier) continue;
+        const out = await handle(t, tier, age);
+        results.push({ task_id: t.task_id, tier, ...out });
+    }
+    return { paused_count: paused.length, acted_on: results };
+}
+
+async function handle(t: Task, tier: "30min" | "4h" | "7d", age: number) {
+    if (tier === "30min") {
+        const ok = await sendPushover({
+            title: `⏰ Task awaiting you (30m): ${t.task_id}`,
+            message: `Agent ${t.target_agent ?? "unknown"} is paused, age ${
+                Math.round(age / 60000)
+            }m. Reply in Zulip #approvals.`,
+            priority: 1,
+            sound: "gamelan",
+        });
+        return { action: "pushover", ok };
+    }
+    if (tier === "4h") {
+        const r = await fetch(
+            `http://langgraph-agents.ai.svc.cluster.local:8765/admin/tasks/${
+                encodeURIComponent(t.task_id)
+            }/timeout-tier`,
+            {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ tier: "4h" }),
+                signal: AbortSignal.timeout(30_000),
+            },
+        );
+        return { action: "mark-cold", ok: r.ok };
+    }
+    // 7d → cancel
+    const r = await fetch(
+        `http://langgraph-agents.ai.svc.cluster.local:8765/admin/tasks/${
+            encodeURIComponent(t.task_id)
+        }/cancel`,
+        {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ reason: "7-day timeout; auto-cancelled by awaiting-user sweep" }),
+            signal: AbortSignal.timeout(30_000),
+        },
+    );
+    return { action: "cancel", ok: r.ok };
+}
+
+async function sendPushover(args: {
+    title: string;
+    message: string;
+    priority: number;
+    sound?: string;
+}): Promise<boolean> {
+    const token = Deno.env.get("PUSHOVER_APP_TOKEN");
+    const user = Deno.env.get("PUSHOVER_USER_KEY");
+    if (!token || !user) {
+        throw new Error("PUSHOVER_APP_TOKEN / PUSHOVER_USER_KEY env not set");
+    }
+    const form = new URLSearchParams({
+        token,
+        user,
+        title: args.title,
+        message: args.message,
+        priority: String(args.priority),
+    });
+    if (args.sound) form.set("sound", args.sound);
+    const r = await fetch("https://api.pushover.net/1/messages.json", {
+        method: "POST",
+        body: form,
+        signal: AbortSignal.timeout(30_000),
+    });
+    return r.ok;
+}

--- a/kubernetes/apps/home/windmill/workflows/langgraph-cost-cap-watcher.ts
+++ b/kubernetes/apps/home/windmill/workflows/langgraph-cost-cap-watcher.ts
@@ -1,0 +1,77 @@
+// Cron: every 4 hours.
+//
+// Polls /admin/costs/today on langgraph-agents and Pushovers if we're
+// approaching (≥80%) or have crossed (≥100%) the daily cap.
+//
+// Endpoint may 404 until Langfuse phase is online — we degrade
+// gracefully.
+//
+// Replaces the n8n flow "LangGraph → Cost cap watcher".
+
+type CostsResponse = {
+    spent_usd?: number;
+    daily_cap_usd?: number;
+    per_agent?: Record<string, number>;
+};
+
+export async function main() {
+    const r = await fetch(
+        "http://langgraph-agents.ai.svc.cluster.local:8765/admin/costs/today",
+        { signal: AbortSignal.timeout(30_000) },
+    );
+    if (!r.ok) {
+        return { skip: true, reason: `endpoint returned ${r.status}` };
+    }
+    const body: CostsResponse = (await r.json().catch(() => ({}))) as CostsResponse;
+    const spent = Number(body.spent_usd ?? 0);
+    const cap = Number(body.daily_cap_usd ?? 30);
+    const pct = cap > 0 ? Math.round((spent / cap) * 100) : 0;
+
+    if (pct >= 100) {
+        await sendPushover({
+            title: `💥 Daily cost cap HIT ($${spent} / $${cap})`,
+            message:
+                "langgraph-agents will refuse Claude-API-eligible specialists for the rest of the day.",
+            priority: 1,
+            sound: "siren",
+        });
+        return { tier: "hit", spent, cap, pct };
+    }
+    if (pct >= 80) {
+        await sendPushover({
+            title: `⚠️ Daily cost cap 80%+ ($${spent} / $${cap})`,
+            message: "Approaching the daily limit. Consider deferring non-urgent Claude-API tasks.",
+            priority: 0,
+            sound: "intermission",
+        });
+        return { tier: "warn", spent, cap, pct };
+    }
+    return { tier: "ok", spent, cap, pct };
+}
+
+async function sendPushover(args: {
+    title: string;
+    message: string;
+    priority: number;
+    sound?: string;
+}) {
+    const token = Deno.env.get("PUSHOVER_APP_TOKEN");
+    const user = Deno.env.get("PUSHOVER_USER_KEY");
+    if (!token || !user) {
+        throw new Error("PUSHOVER_APP_TOKEN / PUSHOVER_USER_KEY env not set");
+    }
+    const form = new URLSearchParams({
+        token,
+        user,
+        title: args.title,
+        message: args.message,
+        priority: String(args.priority),
+    });
+    if (args.sound) form.set("sound", args.sound);
+    const r = await fetch("https://api.pushover.net/1/messages.json", {
+        method: "POST",
+        body: form,
+        signal: AbortSignal.timeout(30_000),
+    });
+    return r.ok;
+}

--- a/kubernetes/apps/home/windmill/workflows/langgraph-daily-digest.ts
+++ b/kubernetes/apps/home/windmill/workflows/langgraph-daily-digest.ts
@@ -1,0 +1,57 @@
+// Cron: daily at 22:00 America/New_York.
+//
+// Triggers the reporter agent via POST /inbox on langgraph-agents,
+// then posts the digest summary to Zulip stream #digests.
+//
+// Replaces the n8n flow "LangGraph → Daily digest".
+
+type InboxResp = { task_id?: string; status?: string; output?: string };
+
+export async function main() {
+    const date = new Date().toISOString().slice(0, 10);
+    const task_id = `digest-${date}`;
+
+    const lgResp = await fetch(
+        "http://langgraph-agents.ai.svc.cluster.local:8765/inbox",
+        {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                task_id,
+                source: "test",
+                content: "Generate today's daily digest from the per-agent activity logs.",
+                user: "rob",
+            }),
+            signal: AbortSignal.timeout(600_000),
+        },
+    );
+    const lg: InboxResp = (await lgResp.json().catch(() => ({}))) as InboxResp;
+
+    const content = lg.output ||
+        `Daily digest task complete; see vault/reports/daily-${date}.md`;
+
+    // Post to Zulip stream #digests, topic "daily-YYYY-MM-DD".
+    const email = Deno.env.get("ZULIP_BOT_EMAIL");
+    const apiKey = Deno.env.get("ZULIP_BOT_API_KEY");
+    if (!email || !apiKey) throw new Error("ZULIP_BOT_EMAIL / ZULIP_BOT_API_KEY env not set");
+    const auth = "Basic " + btoa(`${email}:${apiKey}`);
+    const zulipHost = Deno.env.get("ZULIP_HOST") ?? "chat.thesteamedcrab.com";
+    const form = new URLSearchParams({
+        type: "stream",
+        to: "digests",
+        topic: `daily-${date}`,
+        content,
+    });
+    const zr = await fetch(`https://${zulipHost}/api/v1/messages`, {
+        method: "POST",
+        headers: {
+            Authorization: auth,
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: form,
+        signal: AbortSignal.timeout(30_000),
+    });
+    const zResult = await zr.json().catch(() => ({}));
+
+    return { task_id, langgraph_status: lg.status, zulip: zResult.result ?? zResult };
+}

--- a/kubernetes/apps/home/windmill/workflows/langgraph-inbox.ts
+++ b/kubernetes/apps/home/windmill/workflows/langgraph-inbox.ts
@@ -1,0 +1,126 @@
+// Triggered by webhook (Zulip bot or voice intake).
+//
+// Forwards the inbox payload to langgraph-agents /inbox. If the
+// agent pauses (status=paused), runs the approval-post logic
+// inline (Zulip post + tier-1 Pushover) so there's no second
+// webhook hop, unlike n8n where the flow POSTed back to its own
+// /webhook/ URL.
+//
+// Replaces the n8n flow "LangGraph → Inbox webhook".
+
+type InboxBody = {
+    task_id?: string;
+    source?: string;
+    content: string;
+    user?: string;
+};
+
+type LgResp = {
+    task_id?: string;
+    status?: string;
+    paused_for?: {
+        approval_request?: {
+            proposed_by: string;
+            action_class: string;
+            target: string;
+            payload_summary: string;
+            undo_path?: string;
+            cost_estimate_usd?: number;
+        };
+    };
+};
+
+export async function main(body: InboxBody) {
+    const task_id = body.task_id ||
+        `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+    const source = body.source ?? "voice";
+    const content = body.content;
+    const user = body.user ?? "rob";
+
+    const r = await fetch("http://langgraph-agents.ai.svc.cluster.local:8765/inbox", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ task_id, source, content, user }),
+        signal: AbortSignal.timeout(300_000),
+    });
+    const lg: LgResp = (await r.json().catch(() => ({}))) as LgResp;
+
+    let approval: unknown = null;
+    if (lg.status === "paused" && lg.paused_for?.approval_request) {
+        approval = await postApproval(task_id, lg.paused_for.approval_request);
+    }
+    return { task_id, status: lg.status ?? "unknown", approval };
+}
+
+async function postApproval(
+    task_id: string,
+    r: NonNullable<NonNullable<LgResp["paused_for"]>["approval_request"]>,
+) {
+    const topic = `${task_id} — Class ${r.action_class}: ${r.target}`;
+    const content = [
+        `**Task:** \`${task_id}\``,
+        `**Proposed by:** ${r.proposed_by}`,
+        `**Action class:** ${r.action_class}`,
+        `**Target:** \`${r.target}\``,
+        `**Summary:** ${r.payload_summary}`,
+        `**Undo path:** ${r.undo_path ?? "_(none — will escalate to Class D)_"}`,
+        `**Cost estimate:** $${r.cost_estimate_usd ?? 0}`,
+        "",
+        "React: 👍 approve / 👎 reject / ⏸️ defer 4h",
+    ].join("\n");
+
+    const email = Deno.env.get("ZULIP_BOT_EMAIL");
+    const apiKey = Deno.env.get("ZULIP_BOT_API_KEY");
+    if (!email || !apiKey) throw new Error("ZULIP_BOT_* env not set");
+    const auth = "Basic " + btoa(`${email}:${apiKey}`);
+    const zulipHost = Deno.env.get("ZULIP_HOST") ?? "chat.thesteamedcrab.com";
+    const form = new URLSearchParams({
+        type: "stream",
+        to: "approvals",
+        topic,
+        content,
+    });
+    const zr = await fetch(`https://${zulipHost}/api/v1/messages`, {
+        method: "POST",
+        headers: {
+            Authorization: auth,
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: form,
+        signal: AbortSignal.timeout(30_000),
+    });
+
+    const pushoverResp = await sendPushover({
+        title: `🔔 Approval needed: Class ${r.action_class}`,
+        message: `${r.target}\n${r.payload_summary}\n\nReact in Zulip: ${zulipHost}`,
+        priority: 1,
+        sound: "gamelan",
+    });
+
+    return { zulip_ok: zr.ok, pushover_ok: pushoverResp };
+}
+
+async function sendPushover(args: {
+    title: string;
+    message: string;
+    priority: number;
+    sound?: string;
+}): Promise<boolean> {
+    const token = Deno.env.get("PUSHOVER_APP_TOKEN");
+    const user = Deno.env.get("PUSHOVER_USER_KEY");
+    if (!token || !user) throw new Error("PUSHOVER_* env not set");
+    const form = new URLSearchParams({
+        token,
+        user,
+        title: args.title,
+        message: args.message,
+        priority: String(args.priority),
+    });
+    if (args.sound) form.set("sound", args.sound);
+    const r = await fetch("https://api.pushover.net/1/messages.json", {
+        method: "POST",
+        body: form,
+        signal: AbortSignal.timeout(30_000),
+    });
+    return r.ok;
+}


### PR DESCRIPTION
## Summary

Phase 2A of the n8n → Windmill migration.

- 7 TypeScript scripts replacing the n8n workflows, under \`kubernetes/apps/home/windmill/workflows/\`.
- New ExternalSecret \`windmill-workflows\` pulls 6 fields from existing 1P items (\`langgraph-agents\`, \`zulip-n8n-bot\`) — single source of truth, no duplicated fields.
- HR extends \`windmill.app.extraEnv\` + both \`workerGroups[].extraEnv\` (via YAML anchor) so the secret is visible to every pod where scripts can execute.

Source-of-truth lives in this repo. Runtime push to Windmill happens via the API in a follow-up runtime step (then validated end-to-end).

## Workflows shipped

| # | Workflow | Trigger | Primary call |
|---|---|---|---|
| 1 | alertmanager-holmesgpt-pushover | webhook | HolmesGPT \`/api/chat\` |
| 2 | langgraph-approval-post | webhook | Zulip \`/messages\` |
| 3 | langgraph-approval-receive | webhook | langgraph-agents \`/approval\` |
| 4 | langgraph-awaiting-user-sweep | cron 5m | langgraph-agents \`/admin/tasks\` |
| 5 | langgraph-cost-cap-watcher | cron 4h | langgraph-agents \`/admin/costs/today\` |
| 6 | langgraph-daily-digest | cron daily 22:00 ET | langgraph-agents \`/inbox\` |
| 7 | langgraph-inbox | webhook | langgraph-agents \`/inbox\` |

## Test plan

- [x] \`kubectl kustomize\` renders without error
- [ ] After Flux reconciles: \`kubectl -n home get secret windmill-workflows-secret\` shows 6 keys
- [ ] Worker pod env contains LANGGRAPH_APPROVAL_SIGNING_KEY / PUSHOVER_* / ZULIP_BOT_* / ROB_ZULIP_USER_ID
- [ ] Push scripts via Windmill API + curl one of them to confirm env reading works