### PR TITLE
feat(home/ntfy): Phase 1 deploy — self-hosted push backend

### DIFF
--- a/kubernetes/apps/home/kustomization.yaml
+++ b/kubernetes/apps/home/kustomization.yaml
@@ -26,6 +26,7 @@ resources:
   - ./n8n/ks.yaml
   - ./netbox/ks.yaml
   - ./node-red/ks.yaml
+  - ./ntfy/ks.yaml
   - ./smtp-relay/ks.yaml
   - ./windmill/ks.yaml
   - ./wyoming-services/ks.yaml

--- a/kubernetes/apps/home/ntfy/README.md
+++ b/kubernetes/apps/home/ntfy/README.md
@@ -1,0 +1,134 @@
+# ntfy
+
+Self-hosted push notification backend. Replaces Pushover in the
+Windmill → Pushover → phone path with tap-to-action buttons in the
+notification surface.
+
+See `~/.claude-personal/plans/vivid-riding-waterfall.md` for the full
+migration rationale + phases.
+
+## Phase 1 — what this PR ships
+
+- HelmRelease (app-template) running `binwiederhier/ntfy:v2.13.0`
+- Two `ceph-block` PVCs:
+  - `ntfy-cache` (5 GiB, `/var/cache/ntfy`) — message + attachment cache
+  - `ntfy-data` (1 GiB, `/var/lib/ntfy`) — auth db + (future) web-push db
+- Server config at `/etc/ntfy/server.yml` (from `ntfy-configmap`)
+- HTTPRoute on `ntfy.${SECRET_DOMAIN}` attached to **both** the
+  external (cloudflared) and internal gateways
+- CiliumNetworkPolicy allowing envoy ingress + windmill in-cluster
+  ingress + prometheus metrics scrape
+- `auth-default-access: deny-all` — no anonymous publish/subscribe
+
+This PR does **not** touch the Windmill workflows. The
+Pushover-shape workflows on `feat/windmill-workflows` keep working
+in parallel. Workflow edits land in a follow-up PR after this app
+is verified.
+
+## Post-deploy bootstrap (one-time)
+
+After Flux reconciles and the pod is `Running`:
+
+### 1. Provision the `ntfy` 1P item
+
+Run on the desktop (cluster 1P Connect token is read-only — see
+`reference_1p_connect_token_readonly` memory):
+
+```sh
+ADMIN_PW=$(openssl rand -base64 32)
+WINDMILL_PW=$(openssl rand -base64 32)
+PHONE_PW=$(openssl rand -base64 32)
+
+op item create \
+  --vault Kubernetes \
+  --category "Login" \
+  --title "ntfy" \
+  "admin_password[password]=${ADMIN_PW}" \
+  "windmill_password[password]=${WINDMILL_PW}" \
+  "phone_password[password]=${PHONE_PW}" \
+  "URL=https://ntfy.${SECRET_DOMAIN}"
+```
+
+### 2. Create users + ACLs inside the pod
+
+```sh
+# Fetch passwords back from 1P.
+ADMIN_PW=$(op item get ntfy --vault Kubernetes --reveal --format json | \
+  jq -r '.fields[] | select(.label=="admin_password") | .value')
+WINDMILL_PW=$(op item get ntfy --vault Kubernetes --reveal --format json | \
+  jq -r '.fields[] | select(.label=="windmill_password") | .value')
+PHONE_PW=$(op item get ntfy --vault Kubernetes --reveal --format json | \
+  jq -r '.fields[] | select(.label=="phone_password") | .value')
+
+# `ntfy user add` reads NTFY_PASSWORD from env to skip the TTY prompt.
+kubectl -n home exec deploy/ntfy -- env NTFY_PASSWORD="$ADMIN_PW" \
+  ntfy user add --role=admin admin
+kubectl -n home exec deploy/ntfy -- env NTFY_PASSWORD="$WINDMILL_PW" \
+  ntfy user add windmill
+kubectl -n home exec deploy/ntfy -- env NTFY_PASSWORD="$PHONE_PW" \
+  ntfy user add rob
+
+# Grant ACLs. windmill = write, rob = read on the four operational topics.
+for t in approvals alerts costs digests; do
+  kubectl -n home exec deploy/ntfy -- ntfy access windmill "$t" rw
+  kubectl -n home exec deploy/ntfy -- ntfy access rob "$t" ro
+done
+
+# Verify.
+kubectl -n home exec deploy/ntfy -- ntfy user list
+kubectl -n home exec deploy/ntfy -- ntfy access
+```
+
+### 3. Verify from outside the cluster
+
+```sh
+# Anonymous publish must fail (auth-default-access: deny-all).
+curl -sS -o /dev/null -w "%{http_code}\n" -d "anon test" \
+  https://ntfy.${SECRET_DOMAIN}/approvals  # → 401
+
+# Authenticated publish from windmill role must succeed.
+curl -sS -u "windmill:${WINDMILL_PW}" -H "Title: phase-1-test" \
+  -H "Actions: http, Test action, https://httpbin.org/post" \
+  -d "tap the action button" \
+  https://ntfy.${SECRET_DOMAIN}/approvals
+```
+
+### 4. Subscribe on the Android phone
+
+1. Install ntfy from F-Droid: `io.heckel.ntfy`
+2. Settings → Default server: `https://ntfy.${SECRET_DOMAIN}`
+3. Settings → Manage users → add server + `rob` credentials
+4. Subscribe to topics: `approvals`, `alerts`, `costs`, `digests`
+5. Per-topic notification settings:
+   - `approvals` — high priority, override DND, distinct sound
+   - `alerts` — high priority
+   - `costs`, `digests` — default
+
+### 5. End-to-end action button test
+
+Re-run the curl from step 3 with `windmill` creds. Phone should
+receive the push with a "Test action" button. Tapping it should
+POST to `httpbin.org/post`. Confirm via Android app activity feed
+that the action succeeded.
+
+## Phase 1 verification gate
+
+Mark Phase 1 complete when:
+
+- [ ] All four topics receive an authenticated test message
+- [ ] Phone receives the push within 5 seconds on cellular
+- [ ] Phone receives the push within 5 seconds on home WiFi
+- [ ] Tapping the action button hits the target URL
+- [ ] Anonymous publish returns 401
+- [ ] Prometheus is scraping `ntfy:9090/metrics` (check
+      `up{job="serviceMonitor/home/ntfy/0"}` in Prometheus)
+
+Once green, kick off Phase 2 (workflow file edits in
+`feat/windmill-workflows-ntfy` or wherever the next branch lands).
+
+## Phase 1 follow-ups (separate PR or merged into Phase 2)
+
+- Enable web push (VAPID keys, externalsecret) for the laptop PWA path
+- Pin chart digest after first stable upgrade
+- Route the container image pull through ZOT if/when container
+  pull-through caching lands (today ZOT only proxies Helm charts)

