### PR TITLE
feat(home/windmill): upgrade chart 2.0.508 → 4.0.158

### DIFF
--- a/kubernetes/apps/home/windmill/app/helmrelease.yaml
+++ b/kubernetes/apps/home/windmill/app/helmrelease.yaml
@@ -11,7 +11,9 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: windmill
-      version: 2.x  # TODO: pin to a concrete version after first install
+      # Pinned to 4.0.158 — first deploy on chart v4 line. Chart appVersion
+      # 1.704.1. Re-pin when bumping; let Renovate manage the suffix.
+      version: 4.0.158
   install:
     disableWait: true
   interval: 30m
@@ -43,12 +45,21 @@ spec:
       # Replica count — single instance is fine for a homelab.
       appReplicas: 1
 
+      # Chart v4 defaults `privileged: true` on workers (chart 4.0+ flips
+      # this to enable the OOM-killer + PID-namespace-isolation flow on
+      # k8s 1.32+). We're trusted-script-only here, so prefer
+      # least-privilege: turn off privileged AND turn off unshare-pid.
+      # Net effect: identical to chart 2.x's posture.
+      disableUnsharePid: true
+
       # Default worker group.
       workerGroups:
         - name: default
           replicas: 1
           tolerations: []
           nodeSelector: {}
+          privileged: false
+          disableUnsharePid: true
           resources:
             requests:
               cpu: 100m
@@ -97,6 +108,8 @@ spec:
         # Native worker — runs Bash/PowerShell/etc. without nsjail.
         - name: native
           replicas: 1
+          privileged: false
+          disableUnsharePid: true
           resources:
             requests:
               cpu: 50m


### PR DESCRIPTION
## Summary

Chart v4 upgrade (closing Renovate #11675 in favor of this hand-tailored PR that handles the breaking changes).

- Pin to **4.0.158** (chart appVersion 1.704.1, Windmill app version 1.704.1).
- v4 default \`workerGroups[].privileged: true\` is intentional in the chart (for OOM-killer + PID-namespace isolation via unshare on k8s 1.32+). We don't need it — workers run trusted in-tree scripts only. Explicitly turn off privileged + disable unshare-pid on both worker groups + top-level. Net posture matches what chart 2.x had.
- \`lspReplicas: 2\` → \`extraReplicas: 1\` (chart default change). We don't set it explicitly, so the LSP deployment shrinks 2 → 1 (~256 Mi freed).

## Test plan

- [x] kubectl kustomize renders without error
- [ ] After merge: \`kubectl -n home rollout status deploy/windmill-app\` succeeds (no privileged-required failure)
- [ ] Pod count: 1 app + 1 lsp + 1 default-worker + 1 native-worker = 4 (was 5 with 2 lsp replicas)
- [ ] Smoke test: re-run \`curl POST /api/w/lovenet/jobs/run_wait_result/p/f/lovenet/langgraph-cost-cap-watcher\` → 200