### PR TITLE
feat(ai/langgraph-agents): bump to v0.2.10 (MCPMemoryStore Phase 3)

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/langgraph-agents
-              tag: 0.2.9  # versioned release; Renovate tracks subsequent bumps
+              tag: 0.2.10@sha256:9c5919481d9dfe113390eac74cdf8d28b6e91700b71a70441b6cee56373ccc19
 
             env:
               # --- vault ---


### PR DESCRIPTION
## Summary

\`langgraph-agents\` v0.2.9 → **v0.2.10** (pinned by digest \`9c5919481d...\`).

v0.2.10 adds the **MCPMemoryStore(BaseStore)** adapter — Phase 3 of the memory-mcp plan in home-ops. Fleet agents now share the same \`kg.*\` knowledge graph that \`memory-mcp\` exposes to outside agents (Claude Code, Open WebUI, HolmesGPT).

## v0.2.10 changes (in image, see rwlove/langgraph-agents#13)

- \`MCPMemoryStore(BaseStore)\` — implements LangGraph's BaseStore protocol via direct SQL (psycopg3 + AsyncConnectionPool) against the same Postgres schema as memory-mcp
- Namespace prefix: every BaseStore-created entity lands under \`langgraph/\` (visually distinct from human-seeded entries when other agents query)
- \`build_fleet_graph(checkpointer, store)\` → \`compile(store=store)\`
- \`settings.memory_backend\` (postgres|none, default postgres) + \`settings.memory_embed_model\`

## Test plan

- [x] \`kubectl kustomize\` clean
- [ ] Post-merge: pod logs \`MCPMemoryStore connected (kg.*) — shared with memory-mcp Phase 0\`
- [ ] Post-merge: from any agent / test harness, BaseStore put writes a row visible via \`memory_search(query=..., namespace_filter="langgraph")\` from a different MCP client
- [ ] \`memory_list_entities(type_filter="langgraph-store-item")\` shows fleet writes

🤖 Generated with [Claude Code](https://claude.com/claude-code)