### PR TITLE
fix(slskd): add startupProbe so first-scan-after-shares doesn't fail liveness

### DIFF
--- a/kubernetes/apps/downloads/slskd/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/slskd/app/helmrelease.yaml
@@ -53,6 +53,23 @@ spec:
                   name: *app
 
             probes:
+              # slskd 0.25 doesn't bind its HTTP listener until the initial share
+              # scan completes — for our 3Ti music library that's ~15-20 min on
+              # the first scan after a chart change. A startupProbe defers both
+              # liveness and readiness during that window so the pod isn't
+              # killed mid-scan, then liveness/readiness take over for steady
+              # state. failureThreshold: 180 * periodSeconds: 10 = 30 min grace.
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: *httpPort
+                  failureThreshold: 180
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 3
               # Liveness goes beyond /health (which only checks slskd's API) and asserts
               # that slskd's Soulseek server connection is making forward progress.
               # When the downloads-gateway VXLAN tunnel flaps, slskd loses its server
@@ -74,7 +91,7 @@ spec:
                         wget -qO- http://localhost:5030/api/v0/application \
                           | jq -e '.server.isLoggedIn or .server.isConnecting or .server.isLoggingIn or .connectionWatchdog.isAwaitingVpn' >/dev/null
                   failureThreshold: 10
-                  initialDelaySeconds: 60
+                  initialDelaySeconds: 0
                   periodSeconds: 30
                   timeoutSeconds: 5
               readiness:


### PR DESCRIPTION
## Summary

Follow-up to #11731. Adding `/media/shared` (3 Ti music NFS) means the very first slskd boot after that change has to scan ~130k files across ~15k dirs — slskd 0.25 doesn't bind its HTTP listener until the initial scan finishes, so `/health` is unreachable for 15-20 min. That trips both probes and pulls the pod into a restart loop where every restart starts the scan over.

This adds a `startupProbe` (180 × 10 s = 30 min budget) that defers liveness and readiness while the initial scan runs. Once `/health` responds, the smart liveness probe and cheap readiness probe from #11731 take over for steady state. Subsequent restarts use the on-disk share cache and finish in well under a minute, so the startupProbe is effectively a one-time deferral.

Drops the 60 s `initialDelaySeconds` on liveness since startupProbe now owns startup gating.

## Test plan

- [ ] Flux reconciles slskd HelmRelease; pod has all three probes in `kubectl describe pod slskd-0`.
- [ ] During initial scan, pod status shows `Running` with `Ready=false`, scan progresses past 100%, then `/health` starts responding and `Ready=true`.
- [ ] No container restarts during the scan window.
- [ ] After scan completes, liveness probe successfully runs the `jq -e` server-state check.
- [ ] Pod recreation (e.g. `kubectl delete pod slskd-0`) is fast on subsequent boots because the share cache is warm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)