### PR TITLE
revert(ai/langgraph-agents): 0.2.11 → 0.2.10 (zulip reply-back regression)

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/langgraph-agents
-              tag: 0.2.11  # zulip reply-back on source=zulip; Renovate will pin a digest on its next pass
+              tag: 0.2.10@sha256:9c5919481d9dfe113390eac74cdf8d28b6e91700b71a70441b6cee56373ccc19
 
             env:
               # --- vault ---


### PR DESCRIPTION
Reverting the image bump. /inbox handler hangs on 0.2.11; needs investigation in the langgraph-agents repo before re-landing.