### PR TITLE
fix(home/windmill): ZULIP_API_URL points to in-cluster Service

### DIFF
--- a/kubernetes/apps/home/windmill/app/externalsecret-workflows.yaml
+++ b/kubernetes/apps/home/windmill/app/externalsecret-workflows.yaml
@@ -33,8 +33,15 @@ spec:
         PUSHOVER_APP_TOKEN: "{{ .PUSHOVER_APP_TOKEN }}"
         PUSHOVER_USER_KEY: "{{ .PUSHOVER_USER_KEY }}"
         # Zulip bot creds — used by approval-post + inbox (pause-forward
-        # audit card), approval-receive (for the user_id check + emoji
-        # fallback path), and daily-digest.
+        # audit card), approval-receive (@-mention fallback path), and
+        # daily-digest.
+        # ZULIP_API_URL is the in-cluster Service URL — the external
+        # https://chat.${SECRET_DOMAIN} times out from inside the cluster
+        # for the same Cilium FQDN/world egress reason as NTFY_URL above.
+        # The phone-facing click target (chat.${SECRET_DOMAIN}) is
+        # hardcoded in the workflow source since the phone needs the
+        # external URL.
+        ZULIP_API_URL: "http://zulip.collab.svc.cluster.local"
         ZULIP_BOT_EMAIL: "{{ .ZULIP_BOT_EMAIL }}"
         ZULIP_BOT_API_KEY: "{{ .ZULIP_BOT_API_KEY }}"
         ROB_ZULIP_USER_ID: "{{ .ROB_ZULIP_USER_ID }}"

--- a/kubernetes/apps/home/windmill/app/helmrelease.yaml
+++ b/kubernetes/apps/home/windmill/app/helmrelease.yaml
@@ -78,7 +78,7 @@ spec:
           # follow-up PR once sync + verification is complete.
           extraEnv: &workflow_secrets
             - name: WHITELIST_ENVS
-              value: LANGGRAPH_APPROVAL_SIGNING_KEY,NTFY_URL,NTFY_WRITE_TOKEN,PUSHOVER_APP_TOKEN,PUSHOVER_USER_KEY,ZULIP_BOT_EMAIL,ZULIP_BOT_API_KEY,ROB_ZULIP_USER_ID
+              value: LANGGRAPH_APPROVAL_SIGNING_KEY,NTFY_URL,NTFY_WRITE_TOKEN,PUSHOVER_APP_TOKEN,PUSHOVER_USER_KEY,ZULIP_API_URL,ZULIP_BOT_EMAIL,ZULIP_BOT_API_KEY,ROB_ZULIP_USER_ID
             - name: LANGGRAPH_APPROVAL_SIGNING_KEY
               valueFrom:
                 secretKeyRef:
@@ -104,6 +104,11 @@ spec:
                 secretKeyRef:
                   name: windmill-workflows-secret
                   key: PUSHOVER_USER_KEY
+            - name: ZULIP_API_URL
+              valueFrom:
+                secretKeyRef:
+                  name: windmill-workflows-secret
+                  key: ZULIP_API_URL
             - name: ZULIP_BOT_EMAIL
               valueFrom:
                 secretKeyRef:

