### PR TITLE
feat(mcp-system/memory-mcp): Phase 0 scaffold (suspended) + kg schema

### DIFF
--- a/kubernetes/apps/databases/cloudnative-pg/config/langgraph-memory/cluster.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/langgraph-memory/cluster.yaml
@@ -51,6 +51,19 @@ spec:
         - "CREATE EXTENSION IF NOT EXISTS vector;"
         - "CREATE EXTENSION IF NOT EXISTS vchord;"
 
+  # CNPG generates `postgres-langgraph-memory-app` in this namespace.
+  # Two consumers need it cross-namespace via emberstack reflector:
+  # - ai/langgraph-agents — already consumes today (ad-hoc annotation
+  #   on the live Secret; making it durable here).
+  # - mcp-system/memory-mcp — Phase 0 of the memory-mcp deploy.
+  # Pattern: project_cnpg_cross_namespace_reflector.
+  inheritedMetadata:
+    annotations:
+      reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "ai,mcp-system"
+      reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "ai,mcp-system"
+
   monitoring:
     enablePodMonitor: true
 

--- a/kubernetes/apps/mcp-system/kustomization.yaml
+++ b/kubernetes/apps/mcp-system/kustomization.yaml
@@ -21,6 +21,7 @@ resources:
   - ./immich-mcp/ks.yaml
   - ./kubectl-mcp/ks.yaml
   - ./mcp-gateway/ks.yaml
+  - ./memory-mcp/ks.yaml
   - ./n8n-mcp/ks.yaml
   - ./netbox-mcp/ks.yaml
   - ./omada-mcp/ks.yaml

--- a/kubernetes/apps/mcp-system/memory-mcp/app/cnp-allow.yaml
+++ b/kubernetes/apps/mcp-system/memory-mcp/app/cnp-allow.yaml
@@ -1,0 +1,35 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: memory-mcp-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: memory-mcp
+  # Additive — default-deny enforces; these punch holes. Ingress from
+  # same-ns mcp-gateway broker is covered by baseline allow-intra-ns.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  egress:
+    # langgraph-memory CNPG primary in databases ns. Per
+    # project_cilium_l4_port_targetport, toPorts matches container port.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
+            cnpg.io/cluster: postgres-langgraph-memory
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+    # Ollama for embedding generation (nomic-embed-text).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: ai
+            app.kubernetes.io/name: ollama
+      toPorts:
+        - ports:
+            - port: "11434"
+              protocol: TCP

--- a/kubernetes/apps/mcp-system/memory-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/memory-mcp/app/helmrelease.yaml
@@ -1,0 +1,120 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: memory-mcp
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 1h
+  values:
+    defaultPodOptions:
+      securityContext:
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+    controllers:
+      memory-mcp:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        pod:
+          annotations:
+            sidecar.istio.io/inject: "true"
+        containers:
+          app:
+            image:
+              # v0.1.0 not yet published — see ks.yaml suspend comment.
+              # Will pin @sha256 once the first GHCR build lands.
+              repository: ghcr.io/rwlove/memory-mcp
+              tag: v0.1.0
+            env:
+              # CNPG-generated app Secret reflected from databases ns
+              # via emberstack reflector (see langgraph-memory
+              # cluster.yaml inheritedMetadata). Exposes key `uri`.
+              DATABASE_URL:
+                valueFrom:
+                  secretKeyRef:
+                    name: postgres-langgraph-memory-app
+                    key: uri
+              EMBED_MODEL: nomic-embed-text
+              HOST: "0.0.0.0"
+              OLLAMA_BASE_URL: http://ollama.ai.svc.cluster.local:11434
+              PORT: "8070"
+              TZ: America/New_York
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: &httpPort 8070
+                  initialDelaySeconds: 15
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: *httpPort
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: *httpPort
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                  timeoutSeconds: 5
+                  failureThreshold: 30
+            resources:
+              requests:
+                cpu: 50m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - ALL
+              readOnlyRootFilesystem: true
+              seccompProfile:
+                type: RuntimeDefault
+    persistence:
+      tmp:
+        type: emptyDir
+        advancedMounts:
+          memory-mcp:
+            app:
+              - path: /tmp
+                subPath: tmp
+    service:
+      app:
+        controller: memory-mcp
+        ports:
+          http:
+            port: *httpPort
+    route:
+      app:
+        hostnames:
+          - "memory-mcp.mcp.local"
+        parentRefs:
+          - name: mcp-gateway
+            namespace: mcp-system
+            sectionName: mcps
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /mcp
+            backendRefs:
+              - identifier: app
+                port: *httpPort

