### PR TITLE
fix(collab/zulip): wait for supervisord BEFORE writing smokescreen.conf

### DIFF
--- a/kubernetes/apps/collab/zulip/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/zulip/app/helmrelease.yaml
@@ -45,6 +45,16 @@ spec:
                         - -c
                         - |
                           set -eu
+                          # IMPORTANT: docker-zulip's entrypoint regenerates
+                          # /etc/supervisor/conf.d/zulip/*.conf during boot,
+                          # which races postStart. Wait for supervisord to be
+                          # fully alive (= entrypoint finished) BEFORE we
+                          # write our smokescreen config, otherwise the
+                          # entrypoint clobbers it.
+                          for i in $(seq 1 300); do
+                            supervisorctl status >/dev/null 2>&1 && break
+                            sleep 1
+                          done
                           cat > /etc/supervisor/conf.d/zulip/smokescreen.conf <<'EOF'
                           [program:smokescreen]
                           command=/usr/local/bin/smokescreen-464b1115f802cbd91ffee555a41e71546646d396-go-1.26.0 --listen-ip 127.0.0.1 --expose-prometheus-metrics --prometheus-port 4760 --allow-range 10.42.0.0/16 --allow-range 10.43.0.0/16
@@ -57,11 +67,6 @@ spec:
                           stdout_logfile_maxbytes=0
                           stdout_logfile_backups=0
                           EOF
-                          # Wait for supervisord to be ready (up to 60s), then reload.
-                          for i in $(seq 1 60); do
-                            supervisorctl status >/dev/null 2>&1 && break
-                            sleep 1
-                          done
                           supervisorctl reread || true
                           supervisorctl update || true
 


### PR DESCRIPTION
## Summary

PR #11702's postStart hook had a race: it wrote the smokescreen config immediately, but docker-zulip's entrypoint regenerates supervisor configs during boot and clobbers our ACL. User-visible symptom: \`Egress proxying is denied to host 'windmill-app.home.svc.cluster.local:8000': ... denied by rule 'Deny: Private Range'\`.

Reorder: wait for supervisord to be alive (proxy for entrypoint completion), THEN write the file, THEN reread/update. Bumped the wait window 60s → 300s.

## Test plan

- [ ] After merge + Flux reconcile + pod restart: \`kubectl exec zulip-0 -- grep allow-range /etc/supervisor/conf.d/zulip/smokescreen.conf\` shows both 10.42/16 and 10.43/16
- [ ] \`@**Approval Receiver** approve\` in #approvals fires Windmill with no "Egress proxying is denied" Zulip notification email