### PR TITLE
fix(home/ntfy): listen on :8080 (non-privileged port)

### DIFF
--- a/kubernetes/apps/home/ntfy/app/cnp-allow.yaml
+++ b/kubernetes/apps/home/ntfy/app/cnp-allow.yaml
@@ -12,14 +12,14 @@ spec:
     egress: false
     ingress: false
   ingress:
-    # Envoy gateway → ntfy:80 (public HTTPRoute + LAN HTTPRoute).
+    # Envoy gateway → ntfy:8080 (public HTTPRoute + LAN HTTPRoute).
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: network
             app.kubernetes.io/name: envoy
       toPorts:
         - ports:
-            - port: "80"
+            - port: "8080"
               protocol: TCP
     # In-cluster callers (Windmill workflows in `home` ns) hit the
     # Service directly via cluster DNS, bypassing the gateway.
@@ -32,7 +32,7 @@ spec:
             app.kubernetes.io/name: windmill-workers
       toPorts:
         - ports:
-            - port: "80"
+            - port: "8080"
               protocol: TCP
     # Prometheus → ntfy:9090 /metrics.
     - fromEndpoints:

--- a/kubernetes/apps/home/ntfy/app/helmrelease.yaml
+++ b/kubernetes/apps/home/ntfy/app/helmrelease.yaml
@@ -51,7 +51,7 @@ spec:
         controller: ntfy
         ports:
           http:
-            port: 80
+            port: 8080
           metrics:
             port: 9090
     persistence:

--- a/kubernetes/apps/home/ntfy/app/resources/server.yml
+++ b/kubernetes/apps/home/ntfy/app/resources/server.yml
@@ -12,7 +12,11 @@
 #   kubectl -n home exec deploy/ntfy -- ntfy access rob       'approvals,alerts,costs,digests' ro
 
 base-url: "https://ntfy.${SECRET_DOMAIN}"
-listen-http: ":80"
+# Listening on a non-privileged port because the container runs as
+# UID 1000 with all capabilities dropped — bind to :80 was denied.
+# The Service exposes ClusterIP:8080 and the HTTPRoute backendRef
+# targets 8080; envoy terminates TLS upstream on 443.
+listen-http: ":8080"
 
 cache-file: /var/cache/ntfy/cache.db
 cache-duration: 12h

--- a/kubernetes/apps/home/ntfy/app/route.yaml
+++ b/kubernetes/apps/home/ntfy/app/route.yaml
@@ -28,4 +28,4 @@ spec:
   rules:
     - backendRefs:
         - name: ntfy
-          port: 80
+          port: 8080


### PR DESCRIPTION
## Summary
Container runs as UID 1000 with all caps dropped — bind to `:80` failed with `permission denied`. Switch to `:8080` throughout (server.yml `listen-http`, Service port, HTTPRoute backendRef, CNP allow). Envoy still terminates TLS on 443 upstream.

## Test plan
- [ ] Flux reconcile → ntfy pod transitions out of CrashLoopBackOff
- [ ] `curl -k https://ntfy.${SECRET_DOMAIN}` returns ntfy index page

🤖 Generated with [Claude Code](https://claude.com/claude-code)