### PR TITLE
feat(mcp-system): nightly chrome-mcp smoke sweep CronJob

### DIFF
--- a/kubernetes/apps/mcp-system/chrome-smoke-sweep/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/chrome-smoke-sweep/app/helmrelease.yaml
@@ -1,0 +1,69 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: chrome-smoke-sweep
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 1h
+  values:
+    defaultPodOptions:
+      securityContext:
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+    controllers:
+      chrome-smoke-sweep:
+        type: cronjob
+        cronjob:
+          schedule: "10 5 * * *"
+          timeZone: "Etc/UTC"
+          concurrencyPolicy: Forbid
+          successfulJobsHistoryLimit: 3
+          failedJobsHistoryLimit: 7
+          backoffLimit: 1
+        annotations:
+          reloader.stakater.com/auto: "true"
+        pod:
+          annotations:
+            sidecar.istio.io/inject: "true"
+          restartPolicy: OnFailure
+        containers:
+          app:
+            image:
+              repository: docker.io/alpine/k8s
+              tag: "1.36.1"
+            command:
+              - /bin/sh
+              - /config/sweep.sh
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - ALL
+              readOnlyRootFilesystem: true
+              seccompProfile:
+                type: RuntimeDefault
+    persistence:
+      config:
+        type: configMap
+        name: chrome-smoke-sweep
+        defaultMode: 0o555
+        globalMounts:
+          - path: /config
+            readOnly: true
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/mcp-system/chrome-smoke-sweep/app/kustomization.yaml
+++ b/kubernetes/apps/mcp-system/chrome-smoke-sweep/app/kustomization.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../components/repos/app-template
+resources:
+  - ./helmrelease.yaml
+configMapGenerator:
+  - name: chrome-smoke-sweep
+    files:
+      - hostnames.txt=./resources/hostnames.txt
+      - sweep.sh=./resources/sweep.sh
+generatorOptions:
+  disableNameSuffixHash: true

--- a/kubernetes/apps/mcp-system/chrome-smoke-sweep/app/resources/hostnames.txt
+++ b/kubernetes/apps/mcp-system/chrome-smoke-sweep/app/resources/hostnames.txt
@@ -1,0 +1,28 @@
+# Public hostnames swept nightly via chrome-mcp. One per line.
+# Comment lines (#) and blanks are skipped. Order is not significant.
+
+# Auth + recently-changed
+auth.thesteamedcrab.com
+windmill.thesteamedcrab.com
+holmesgpt.thesteamedcrab.com
+
+# Daily-driver UI
+hass.thesteamedcrab.com
+photos.thesteamedcrab.com
+chat.thesteamedcrab.com
+gonic.thesteamedcrab.com
+glance.thesteamedcrab.com
+start.thesteamedcrab.com
+
+# OIDC-gated apps (bjw-s items[] regression class)
+paperless.thesteamedcrab.com
+jellyfin.thesteamedcrab.com
+open-webui.thesteamedcrab.com
+stash.thesteamedcrab.com
+romm.thesteamedcrab.com
+frigate.thesteamedcrab.com
+music-assistant.thesteamedcrab.com
+
+# Observability
+grafana.thesteamedcrab.com
+alertmanager.thesteamedcrab.com