--- a/kubernetes/apps/home/ntfy/app/cnp-allow.yaml
+++ b/kubernetes/apps/home/ntfy/app/cnp-allow.yaml
@@ -1,0 +1,45 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: ntfy-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: ntfy
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # Envoy gateway → ntfy:80 (public HTTPRoute + LAN HTTPRoute).
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "80"
+              protocol: TCP
+    # In-cluster callers (Windmill workflows in `home` ns) hit the
+    # Service directly via cluster DNS, bypassing the gateway.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: home
+            app.kubernetes.io/name: windmill-app
+        - matchLabels:
+            io.kubernetes.pod.namespace: home
+            app.kubernetes.io/name: windmill-workers
+      toPorts:
+        - ports:
+            - port: "80"
+              protocol: TCP
+    # Prometheus → ntfy:9090 /metrics.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: observability
+            app.kubernetes.io/name: prometheus
+      toPorts:
+        - ports:
+            - port: "9090"
+              protocol: TCP

--- a/kubernetes/apps/home/ntfy/app/helmrelease.yaml
+++ b/kubernetes/apps/home/ntfy/app/helmrelease.yaml
@@ -1,0 +1,91 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app ntfy
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 30m
+  values:
+    controllers:
+      ntfy:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            fsGroupChangePolicy: OnRootMismatch
+            seccompProfile:
+              type: RuntimeDefault
+        replicas: 1
+        strategy: Recreate  # RWO PVCs
+        type: deployment
+        containers:
+          app:
+            image:
+              # ntfy is published to Docker Hub only — no GHCR mirror.
+              # If/when ZOT container-image pull-through lands, route here.
+              repository: binwiederhier/ntfy
+              tag: v2.13.0
+            args: ["serve"]
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+    service:
+      app:
+        controller: ntfy
+        ports:
+          http:
+            port: 80
+          metrics:
+            port: 9090
+    persistence:
+      cache:
+        type: persistentVolumeClaim
+        existingClaim: ntfy-cache
+        advancedMounts:
+          ntfy:
+            app:
+              - path: /var/cache/ntfy
+      data:
+        type: persistentVolumeClaim
+        existingClaim: ntfy-data
+        advancedMounts:
+          ntfy:
+            app:
+              - path: /var/lib/ntfy
+      config-file:
+        type: configMap
+        name: ntfy-configmap
+        advancedMounts:
+          ntfy:
+            app:
+              - path: /etc/ntfy/server.yml
+                subPath: server.yml
+                readOnly: true
+      tmp:
+        type: emptyDir
+        advancedMounts:
+          ntfy:
+            app:
+              - path: /tmp
+    serviceMonitor:
+      app:
+        serviceName: ntfy
+        endpoints:
+          - port: metrics

