### PR TITLE
feat(mcp-system): Phase 0c observability pre-flight — dashboard + recording rules

### DIFF
--- a/kubernetes/apps/mcp-system/kustomization.yaml
+++ b/kubernetes/apps/mcp-system/kustomization.yaml
@@ -24,6 +24,7 @@ resources:
   - ./mcp-gateway/ks.yaml
   - ./memory-mcp/ks.yaml
   - ./netbox-mcp/ks.yaml
+  - ./observability/ks.yaml
   - ./omada-mcp/ks.yaml
   - ./paperless-mcp/ks.yaml
   - ./prometheus-mcp/ks.yaml

--- a/kubernetes/apps/mcp-system/observability/app/kustomization.yaml
+++ b/kubernetes/apps/mcp-system/observability/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./prometheusrule.yaml

--- a/kubernetes/apps/mcp-system/observability/app/prometheusrule.yaml
+++ b/kubernetes/apps/mcp-system/observability/app/prometheusrule.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: mcp-system-rules
+spec:
+  groups:
+    # Per-backend recording rules project each backend's native metric
+    # names into a normalized series with a `backend` label. Alerts
+    # query the projected metric and fan out across backends
+    # automatically. Add one group per instrumented backend.
+    - name: mcp.recording.memory.rules
+      interval: 1m
+      rules:
+        - record: mcp:tool_calls:rate5m
+          expr: sum by (tool, status) (rate(memory_mcp_tool_calls_total[5m]))
+          labels:
+            backend: memory
+        - record: mcp:tool_call_duration:p99_5m
+          expr: |
+            histogram_quantile(
+              0.99,
+              sum by (le, tool) (rate(memory_mcp_tool_call_duration_seconds_bucket[5m]))
+            )
+          labels:
+            backend: memory
+        - record: mcp:embed_calls:rate5m
+          expr: sum by (status) (rate(memory_mcp_embed_calls_total[5m]))
+          labels:
+            backend: memory

--- a/kubernetes/apps/mcp-system/observability/ks.yaml
+++ b/kubernetes/apps/mcp-system/observability/ks.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app mcp-system-observability
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: mcp-system
+  path: ./kubernetes/apps/mcp-system/observability/app
+  interval: 1h
+  timeout: 5m
+  prune: true
+  wait: false
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: memory-mcp
+      namespace: mcp-system
+  retryInterval: 2m

--- a/kubernetes/apps/observability/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/grafana/app/helmrelease.yaml
@@ -196,6 +196,10 @@ spec:
           datasource: Prometheus
           gnetId: 11454
           revision: 14
+      mcp:
+        mcp-system:
+          datasource: Prometheus
+          url: https://raw.githubusercontent.com/rwlove/home-ops/main/kubernetes/apps/observability/grafana/dashboards/mcp-system.json
       network:
         cloudflared:
           # renovate: depName="Cloudflare Tunnels (cloudflared)"