--- a/kubernetes/apps/home/windmill/workflows/langgraph-approval-post.ts
+++ b/kubernetes/apps/home/windmill/workflows/langgraph-approval-post.ts
@@ -181,9 +181,9 @@ async function postZulipApprovalCard(task_id: string, r: ApprovalRequest) {
     const apiKey = Deno.env.get("ZULIP_BOT_API_KEY");
     if (!email || !apiKey) throw new Error("ZULIP_BOT_EMAIL / ZULIP_BOT_API_KEY env not set");
     const auth = "Basic " + btoa(`${email}:${apiKey}`);
-    const zulipHost = Deno.env.get("ZULIP_HOST") ?? "chat.thesteamedcrab.com";
+    const zulipApiUrl = Deno.env.get("ZULIP_API_URL") ?? "http://zulip.collab.svc.cluster.local";
     const form = new URLSearchParams({ type: "stream", to: "approvals", topic, content });
-    const zr = await fetch(`https://${zulipHost}/api/v1/messages`, {
+    const zr = await fetch(`${zulipApiUrl}/api/v1/messages`, {
         method: "POST",
         headers: { Authorization: auth, "Content-Type": "application/x-www-form-urlencoded" },
         body: form,

--- a/kubernetes/apps/home/windmill/workflows/langgraph-approval-receive.ts
+++ b/kubernetes/apps/home/windmill/workflows/langgraph-approval-receive.ts
@@ -138,7 +138,7 @@ async function postAck(topic: string, reaction: string, lgStatus: string) {
     const apiKey = Deno.env.get("ZULIP_BOT_API_KEY");
     if (!email || !apiKey) return;
     const auth = "Basic " + btoa(`${email}:${apiKey}`);
-    const zulipHost = Deno.env.get("ZULIP_HOST") ?? "chat.thesteamedcrab.com";
+    const zulipApiUrl = Deno.env.get("ZULIP_API_URL") ?? "http://zulip.collab.svc.cluster.local";
     const emoji = reaction === "approve" ? "✅" : reaction === "reject" ? "🛑" : "⏸";
     const form = new URLSearchParams({
         type: "stream",
@@ -146,7 +146,7 @@ async function postAck(topic: string, reaction: string, lgStatus: string) {
         topic,
         content: `${emoji} **${reaction}** → langgraph status: \`${lgStatus ?? "ok"}\``,
     });
-    await fetch(`https://${zulipHost}/api/v1/messages`, {
+    await fetch(`${zulipApiUrl}/api/v1/messages`, {
         method: "POST",
         headers: {
             Authorization: auth,

--- a/kubernetes/apps/home/windmill/workflows/langgraph-daily-digest.ts
+++ b/kubernetes/apps/home/windmill/workflows/langgraph-daily-digest.ts
@@ -35,14 +35,14 @@ export async function main() {
     const apiKey = Deno.env.get("ZULIP_BOT_API_KEY");
     if (!email || !apiKey) throw new Error("ZULIP_BOT_EMAIL / ZULIP_BOT_API_KEY env not set");
     const auth = "Basic " + btoa(`${email}:${apiKey}`);
-    const zulipHost = Deno.env.get("ZULIP_HOST") ?? "chat.thesteamedcrab.com";
+    const zulipApiUrl = Deno.env.get("ZULIP_API_URL") ?? "http://zulip.collab.svc.cluster.local";
     const form = new URLSearchParams({
         type: "stream",
         to: "digests",
         topic: `daily-${date}`,
         content,
     });
-    const zr = await fetch(`https://${zulipHost}/api/v1/messages`, {
+    const zr = await fetch(`${zulipApiUrl}/api/v1/messages`, {
         method: "POST",
         headers: {
             Authorization: auth,

--- a/kubernetes/apps/home/windmill/workflows/langgraph-inbox.ts
+++ b/kubernetes/apps/home/windmill/workflows/langgraph-inbox.ts
@@ -204,9 +204,9 @@ async function postZulipApprovalCard(task_id: string, r: ApprovalRequest) {
     const apiKey = Deno.env.get("ZULIP_BOT_API_KEY");
     if (!email || !apiKey) throw new Error("ZULIP_BOT_* env not set");
     const auth = "Basic " + btoa(`${email}:${apiKey}`);
-    const zulipHost = Deno.env.get("ZULIP_HOST") ?? "chat.thesteamedcrab.com";
+    const zulipApiUrl = Deno.env.get("ZULIP_API_URL") ?? "http://zulip.collab.svc.cluster.local";
     const form = new URLSearchParams({ type: "stream", to: "approvals", topic, content });
-    const zr = await fetch(`https://${zulipHost}/api/v1/messages`, {
+    const zr = await fetch(`${zulipApiUrl}/api/v1/messages`, {
         method: "POST",
         headers: { Authorization: auth, "Content-Type": "application/x-www-form-urlencoded" },
         body: form,


### PR DESCRIPTION
## Summary
Same Cilium FQDN/world egress issue as #11709 — windmill workers can't reach `chat.thesteamedcrab.com` (split-horizon LB IP). Switches Zulip API base URL to the in-cluster Service URL.

## Changes
- New env `ZULIP_API_URL` = `http://zulip.collab.svc.cluster.local` in ExternalSecret + HelmRelease + WHITELIST_ENVS
- All 4 Zulip-calling workflows now use `${ZULIP_API_URL}/api/v1/messages` instead of building from `ZULIP_HOST`
- Phone-facing `click:` deep links still point at the external Zulip host (unaffected)

## Test plan
- [ ] Flux reconcile → ESO refreshes secret → workers restart with new env
- [ ] Sync the 4 modified workflows to Windmill DB
- [ ] Trigger synthetic `langgraph-approval-post` — completes without TimeoutError
- [ ] ntfy push + Zulip card both land

🤖 Generated with [Claude Code](https://claude.com/claude-code)