### PR TITLE
fix(mcp-system/chrome-mcp): allow egress to Cilium LB pool

### DIFF
--- a/kubernetes/apps/mcp-system/chrome-mcp/app/cnp-allow.yaml
+++ b/kubernetes/apps/mcp-system/chrome-mcp/app/cnp-allow.yaml
@@ -13,11 +13,21 @@ spec:
     egress: false
     ingress: false
   egress:
-    # Chromium browses public-facing apps (immich.${SECRET_DOMAIN} etc.)
-    # via the Cloudflared tunnel — the realistic user-side path, not
-    # a curl-pod shortcut.
+    # True-external HTTPS — Chromium hits public sites (example.com)
+    # AND traverses the Cloudflared tunnel back to the cluster for
+    # apps whose public DNS doesn't resolve to a LAN address.
     - toEntities:
         - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+    # Cilium LB pool — split-horizon bind9 resolves internal hostnames
+    # (auth.${SECRET_DOMAIN}, etc.) to the in-cluster LB IPs, not the
+    # Cloudflared edge. Without this, navigating to any internal app
+    # hangs at TCP connect.
+    - toCIDR:
+        - "10.45.0.0/24"
       toPorts:
         - ports:
             - port: "443"


### PR DESCRIPTION
## Summary

Follow-up to the chrome-mcp deployment. Smoke-testing \`chrome_browser_navigate https://auth.\${SECRET_DOMAIN}\` hung at TCP connect because the cluster's split-horizon bind9 resolves internal hostnames to the Cilium LB pool (10.45.0.0/24), not the Cloudflared edge. The current CNP only permits \`world:443\`, which excludes the in-cluster LB IPs.

This adds \`toCIDR: 10.45.0.0/24:443\` to the egress list so chrome-mcp can reach internal apps the same way external users see them — via their public hostname — but via the in-cluster path the DNS hands us.

## Repro

```
$ kubectl exec -n mcp-system chrome-mcp-... -- node -e "require('dns').resolve4('auth.\${SECRET_DOMAIN}', console.log)"
[null, ['10.45.0.13']]     # cluster LB pool

$ chrome_browser_navigate https://auth.\${SECRET_DOMAIN}
Streamable HTTP error: Session not found    # Chromium TCP connect timed out
```

## Test plan

- [ ] Flux reconciles, CNP rule updated
- [ ] \`chrome_browser_navigate https://auth.\${SECRET_DOMAIN}\` returns Authelia login snapshot
- [ ] \`chrome_browser_navigate https://example.com\` still works (world rule unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)