### PR TITLE
chore(home/windmill): drop PUSHOVER_* envs — ntfy cutover verified

### DIFF
--- a/kubernetes/apps/home/windmill/app/externalsecret-workflows.yaml
+++ b/kubernetes/apps/home/windmill/app/externalsecret-workflows.yaml
@@ -26,12 +26,6 @@ spec:
         # internal LB IPs.
         NTFY_URL: "http://ntfy.home.svc.cluster.local:8080"
         NTFY_WRITE_TOKEN: "{{ .NTFY_WRITE_TOKEN }}"
-        # Pushover creds remain through the overlap window between
-        # Flux applying this manifest and the new workflows being
-        # synced to the Windmill DB. Removed in a follow-up PR once
-        # sync + verification is complete.
-        PUSHOVER_APP_TOKEN: "{{ .PUSHOVER_APP_TOKEN }}"
-        PUSHOVER_USER_KEY: "{{ .PUSHOVER_USER_KEY }}"
         # Zulip bot creds — used by approval-post + inbox (pause-forward
         # audit card), approval-receive (@-mention fallback path), and
         # daily-digest.
@@ -46,7 +40,7 @@ spec:
         ZULIP_BOT_API_KEY: "{{ .ZULIP_BOT_API_KEY }}"
         ROB_ZULIP_USER_ID: "{{ .ROB_ZULIP_USER_ID }}"
   dataFrom:
-    # LANGGRAPH_APPROVAL_SIGNING_KEY + PUSHOVER_*
+    # LANGGRAPH_APPROVAL_SIGNING_KEY
     - extract:
         key: langgraph-agents
     # NTFY_WRITE_TOKEN

--- a/kubernetes/apps/home/windmill/app/helmrelease.yaml
+++ b/kubernetes/apps/home/windmill/app/helmrelease.yaml
@@ -72,13 +72,9 @@ spec:
           # spawned Deno/Python/Bash subprocesses (default is none for
           # nsjail-style isolation; Windmill strips parent env without
           # an explicit allowlist).
-          # Pushover envs remain for the brief overlap window between
-          # Flux applying this manifest and the new ntfy-shape workflow
-          # scripts being synced to the Windmill DB. Removed in a
-          # follow-up PR once sync + verification is complete.
           extraEnv: &workflow_secrets
             - name: WHITELIST_ENVS
-              value: LANGGRAPH_APPROVAL_SIGNING_KEY,NTFY_URL,NTFY_WRITE_TOKEN,PUSHOVER_APP_TOKEN,PUSHOVER_USER_KEY,ZULIP_API_URL,ZULIP_BOT_EMAIL,ZULIP_BOT_API_KEY,ROB_ZULIP_USER_ID
+              value: LANGGRAPH_APPROVAL_SIGNING_KEY,NTFY_URL,NTFY_WRITE_TOKEN,ZULIP_API_URL,ZULIP_BOT_EMAIL,ZULIP_BOT_API_KEY,ROB_ZULIP_USER_ID
             - name: LANGGRAPH_APPROVAL_SIGNING_KEY
               valueFrom:
                 secretKeyRef:
@@ -94,16 +90,6 @@ spec:
                 secretKeyRef:
                   name: windmill-workflows-secret
                   key: NTFY_WRITE_TOKEN
-            - name: PUSHOVER_APP_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: windmill-workflows-secret
-                  key: PUSHOVER_APP_TOKEN
-            - name: PUSHOVER_USER_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: windmill-workflows-secret
-                  key: PUSHOVER_USER_KEY
             - name: ZULIP_API_URL
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Summary
Phase 4 finale. All 4 push-emitting workflows are now ntfy-shape in the Windmill DB and verified end-to-end (synthetic `langgraph-approval-post` lands on Android with tap-to-action buttons; cf. #11689/#11709/#11719/#11723).

Removes:
- `PUSHOVER_APP_TOKEN` + `PUSHOVER_USER_KEY` env entries from windmill HelmRelease `workflow_secrets`
- Same keys from `WHITELIST_ENVS`
- Same keys from the `windmill-workflows-secret` ExternalSecret template

Leaves:
- PUSHOVER_* fields in the 1P `langgraph-agents` item for audit / rollback through ~2026-06-19 — cancel the Pushover SaaS account after that soak

## Test plan
- [ ] Flux reconcile applies the HR + ExternalSecret changes
- [ ] `kubectl -n home get secret windmill-workflows-secret -o json | jq '.data | keys'` no longer lists `PUSHOVER_*`
- [ ] All 4 ntfy-shape workflows continue functioning (manual or natural-trigger spot-check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)