### PR TITLE
feat(mcp-system/kubectl-mcp): grant read on CNPG + Barman CRs

### DIFF
--- a/kubernetes/apps/mcp-system/kubectl-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/kubectl-mcp/app/helmrelease.yaml
@@ -119,6 +119,12 @@ spec:
             - apiGroups: ["external-secrets.io"]
               resources: ["externalsecrets"]
               verbs: ["get", "list", "watch"]
+            - apiGroups: ["postgresql.cnpg.io"]
+              resources: ["clusters", "backups", "scheduledbackups"]
+              verbs: ["get", "list", "watch"]
+            - apiGroups: ["barmancloud.cnpg.io"]
+              resources: ["objectstores"]
+              verbs: ["get", "list", "watch"]
         kubectl-mcp-write-restricted:
           type: Role
           rules:


### PR DESCRIPTION
## Summary

- Adds read-only RBAC (get/list/watch) for the four CNPG/Barman CRs that the `kubectl-mcp` ServiceAccount has been silently denied on: `clusters`/`backups`/`scheduledbackups` (postgresql.cnpg.io) + `objectstores` (barmancloud.cnpg.io).
- Closes the deferred decision tracked in `project_todo_mcp_kubectl_cnpg_rbac`.
- Unblocks Barman backup-recency observability for smart-home-operator (recorder-health sweep), storage-operator (CNPG/Barman section), and any future MCP-driven diagnostics that need CR-shaped state.

## Why

Every operator agent's `kubectl_*` tool calls run as `system:serviceaccount:mcp-system:kubectl-mcp`. The inline `kubectl-mcp-read-all` ClusterRole granted Flux/ESO/Gateway/RBAC/metrics read but no CNPG groups. Result: agents fell back to pod count + `cnpg_collector_up` + `cnpg_pg_database_size_bytes` and surfaced "Barman recency unobservable" as a coverage gap.

This change is **additive, read-only, and minimum-scope** (4 resources, not the full CNPG CRD surface). Discovered gaps for `poolers`/`databases`/`publications`/`subscriptions` etc. are intentionally deferred to follow-ups.

## Diff

```yaml
+- apiGroups: ["postgresql.cnpg.io"]
+  resources: ["clusters", "backups", "scheduledbackups"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["barmancloud.cnpg.io"]
+  resources: ["objectstores"]
+  verbs: ["get", "list", "watch"]
```

No other field changes — image digest, securityContext, service, route, and `kubectl-mcp-write-restricted` Role are untouched.

## Baseline (pre-merge)

`kubectl auth can-i <verb> <resource> --as=system:serviceaccount:mcp-system:kubectl-mcp -A`

| resource                            | get | list | watch |
|-------------------------------------|-----|------|-------|
| clusters.postgresql.cnpg.io         | no  | no   | no    |
| backups.postgresql.cnpg.io          | no  | no   | no    |
| scheduledbackups.postgresql.cnpg.io | no  | no   | no    |
| objectstores.barmancloud.cnpg.io    | no  | no   | no    |

## Test plan

- [x] yamllint clean
- [x] CRDs confirmed present (`kubectl api-resources --api-group=postgresql.cnpg.io|barmancloud.cnpg.io`)
- [ ] Post-merge: `flux get ks kubectl-mcp -n mcp-system` shows new revision
- [ ] Post-merge: 4×3 matrix above flips entirely to `yes`
- [ ] Post-merge: `mcp__lovenet-gateway__kubectl_kubectl_generic get clusters.postgresql.cnpg.io -A` returns rows
- [ ] Post-merge cleanup (separate, outside PR): strip "Barman recency unobservable" caveats from `smart-home-operator.md` and `storage-operator.md`; close the memory TODO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)