--- a/kubernetes/apps/mcp-system/chrome-smoke-sweep/app/resources/sweep.sh
+++ b/kubernetes/apps/mcp-system/chrome-smoke-sweep/app/resources/sweep.sh
@@ -1,0 +1,121 @@
+#!/bin/sh
+# chrome-smoke-sweep — nightly browser smoke test of public-facing apps.
+# Talks directly to chrome-mcp via the in-namespace Service (no broker /
+# no JWT — intra-namespace traffic is allowed via the baseline CNP).
+#
+# MVP: navigates each hostname, captures title + console error count, logs
+# results. Exits non-zero if any host fails to return a final URL (proxy
+# for "browser couldn't load anything"). No baseline-diff yet — that's a
+# follow-up; this run just makes the data visible in kubectl logs.
+
+set -eu
+
+PW_URL="${PW_URL:-http://chrome-mcp.mcp-system.svc.cluster.local:8931/mcp}"
+HOSTS_FILE="${HOSTS_FILE:-/config/hostnames.txt}"
+
+HEADERS_FILE="$(mktemp)"
+trap 'rm -f "${HEADERS_FILE}"' EXIT
+
+mcp_post() {
+  # $1 = JSON body. Captures response headers to HEADERS_FILE (overwrite).
+  # Handles both plain-JSON and SSE response framing: if the body has a
+  # `data: ` line, emit just that payload; otherwise emit the body as-is.
+  RAW="$(curl -fsS -X POST "${PW_URL}" \
+    -D "${HEADERS_FILE}" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json, text/event-stream" \
+    ${SESSION_ID:+-H "Mcp-Session-Id: ${SESSION_ID}"} \
+    --data "$1")"
+  SSE_LINE="$(printf '%s' "${RAW}" | sed -n '/^data: /{s///;p;q;}')"
+  if [ -n "${SSE_LINE}" ]; then
+    printf '%s' "${SSE_LINE}"
+  else
+    printf '%s' "${RAW}"
+  fi
+}
+
+mcp_notify() {
+  # Notifications never get a response body; suppress.
+  curl -fsS -X POST "${PW_URL}" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json, text/event-stream" \
+    -H "Mcp-Session-Id: ${SESSION_ID}" \
+    --data "$1" \
+    >/dev/null
+}
+
+echo "== chrome-smoke-sweep =="
+echo "PW_URL=${PW_URL}"
+echo "HOSTS_FILE=${HOSTS_FILE}"
+echo
+
+SESSION_ID=""
+INIT_RESP="$(mcp_post '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"chrome-smoke-sweep","version":"1.0"}}}')"
+SESSION_ID="$(awk 'BEGIN{IGNORECASE=1} /^mcp-session-id:/{print $2}' "${HEADERS_FILE}" | tr -d '\r\n')"
+
+if [ -z "${SESSION_ID}" ]; then
+  echo "FATAL: no Mcp-Session-Id header from chrome-mcp" >&2
+  cat "${HEADERS_FILE}" >&2
+  exit 2
+fi
+
+# Don't print the full SESSION_ID — it's a per-invocation token, not secret
+# in the traditional sense but no reason to leak it to logs either.
+echo "Session established."
+echo
+
+mcp_notify '{"jsonrpc":"2.0","method":"notifications/initialized"}'
+
+REQ_ID=10
+TOTAL=0
+FAILED=0
+HIGH_CONSOLE=0
+printf '%-9s  %-45s  %s\n' "STATUS" "HOSTNAME" "TITLE / FINAL URL / CONSOLE"
+
+while IFS= read -r LINE; do
+  HOST="$(printf '%s' "${LINE}" | sed -e 's/[[:space:]]*$//' -e 's/^[[:space:]]*//')"
+  [ -z "${HOST}" ] && continue
+  case "${HOST}" in \#*) continue ;; esac
+
+  TOTAL=$((TOTAL + 1))
+  REQ_ID=$((REQ_ID + 1))
+  BODY="$(printf '{"jsonrpc":"2.0","id":%d,"method":"tools/call","params":{"name":"browser_navigate","arguments":{"url":"https://%s"}}}' "${REQ_ID}" "${HOST}")"
+  RESP="$(mcp_post "${BODY}" || echo '{}')"
+
+  # Retry once on the known "Session not found" intermittency
+  # (see project_chrome_mcp_playwright_gotchas).
+  if printf '%s' "${RESP}" | grep -q "Session not found"; then
+    REQ_ID=$((REQ_ID + 1))
+    BODY="$(printf '{"jsonrpc":"2.0","id":%d,"method":"tools/call","params":{"name":"browser_navigate","arguments":{"url":"https://%s"}}}' "${REQ_ID}" "${HOST}")"
+    RESP="$(mcp_post "${BODY}" || echo '{}')"
+  fi
+
+  TEXT="$(printf '%s' "${RESP}" | jq -r '.result.content[]?.text // empty' 2>/dev/null | tr -s '\n' ' ')"
+
+  TITLE="$(printf '%s' "${TEXT}" | sed -n 's/.*Page Title: \([^#]*\) #*.*/\1/p' | sed 's/ *$//' | head -c 60)"
+  FINAL_URL="$(printf '%s' "${TEXT}" | sed -n 's/.*Page URL: \([^ ]*\) .*/\1/p' | head -1)"
+  ERRORS="$(printf '%s' "${TEXT}" | sed -n 's/.*Console: \([0-9]*\) errors.*/\1/p' | head -1)"
+  ERRORS="${ERRORS:-0}"
+
+  STATUS="OK"
+  if [ -z "${FINAL_URL}" ]; then
+    STATUS="FAIL"
+    FAILED=$((FAILED + 1))
+  elif [ "${ERRORS}" -gt 15 ]; then
+    # Threshold matches what an unauthenticated SPA login page (Windmill,
+    # etc.) typically emits — see memory. Above this is a probable
+    # regression worth eyeballing.
+    STATUS="LOUD"
+    HIGH_CONSOLE=$((HIGH_CONSOLE + 1))
+  fi
+
+  printf '%-9s  %-45s  %s | %s | %s errors\n' "${STATUS}" "${HOST}" "${TITLE:-<no title>}" "${FINAL_URL:-<no url>}" "${ERRORS}"
+done < "${HOSTS_FILE}"
+
+echo
+echo "Summary: ${TOTAL} hosts | ${FAILED} failed | ${HIGH_CONSOLE} loud-console"
+
+# Exit non-zero only on hard navigate failures. LOUD is a signal for the
+# operator to look, not a CronJob failure — the cluster has plenty of
+# legitimate "noisy console on the login page" cases.
+[ "${FAILED}" -eq 0 ]

