### PR TITLE
feat(home/windmill): stand up approval-receive flow via Zulip bot

### DIFF
--- a/kubernetes/apps/collab/zulip/app/cnp-allow.yaml
+++ b/kubernetes/apps/collab/zulip/app/cnp-allow.yaml
@@ -65,6 +65,19 @@ spec:
         - ports:
             - port: "2525"
               protocol: TCP
+    # Outgoing-webhook bots (approval-receiver-bot) post to Windmill
+    # on @-mention. Routes through smokescreen (127.0.0.1:4750) which
+    # then dials windmill-app:8000 directly — smokescreen needs
+    # --allow-range 10.42.0.0/16 + 10.43.0.0/16 to permit cluster
+    # CIDRs (currently a manual edit; codify in HR initContainer).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: home
+            app.kubernetes.io/name: windmill-app
+      toPorts:
+        - ports:
+            - port: "8000"
+              protocol: TCP
     # Mobile push notifications via the Zulip-operated PNS at
     # push.zulipchat.com (SETTING_ZULIP_SERVICE_PUSH_NOTIFICATIONS=true).
     # Uncertain whether push.zulipchat.com has a CNAME chain or is

--- a/kubernetes/apps/home/windmill/app/cnp-allow.yaml
+++ b/kubernetes/apps/home/windmill/app/cnp-allow.yaml
@@ -34,6 +34,12 @@ spec:
         - matchLabels:
             io.kubernetes.pod.namespace: observability
             app.kubernetes.io/name: alertmanager
+        # Zulip outgoing-webhook (approval-receiver-bot) calls
+        # /api/w/lovenet/jobs/run/p/f/lovenet/langgraph-approval-receive
+        # when Rob @-mentions the bot in the #approvals stream.
+        - matchLabels:
+            io.kubernetes.pod.namespace: collab
+            app.kubernetes.io/name: zulip
       toPorts:
         - ports:
             - port: "8000"

--- a/kubernetes/apps/home/windmill/workflows/langgraph-approval-post.ts
+++ b/kubernetes/apps/home/windmill/workflows/langgraph-approval-post.ts
@@ -31,7 +31,10 @@ export async function main(body: ApprovalRequest) {
         `**Undo path:** ${r.undo_path ?? "_(none — will escalate to Class D)_"}`,
         `**Cost estimate:** $${r.cost_estimate_usd ?? 0}`,
         "",
-        "React: 👍 approve / 👎 reject / ⏸️ defer 4h",
+        "Reply with one of (Zulip outgoing webhooks fire on @-mentions, not reactions):",
+        "  @**Approval Receiver** approve",
+        "  @**Approval Receiver** reject",
+        "  @**Approval Receiver** defer",
     ].join("\n");
 
     // Post to Zulip via REST as the n8n-bot user.

--- a/kubernetes/apps/home/windmill/workflows/langgraph-approval-receive.ts
+++ b/kubernetes/apps/home/windmill/workflows/langgraph-approval-receive.ts
@@ -1,35 +1,67 @@
-// Triggered by Zulip outgoing-webhook on emoji reactions in #approvals.
+// Outgoing-webhook target for the @Approval-Receiver Zulip bot.
 //
-// Verifies the reactor is Rob, maps the emoji → approve/reject/defer,
-// parses task_id from the topic, signs an HMAC-SHA256 approval token,
-// and POSTs it to langgraph-agents /approval.
+// Zulip outgoing webhooks fire on messages (not reactions), so the
+// approval UX is: Rob types "@Approval-Receiver approve" (or reject /
+// defer) inside the topic for the approval request. We:
 //
-// Replaces the n8n flow "LangGraph → Approval receive (Zulip reaction)".
+//   1. Verify the sender is Rob (sender_id match against
+//      ROB_ZULIP_USER_ID)
+//   2. Parse the message body for an intent keyword
+//   3. Parse the topic for task_id + class + target (same format as
+//      approval-post used: "<task_id> — Class <C/D>: <action>")
+//   4. HMAC-sign an approval token
+//   5. POST it to langgraph-agents /approval
+//
+// Bot ingress uses ?token=<TOKEN> in the URL (Zulip outgoing webhook
+// posts can't carry custom Authorization headers).
 
 import { crypto } from "https://deno.land/std@0.224.0/crypto/mod.ts";
 
