### PR TITLE
fix(mcp-system/chrome-smoke-sweep): app-template cronjob schema

### DIFF
--- a/kubernetes/apps/mcp-system/chrome-smoke-sweep/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/chrome-smoke-sweep/app/helmrelease.yaml
@@ -22,11 +22,11 @@ spec:
         type: cronjob
         cronjob:
           schedule: "10 5 * * *"
-          timeZone: "Etc/UTC"
           concurrencyPolicy: Forbid
-          successfulJobsHistoryLimit: 3
-          failedJobsHistoryLimit: 7
+          successfulJobsHistory: 3
+          failedJobsHistory: 7
           backoffLimit: 1
+          ttlSecondsAfterFinished: 86400
         annotations:
           reloader.stakater.com/auto: "true"
         pod:


### PR DESCRIPTION
Follow-up to #11693 — bjw-s app-template rejected install: `successfulJobsHistoryLimit` / `failedJobsHistoryLimit` are k8s-native names, the chart wants `successfulJobsHistory` / `failedJobsHistory`. `timeZone` isn't in the schema either (cluster is UTC). Adds `ttlSecondsAfterFinished: 86400` matching beets/lidarr-bridge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)