### PR TITLE
fix(home/frigate): allow egress to Frigate+ cloud API

### DIFF
--- a/kubernetes/apps/home/frigate/app/cnp-allow.yaml
+++ b/kubernetes/apps/home/frigate/app/cnp-allow.yaml
@@ -51,3 +51,20 @@ spec:
               protocol: TCP
             - port: "80"
               protocol: TCP
+    # Frigate+ cloud API. Used for model submission, license verification,
+    # and pulling custom-trained models (model_path `plus://<id>` in the
+    # Frigate config). Three hostnames in active use:
+    #   * api.frigate.video  — REST API (AWS us-east-2 ELB)
+    #   * plus.frigate.video — portal UI (CloudFront)
+    #   * frigate.video      — apex (AWS us-east-2)
+    # matchPattern only matches one DNS label (see
+    # [[project_cilium_matchpattern_fqdn_limits]]), so the apex needs an
+    # explicit matchName. DNS resolution is via the Cilium DNS proxy
+    # provisioned by the baseline allow-dns component.
+    - toFQDNs:
+        - matchName: frigate.video
+        - matchPattern: "*.frigate.video"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP


### PR DESCRIPTION
## Summary

- Frigate+ is configured in this cluster (`PLUS_API_KEY` in the ExternalSecret + `model_path: plus://3e711036dc2003b0afdbfd8fa61de75e` in `snapshots/config.yml`) but the home-namespace default-deny rollout in PR #11592 only opened egress to the birdcam at `192.168.1.31`.
- Frigate has been silently retrying outbound to `*.frigate.video:443` since then, firing `CiliumPolicyDropBurst` + `CiliumPolicyDropsSustained` on the empty `destination_namespace` (external traffic) bucket.
- Adds a `toFQDNs` egress rule covering all three hostnames in active use (resolved live from the pod): `api.frigate.video`, `plus.frigate.video`, `frigate.video` (apex). Cilium `matchPattern` only matches one DNS label per [[project_cilium_matchpattern_fqdn_limits]], so the apex gets an explicit `matchName`.

## Test plan

- [ ] Flux reconciles `frigate-allow` CNP
- [ ] Hubble: `home/frigate-0 → *.frigate.video:443` flows show `FORWARDED` (not `POLICY_DENIED`)
- [ ] Frigate+ submission / model fetch round-trips work in the Frigate UI
- [ ] `CiliumPolicyDropBurst` + `CiliumPolicyDropsSustained` for the empty-destination_namespace bucket clear in AlertManager (sustained drop volume should fall close to the postgres-windmill ICMP residual — handled separately in #3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)