### PR TITLE
fix(databases/langgraph-checkpoints): postgres timeouts (loud failures over hangs)

### DIFF
--- a/kubernetes/apps/databases/cloudnative-pg/config/langgraph-checkpoints/cluster.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/langgraph-checkpoints/cluster.yaml
@@ -20,6 +20,19 @@ spec:
   postgresql:
     parameters:
       timezone: "America/New_York"
+      # Loud failures over hangs. langgraph-agents' workload is small
+      # fast queries (aget_tuple / aput / aput_writes); nothing here
+      # legitimately runs close to 60s. If a future regression
+      # reintroduces a hang shape, postgres aborts the offending txn
+      # with a visible error in pod logs instead of letting the runtime
+      # park forever. Paired with the AsyncConnectionPool fix in
+      # langgraph-agents v0.2.12. MERGE ORDER: pool fix first, then
+      # this — otherwise the CNPG rolling restart triggered by these
+      # params would drop the live pod's stale conn and the (still
+      # single-conn) pod would hang on reconnect.
+      statement_timeout: "60s"
+      idle_in_transaction_session_timeout: "60s"
+      lock_timeout: "30s"
 
   storage:
     size: 8Gi


### PR DESCRIPTION
## Summary

- Adds `statement_timeout=60s`, `idle_in_transaction_session_timeout=60s`, `lock_timeout=30s` to the langgraph-checkpoints CNPG cluster.

## Why

Defense in depth for the langgraph-agents reporter post-node hang (`project_langgraph_reporter_post_node_hang`). Phase 1's `AsyncConnectionPool` fix in rwlove/langgraph-agents#17 is the root-cause repair; this PR is the loud-failure-over-hang safety net.

langgraph-agents' workload against this DB is small fast queries (`aget_tuple` / `aput` / `aput_writes` / `setup()` migrations). Nothing legitimately runs close to 60s. If a future regression reintroduces a hang shape, postgres aborts the offending txn with a visible error in pod logs instead of letting the runtime park forever.

## ⚠️ Merge order

This PR is **DRAFT** because of sequencing:

1. **First:** merge https://github.com/rwlove/langgraph-agents/pull/17, push `v0.2.12` tag → image builds.
2. **Second:** bump `kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml` `tag:` 0.2.11 → 0.2.12 (Renovate will likely open this PR automatically once the image is published, or do it manually). Apply + verify new langgraph pod is on the pool-backed code path.
3. **Third:** undraft + merge this PR. CNPG will roll the three checkpoints instances; the new langgraph pod's pool will transparently survive the conn drops because of the `check=` parameter.

If you merge this PR before step 2, the CNPG rolling restart will sever the live pod's single stale conn — exactly the failure mode this whole sequence is designed to fix. Don't do that.

## Test plan

- [ ] Apply cluster.yaml change — CNPG rolling restart (three instances, `failoverDelay: 30s` already set).
- [ ] Verify `kubectl logs postgres-langgraph-checkpoints-1 -c postgres` shows no `statement_timeout` / `idle_in_transaction_session_timeout` firings during normal operation.
- [ ] Run a daily-digest reporter task and confirm completion + 4 checkpoints + Zulip reply-back. (Full Phase 5 SLO criteria in the plan file.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)