### PR TITLE
feat(mcp-system/memory-mcp): httpGet probes + open-webui memory mention

### DIFF
--- a/kubernetes/apps/collab/open-webui/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/open-webui/app/helmrelease.yaml
@@ -91,7 +91,7 @@ spec:
                     "info": {
                       "id": "lovenet-gateway",
                       "name": "Lovenet MCP Gateway",
-                      "description": "Aggregated MCP tools: kubectl, grafana, ha, paperless, prometheus, frigate, omada, netbox, *arr, searxng"
+                      "description": "Aggregated MCP tools: kubectl, grafana, ha, paperless, prometheus, frigate, omada, netbox, *arr, searxng, memory (knowledge-graph search across all agents)"
                     }
                   }
                 ]

--- a/kubernetes/apps/mcp-system/memory-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/memory-mcp/app/helmrelease.yaml
@@ -42,11 +42,16 @@ spec:
               PORT: "8070"
               TZ: America/New_York
             probes:
+              # v0.1.2 server exposes /healthz (DB ping) and /readyz
+              # (DB + Ollama probe) via FastMCP custom_route. Switch from
+              # TCP-only to httpGet so the kubelet drops us out of
+              # Service rotation if Postgres or Ollama go sideways.
               liveness:
                 enabled: true
                 custom: true
                 spec:
-                  tcpSocket:
+                  httpGet:
+                    path: /healthz
                     port: &httpPort 8070
                   initialDelaySeconds: 15
                   periodSeconds: 30
@@ -56,7 +61,8 @@ spec:
                 enabled: true
                 custom: true
                 spec:
-                  tcpSocket:
+                  httpGet:
+                    path: /readyz
                     port: *httpPort
                   initialDelaySeconds: 5
                   periodSeconds: 10
@@ -66,7 +72,8 @@ spec:
                 enabled: true
                 custom: true
                 spec:
-                  tcpSocket:
+                  httpGet:
+                    path: /healthz
                     port: *httpPort
                   initialDelaySeconds: 5
                   periodSeconds: 5


### PR DESCRIPTION
## Summary

Two small follow-ups now that #11695 (Renovate) bumped the image to v0.1.2:

1. **Probes switch from TCP to httpGet** against the new \`/healthz\` (liveness + startup) and \`/readyz\` (readiness) endpoints that v0.1.2 introduces. Partial outages — Postgres or Ollama unreachable — now drop the pod out of the Service via 503 instead of being silently masked under a passing TCP socket.
2. **Open WebUI catalog description** — lovenet-gateway TOOL_SERVER_CONNECTIONS gets a memory mention. Cosmetic (tools auto-discover via MCP).

## Test plan

- [x] \`kubectl kustomize\` clean
- [ ] Post-merge: \`curl <pod>:8070/healthz\` → 200 \`{"status":"ok"}\`
- [ ] Post-merge: \`curl <pod>:8070/readyz\` → 200 (or 503 if Ollama briefly hiccups, which is the point)
- [ ] Kubelet probe events show httpGet instead of tcp-socket

🤖 Generated with [Claude Code](https://claude.com/claude-code)