### PR TITLE
feat(observability): allow HA ingress to Prometheus :9090

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/cnp-allow.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/cnp-allow.yaml
@@ -18,10 +18,16 @@ spec:
     ingress: false
   ingress:
     # HTTPRoute on internal gateway → prometheus:9090 (web UI / API).
+    # Home Assistant prometheus sensor → prometheus:9090 (direct pull
+    # from home ns for the HA `prometheus` integration; egress side
+    # was punched through in PR #11699).
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: network
             app.kubernetes.io/name: envoy
+        - matchLabels:
+            io.kubernetes.pod.namespace: home
+            app.kubernetes.io/name: home-assistant
       toPorts:
         - ports:
             - port: "9090"


### PR DESCRIPTION
## Summary
- Mirrors PR #11699 on the Prometheus ingress side. HA `prometheus` sensor was timing out because `prometheus-allow` only permitted ingress from `network/envoy`.
- Adds a second `fromEndpoints` entry for `home/home-assistant` on TCP 9090 under the existing ingress rule. No other CNPs touched.

## Failure mode
If the selector is wrong, HA prometheus sensor remains broken (current state) — no other traffic is affected. Rollback = revert this commit.

## Test plan
- [ ] Flux reconciles `cluster-apps-kube-prometheus-stack`.
- [ ] `kubectl exec -n home home-assistant-0 -c app -- curl -sS --max-time 5 http://kube-prometheus-stack-prometheus.observability.svc.cluster.local:9090/-/healthy` returns "Prometheus Server is Healthy."

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>