### PR TITLE
fix(kube-system/gpu-operator): tolerate kubernetes.io/arch=arm64 on Spark

### DIFF
--- a/kubernetes/apps/kube-system/gpu-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/gpu-operator/app/helmrelease.yaml
@@ -23,6 +23,21 @@ spec:
     operator:
       cleanupCRD: false
       upgradeCRD: true
+    # Tolerations applied to every operand DaemonSet (toolkit,
+    # device-plugin, dcgmExporter, gfd, nodeStatusExporter, validator).
+    # The chart default tolerates `nvidia.com/gpu` only; appending
+    # `kubernetes.io/arch=arm64` lets the NVIDIA stack run on Spark
+    # (arm64, NVIDIA Grace-Blackwell) which is tainted to keep generic
+    # workloads off but still needs the GPU operands for ollama-spark.
+    daemonsets:
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+        - key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
+          effect: NoSchedule
     driver:
       enabled: false
     toolkit:


### PR DESCRIPTION
## Summary

Spark (NVIDIA Grace-Blackwell, arm64) joined the cluster with `kubernetes.io/arch=arm64:NoSchedule` to keep generic workloads off and dedicate the node to AI inference (ollama-spark-0). The gpu-operator chart's default `daemonsets.tolerations` only includes `nvidia.com/gpu`, so six operand DaemonSets are flagged as misscheduled on Spark by kube-state-metrics:

- `nvidia-container-toolkit-daemonset`
- `nvidia-dcgm-exporter`
- `nvidia-device-plugin-daemonset`
- `gpu-feature-discovery`
- `nvidia-node-status-exporter`
- `nvidia-operator-validator`

The pods are still running (placed before the taint was added; `NoSchedule` doesn't evict) but the DS spec now forbids the placement, so KSM correctly reports `numberMisscheduled: 1` for each.

Adding `kubernetes.io/arch=arm64:NoSchedule` to the operand tolerations matches actual intent — the GPU stack DOES need to be on Spark so `ollama-spark-0` can use the GPU. After Flux reconciles, six entries each clear from `KubeDaemonSetMisScheduled` and `KubeDaemonSetRolloutStuck`.

## Test plan

- [ ] Flux reconciles `gpu-operator` HelmRelease
- [ ] DS template tolerations include both `nvidia.com/gpu` and `kubernetes.io/arch=arm64` for the 6 operand DSes
- [ ] `kube-state-metrics` `kube_daemonset_status_number_misscheduled` for those 6 DSes returns to 0
- [ ] `ollama-spark-0` continues running with GPU access (no eviction of the existing NVIDIA pods on Spark)
- [ ] Other GPU nodes (worker8) unaffected

## Related

- Separate worker8 `nvidia-container-toolkit-daemonset-zszpp` crashloop ("dial unix /runtime/sock-dir/containerd.sock: no such file or directory") is unrelated to this fix — needs its own investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)