--- a/kubernetes/apps/home/ntfy/app/kustomization.yaml
+++ b/kubernetes/apps/home/ntfy/app/kustomization.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../components/repos/app-template
+resources:
+  - ./cnp-allow.yaml
+  - ./helmrelease.yaml
+  - ./pvc.yaml
+  - ./route.yaml
+configMapGenerator:
+  - name: ntfy-configmap
+    files:
+      - server.yml=./resources/server.yml
+generatorOptions:
+  disableNameSuffixHash: true

--- a/kubernetes/apps/home/ntfy/app/pvc.yaml
+++ b/kubernetes/apps/home/ntfy/app/pvc.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ntfy-cache
+spec:
+  accessModes: ["ReadWriteOnce"]
+  storageClassName: ceph-block
+  resources:
+    requests:
+      storage: 5Gi
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ntfy-data
+spec:
+  accessModes: ["ReadWriteOnce"]
+  storageClassName: ceph-block
+  resources:
+    requests:
+      storage: 1Gi

--- a/kubernetes/apps/home/ntfy/app/resources/server.yml
+++ b/kubernetes/apps/home/ntfy/app/resources/server.yml
@@ -1,0 +1,39 @@
+# ntfy server config — mounted at /etc/ntfy/server.yml.
+#
+# Storage layout:
+#   /var/cache/ntfy/   — message cache + attachment cache (PVC ntfy-cache, ceph-block)
+#   /var/lib/ntfy/     — auth db + web-push db (PVC ntfy-data, ceph-block)
+#
+# Bootstrap (post-deploy, one-time):
+#   kubectl -n home exec deploy/ntfy -- ntfy user add --role=admin admin
+#   kubectl -n home exec deploy/ntfy -- ntfy user add windmill
+#   kubectl -n home exec deploy/ntfy -- ntfy user add rob
+#   kubectl -n home exec deploy/ntfy -- ntfy access windmill 'approvals,alerts,costs,digests' rw
+#   kubectl -n home exec deploy/ntfy -- ntfy access rob       'approvals,alerts,costs,digests' ro
+
+base-url: "https://ntfy.${SECRET_DOMAIN}"
+listen-http: ":80"
+
+cache-file: /var/cache/ntfy/cache.db
+cache-duration: 12h
+attachment-cache-dir: /var/cache/ntfy/attachments
+attachment-total-size-limit: 1G
+attachment-file-size-limit: 15M
+
+auth-file: /var/lib/ntfy/user.db
+# deny-all blocks anonymous publish + subscribe. Per-topic ACLs are
+# granted to named users via `ntfy access` post-bootstrap.
+auth-default-access: deny-all
+
+# Envoy gateway terminates TLS and forwards X-Forwarded-* headers.
+behind-proxy: true
+
+# /metrics scraped by Prometheus on a dedicated port (CNP-allowed).
+enable-metrics: true
+metrics-listen-http: ":9090"
+
+# Web push is deferred — only Android app + native ntfy subscription
+# is in scope for Phase 1. Re-enable + provision VAPID keys when
+# the laptop PWA path lands in Phase 1 follow-up.
+# web-push-file: /var/lib/ntfy/webpush.db
+# web-push-email-address: rob@example.com

