### PR TITLE
feat(mcp-system/memory-mcp): bump v0.1.3 + ServiceMonitor

### DIFF
--- a/kubernetes/apps/mcp-system/memory-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/memory-mcp/app/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/memory-mcp
-              tag: 0.1.2@sha256:0726dbd4fc8336b0450a0ac95eed5d929a85d7c467d14af1e8f0556971a96f87
+              tag: 0.1.3@sha256:984d1f55842cfc7bf4b7e62fa6972c309201b47a3168ecea169591f093129aa4
             env:
               # CNPG-generated app Secret reflected from databases ns
               # via emberstack reflector (see langgraph-memory

--- a/kubernetes/apps/mcp-system/memory-mcp/app/kustomization.yaml
+++ b/kubernetes/apps/mcp-system/memory-mcp/app/kustomization.yaml
@@ -14,3 +14,4 @@ resources:
   - ./cnp-allow.yaml
   - ./helmrelease.yaml
   - ./schema-init-job.yaml
+  - ./servicemonitor.yaml

--- a/kubernetes/apps/mcp-system/memory-mcp/app/servicemonitor.yaml
+++ b/kubernetes/apps/mcp-system/memory-mcp/app/servicemonitor.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/servicemonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: memory-mcp
+  labels:
+    app.kubernetes.io/name: memory-mcp
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: memory-mcp
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+  namespaceSelector:
+    matchNames:
+      - mcp-system


### PR DESCRIPTION
## Summary

- memory-mcp **v0.1.2 → v0.1.3** (digest \`984d1f5584...\`).
- New **ServiceMonitor** for memory-mcp — first scrape surface among the ~18 MCP backends in mcp-system.

## v0.1.3 changes (in image)

- \`memory_graph_walk(start, depth, ...)\` — BFS to N hops, returns entities + edges + frontier_hit flag
- \`memory_recent(limit, agent_filter?, since?, entity_name?)\` — most-recent observations
- \`memory_create_entities\` + \`memory_add_observations\` — transactional bulk ops
- \`/metrics\` Prometheus endpoint (process + GC collectors)

## Test plan

- [x] \`kubectl kustomize\` clean
- [ ] Post-merge: \`curl <pod>:8070/metrics\` returns Prometheus exposition format
- [ ] Post-merge: ServiceMonitor target shows up healthy on prometheus
- [ ] Post-merge: \`memory_graph_walk\`, \`memory_recent\`, \`memory_create_entities\`, \`memory_add_observations\` appear in lovenet-gateway tool list + work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)