### PR TITLE
fix(rook-ceph): allow egress to cluster Service CIDR

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/app/cnp-allow.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/app/cnp-allow.yaml
@@ -42,6 +42,16 @@ spec:
         - host
         - remote-node
         - kube-apiserver
+    # Cluster Service CIDR. `toEntities: cluster` matches pod + node
+    # endpoint identities, but NOT raw Service VIPs whose backing
+    # endpoints have been deleted (e.g. a stale mon Service IP cached
+    # in a mon's peer table after a mon was rotated out). Those packets
+    # leave with the Service IP as destination and have no Cilium
+    # identity, so default-deny kicks in. Allowing the Service CIDR
+    # explicitly absorbs that retry noise and also tolerates future
+    # mon Service rotations without CNP churn.
+    - toCIDR:
+        - 10.43.0.0/16
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
 apiVersion: cilium.io/v2


### PR DESCRIPTION
## Summary

`toEntities: cluster` matches pod and node endpoint identities but does NOT match raw Service VIPs whose backing endpoints have been deleted — those packets leave with the Service IP as the destination, have no Cilium identity, and hit default-deny.

Currently observed: `rook-ceph-mon-l` holds a stale `10.43.177.203` reference in its peer table (the IP was a previously-allocated mon Service that got rotated out — current mons are at `10.43.{47.89, 136.224, 154.244}`). The mon retries the dead peer indefinitely, producing ~0.31 pkt/s of `POLICY_DENIED` drops that contribute to `CiliumPolicyDropsSustained` on the empty `destination_namespace` bucket.

Allowing `toCIDR: 10.43.0.0/16` (cluster Service CIDR) on `ceph-broad-allow.spec.egress`:
- absorbs the stale-peer retry noise
- tolerates future mon Service rotations without CNP churn
- doesn't widen anything outside the cluster — the Service CIDR is internal-only

The underlying ceph state is still broken: a mon should not hold a reference to a Service IP that no longer exists. That should be cleaned up separately via the storage-operator (likely a monmap edit or mon-l replacement); leaving a `TODO` rather than blocking the alert fix on it.

## Test plan

- [ ] Flux reconciles `ceph-broad-allow` CNP
- [ ] Hubble: `rook-ceph/rook-ceph-mon-l → 10.43.177.203:3300 TCP` flows show `FORWARDED` (the packet is forwarded into the void — the IP is unassigned — but Cilium policy permits the attempt)
- [ ] `hubble_drop_total{source_namespace="rook-ceph",destination_namespace=""}` falls to 0
- [ ] No new drops appear elsewhere in the Ceph cluster (`toCIDR: 10.43.0.0/16` is strictly additive vs `toEntities: cluster`, no narrowing)
- [ ] Follow-up: investigate mon-l's stale peer reference under storage-operator

🤖 Generated with [Claude Code](https://claude.com/claude-code)