--- a/kubernetes/apps/home/ntfy/app/route.yaml
+++ b/kubernetes/apps/home/ntfy/app/route.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ntfy
+  annotations:
+    glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/ntfy.png"
+    glance/id: "Automation"
+    glance/name: "ntfy"
+    glance/show: "true"
+spec:
+  hostnames:
+    - "ntfy.${SECRET_DOMAIN}"
+  parentRefs:
+    # Public via cloudflared so the Android app reaches the server
+    # from cellular without requiring wg-easy 24/7. ntfy native auth
+    # gates publish + subscribe; cloudflared is unauthenticated tunnel.
+    - name: external
+      namespace: network
+      sectionName: https
+    # LAN reachability for cluster-internal callers (Windmill workflows
+    # hit the in-cluster Service directly, but in-browser PWA users on
+    # LAN benefit from internal split-horizon resolution).
+    - name: internal
+      namespace: network
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: ntfy
+          port: 80

--- a/kubernetes/apps/home/ntfy/ks.yaml
+++ b/kubernetes/apps/home/ntfy/ks.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app ntfy
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: home
+  path: ./kubernetes/apps/home/ntfy/app
+  interval: 30m
+  timeout: 3m
+  prune: true
+  wait: true
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: onepassword-connect
+      namespace: external-secrets


### PR DESCRIPTION
## Summary

- ntfy.sh self-hosted on app-template (Apache 2.0, Docker Hub image), exposed at `ntfy.${SECRET_DOMAIN}` via cloudflared (external) + LAN (internal) gateways
- Two `ceph-block` PVCs: 5 GiB cache + 1 GiB auth/state
- `auth-default-access: deny-all` — no anonymous publish/subscribe
- CNP allows envoy ingress + in-cluster windmill app/workers + prometheus metrics scrape

**No workflow file edits in this PR.** The Pushover-shape Windmill workflows on `feat/windmill-workflows` keep running unchanged. Workflow migration (Phase 2: HMAC-signing refactor + dual-emit Pushover + ntfy) lands in a separate follow-up branch after this app's bootstrap is verified.

## Why

Pushover is the only paid SaaS in the agent push path and offers no inline action buttons — every approval requires opening Zulip and reacting with an emoji. ntfy.sh adds tap-to-approve directly from the Android push notification and removes the SaaS dependency.

Full rationale + phased migration: `~/.claude-personal/plans/vivid-riding-waterfall.md`

## Test plan

Documented in `kubernetes/apps/home/ntfy/README.md`. Verification gate before kicking off Phase 2:

- [ ] Pod reaches `Running` after Flux reconcile
- [ ] Anonymous publish returns 401 (deny-all confirmed)
- [ ] Bootstrap recipe runs cleanly: create 1P `ntfy` item; `ntfy user add admin/windmill/rob`; grant per-topic ACLs
- [ ] Authenticated publish from `windmill` credentials → push arrives on Android (ntfy app from F-Droid: `io.heckel.ntfy`)
- [ ] Action button in push notification → POSTs to target URL
- [ ] Prometheus scrapes `ntfy:9090/metrics`

## Out of scope (Phase 1 follow-ups)

- Web push (VAPID keys) for the Fedora PWA path
- Pinning the Docker Hub image digest after the first stable upgrade
- Routing the container image through ZOT (today ZOT pull-through only covers Helm charts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)