### PR TITLE
fix(observability/vector-agent): tolerate arm64 on Spark

### DIFF
--- a/kubernetes/apps/observability/vector/agent/helmrelease.yaml
+++ b/kubernetes/apps/observability/vector/agent/helmrelease.yaml
@@ -22,8 +22,15 @@ spec:
     controllers:
       vector-agent:
         pod:
+          # Tolerate masters (legacy: log-collection ran cluster-wide
+          # including control plane) and Spark's arm64 dedication taint
+          # so per-node log shipping reaches every node.
           tolerations:
             - key: node-role.kubernetes.io/master
+              effect: NoSchedule
+            - key: kubernetes.io/arch
+              operator: Equal
+              value: arm64
               effect: NoSchedule
 
         annotations:


### PR DESCRIPTION
## Summary

Per-node log shipping should cover Spark (NVIDIA Grace-Blackwell, arm64) too — without the `kubernetes.io/arch=arm64:NoSchedule` toleration, vector-agent isn't (re)scheduled there and `ollama-spark-0` logs only flow through stdout → kubelet, never reaching Loki.

Adds the toleration alongside the existing `node-role.kubernetes.io/master` one. Clears one entry each from `KubeDaemonSetMisScheduled` + `KubeDaemonSetRolloutStuck`.

## Test plan

- [ ] Flux reconciles `vector-agent` HelmRelease
- [ ] DS template tolerations include `kubernetes.io/arch=arm64`
- [ ] `vector-agent-*` pod present on Spark
- [ ] ollama-spark logs visible in Loki (`{namespace="ai", pod="ollama-spark-0"}`)
- [ ] kube-state-metrics `kube_daemonset_status_number_misscheduled{daemonset="vector-agent"}` returns to 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)