### PR TITLE
fix(kube-system/node-feature-discovery): tolerate arm64 on Spark

### DIFF
--- a/kubernetes/apps/kube-system/node-feature-discovery/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/node-feature-discovery/app/helmrelease.yaml
@@ -57,5 +57,14 @@ spec:
         requests:
           cpu: 20m
           memory: 86M
+
+      # Tolerate Spark's arm64 dedication taint so NFD discovers GPU /
+      # PCI features there too — needed by gpu-operator's nodeSelector
+      # logic (`nvidia.com/gpu.deploy.*` labels are NFD-driven).
+      tolerations:
+        - key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
+          effect: NoSchedule
   uninstall:
     keepHistory: false


### PR DESCRIPTION
## Summary

NFD worker emits the `nvidia.com/gpu.deploy.*` labels used by gpu-operator's nodeSelectors. Without an arm64 toleration, NFD doesn't run on Spark (NVIDIA Grace-Blackwell, arm64), so the GPU labels never get attached there and gpu-operator's operand DS scheduling misses.

Adds `kubernetes.io/arch=arm64:NoSchedule` toleration to `worker.tolerations`. master/gc/topologyUpdater stay control-plane-only.

Clears one entry each from `KubeDaemonSetMisScheduled` + `KubeDaemonSetRolloutStuck`.

## Test plan

- [ ] Flux reconciles `node-feature-discovery` HelmRelease
- [ ] NFD worker DS template tolerations include `kubernetes.io/arch=arm64`
- [ ] `node-feature-discovery-worker-*` pod present on Spark
- [ ] kube-state-metrics `kube_daemonset_status_number_misscheduled{daemonset="node-feature-discovery-worker"}` returns to 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)