### PR TITLE
feat(zot): add mcr.microsoft.com to pull-through sync

### DIFF
--- a/kubernetes/apps/kube-system/zot/app/resources/config.json
+++ b/kubernetes/apps/kube-system/zot/app/resources/config.json
@@ -132,6 +132,17 @@
           "tlsVerify": true
         },
         {
+          "urls": ["https://mcr.microsoft.com"],
+          "content": [
+            {
+              "prefix": "**",
+              "destination": "/mcr.microsoft.com"
+            }
+          ],
+          "onDemand": true,
+          "tlsVerify": true
+        },
+        {
           "urls": ["http://lovenet-registry.${SECRET_DOMAIN}:5000"],
           "content": [
             {


### PR DESCRIPTION
chrome-mcp pulls \`mcr.microsoft.com/playwright/mcp\` directly today; follow-up from #11665. Adds MCR to ZOT's sync list so future image pulls go through the in-cluster cache.

On-demand sync; pattern matches the existing docker.io / ghcr.io / gcr.io / registry.k8s.io / public.ecr.aws entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)