### PR TITLE
fix(mcp-system/chrome-mcp): allow egress to envoy backend (replace stale LB-CIDR rule)

### DIFF
--- a/kubernetes/apps/mcp-system/chrome-mcp/app/cnp-allow.yaml
+++ b/kubernetes/apps/mcp-system/chrome-mcp/app/cnp-allow.yaml
@@ -22,12 +22,16 @@ spec:
         - ports:
             - port: "443"
               protocol: TCP
-    # Cilium LB pool — split-horizon bind9 resolves internal hostnames
-    # (auth.${SECRET_DOMAIN}, etc.) to the in-cluster LB IPs, not the
-    # Cloudflared edge. Without this, navigating to any internal app
-    # hangs at TCP connect.
-    - toCIDR:
-        - "10.45.0.0/24"
+    # Internal apps via their public hostname. Split-horizon bind9
+    # resolves them to the Cilium LB pool (10.45.0.0/24), but Cilium's
+    # L4LB NATs to the backend pod identity before policy evaluation,
+    # so a `toCIDR: 10.45.0.0/24` rule never matches. envoy in the
+    # network ns fronts every public-facing app (Authelia, immich,
+    # paperless, gonic, etc.) and is the actual destination identity.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
       toPorts:
         - ports:
             - port: "443"


### PR DESCRIPTION
## Summary

Supersedes the \`toCIDR: 10.45.0.0/24\` rule from #11676. That rule never matched because Cilium's L4LB resolves Service LoadBalancer IPs to a backend pod identity *before* policy evaluation. The actual destination identity for traffic to \`auth.\${SECRET_DOMAIN}\` (which resolves to 10.45.0.13 via split-horizon bind9) is the envoy pod in the network namespace.

Replacing the no-op CIDR rule with a \`toEndpoints\` selector for envoy in the network ns. Same trust posture, working policy.

## Verification

After this lands:

```
$ kubectl exec -n mcp-system chrome-mcp-... -- node -e "
  const net = require('net');
  const s = net.connect({host:'10.45.0.13', port:443}, () => { console.log('OK'); s.end(); });
  s.on('error', e => console.log('err:', e.message));
  s.setTimeout(5000, () => { console.log('timeout'); s.destroy(); });"
OK     # was: timeout

$ chrome_browser_navigate https://auth.\${SECRET_DOMAIN}
[returns Authelia login accessibility-tree snapshot]
```

## Test plan

- [ ] Flux reconciles, CNP rule updated
- [ ] TCP to 10.45.0.13:443 from chrome-mcp pod succeeds
- [ ] \`chrome_browser_navigate https://auth.\${SECRET_DOMAIN}\` returns Authelia snapshot
- [ ] External egress still works (\`chrome_browser_navigate https://example.com\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)