### PR TITLE
feat(home-assistant): allow egress to observability Prometheus :9090

### DIFF
--- a/kubernetes/apps/home/home-assistant/app/cnp-allow.yaml
+++ b/kubernetes/apps/home/home-assistant/app/cnp-allow.yaml
@@ -77,6 +77,19 @@ spec:
         - ports:
             - port: "8095"
               protocol: TCP
+    # Prometheus consumer integration (Pattern E — cross-ns to specific
+    # app). HA scrapes kube-prometheus-stack Prometheus for in-cluster
+    # metrics (GPU utilization, UPS, Ceph health, etc.) and surfaces
+    # them on Lovelace dashboards. Selector matches the Prometheus
+    # StatefulSet pod exclusively (not alertmanager, not the operator).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: observability
+            app.kubernetes.io/name: prometheus
+      toPorts:
+        - ports:
+            - port: "9090"
+              protocol: TCP
     # Home Assistant integrations call out to an unbounded set of cloud
     # APIs (weather, Pushover, OpenAI, voice cloud services, Frigate
     # MQTT/HTTP, calendar, etc.) plus arbitrary user-installed HACS


### PR DESCRIPTION
## Summary
- Adds a narrow egress rule to `home-assistant-allow` CiliumNetworkPolicy permitting TCP 9090 from `home-assistant` to the `kube-prometheus-stack` Prometheus StatefulSet pod (`app.kubernetes.io/name: prometheus`) in the `observability` namespace.
- Unblocks Home Assistant's Prometheus consumer integration so Lovelace dashboards can scrape in-cluster metrics — first use case is GPU utilization; UPS / Ceph health are no-cost follow-ons.

## Why
HA pod hits `kube-prometheus-stack-prometheus.observability.svc:9090` timed out under `home` ns default-deny. The existing CNP covered databases / smtp-relay / jellyfin / music-assistant / `world:443/80/8883/1883` but had no observability egress. DNS resolution is already permitted via the baseline component (`allow-dns` → `k8s-app: kube-dns`).

## Blast radius
- Single additive egress rule, selector-scoped to one pod label set in one ns. No CIDR, no `0.0.0.0/0`, no whole-ns allow.
- TCP 9090 only — does NOT open `:9093` (alertmanager) or `:10250` (kubelet).
- Does not touch any recovery-path resource (brain, wg-easy, Omada controller, DNS, BGP).
- Rollback: revert the commit; Flux reconciles in <1m.

## Test plan
- [ ] Wait for Flux reconcile after merge.
- [ ] `kubectl exec -n home home-assistant-0 -c app -- curl -sS --max-time 5 http://kube-prometheus-stack-prometheus.observability.svc.cluster.local:9090/-/healthy` returns `Prometheus Server is Healthy.` (HTTP 200).
- [ ] HA Prometheus integration loads metrics in the UI without timeout errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)