### PR TITLE
fix(ci): allowlist docker.io/binwiederhier/ntfy

### DIFF
--- a/.github/image-registry-allowlist.txt
+++ b/.github/image-registry-allowlist.txt
@@ -52,4 +52,5 @@ docker.io/rclone/rclone                 # ghcr.io/rclone/rclone has no stable se
 docker.io/emberstack/kubernetes-reflector  # chart on ghcr.io but image is docker.io
 docker.io/qdrant/qdrant                 # ghcr.io/qdrant/qdrant ships only dev-*/master-* tags
 docker.io/robustadev/holmes             # no ghcr.io publication (ghcr.io/robusta-dev/holmes 403)
+docker.io/binwiederhier/ntfy            # no ghcr.io publication (verified 2026-05)
 lscr.io/linuxserver/openssh-server      # linuxserver's canonical registry; ghcr mirror stops at 8.3_p1


### PR DESCRIPTION
## Summary

- ntfy publishes only to Docker Hub — verified 2026-05: `skopeo list-tags docker://ghcr.io/binwiederhier/ntfy` → `name unknown`, and no `ghcr.io/home-operations/ntfy` curated mirror exists either
- adds `docker.io/binwiederhier/ntfy` to `.github/image-registry-allowlist.txt` so the `Check new images` policy step accepts ntfy version bumps

## Why

#11696 (renovate, `binwiederhier/ntfy v2.13.0 → v2.23.0`) is currently red on `Image Registry Check / Check new images`. The chrome-smoke-sweep schema block (#11701) was masking this; with that cleared, the policy step ran and correctly flagged ntfy as a non-ghcr image with no allowlist entry.

This is the same pattern as the 27 other docker.io entries already in the allowlist.

## Test plan

- [x] CI workflow `Image Registry Check / Check new images` passes on this branch
- [ ] After merge, re-run CI on #11696 (or wait for renovate-operator rebase) — ntfy bump should go green

🤖 Generated with [Claude Code](https://claude.com/claude-code)