### PR TITLE
fix(collab/zulip): allow ingress from home/windmill workflows

### DIFF
--- a/kubernetes/apps/collab/zulip/app/cnp-allow.yaml
+++ b/kubernetes/apps/collab/zulip/app/cnp-allow.yaml
@@ -37,6 +37,23 @@ spec:
         - ports:
             - port: "80"
               protocol: TCP
+    # home/windmill workflows post approval cards + digests to zulip's
+    # bot API on port 80. Worker pods carry the windmill-workers label;
+    # the app pod can also trigger sync execution that POSTs.
+    - fromEndpoints:
+        - matchExpressions:
+            - key: io.kubernetes.pod.namespace
+              operator: In
+              values: [home]
+            - key: app.kubernetes.io/name
+              operator: In
+              values:
+                - windmill-app
+                - windmill-workers
+      toPorts:
+        - ports:
+            - port: "80"
+              protocol: TCP
   egress:
     # CNPG cluster postgres-zulip in databases ns (Pattern B).
     - toEndpoints:


### PR DESCRIPTION
## Summary
After #11719 switched windmill workflows to the in-cluster Zulip Service URL, the 4 Zulip-calling flows (approval-post, inbox, approval-receive @-mention, daily-digest) all timed out at the 30s AbortSignal — `zulip-allow` CNP only permitted ingress from `network/envoy` and `ai/langgraph-agents`.

## Fix
Add an ingress rule for `home` namespace + `windmill-app` / `windmill-workers` labels on port 80.

## Test plan
- [ ] Flux reconcile applies the CNP update
- [ ] Re-trigger synthetic `langgraph-approval-post` — completes successfully
- [ ] Zulip card lands in #approvals; ntfy push with action buttons lands on phone

🤖 Generated with [Claude Code](https://claude.com/claude-code)