### PR TITLE
fix(home/windmill): CNP selector → windmill-extra (chart v4 rename)

### DIFF
--- a/kubernetes/apps/home/windmill/app/cnp-allow.yaml
+++ b/kubernetes/apps/home/windmill/app/cnp-allow.yaml
@@ -5,8 +5,8 @@ kind: CiliumNetworkPolicy
 metadata:
   name: windmill-allow
 spec:
-  # The chart labels are inconsistent: app + workers carry
-  # `release=windmill`, but `windmill-lsp` does NOT. Cover all three
+  # Chart label coverage (v4): app + workers carry
+  # `release=windmill`, but `windmill-extra` does NOT. Cover all three
   # via matchExpressions across the chart-set
   # `app.kubernetes.io/name` field.
   endpointSelector:
@@ -15,7 +15,7 @@ spec:
         operator: In
         values:
           - windmill-app
-          - windmill-lsp
+          - windmill-extra
           - windmill-workers
   enableDefaultDeny:
     egress: false
@@ -47,14 +47,14 @@ spec:
         - ports:
             - port: "8001"
               protocol: TCP
-    # windmill-app → windmill-lsp:3001 (in-browser code-completion LSP).
+    # windmill-app → windmill-extra:3001 (in-browser code-completion LSP).
     - fromEndpoints:
         - matchExpressions:
             - key: app.kubernetes.io/name
               operator: In
               values:
                 - windmill-app
-                - windmill-lsp
+                - windmill-extra
                 - windmill-workers
       toPorts:
         - ports:
@@ -89,7 +89,7 @@ spec:
               operator: In
               values:
                 - windmill-app
-                - windmill-lsp
+                - windmill-extra
                 - windmill-workers
       toPorts:
         - ports:


### PR DESCRIPTION
Chart v4 collapsed `windmill-lsp` into the new `windmill-extra` deployment. The CNP's matchExpressions In-list needs to use the new label name.