### PR TITLE
fix(databases/langgraph-checkpoints): codify reflector annotations

### DIFF
--- a/kubernetes/apps/databases/cloudnative-pg/config/langgraph-checkpoints/cluster.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/langgraph-checkpoints/cluster.yaml
@@ -45,6 +45,19 @@ spec:
       database: langgraph_checkpoints
       owner: langgraph
 
+  # CNPG generates `postgres-langgraph-checkpoints-app` in this namespace.
+  # langgraph-agents in `ai` ns consumes it today (via ad-hoc reflector
+  # annotation on the live Secret, not declared in git — drift that
+  # would silently break on cluster rebuild). Making it durable here.
+  # Sibling of langgraph-memory cluster's inheritedMetadata.
+  # Pattern: project_cnpg_cross_namespace_reflector.
+  inheritedMetadata:
+    annotations:
+      reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: ai
+      reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: ai
+
   monitoring:
     enablePodMonitor: true
 


### PR DESCRIPTION
## Summary

- Add `spec.inheritedMetadata.annotations` to `postgres-langgraph-checkpoints` CNPG cluster
- Annotations mirror the `postgres-langgraph-checkpoints-app` Secret into `ai` namespace (which langgraph-agents already consumes today)
- Sibling change to the `langgraph-memory` inheritedMetadata that landed in #11673

## Why

`langgraph-agents` in `ai` ns has been pulling `postgres-langgraph-checkpoints-app` cross-namespace via an ad-hoc reflector annotation **on the live Secret only** — not declared in git. Drift that would silently break if the CNPG cluster is recreated (the new generated Secret wouldn't carry the annotation, mirror would vanish, langgraph-agents would CrashLoop on missing env).

Strictly additive — annotation values match what's already on the live Secret.

Surfaced during memory-mcp Phase 0 scaffolding (see [project_memory_mcp_phase0_done](https://github.com/rwlove/home-ops/blob/main/) — caught the same pattern on `langgraph-memory`, fixed it there, left the sibling for this follow-up).

## Test plan

- [x] `kubectl kustomize` clean
- [ ] Post-merge: live `postgres-langgraph-checkpoints-app` Secret picks up the new annotations on CNPG reconcile
- [ ] Post-merge: existing `ai`-ns mirror remains (additive, not destructive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)