### PR TITLE
fix(home/windmill): NTFY_URL points to in-cluster Service

### DIFF
--- a/kubernetes/apps/home/windmill/app/cnp-allow.yaml
+++ b/kubernetes/apps/home/windmill/app/cnp-allow.yaml
@@ -132,6 +132,19 @@ spec:
         - ports:
             - port: "80"
               protocol: TCP
+    # ntfy (in-cluster Service) — Windmill workflows publish pushes
+    # here. External URL https://ntfy.${SECRET_DOMAIN} doesn't work
+    # from inside the cluster (Cilium FQDN egress doesn't match the
+    # split-horizon internal LB IP), so we use the cluster-internal
+    # Service URL set in the windmill-workflows-secret NTFY_URL.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: home
+            app.kubernetes.io/name: ntfy
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
     - toEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: mcp-system

--- a/kubernetes/apps/home/windmill/app/externalsecret-workflows.yaml
+++ b/kubernetes/apps/home/windmill/app/externalsecret-workflows.yaml
@@ -20,7 +20,11 @@ spec:
         # ntfy push backend — used by the new ntfy-shape workflow
         # scripts (approval-post + inbox with action buttons,
         # awaiting-user-sweep, cost-cap-watcher, alertmanager-HolmesGPT).
-        NTFY_URL: "https://ntfy.${SECRET_DOMAIN}"
+        # In-cluster Service URL; the external URL
+        # (https://ntfy.${SECRET_DOMAIN}) times out from inside the
+        # cluster because Cilium FQDN egress doesn't match split-horizon
+        # internal LB IPs.
+        NTFY_URL: "http://ntfy.home.svc.cluster.local:8080"
         NTFY_WRITE_TOKEN: "{{ .NTFY_WRITE_TOKEN }}"
         # Pushover creds remain through the overlap window between
         # Flux applying this manifest and the new workflows being


### PR DESCRIPTION
## Summary

Workflow workers time out trying to publish to `https://ntfy.thesteamedcrab.com` from inside the cluster — Cilium's `toEntities: [world]` egress doesn't match the split-horizon internal LB IP that bind9 returns for that hostname. Verified with `kubectl exec`: external URL exits 124, in-cluster Service URL returns HTTP 200 in 4 ms.

## Fix

- `NTFY_URL` in the `windmill-workflows-secret` template now points at `http://ntfy.home.svc.cluster.local:8080`.
- New `toEndpoints` egress rule in the windmill CNP for `home/ntfy:8080`.

Phone-side action button URLs (`https://langgraph.${SECRET_DOMAIN}/approval`) are unaffected — those resolve from outside the cluster and route through cloudflared normally.

## Test plan

- [ ] Flux reconcile → windmill-workflows-secret refreshes with new URL
- [ ] Trigger `langgraph-approval-post` with synthetic body — workflow completes successfully (no TimeoutError)
- [ ] ntfy push lands on Android with action buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)