### PR TITLE
fix(windmill): script args + holmesgpt ingress + sweep timeout

### DIFF
--- a/kubernetes/apps/observability/holmesgpt/app/cnp-allow.yaml
+++ b/kubernetes/apps/observability/holmesgpt/app/cnp-allow.yaml
@@ -11,10 +11,25 @@ spec:
   enableDefaultDeny:
     egress: false
     ingress: false
-  # No ingress rules needed: holmesgpt-oauth2-proxy is the only door,
-  # and baseline allow-intra-namespace already permits that path. The
-  # n8n webhook in `home` ns reaches holmesgpt via its oauth2-proxy
-  # (gateway path + cross-ns auth-bearing call) — see Pattern A.
+  ingress:
+    # Windmill workflow `alertmanager-holmesgpt-pushover` POSTs directly
+    # to /api/chat from the home ns. n8n previously reached HolmesGPT
+    # through its oauth2-proxy + gateway; Windmill skips that hop and
+    # talks to the in-cluster Service for lower latency.
+    - fromEndpoints:
+        - matchExpressions:
+            - key: io.kubernetes.pod.namespace
+              operator: In
+              values: [home]
+            - key: app.kubernetes.io/name
+              operator: In
+              values:
+                - windmill-app
+                - windmill-workers
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
   egress:
     # LLM backend — ollama in ai ns (Pattern E).
     - toEndpoints:


### PR DESCRIPTION
## Summary

Three fixes from smoke-testing the new Windmill workflows.

1. **Script function signatures**: refactor each \`main()\` to take the workflow-specific top-level body keys as separate parameters (Windmill maps body keys → fn args by name). Original \`main(body)\` shape forced callers to wrap their payload in \`{body: ...}\` which Alertmanager / Zulip don't do.
2. **awaiting-user-sweep timeout-tolerant**: wrap the \`/admin/tasks\` fetch in try/catch — that endpoint hangs (pre-existing langgraph issue) and we want a clean skip rather than an exception.
3. **holmesgpt CNP ingress**: allow \`home/[windmill-app|windmill-workers]\` so the alertmanager flow's direct call to \`holmesgpt.observability.svc.cluster.local:8080\` isn't blocked by the observability ns default-deny.

## Test plan

- [x] Local — \`curl POST /run_wait_result/p/f/lovenet/alertmanager-…\` with \`{alerts:[...]}\` payload reaches HolmesGPT after merge
- [x] Local — approval-receive with \`user_id != ROB_USER_ID\` returns \`{skip:true}\` in 200ms
- [x] Local — awaiting-user-sweep returns \`{skip:true, reason:"…timeout"}\` in 30s, not 500