### PR TITLE
feat(ai/langgraph-agents): zulip reply-back (v0.2.11)

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/externalsecret.yaml
@@ -34,6 +34,20 @@ spec:
         # (sourced from the same 1Password item — see
         # kubernetes/apps/home/windmill/app/externalsecret-workflows.yaml).
         LANGGRAPH_APPROVAL_SIGNING_KEY: "{{ .LANGGRAPH_APPROVAL_SIGNING_KEY }}"
+
+        # Zulip reply-back path for /inbox source=zulip. When the
+        # Windmill zulip-triager-webhook adapter forwards a DM, the
+        # graph runs to completion and POSTs the final output back as
+        # a triager-bot DM to the originating user. Creds live in the
+        # `zulip-bots-langgraph` 1P item (single source — same place
+        # the bot identities pull from).
+        ZULIP_HOST: chat.${SECRET_DOMAIN}
+        ZULIP_TRIAGER_EMAIL: "{{ .ZULIP_TRIAGER_EMAIL }}"
+        ZULIP_TRIAGER_API_KEY: "{{ .ZULIP_TRIAGER_API_KEY }}"
   dataFrom:
     - extract:
         key: langgraph-agents
+    # Bot email + API key for triager-bot (used by the Zulip
+    # reply-back path on source=zulip).
+    - extract:
+        key: zulip-bots-langgraph

--- a/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/langgraph-agents
-              tag: 0.2.10@sha256:9c5919481d9dfe113390eac74cdf8d28b6e91700b71a70441b6cee56373ccc19
+              tag: 0.2.11  # zulip reply-back on source=zulip; Renovate will pin a digest on its next pass
 
             env:
               # --- vault ---

--- a/kubernetes/apps/home/windmill/workflows/zulip-triager-webhook.ts
+++ b/kubernetes/apps/home/windmill/workflows/zulip-triager-webhook.ts
@@ -61,6 +61,10 @@ export async function main(
         source: "zulip",
         content: text,
         user: "rob",
+        // langgraph-agents 0.2.11+ uses this to DM the final graph
+        // output back to the originating user from triager-bot.
+        // Older versions silently ignore the extra field.
+        zulip_user_id: message.sender_id,
     });
     let dispatched = false;
     try {


### PR DESCRIPTION
Paired with rwlove/langgraph-agents PR #15 / v0.2.11. Closes the loop on the Zulip DM → triager → specialist → reply path. Windmill adapter passes zulip_user_id; langgraph posts the output back as a triager-bot DM.