### PR TITLE
feat(mcp-system/memory-mcp): bump v0.1.2 + httpGet probes; open-webui catalog

### DIFF
--- a/kubernetes/apps/collab/open-webui/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/open-webui/app/helmrelease.yaml
@@ -91,7 +91,7 @@ spec:
                     "info": {
                       "id": "lovenet-gateway",
                       "name": "Lovenet MCP Gateway",
-                      "description": "Aggregated MCP tools: kubectl, grafana, ha, paperless, prometheus, frigate, omada, netbox, *arr, searxng"
+                      "description": "Aggregated MCP tools: kubectl, grafana, ha, paperless, prometheus, frigate, omada, netbox, *arr, searxng, memory (knowledge-graph search across all agents)"
                     }
                   }
                 ]

--- a/kubernetes/apps/mcp-system/memory-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/memory-mcp/app/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/memory-mcp
-              tag: 0.1.1@sha256:8f5e85891dd1b80a4811538114de35e186f2a5e140397bbe2f99fe55a3ff97f1
+              tag: v0.1.2@sha256:0726dbd4fc8336b0450a0ac95eed5d929a85d7c467d14af1e8f0556971a96f87
             env:
               # CNPG-generated app Secret reflected from databases ns
               # via emberstack reflector (see langgraph-memory
@@ -42,11 +42,16 @@ spec:
               PORT: "8070"
               TZ: America/New_York
             probes:
+              # v0.1.2 server exposes /healthz (DB ping) and /readyz
+              # (DB + Ollama probe) via FastMCP custom_route. Switch from
+              # TCP-only to httpGet so the kubelet drops us out of
+              # Service rotation if Postgres or Ollama go sideways.
               liveness:
                 enabled: true
                 custom: true
                 spec:
-                  tcpSocket:
+                  httpGet:
+                    path: /healthz
                     port: &httpPort 8070
                   initialDelaySeconds: 15
                   periodSeconds: 30
@@ -56,7 +61,8 @@ spec:
                 enabled: true
                 custom: true
                 spec:
-                  tcpSocket:
+                  httpGet:
+                    path: /readyz
                     port: *httpPort
                   initialDelaySeconds: 5
                   periodSeconds: 10
@@ -66,7 +72,8 @@ spec:
                 enabled: true
                 custom: true
                 spec:
-                  tcpSocket:
+                  httpGet:
+                    path: /healthz
                     port: *httpPort
                   initialDelaySeconds: 5
                   periodSeconds: 5


### PR DESCRIPTION
## Summary

Two related changes:

1. **memory-mcp v0.1.1 → v0.1.2** (pinned by digest `sha256:0726dbd4fc8336b0450a0ac95eed5d929a85d7c467d14af1e8f0556971a96f87`). New surface in v0.1.2:
   - \`update_entity\` tool — rename / retype / re-namespace, relations survive via id-based join
   - \`update_observation\` tool — replace content + re-embed in place
   - \`/healthz\` endpoint (process up + Postgres SELECT 1)
   - \`/readyz\` endpoint (\`/healthz\` + Ollama \`/api/tags\` reachable)
2. **kubelet probes switch from TCP to httpGet** against \`/healthz\` (liveness + startup) and \`/readyz\` (readiness). Real partial-outage detection now — kubelet drops us out of the Service if Postgres or Ollama go sideways.
3. **Open WebUI catalog** — lovenet-gateway TOOL_SERVER_CONNECTIONS description mentions memory tools. Cosmetic (tools auto-discover via MCP), but makes the catalog self-explanatory.

## Test plan

- [x] \`kubectl kustomize\` clean on both helmrelease.yaml's
- [ ] Post-merge: memory-mcp pod restarts with new image (v0.1.2 digest)
- [ ] Post-merge: \`curl <pod>/healthz\` returns 200 with \`{"status":"ok"}\`; \`curl <pod>/readyz\` likewise
- [ ] Post-merge: \`memory_update_entity\` and \`memory_update_observation\` appear in the MCP gateway tool list
- [ ] Post-merge: Open WebUI's lovenet-gateway entry shows the updated description

🤖 Generated with [Claude Code](https://claude.com/claude-code)