### PR TITLE
fix(mcp-system/memory-mcp): schema-init Job echo no longer eats DATABASE_URL

### DIFF
--- a/kubernetes/apps/mcp-system/memory-mcp/app/schema-init-job.yaml
+++ b/kubernetes/apps/mcp-system/memory-mcp/app/schema-init-job.yaml
@@ -39,7 +39,10 @@ spec:
             - -c
             - |
               set -euo pipefail
-              echo "Applying kg schema to ${DATABASE_URL%%\?*}"
+              # Don't echo DATABASE_URL — contains credentials. The earlier
+              # ${DATABASE_URL%%\?*} attempt globbed away the whole string
+              # because `?*` matches everything (bash glob, not regex).
+              echo "Applying kg schema to the langgraph_memory database."
               psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f /sql/schema.sql
               echo "Schema apply complete."
           env:


### PR DESCRIPTION
## Summary

Cosmetic fix to the schema-init Job's diagnostic echo. The previous \`echo \"Applying kg schema to \${DATABASE_URL%%\?*}\"\` was meant to strip query params from a printed URL but bash glob expansion treats \`?*\` as "any char followed by anything" — which matches the whole string. Result: the diagnostic always printed \`Applying kg schema to \` with nothing after.

\`psql\` reads \`\$DATABASE_URL\` directly, not the echo'd value, so this was purely cosmetic. Replacing with a static message keeps credentials out of logs without resurrecting the glob trap.

## Test plan

- [x] \`kubectl kustomize\` clean
- [ ] Next schema-init Job run shows \`Applying kg schema to the langgraph_memory database.\` instead of the empty form (will trigger naturally on the next memory-mcp manifest change that bumps the Job's ConfigMap hash, otherwise can be forced via Job delete)

🤖 Generated with [Claude Code](https://claude.com/claude-code)