--- a/kubernetes/apps/observability/grafana/dashboards/mcp-system.json
+++ b/kubernetes/apps/observability/grafana/dashboards/mcp-system.json
@@ -1,0 +1,194 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "type": "row",
+      "title": "Fleet (istio sidecar — covers all 14 backends)",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 100,
+      "panels": []
+    },
+    {
+      "datasource": "Prometheus",
+      "type": "timeseries",
+      "title": "Inbound req rate per backend (calls/sec)",
+      "id": 101,
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 1 },
+      "fieldConfig": { "defaults": { "unit": "reqps", "color": { "mode": "palette-classic" } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "right", "calcs": ["mean", "lastNotNull"] }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "expr": "sum by (destination_workload) (rate(istio_requests_total{destination_workload_namespace=\"mcp-system\", reporter=\"destination\"}[5m]))",
+          "legendFormat": "{{destination_workload}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "type": "timeseries",
+      "title": "Inbound 5xx rate per backend",
+      "id": 102,
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 1 },
+      "fieldConfig": { "defaults": { "unit": "reqps", "color": { "mode": "palette-classic" } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "right", "calcs": ["mean", "lastNotNull"] }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "expr": "sum by (destination_workload) (rate(istio_requests_total{destination_workload_namespace=\"mcp-system\", reporter=\"destination\", response_code=~\"5..\"}[5m]))",
+          "legendFormat": "{{destination_workload}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "type": "timeseries",
+      "title": "Outbound req rate (egress per backend — chrome/searxng signal)",
+      "id": 103,
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 9 },
+      "fieldConfig": { "defaults": { "unit": "reqps", "color": { "mode": "palette-classic" } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "right", "calcs": ["mean", "lastNotNull"] }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "expr": "sum by (source_workload) (rate(istio_requests_total{source_workload_namespace=\"mcp-system\", reporter=\"source\"}[5m]))",
+          "legendFormat": "{{source_workload}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "type": "timeseries",
+      "title": "Outbound 5xx rate",
+      "id": 104,
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 9 },
+      "fieldConfig": { "defaults": { "unit": "reqps", "color": { "mode": "palette-classic" } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "right", "calcs": ["mean", "lastNotNull"] }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "expr": "sum by (source_workload) (rate(istio_requests_total{source_workload_namespace=\"mcp-system\", reporter=\"source\", response_code=~\"5..\"}[5m]))",
+          "legendFormat": "{{source_workload}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Per-backend (instrumented via @track_tool — currently: $backend)",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 17 },
+      "id": 200,
+      "panels": []
+    },
+    {
+      "datasource": "Prometheus",
+      "type": "timeseries",
+      "title": "Tool calls/sec by tool",
+      "id": 201,
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 18 },
+      "fieldConfig": { "defaults": { "unit": "cps", "color": { "mode": "palette-classic" }, "custom": { "drawStyle": "line", "fillOpacity": 10, "stacking": { "mode": "normal", "group": "A" }, "showPoints": "never", "lineWidth": 2 } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "right", "calcs": ["sum"] }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "expr": "sum by (tool) (mcp:tool_calls:rate5m{backend=~\"$backend\"})",
+          "legendFormat": "{{tool}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "type": "timeseries",
+      "title": "Tool errors/sec by tool",
+      "id": 202,
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 18 },
+      "fieldConfig": { "defaults": { "unit": "cps", "color": { "mode": "palette-classic" } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "right", "calcs": ["sum"] }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "expr": "sum by (tool) (mcp:tool_calls:rate5m{backend=~\"$backend\", status=\"error\"})",
+          "legendFormat": "{{tool}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "type": "timeseries",
+      "title": "Tool p99 latency by tool",
+      "id": 203,
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 26 },
+      "fieldConfig": { "defaults": { "unit": "s", "color": { "mode": "palette-classic" } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "right", "calcs": ["lastNotNull"] }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "expr": "mcp:tool_call_duration:p99_5m{backend=~\"$backend\"}",
+          "legendFormat": "{{tool}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "type": "timeseries",
+      "title": "Embed calls/sec (memory-mcp only)",
+      "id": 204,
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 26 },
+      "fieldConfig": { "defaults": { "unit": "cps", "color": { "mode": "palette-classic" } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "right", "calcs": ["sum"] }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "expr": "mcp:embed_calls:rate5m{backend=~\"$backend\"}",
+          "legendFormat": "{{status}}",
+          "refId": "A"
+        }
+      ]
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "tags": ["mcp", "observability"],
+  "templating": {
+    "list": [
+      {
+        "current": { "selected": false, "text": "All", "value": "$__all" },
+        "datasource": "Prometheus",
+        "definition": "label_values(mcp:tool_calls:rate5m, backend)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "backend",
+        "multi": true,
+        "name": "backend",
+        "options": [],
+        "query": { "query": "label_values(mcp:tool_calls:rate5m, backend)", "refId": "StandardVariableQuery" },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "MCP System",
+  "uid": "mcp-system",
+  "version": 1,
+  "weekStart": ""
+}


### PR DESCRIPTION
## Summary
- Phase 0c of the MCP fleet observability rollout (Plan v5 — `/home/rwlove/.claude-personal/plans/on-a-plan-to-adaptive-ripple.md`, 4 adversarial audit passes).
- Substrate-only: dashboard + recording rules. **Zero alerts** ship in this PR (alerts come in Phase 5 after Class A backends are instrumented).
- Memory-mcp v0.1.4 already emits per-tool metrics (verified live via `kubectl exec` against the running pod). This PR makes them queryable + visible.

## What lands
- `kubernetes/apps/mcp-system/observability/` — Flux Kustomization + PrometheusRule projecting memory-mcp's native metrics into normalized `mcp:tool_calls:rate5m{backend, tool, status}` / `mcp:tool_call_duration:p99_5m{backend, tool}` / `mcp:embed_calls:rate5m{backend, status}`. Eval interval 1m to match the global scrape interval. Per-backend recording rules are added in subsequent phases.
- `kubernetes/apps/observability/grafana/dashboards/mcp-system.json` — two-row dashboard with `$backend` template variable:
  - **Row 1 — Fleet (istio sidecar):** covers all 14 MCP backends from day one via `istio_requests_total` for inbound + outbound (chrome-mcp / searxng-mcp egress signal).
  - **Row 2 — Per-backend (`@track_tool`):** driven by the normalized recording rules. Today shows memory-mcp; Phase 1/2 add time-mcp + netbox-mcp without dashboard JSON changes (the template variable auto-enumerates).

## Subsequent rollout phases (queued)
- **Phase 1:** time-mcp `@track_tool` instrumentation + ServiceMonitor + per-backend recording rule group. (FastMCP framework confirmed; `mcp.server.fastmcp.FastMCP` has `custom_route`.)
- **Phase 2:** netbox-mcp same template (fastmcp 3.x standalone).
- **arr-mcp:** Node.js per Dockerfile (clones aplaceforallmystuff/mcp-arr) — Class C, handled in Phase 3 upstream investigation, not in this rollout.
- **Phase 3:** Upstream-metrics verification sweep for grafana-mcp, prometheus-mcp, github-mcp, kubectl-mcp, ha-mcp, omada-mcp, paperless-mcp, immich-mcp, searxng-mcp. Per-backend memory file using the schema in the plan.
- **Phase 4:** Per-backend ServiceMonitor PRs for confirmed-metrics-emitting upstreams.
- **Phase 5:** Alert activation (recording-rule-driven `MCPBackendScrapeFailed` / `MCPBackendHighErrorRate` / `MCPBackendHighLatency` at warning tier; optional `MCPGatewayDown` at critical with HolmesGPT enrichment).
- **Phase 6:** Tag pinning for `paperless-mcp` + `immich-mcp` `:latest`.

## Test plan
- [x] `kubectl kustomize kubernetes/apps/mcp-system/observability/app` renders clean PrometheusRule.
- [x] `kubectl kustomize kubernetes/apps/mcp-system` renders without conflict.
- [x] `python3 -m json.tool mcp-system.json` validates dashboard JSON.
- [x] `# HELP memory_mcp_tool_calls_total` confirmed live in memory-mcp pod's `/metrics`.
- [x] Dashboard wired into `grafana/app/helmrelease.yaml` `dashboards:` block (alphabetically between `kubernetes:` and `network:`).
- [ ] Post-merge: verify `mcp:tool_calls:rate5m{backend="memory"}` is queryable in Prom within ~2 min.
- [ ] Post-merge: dashboard shows non-zero data in both rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)