--- a/kubernetes/apps/mcp-system/memory-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/memory-mcp/app/helmrelease.yaml
@@ -25,10 +25,8 @@ spec:
         containers:
           app:
             image:
-              # v0.1.0 not yet published — see ks.yaml suspend comment.
-              # Will pin @sha256 once the first GHCR build lands.
               repository: ghcr.io/rwlove/memory-mcp
-              tag: v0.1.0
+              tag: 0.1.0@sha256:8f215c1deb7554551a57a7f389e407a03300a66b13cf250aa57009dd04e2f58b
             env:
               # CNPG-generated app Secret reflected from databases ns
               # via emberstack reflector (see langgraph-memory

--- a/kubernetes/apps/mcp-system/memory-mcp/app/kustomization.yaml
+++ b/kubernetes/apps/mcp-system/memory-mcp/app/kustomization.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../components/repos/app-template
+configMapGenerator:
+  - name: memory-mcp-schema
+    files:
+      - schema.sql=./resources/schema.sql
+generatorOptions:
+  disableNameSuffixHash: true
+resources:
+  - ./cnp-allow.yaml
+  - ./helmrelease.yaml
+  - ./schema-init-job.yaml

--- a/kubernetes/apps/mcp-system/memory-mcp/app/resources/schema.sql
+++ b/kubernetes/apps/mcp-system/memory-mcp/app/resources/schema.sql
@@ -1,0 +1,51 @@
+-- memory-mcp knowledge-graph schema for the langgraph_memory database.
+-- Applied idempotently by schema-init-job.yaml. Re-running is a no-op.
+-- See plan: ~/.claude-personal/plans/i-would-like-memory-ethereal-pebble.md
+--
+-- The vchord + vector extensions are already enabled at CNPG bootstrap
+-- (see langgraph-memory cluster.yaml postInitApplicationSQL).
+
+CREATE SCHEMA IF NOT EXISTS kg;
+
+CREATE TABLE IF NOT EXISTS kg.entities (
+  id          BIGSERIAL PRIMARY KEY,
+  name        TEXT NOT NULL UNIQUE,
+  type        TEXT NOT NULL,
+  namespace   TEXT,
+  source      JSONB NOT NULL,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS kg.observations (
+  id          BIGSERIAL PRIMARY KEY,
+  entity_id   BIGINT NOT NULL REFERENCES kg.entities(id) ON DELETE CASCADE,
+  content     TEXT NOT NULL,
+  embedding   vector(768),
+  source      JSONB NOT NULL,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  deleted_at  TIMESTAMPTZ
+);
+
+CREATE TABLE IF NOT EXISTS kg.relations (
+  id           BIGSERIAL PRIMARY KEY,
+  from_entity  BIGINT NOT NULL REFERENCES kg.entities(id) ON DELETE CASCADE,
+  to_entity    BIGINT NOT NULL REFERENCES kg.entities(id) ON DELETE CASCADE,
+  type         TEXT NOT NULL,
+  source       JSONB NOT NULL,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (from_entity, to_entity, type)
+);
+
+CREATE INDEX IF NOT EXISTS kg_obs_entity_idx
+  ON kg.observations(entity_id)
+  WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS kg_ent_type_idx ON kg.entities(type);
+CREATE INDEX IF NOT EXISTS kg_ent_namespace_idx ON kg.entities(namespace);
+
+-- vchord HNSW over observation embeddings. vchord auto-tunes `lists`
+-- on startup (see project_immich_clip_index_rebuild) so we don't set it.
+CREATE INDEX IF NOT EXISTS kg_obs_embedding_hnsw
+  ON kg.observations
+  USING vchordrq (embedding vector_cosine_ops);

--- a/kubernetes/apps/mcp-system/memory-mcp/app/schema-init-job.yaml
+++ b/kubernetes/apps/mcp-system/memory-mcp/app/schema-init-job.yaml
@@ -1,0 +1,75 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/job-batch-v1.json
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: memory-mcp-schema-init
+  annotations:
+    # Re-run this Job whenever the SQL changes. The ConfigMap is hashed
+    # into the Job name via configMapGenerator name suffix... except
+    # we have disableNameSuffixHash. So bump this manually if you edit
+    # resources/schema.sql, OR delete the Job and let Flux recreate it.
+    home-ops.thesteamedcrab.com/schema-version: "1"
+spec:
+  backoffLimit: 5
+  template:
+    metadata:
+      annotations:
+        # Sidecar would prevent Job completion (stays running). Skip.
+        sidecar.istio.io/inject: "false"
+      # CNP selects on this label — Job pods need to match the
+      # memory-mcp-allow policy so they can reach postgres.
+      labels:
+        app.kubernetes.io/name: memory-mcp
+    spec:
+      restartPolicy: OnFailure
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: psql
+          image: ghcr.io/cloudnative-pg/postgresql:14.17
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -euo pipefail
+              echo "Applying kg schema to ${DATABASE_URL%%\?*}"
+              psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f /sql/schema.sql
+              echo "Schema apply complete."
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-langgraph-memory-app
+                  key: uri
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - mountPath: /sql/schema.sql
+              name: schema
+              readOnly: true
+              subPath: schema.sql
+            - mountPath: /tmp
+              name: tmp
+      volumes:
+        - configMap:
+            name: memory-mcp-schema
+          name: schema
+        - emptyDir: {}
+          name: tmp

--- a/kubernetes/apps/mcp-system/memory-mcp/ks.yaml
+++ b/kubernetes/apps/mcp-system/memory-mcp/ks.yaml
@@ -14,14 +14,6 @@ spec:
   timeout: 5m
   prune: true
   wait: false
-  # Suspended at scaffold time: this Kustomization references
-  # ghcr.io/rwlove/memory-mcp:v0.1.0 which doesn't exist yet. The server
-  # repo (github.com/rwlove/memory-mcp) is the next deliverable. When
-  # v0.1.0 lands in GHCR, flip this to false in a "feat(memory-mcp):
-  # activate Phase 0" commit and the schema-init Job + HelmRelease +
-  # MCPServerRegistration will reconcile in order.
-  # Plan: ~/.claude-personal/plans/i-would-like-memory-ethereal-pebble.md
-  suspend: true
   sourceRef:
     kind: GitRepository
     name: home-ops-kubernetes
@@ -48,8 +40,6 @@ spec:
   timeout: 5m
   prune: true
   wait: false
-  # Same suspend rationale as the parent — un-suspend together.
-  suspend: true
   sourceRef:
     kind: GitRepository
     name: home-ops-kubernetes

--- a/kubernetes/apps/mcp-system/memory-mcp/ks.yaml
+++ b/kubernetes/apps/mcp-system/memory-mcp/ks.yaml
@@ -1,0 +1,60 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app memory-mcp
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: mcp-system
+  path: ./kubernetes/apps/mcp-system/memory-mcp/app
+  interval: 1h
+  timeout: 5m
+  prune: true
+  wait: false
+  # Suspended at scaffold time: this Kustomization references
+  # ghcr.io/rwlove/memory-mcp:v0.1.0 which doesn't exist yet. The server
+  # repo (github.com/rwlove/memory-mcp) is the next deliverable. When
+  # v0.1.0 lands in GHCR, flip this to false in a "feat(memory-mcp):
+  # activate Phase 0" commit and the schema-init Job + HelmRelease +
+  # MCPServerRegistration will reconcile in order.
+  # Plan: ~/.claude-personal/plans/i-would-like-memory-ethereal-pebble.md
+  suspend: true
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: mcp-gateway
+      namespace: mcp-system
+    - name: langgraph-memory
+      namespace: databases
+  retryInterval: 2m
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app memory-mcp-mcpserverregistration
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: mcp-system
+  path: ./kubernetes/apps/mcp-system/memory-mcp/mcp
+  interval: 1h
+  timeout: 5m
+  prune: true
+  wait: false
+  # Same suspend rationale as the parent — un-suspend together.
+  suspend: true
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: memory-mcp
+      namespace: mcp-system
+  retryInterval: 2m

--- a/kubernetes/apps/mcp-system/memory-mcp/mcp/kustomization.yaml
+++ b/kubernetes/apps/mcp-system/memory-mcp/mcp/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./mcpserverregistration.yaml

--- a/kubernetes/apps/mcp-system/memory-mcp/mcp/mcpserverregistration.yaml
+++ b/kubernetes/apps/mcp-system/memory-mcp/mcp/mcpserverregistration.yaml
@@ -1,0 +1,14 @@
+---
+# TODO: apply schema
+apiVersion: mcp.kuadrant.io/v1alpha1
+kind: MCPServerRegistration
+metadata:
+  name: memory-tools
+  labels:
+    mcp.kuadrant.io/managed: "true"
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: memory-mcp
+  toolPrefix: memory_


### PR DESCRIPTION
## Summary

- Scaffolds `kubernetes/apps/mcp-system/memory-mcp/` for a knowledge-graph MCP server fronting `postgres-langgraph-memory` (pgvector + vchord HNSW), exposed through `mcp-gateway` with `toolPrefix: memory_`.
- Both Flux Kustomizations ship `spec.suspend: true` — image `ghcr.io/rwlove/memory-mcp:v0.1.0` doesn't exist yet; server repo is the next deliverable. Un-suspend in a follow-up commit when v0.1.0 lands.
- Adds `inheritedMetadata` reflector annotations on `langgraph-memory/cluster.yaml` targeting `ai,mcp-system`. Strictly additive — also closes existing `ai`-only drift where reflection was running off ad-hoc annotations on the live Secret.

## Why now

Cross-agent persistent memory: LangGraph in-cluster, Open WebUI / HolmesGPT, specialist Claude Code subagents, and cross-namespace Claude Code itself. The existing markdown auto-memory is per-project-partitioned and invisible to non-Claude-Code agents. The CNPG substrate exists but no MCP layer reads/writes it yet — this lays the cluster-side groundwork.

## Plan reference

`~/.claude-personal/plans/i-would-like-memory-ethereal-pebble.md`

## Scope (cluster-side only)

**New (`kubernetes/apps/mcp-system/memory-mcp/`):**
- `ks.yaml` — two Kustomizations, both suspended
- `app/helmrelease.yaml` — `DATABASE_URL` from reflected secret via `valueFrom: secretKeyRef`; Ollama egress for embeddings
- `app/cnp-allow.yaml` — egress to postgres + ollama
- `app/schema-init-job.yaml` + `app/resources/schema.sql` — idempotent DDL for `kg.entities` / `kg.observations` / `kg.relations` + vchordrq HNSW
- `mcp/mcpserverregistration.yaml` — `toolPrefix: memory_`

**Modified:**
- `kubernetes/apps/mcp-system/kustomization.yaml` — `./memory-mcp/ks.yaml` inserted alphabetically
- `kubernetes/apps/databases/cloudnative-pg/config/langgraph-memory/cluster.yaml` — `inheritedMetadata` block

## Out of scope (separate work)

- `github.com/rwlove/memory-mcp` — the actual Python/FastAPI MCP server. Next deliverable; needs `v0.1.0` shipped to GHCR before the suspend flips.
- `langgraph-checkpoints/cluster.yaml` has the same drift pattern (live reflection annotations not in git). Left for a follow-up "CNPG reflector durability" PR.

## Test plan

- [x] `kubectl kustomize` clean on `app/`, `mcp/`, parent `mcp-system/`, and `langgraph-memory/`
- [x] All new files render to valid Kubernetes resources
- [x] Schema applied idempotently on re-runs (`CREATE IF NOT EXISTS` everywhere)
- [ ] Post-merge: Flux reconciles langgraph-memory cluster; reflector mirrors `postgres-langgraph-memory-app` Secret into `mcp-system`
- [ ] Post-merge: `flux get kustomizations -n mcp-system memory-mcp memory-mcp-mcpserverregistration` both show Suspended=True
- [ ] Post-merge: no Pod attempts ImagePullBackOff (Kustomization is suspended → no reconcile → no pod)
- [ ] Un-suspend trigger (out of scope): `ghcr.io/rwlove/memory-mcp:v0.1.0` published; `nomic-embed-text` available on Ollama

🤖 Generated with [Claude Code](https://claude.com/claude-code)