### PR TITLE
fix(windmill): unblock egress to langgraph + codify Postgres grants

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/cnp-allow.yaml
@@ -15,9 +15,9 @@ spec:
     ingress: false
   ingress:
     # HTTPRoute on internal gateway → langgraph-agents:8765
-    # (agents.${SECRET_DOMAIN}). n8n's approval-receive workflow also
-    # POSTs here, but that traffic still arrives via the internal
-    # Envoy gateway (n8n → HTTPRoute → envoy → langgraph-agents).
+    # (agents.${SECRET_DOMAIN}). Windmill workers + app (in home ns)
+    # POST here directly for the inbox / approval / awaiting-user /
+    # cost-cap-watcher / daily-digest flows (replacing n8n's role).
     # collab/open-webui hits the in-cluster Service directly via
     # OPENAI_API_BASE_URLS (each agent id registered as a model).
     - fromEndpoints:
@@ -27,6 +27,15 @@ spec:
         - matchLabels:
             io.kubernetes.pod.namespace: collab
             app.kubernetes.io/name: open-webui
+        - matchExpressions:
+            - key: io.kubernetes.pod.namespace
+              operator: In
+              values: [home]
+            - key: app.kubernetes.io/name
+              operator: In
+              values:
+                - windmill-app
+                - windmill-workers
       toPorts:
         - ports:
             - port: "8765"

--- a/kubernetes/apps/databases/cloudnative-pg/config/windmill/cluster.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/windmill/cluster.yaml
@@ -47,6 +47,14 @@ spec:
       # Windmill's migration 20221211192539 grants USAGE on the schema to
       # windmill_admin + windmill_user (NOLOGIN roles it expects to exist).
       # Without these, migrations fail mid-run and the app crash-loops.
+      #
+      # The DEFAULT PRIVILEGES + GRANT ALL block is needed because the
+      # Windmill app `SET LOCAL ROLE windmill_admin`s before INSERT/UPDATE
+      # operations on the public schema. When the app's role becomes
+      # windmill_admin, it loses windmill's owner-implicit table perms
+      # and falls back to per-role grants — which would be empty without
+      # this. Without this block, `POST /scripts/create` fails with
+      # `permission denied for table script`.
       postInitApplicationSQL:
         - CREATE ROLE windmill_admin WITH NOLOGIN
         - CREATE ROLE windmill_user WITH NOLOGIN
@@ -54,6 +62,11 @@ spec:
         - GRANT windmill_user TO windmill
         - GRANT ALL ON SCHEMA public TO windmill_admin
         - GRANT ALL ON SCHEMA public TO windmill_user
+        # FOR ROLE windmill — Windmill migrations CREATE TABLE while
+        # connected as windmill, so default privileges must target that
+        # role to auto-grant on every future migration's table.
+        - ALTER DEFAULT PRIVILEGES FOR ROLE windmill IN SCHEMA public GRANT ALL ON TABLES TO windmill_admin, windmill_user
+        - ALTER DEFAULT PRIVILEGES FOR ROLE windmill IN SCHEMA public GRANT ALL ON SEQUENCES TO windmill_admin, windmill_user
 
   # CNPG generates the `postgres-windmill-app` Secret with the connection
   # URI in this namespace. The Windmill HR consumes it cross-namespace


### PR DESCRIPTION
## Summary

Two fixes surfaced while smoke-testing the new Windmill workflows against langgraph-agents.

1. **langgraph-agents CNP ingress**: add \`home/[windmill-app|windmill-workers]\` to the allowlist alongside the existing envoy + open-webui entries.
2. **postgres-windmill ALTER DEFAULT PRIVILEGES**: ensure windmill_admin + windmill_user auto-receive ALL on every future migration's tables, fixing the \`permission denied for table script\` failure when Windmill \`SET LOCAL ROLE\`s before INSERT.

Both verified live. Already-running cluster was unblocked via a one-shot kubectl + psql; this PR codifies the same effect for cluster rebuilds.

## Test plan

- [x] \`POST /api/w/lovenet/scripts/create\` succeeds after the GRANT
- [ ] After merge: worker can curl \`http://langgraph-agents.ai.svc.cluster.local:8765/healthz\` from inside the pod
- [ ] After merge: \`curl POST /api/w/lovenet/jobs/run_wait_result/p/f/lovenet/langgraph-cost-cap-watcher\` returns within 30s (not a TimeoutError)