### PR TITLE
fix(rook-ceph/operator): tolerate arm64 on CSI nodeplugins for Spark

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/app/operator/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/app/operator/helmrelease.yaml
@@ -10,6 +10,18 @@ spec:
     name: rook-ceph
   interval: 1h
   values:
+    csi:
+      # Tolerate Spark's arm64 dedication taint. ollama-spark-0 uses
+      # ceph-block PVCs (ollama-spark-data-pvc + ollama-spark-models-
+      # pvc), so the RBD CSI nodeplugin MUST run on Spark — without
+      # this it cannot mount RBD volumes on a tainted node. The chart
+      # applies pluginTolerations to both RBD and CephFS nodeplugin
+      # DaemonSets; cephfs CSI on Spark is unused but harmless.
+      pluginTolerations:
+        - key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
+          effect: NoSchedule
     image:
       repository: ghcr.io/rook/ceph
 


### PR DESCRIPTION
## Summary

`ollama-spark-0` uses ceph-block PVCs (`ollama-spark-data-pvc` + `ollama-spark-models-pvc`), so the RBD CSI nodeplugin must run on Spark to mount the volumes. Without an arm64 toleration the existing pod is technically misscheduled, and any reschedule (rook upgrade, drain) would orphan ollama-spark's volume mounts.

The chart applies `csi.pluginTolerations` to **both** RBD and CephFS nodeplugin DaemonSets together — there's no per-driver toleration knob — so cephfs CSI also stays on Spark. That's a small amortized cost (~2 sidecars worth of memory) for an unused-on-Spark filesystem; not worth a chart fork.

Clears two entries each from `KubeDaemonSetMisScheduled` + `KubeDaemonSetRolloutStuck`.

## Test plan

- [ ] Flux reconciles `rook-ceph-operator` HelmRelease
- [ ] `rook-ceph.rbd.csi.ceph.com-nodeplugin-*` + `rook-ceph.cephfs.csi.ceph.com-nodeplugin-*` pod template tolerations include `kubernetes.io/arch=arm64`
- [ ] Existing Spark plugin pods continue to mount ollama-spark's RBD volumes
- [ ] kube-state-metrics `kube_daemonset_status_number_misscheduled` for those 2 DSes returns to 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)