-type ZulipReactionEvent = {
-    user_id?: number;
-    emoji_name?: string;
+type ZulipOutgoingMessage = {
+    sender_id: number;
+    sender_email: string;
+    subject: string; // alias for topic
     topic?: string;
-    message?: { topic?: string };
+    content: string;
+    stream_id?: number;
+    type?: "stream" | "private";
 };
 
-export async function main(body: ZulipReactionEvent) {
+// Zulip outgoing-webhook payload top-level keys.
+// `data` is the message text with the bot mention stripped.
+export async function main(
+    data?: string,
+    trigger?: string,
+    message?: ZulipOutgoingMessage,
+    bot_email?: string,
+) {
     const robId = parseInt(Deno.env.get("ROB_ZULIP_USER_ID") ?? "0", 10);
-    if (body.user_id !== robId) {
-        return { skip: true, reason: "reactor is not Rob", user_id: body.user_id };
+    if (!message || message.sender_id !== robId) {
+        return { skip: true, reason: "sender not Rob", sender_id: message?.sender_id };
+    }
+    if (message.type !== "stream") {
+        return { skip: true, reason: "not a stream message", type: message.type };
     }
 
-    const emoji = body.emoji_name ?? "";
+    // Parse intent from message text (already has the @mention stripped by Zulip).
+    const text = (data ?? "").toLowerCase();
     let reaction: "approve" | "reject" | "defer" | undefined;
-    if (emoji === "thumbs_up" || emoji === "+1") reaction = "approve";
-    else if (emoji === "thumbs_down" || emoji === "-1") reaction = "reject";
-    else if (emoji === "pause" || emoji === "pause_button") reaction = "defer";
-    else return { skip: true, reason: "irrelevant emoji", emoji };
+    if (/\bapprove\b/.test(text) || text.includes("👍") || text.includes(":thumbs_up:")) {
+        reaction = "approve";
+    } else if (/\breject\b/.test(text) || text.includes("👎") || text.includes(":thumbs_down:")) {
+        reaction = "reject";
+    } else if (/\bdefer\b/.test(text) || text.includes("⏸️") || text.includes(":pause:")) {
+        reaction = "defer";
+    } else {
+        return {
+            skip: true,
+            reason: "no approve/reject/defer keyword in message",
+            text: text.slice(0, 80),
+        };
+    }
 
     // Topic format: "<task_id> — Class <C/D>: <action>"
-    const topic = body.message?.topic ?? body.topic ?? "";
+    const topic = message.topic ?? message.subject ?? "";
     const taskMatch = topic.match(/^([\w-]+)\s/);
     if (!taskMatch) return { skip: true, reason: "no task_id in topic", topic };
     const task_id = taskMatch[1];
@@ -44,7 +76,6 @@ export async function main(body: ZulipReactionEvent) {
     const [server, ...rest] = target.split(".");
     const method = rest.join(".");
 
-    // Sign approval token.
     const secret = Deno.env.get("LANGGRAPH_APPROVAL_SIGNING_KEY");
     if (!secret) throw new Error("LANGGRAPH_APPROVAL_SIGNING_KEY env not set");
 
@@ -55,7 +86,6 @@ export async function main(body: ZulipReactionEvent) {
     const sig = await hmacSha256Hex(secret, payload);
     const approval_token = `${payload}:${sig}`;
 
-    // POST to langgraph-agents.
     const r = await fetch("http://langgraph-agents.ai.svc.cluster.local:8765/approval", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -63,7 +93,42 @@ export async function main(body: ZulipReactionEvent) {
         signal: AbortSignal.timeout(300_000),
     });
     const lgResult = await r.json().catch(() => ({}));
+
+    // Post a Zulip ack in the same topic so Rob sees the bot
+    // acknowledged the action. Uses the existing n8n-bot creds
+    // (still write-authorized to the approvals stream). Best-effort —
+    // we don't fail the job if the ack post errors out.
+    try {
+        await postAck(message.topic ?? message.subject ?? "", reaction, lgResult.status);
+    } catch (e) {
+        console.error("post-ack failed (non-fatal):", e);
+    }
+
     return { status: lgResult.status ?? "completed", task_id, reaction };
+}
+
+async function postAck(topic: string, reaction: string, lgStatus: string) {
+    const email = Deno.env.get("ZULIP_BOT_EMAIL");
+    const apiKey = Deno.env.get("ZULIP_BOT_API_KEY");
+    if (!email || !apiKey) return;
+    const auth = "Basic " + btoa(`${email}:${apiKey}`);
+    const zulipHost = Deno.env.get("ZULIP_HOST") ?? "chat.thesteamedcrab.com";
+    const emoji = reaction === "approve" ? "✅" : reaction === "reject" ? "🛑" : "⏸";
+    const form = new URLSearchParams({
+        type: "stream",
+        to: "approvals",
+        topic,
+        content: `${emoji} **${reaction}** → langgraph status: \`${lgStatus ?? "ok"}\``,
+    });
+    await fetch(`https://${zulipHost}/api/v1/messages`, {
+        method: "POST",
+        headers: {
+            Authorization: auth,
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: form,
+        signal: AbortSignal.timeout(15_000),
+    });
 }
 
 async function hmacSha256Hex(secret: string, msg: string): Promise<string> {

--- a/kubernetes/apps/home/windmill/workflows/langgraph-inbox.ts
+++ b/kubernetes/apps/home/windmill/workflows/langgraph-inbox.ts
@@ -66,7 +66,10 @@ async function postApproval(
         `**Undo path:** ${r.undo_path ?? "_(none — will escalate to Class D)_"}`,
         `**Cost estimate:** $${r.cost_estimate_usd ?? 0}`,
         "",
-        "React: 👍 approve / 👎 reject / ⏸️ defer 4h",
+        "Reply with one of (Zulip outgoing webhooks fire on @-mentions, not reactions):",
+        "  @**Approval Receiver** approve",
+        "  @**Approval Receiver** reject",
+        "  @**Approval Receiver** defer",
     ].join("\n");
 
     const email = Deno.env.get("ZULIP_BOT_EMAIL");


### PR DESCRIPTION
## Summary

Wires up Windmill \`langgraph-approval-receive\` to fire on Zulip @-mention of a new outgoing-webhook bot \`approval-receiver-bot\`. Rob types \`@**Approval Receiver** approve\` (or reject / defer) in any topic of \`#approvals\` to act on the paused langgraph task.

## Changes in this PR

- approval-receive.ts: rewritten to handle Zulip outgoing-webhook payload (message-based, not reaction-based).
- approval-post.ts + langgraph-inbox.ts: instruction text updated to direct Rob to @-mention the new bot.
- windmill-allow CNP: add \`collab/zulip\` ingress → \`:8000\`.
- zulip-allow CNP: add \`home/windmill-app\` egress → \`:8000\`.

## Out-of-tree state (created live)

- Zulip bot \`approval-receiver-bot@chat.thesteamedcrab.com\` (user_id 63, bot_type 3) — created via \`manage.py shell\` since the API endpoint requires session cookies.
- Subscribed to \`#approvals\`.
- Service URL points at Windmill with \`?token=<TOKEN>\` (token in 1P \`windmill.zulip_approval_webhook_token\`).
- Smokescreen (Zulip's SSRF-protection proxy) was patched live to allow cluster CIDRs (10.42/16 + 10.43/16) — currently a manual edit, not persisted across pod restarts.

## Known follow-up

- **Codify the smokescreen ACL** in the Zulip chart (initContainer that writes \`/etc/supervisor/conf.d/zulip/smokescreen.conf\` with the \`--allow-range\` flags). Without this, a Zulip pod restart breaks the approval-receive path.

## Test plan

- [x] Bot creation succeeded; bot subscribed to \`#approvals\`.
- [x] Synthetic webhook POST to Windmill returns success.
- [ ] After merge + Flux reconcile: \`@**Approval Receiver** approve\` posted to a \`#approvals\` topic fires the Windmill job within 10s.