### PR TITLE
fix(observability/loki): CNP egress to RGW pod port 8080 not Service port 80

### DIFF
--- a/kubernetes/apps/observability/loki/app/cnp-allow.yaml
+++ b/kubernetes/apps/observability/loki/app/cnp-allow.yaml
@@ -18,17 +18,19 @@ spec:
   # Loki publicly.
   egress:
     # Chunk + index storage on Rook Ceph RGW (S3 API). Loki's S3
-    # endpoint comes from the `loki-chunks-bucket-v1` ConfigMap which
-    # points at `rook-ceph-rgw-ceph-objectstore.rook-ceph.svc`. Use
-    # Pattern E (cross-ns endpoint match) rather than FQDN — the
-    # rook-ceph-rgw selector is stable.
+    # endpoint resolves to the `rook-ceph-rgw-ceph-objectstore` Service
+    # (port 80 → targetPort 8080). Cilium L4 egress is evaluated against
+    # the post-translation pod port: radosgw starts with
+    # `--rgw-frontends=beast port=8080`, so the rule must allow 8080,
+    # not the Service port 80. Use Pattern E (cross-ns endpoint match)
+    # rather than FQDN — the rook-ceph-rgw selector is stable.
     - toEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: rook-ceph
             app.kubernetes.io/name: ceph-rgw
       toPorts:
         - ports:
-            - port: "80"
+            - port: "8080"
               protocol: TCP
     # Ruler alerting target — Loki rule evaluations fire alerts at
     # alertmanager-operated:9093 (intra-ns; baseline covers).


### PR DESCRIPTION
## Summary

- CiliumNetworkPolicy L4 egress is evaluated against the **post-translation pod port**, not the Service port. The `rook-ceph-rgw-ceph-objectstore` Service maps `80 → targetPort 8080`, and radosgw is launched with `--rgw-frontends=beast port=8080`. The egress rule on `loki-allow` had `port: "80"`, which silently dropped every Loki S3 write.
- This has been firing `CiliumPolicyDropBurst` + `CiliumPolicyDropsSustained` on `destination_namespace=rook-ceph` continuously since the Phase 2 rook-ceph default-deny rollout (PR #11579, 2026-05-18).
- Loki retries S3 writes forever, so there was no UI symptom — chunk ingestion to the durable backend was just failing in the background.

## Test plan

- [ ] Flux reconciles `loki-allow` CNP
- [ ] Hubble shows `observability/loki-0 → rook-ceph/rook-ceph-rgw-*:8080` flows as `FORWARDED` (not `POLICY_DENIED`)
- [ ] `hubble_drop_total{reason="POLICY_DENIED",destination_namespace="rook-ceph"}` rate falls to 0
- [ ] `CiliumPolicyDropBurst` + `CiliumPolicyDropsSustained` alerts for `destination_namespace=rook-ceph` clear in AlertManager
- [ ] Loki HelmRelease remains healthy; check `loki_ingester_chunks_flushed_total` continues to climb

🤖 Generated with [Claude Code](https://claude.com/claude-code)