### PR TITLE
fix(renovate/jobs): allow egress to in-cluster ZOT (kube-system/zot:5000)

### DIFF
--- a/kubernetes/apps/renovate/renovate-operator/jobs/cnp-allow.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/jobs/cnp-allow.yaml
@@ -31,6 +31,21 @@ spec:
         - ports:
             - port: "6379"
               protocol: TCP
+    # In-cluster ZOT pull-through cache (kube-system/zot:5000). Renovate
+    # tracks the 41 OCIRepository sources that now point at
+    # `oci://zot.kube-system.svc.cluster.local:5000/<upstream>/<repo>`
+    # (see [[project_zot_chart_cache_phase1_done]]), and the job pods
+    # query ZOT directly for available tags/digests. toFQDNs:* doesn't
+    # match in-cluster Service DNS, so this needs an explicit
+    # toEndpoints rule.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: kube-system
+            app.kubernetes.io/name: zot
+      toPorts:
+        - ports:
+            - port: "5000"
+              protocol: TCP
     # Conservative wildcard for renovate scanning: discovery + executor
     # pods clone GitHub repos, query every registry mentioned by every
     # tracked dependency (ghcr.io, registry.k8s.io, docker.io, quay.io,


### PR DESCRIPTION
## Summary

- Phase 1 of the ZOT chart-cache rollout (#11704) routed 41 OCIRepositories through `oci://zot.kube-system.svc.cluster.local:5000/<upstream>/<repo>`.
- Renovate's discovery + executor job pods track those OCI sources and query ZOT directly for available tags/digests.
- The existing `toFQDNs: matchPattern: "*"` rule only resolves external DNS via the Cilium FQDN proxy — it does NOT cover in-cluster Service DNS — so renovate→ZOT calls were being POLICY_DENIED.
- Hubble showed ~63 packets per sample of `renovate/rwlove-home-ops-* → kube-system/zot-0:5000 TCP` denied, contributing to the empty-`destination_namespace` CiliumPolicyDrop alert bucket.
- Adds an explicit `toEndpoints` rule for `kube-system/zot:5000`.

## Test plan

- [ ] Flux reconciles `renovate-jobs-allow` CNP
- [ ] Hubble: `renovate/* → kube-system/zot-0:5000` flows show `FORWARDED` (not `POLICY_DENIED`)
- [ ] Renovate runs complete without ZOT lookup failures (any `oci://zot.kube-system.svc.cluster.local:5000/...` OCIRepository tracked source resolves)
- [ ] `hubble_drop_total{source_namespace="renovate",destination_namespace="kube-system"}` falls to 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)