### PR TITLE
fix(home-assistant): pre-bake sync image + CNP for sync pod

### DIFF
--- a/kubernetes/apps/home/home-assistant/app/cnp-allow.yaml
+++ b/kubernetes/apps/home/home-assistant/app/cnp-allow.yaml
@@ -38,6 +38,17 @@ spec:
         - ports:
             - port: "8123"
               protocol: TCP
+    # home-assistant-config-sync CronJob (same ns) calls
+    # /api/services/homeassistant/reload_all after a successful `git
+    # pull`. Sync pod's egress to HA is the matching half of this hole.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: home
+            app.kubernetes.io/name: home-assistant-config-sync
+      toPorts:
+        - ports:
+            - port: "8123"
+              protocol: TCP
   egress:
     # Postgres recorder backend (Pattern B — CNPG cluster in databases).
     - toEndpoints:

--- a/kubernetes/apps/home/home-assistant/app/kustomization.yaml
+++ b/kubernetes/apps/home/home-assistant/app/kustomization.yaml
@@ -9,5 +9,6 @@ resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./longhorn-pvc.yaml
-  - ./sync-externalsecret.yaml
+  - ./sync-cnp.yaml
   - ./sync-cronjob.yaml
+  - ./sync-externalsecret.yaml

--- a/kubernetes/apps/home/home-assistant/app/sync-cnp.yaml
+++ b/kubernetes/apps/home/home-assistant/app/sync-cnp.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: home-assistant-config-sync-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: home-assistant-config-sync
+  # Additive — default-deny in `home` ns is what triggers the lockdown;
+  # these rules punch holes through it for the 5-min git pull + HA
+  # reload_all flow.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  egress:
+    # SSH to github.com to fetch + pull config. Cilium FQDN matching for
+    # `github.com` is feasible but the SSH session is short-lived and the
+    # broader world:22 entity already constrains by port — narrow enough
+    # for this single-purpose pod.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "22"
+              protocol: TCP
+    # /api/services/homeassistant/reload_all on the home-assistant pod
+    # after a successful pull. Intra-namespace, but explicit for
+    # grep-ability — and the home-assistant-allow CNP only opens the
+    # 8123 ingress to specific labelled clients.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: home
+            app.kubernetes.io/name: home-assistant
+      toPorts:
+        - ports:
+            - port: "8123"
+              protocol: TCP

--- a/kubernetes/apps/home/home-assistant/app/sync-cronjob.yaml
+++ b/kubernetes/apps/home/home-assistant/app/sync-cronjob.yaml
@@ -14,22 +14,26 @@ spec:
       backoffLimit: 1
       ttlSecondsAfterFinished: 86400
       template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: home-assistant-config-sync
         spec:
           restartPolicy: OnFailure
-          # Run as root so apk add can install git/curl/openssh. /config is
-          # chmod 777 and HA writes its own files as uid 568, so root-created
-          # files written by `git pull` remain accessible to HA. The
-          # safe.directory line below stops git's CVE-2022-24765 check from
-          # tripping on the uid mismatch.
+          # Run as root so files created by `git pull` keep working with
+          # uid 568 (HA). /config is owned 568; safe.directory below opts
+          # past git's CVE-2022-24765 uid-mismatch check.
           containers:
             - name: sync
-              image: docker.io/library/alpine:3.23
+              # Pre-baked image with git + ssh + wget. Avoids runtime
+              # `apk add` (which fails under home/default-deny since
+              # 2026-05-18 — alpine repos aren't reachable from this
+              # pod's egress slice).
+              image: docker.io/alpine/git:v2.52.0
               command:
                 - /bin/sh
                 - -c
                 - |
                   set -eu
-                  apk add --no-cache --quiet git curl openssh-client > /dev/null
 
                   # Set up SSH for GitHub deploy key
                   export HOME=/tmp/git-home
@@ -68,11 +72,12 @@ spec:
                     echo "Updated $BEFORE -> $AFTER"
                     # Trigger HA to reload everything reloadable; restart for unreloadable changes
                     # (this only reloads — for new packages or integrations a full restart is still needed)
-                    curl -sSf -X POST \
-                      -H "Authorization: Bearer $HA_TOKEN" \
-                      -H "Content-Type: application/json" \
+                    wget --quiet -O - \
+                      --post-data='{}' \
+                      --header="Authorization: Bearer $HA_TOKEN" \
+                      --header="Content-Type: application/json" \
                       http://home-assistant.home.svc.cluster.local:8123/api/services/homeassistant/reload_all \
-                      -d '{}' > /dev/null
+                      > /dev/null
                     echo "Triggered HA reload_all"
                   else
                     echo "No changes (HEAD=$AFTER)"


### PR DESCRIPTION
## Summary
- The `home-assistant-config-sync` CronJob has been failing since the `home/default-deny` CNP landed 2026-05-18. Pod template has no labels (no allow-CNP selects it) and runs `apk add git curl openssh-client` at runtime — alpine repos aren't reachable under default-deny. Same root cause as `project_frigate_snapshot_cronjob_broken.md`.
- **Image swap**: `docker.io/library/alpine:3.23` → `docker.io/alpine/git:v2.52.0`. Pre-baked image ships git + ssh + busybox-wget. Dropped the `apk add` line. `curl` was the only missing piece — replaced with `wget --post-data` for the single `reload_all` call.
- **Label + CNP**: Added `app.kubernetes.io/name: home-assistant-config-sync` to the pod template, then a dedicated `home-assistant-config-sync-allow` CNP opening egress to `world:22` (SSH to github) + intra-ns to `home-assistant:8123` (the reload call). Matching ingress entry added to `home-assistant-allow`.

## Blast radius
- Single new CNP scoped to one label in one ns. TCP 22 + TCP 8123 only.
- `home-assistant-allow` gains exactly one `fromEndpoints` entry for the sync pod on TCP 8123 — additive, surgical.
- Image is well-known `alpine/git`; Renovate will pin digest on next pass.
- Rollback: revert; Flux reconciles in <1m. CronJob returns to its current (already broken) state.

## Test plan
- [ ] Flux reconciles after merge.
- [ ] `kubectl create job -n home --from=cronjob/home-assistant-config-sync sync-test` runs and succeeds (no `BackoffLimitExceeded`).
- [ ] Cron at next `*/5` interval shows clean run: "No changes" or "Updated …" + "Triggered HA reload_all".
- [ ] Hubble shows no drops on the sync pod's egress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)