### PR TITLE
fix(mcp-system/chrome-mcp): envoy egress on 10443, not 443

### DIFF
--- a/kubernetes/apps/mcp-system/chrome-mcp/app/cnp-allow.yaml
+++ b/kubernetes/apps/mcp-system/chrome-mcp/app/cnp-allow.yaml
@@ -24,15 +24,14 @@ spec:
               protocol: TCP
     # Internal apps via their public hostname. Split-horizon bind9
     # resolves them to the Cilium LB pool (10.45.0.0/24), but Cilium's
-    # L4LB NATs to the backend pod identity before policy evaluation,
-    # so a `toCIDR: 10.45.0.0/24` rule never matches. envoy in the
-    # network ns fronts every public-facing app (Authelia, immich,
-    # paperless, gonic, etc.) and is the actual destination identity.
+    # L4LB NATs to the backend pod identity AND its containerPort
+    # before policy evaluation. envoy-gateway listens on 10443 inside
+    # the pod (mapped to LB :443), so the rule has to allow 10443.
     - toEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: network
             app.kubernetes.io/name: envoy
       toPorts:
         - ports:
-            - port: "443"
+            - port: "10443"
               protocol: TCP


### PR DESCRIPTION
Cilium L4LB rewrites the destination to the backend pod's \`containerPort\` before policy evaluation. envoy-gateway's pods listen on 10443 internally (mapped to LB IP :443). Hubble showed:

\`\`\`
chrome-mcp:48824 -> network/external-9b6c58868-29s8v:10443 Policy denied DROPPED
\`\`\`

Switching the port from 443 to 10443 in the envoy \`toEndpoints\` rule lets the policy match the actual flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)