### PR TITLE
fix(mcp-system/memory-mcp): bump to v0.1.4 (per-tool metrics)

### DIFF
--- a/kubernetes/apps/mcp-system/memory-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/memory-mcp/app/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/memory-mcp
-              tag: 0.1.3@sha256:984d1f55842cfc7bf4b7e62fa6972c309201b47a3168ecea169591f093129aa4
+              tag: v0.1.4@sha256:0266688aa58f7f79b97c5a2eec4677bb3c2e9c4da0f8894f1d5c9eef8a0dd4b0
             env:
               # CNPG-generated app Secret reflected from databases ns
               # via emberstack reflector (see langgraph-memory


### PR DESCRIPTION
## Summary

memory-mcp **v0.1.3 → v0.1.4** (digest `0266688aa5...`).

v0.1.4 adds application-level Prometheus metrics on top of v0.1.3's process collectors:

- `memory_mcp_tool_calls_total{tool, status}` — counter per tool
- `memory_mcp_tool_call_duration_seconds{tool}` — histogram
- `memory_mcp_embed_calls_total{status}` — embed counter (success/empty/error)
- `memory_mcp_embed_call_duration_seconds` — embed latency histogram

ServiceMonitor wired in #11706 will pick these up on the next scrape (30s interval).

🤖 Generated with [Claude Code](https://claude.com/claude-code)