--- a/kubernetes/apps/mcp-system/chrome-smoke-sweep/ks.yaml
+++ b/kubernetes/apps/mcp-system/chrome-smoke-sweep/ks.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app chrome-smoke-sweep
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: mcp-system
+  path: ./kubernetes/apps/mcp-system/chrome-smoke-sweep/app
+  interval: 1h
+  timeout: 5m
+  prune: true
+  wait: false
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: chrome-mcp
+      namespace: mcp-system
+  retryInterval: 2m

--- a/kubernetes/apps/mcp-system/kustomization.yaml
+++ b/kubernetes/apps/mcp-system/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
   - ./namespace.yaml
   - ./arr-mcp/ks.yaml
   - ./chrome-mcp/ks.yaml
+  - ./chrome-smoke-sweep/ks.yaml
   - ./github-mcp/ks.yaml
   - ./grafana-mcp/ks.yaml
   - ./ha-mcp/ks.yaml


### PR DESCRIPTION
## Summary

MVP CronJob that closes the [[feedback_netpol_rollout_needs_per_app_browser_test]] loop: hits 18 public-facing hostnames via chrome-mcp every night at **05:10 UTC**, captures page title + final URL + console error count, logs the result to stdout (`kubectl logs -n mcp-system <pod>`).

- Connects **directly** to chrome-mcp via the in-namespace Service (`http://chrome-mcp.mcp-system.svc.cluster.local:8931/mcp`), bypassing the broker + JWT. Same trust boundary — both pods live in `mcp-system` behind default-deny + allow-intra-namespace.
- Image is `alpine/k8s:1.36.1` (same as `mcp-gateway-jwt-rotator`) — carries `curl + jq + sed + sh`, all the streamable-HTTP MCP dance needs.
- Script handles SSE-vs-plain-JSON response framing and the documented [[project_chrome_mcp_playwright_gotchas]] "Session not found" retry-once pattern.
- Hostname list at `app/resources/hostnames.txt` — edit + Flux reconcile to change coverage.

## What this does NOT do (yet)

- **No regression baseline.** Today the operator looks at logs; tomorrow we add a baseline ConfigMap + diff. Out of scope here.
- **No Pushover / Zulip routing.** A CronJob failure → existing `KubernetesJobFailed`-class alert. The "LOUD console" status (>15 errors) is informational only.

## Test plan

- [ ] Flux reconciles \`chrome-smoke-sweep\` HelmRelease cleanly
- [ ] CronJob fires once manually (\`kubectl create job ... --from=cronjob/chrome-smoke-sweep\`)
- [ ] Pod log shows the punch-list table for all 18 hosts
- [ ] Exit code is 0 (no hard navigate failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)