### PR TITLE
fix(mcp-system/memory-mcp): bump to v0.1.1 (Ollama /api/embed)

### DIFF
--- a/kubernetes/apps/mcp-system/memory-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/memory-mcp/app/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/memory-mcp
-              tag: 0.1.0@sha256:8f215c1deb7554551a57a7f389e407a03300a66b13cf250aa57009dd04e2f58b
+              tag: 0.1.1@sha256:8f5e85891dd1b80a4811538114de35e186f2a5e140397bbe2f99fe55a3ff97f1
             env:
               # CNPG-generated app Secret reflected from databases ns
               # via emberstack reflector (see langgraph-memory


### PR DESCRIPTION
## Summary

- Bump `ghcr.io/rwlove/memory-mcp` from `0.1.0` → `0.1.1`
- `0.1.1` switches the embedder from the legacy `/api/embeddings` endpoint to the modern `/api/embed`
- Image digest pinned: `sha256:8f5e85891dd1b80a4811538114de35e186f2a5e140397bbe2f99fe55a3ff97f1`

## Why

Phase 0 smoke test (after #11673 merge) found that semantic search consistently returned 0 results. Pod logs showed `404 Not Found` on `POST /api/embeddings`. Investigation:

1. Recent Ollama versions removed `/api/embeddings` in favor of `/api/embed` (batch-capable).
2. `nomic-embed-text` model was not pulled on the cluster's Ollama; pulled it out-of-band via `/api/pull` (now resident).

After both fixes, `/api/embed` returns HTTP 200 with a 768-dim vector — matches the `vector(768)` schema.

## Test plan

- [x] `kubectl kustomize` clean
- [x] Out-of-band `/api/embed` test against Ollama returns 200 + 768-dim
- [ ] Post-deploy: `memory_search(mode=semantic)` returns relevant results
- [ ] Post-deploy: `memory_search(mode=hybrid)` blends keyword + semantic
- [ ] Existing observations re-embed lazily as new searches hit them (NULL embedding ↔ keyword fallback already works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)