### PR TITLE
fix(slskd): unstick downloads — share music NFS, smart liveness, pod-gateway tolerance

### DIFF
--- a/kubernetes/apps/downloads/slskd/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/slskd/app/helmrelease.yaml
@@ -53,7 +53,31 @@ spec:
                   name: *app
 
             probes:
-              liveness: &probes
+              # Liveness goes beyond /health (which only checks slskd's API) and asserts
+              # that slskd's Soulseek server connection is making forward progress.
+              # When the downloads-gateway VXLAN tunnel flaps, slskd loses its server
+              # session and — without VPN integration — sits in "Disconnecting" forever
+              # because connectionWatchdog never engages. The exec probe catches that
+              # state and restarts the pod after 10×30s = 5 min of stuck Disconnecting,
+              # which is the only path back to a logged-in state until upstream slskd
+              # exposes a real watchdog config.
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  exec:
+                    command:
+                      - sh
+                      - -c
+                      - |
+                        wget -qO- http://localhost:5030/health >/dev/null || exit 1
+                        wget -qO- http://localhost:5030/api/v0/application \
+                          | jq -e '.server.isLoggedIn or .server.isConnecting or .server.isLoggingIn or .connectionWatchdog.isAwaitingVpn' >/dev/null
+                  failureThreshold: 10
+                  initialDelaySeconds: 60
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+              readiness:
                 enabled: true
                 custom: true
                 spec:
@@ -64,7 +88,6 @@ spec:
                   initialDelaySeconds: 0
                   periodSeconds: 10
                   timeoutSeconds: 1
-              readiness: *probes
 
             resources:
               requests:
@@ -116,6 +139,16 @@ spec:
 
       media:
         existingClaim: slskd-downloads-pvc
+
+      # Soulseek peers deprioritize zero-share users → every transfer parks
+      # in "Queued, Remotely" indefinitely. Mount the music NFS read-only at
+      # /media/shared (the path slskd.yml's `shares.directories` lists) so
+      # slskd has something to share back and gets normal peer reciprocity.
+      shares:
+        existingClaim: slskd-shares-pvc
+        globalMounts:
+          - path: /media/shared
+            readOnly: true
 
       tmp:
         type: emptyDir

--- a/kubernetes/apps/downloads/slskd/app/nfs-pvc.yaml
+++ b/kubernetes/apps/downloads/slskd/app/nfs-pvc.yaml
@@ -32,3 +32,38 @@ spec:
       storage: 5Gi
   volumeName: slskd-downloads-pv
   storageClassName: slskd-downloads-storage-class
+
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolume-v1.json
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: slskd-shares-pv
+  labels:
+    type: nfs
+spec:
+  storageClassName: slskd-shares-storage-class
+  capacity:
+    storage: 3Ti
+  accessModes:
+    - ReadOnlyMany
+  nfs:
+    server: "${NFS_HOST_2}"
+    path: /mnt/mass_storage/storage/MP3s/
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: slskd-shares-pvc
+  labels:
+    type: nfs
+spec:
+  accessModes:
+    - ReadOnlyMany
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: 3Ti
+  volumeName: slskd-shares-pv
+  storageClassName: slskd-shares-storage-class

--- a/kubernetes/apps/vpn/downloads-gateway/app/helmrelease.yaml
+++ b/kubernetes/apps/vpn/downloads-gateway/app/helmrelease.yaml
@@ -115,6 +115,13 @@ spec:
       - downloads
 
     settings:
+      # Default is 1 — a single dropped ICMP packet kills the client-side
+      # gateway-sidecar via `set -e` in client_sidecar.sh/client_init.sh,
+      # restarting the whole consumer pod (slskd, qbittorrent, sabnzbd).
+      # Observed restart counts: slskd 16/34h, qbit 6/34h, sab 6/9h. The
+      # default settings.sh literally says "use a higher value for unreliable
+      # network connections" — that's us (Cilium VXLAN + Mullvad WG).
+      CONNECTION_RETRY_COUNT: "5"
       DNS_LOCAL_CIDRS: "${SECRET_DOMAIN} cluster.local local"
       NOT_ROUTED_TO_GATEWAY_CIDRS: 10.42.0.0/16 10.43.0.0/16 192.168.0.0/16
       VPN_BLOCK_OTHER_TRAFFIC: true


### PR DESCRIPTION
## Summary

Three related fixes for "Lidarr queue shows 100% but downloads never actually arrive." Observed today with 72 slskd transfers parked in `Queued, Remotely` and slskd stuck in `Disconnecting` for 8+ hours.

- **slskd shares**: mount music NFS RO at `/media/shared`. slskd's config has always listed `shares.directories: [/media/shared]` but the dir was empty → we appeared on Soulseek as a zero-share peer, which puts every download at the back of every peer's upload queue. New PV+PVC point at the same beast `/mnt/mass_storage/storage/MP3s/` path gonic/jellyfin/music-assistant already use, `ReadOnlyMany`.
- **slskd liveness**: state-aware exec probe. The downloads-gateway VXLAN tunnel flaps occasionally; slskd loses its Soulseek session and — without VPN integration — sits in `state: Disconnecting, isTransitioning: true` forever, because slskd 0.25's `connectionWatchdog` requires Gluetun-API integration that pod-gateway doesn't expose. New `exec` liveness probe checks both `/health` and that `server.isLoggedIn or isConnecting or isLoggingIn or connectionWatchdog.isAwaitingVpn`; after 10×30 s = 5 min of stuck Disconnecting the kubelet restarts the pod. Readiness keeps the original cheap httpGet.
- **downloads-gateway**: `CONNECTION_RETRY_COUNT=5`. pod-gateway v1.13.0's `client_sidecar.sh` pings the gateway under `set -e` with `-c $CONNECTION_RETRY_COUNT` defaulting to 1 — a single dropped ICMP packet collapses the sidecar and restarts the consumer pod. Restart counts observed: slskd 16/34 h, qbittorrent 6/34 h, sabnzbd 6/9 h. Upstream `settings.sh` literally says *"use a higher value for unreliable network connections"* — Cilium VXLAN + Mullvad WG qualifies.

## Test plan

- [ ] Flux reconciles `slskd` HelmRelease; pod restarts cleanly with the new `slskd-shares-pvc` mounted RO at `/media/shared`.
- [ ] `kubectl -n downloads exec slskd-0 -- ls /media/shared | head` shows the music library (not empty).
- [ ] After scan completes, `wget -qO- http://localhost:5030/api/v0/application | jq .shares` shows non-zero `files` and `directories`.
- [ ] Soulseek UI loads at `soulseek.${SECRET_DOMAIN}` (no spinner-of-death).
- [ ] After downloads-gateway HelmRelease rolls, `kubectl -n downloads get pod -o jsonpath='{.items[*].spec.containers[?(@.name=="gateway-sidecar")].env}'` reflects `CONNECTION_RETRY_COUNT=5` on **newly-started** consumer pods (existing pods carry the old value until they cycle).
- [ ] Restart counts on slskd / qbit / sab drop to near zero over the next 24 h.
- [ ] slskd transfers actually progress from `Queued, Remotely` to `InProgress` to `Completed` once the share scan exposes our library to peers.

## Rollback

If shares-mount causes problems (NFS unreachable, slskd OOM during indexing, etc.):

1. Revert the `persistence.shares` block + the `slskd-shares-pv/pvc` definitions.
2. The liveness-probe change and `CONNECTION_RETRY_COUNT` are independent and safe to keep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)