### PR TITLE
fix(ai/langgraph-agents): bump 0.2.11 → 0.2.12 (AsyncConnectionPool checkpoint fix)

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/langgraph-agents
-              tag: 0.2.11@sha256:125d29158942bbd08e5077a6327439a6637d252c48901f629055951a5cdd99fc
+              tag: 0.2.12@sha256:1e2e97c01a20048f0fb46a9159054abc9e8b77799bb2f3c5a70931bf900dda6f
 
             env:
               # --- vault ---


### PR DESCRIPTION
## Summary

- Bump langgraph-agents `0.2.11 → 0.2.12@sha256:1e2e97c0...`
- Upstream: rwlove/langgraph-agents#17 (merged)
- Fixes the cluster's "reporter post-node hang" (memory: `project_langgraph_reporter_post_node_hang`)

## Why

v0.2.12 swaps the single `AsyncPostgresSaver.from_conn_string` connection for an `AsyncConnectionPool` with `check=AsyncConnectionPool.check_connection`. Forensics on 2026-05-19 showed the prior single conn idle for **88 minutes** on the cluster's primary postgres before the next `aget_tuple` parked on it forever — Cilium conntrack expiry (or similar silent TCP half-open) was the trigger. The pooled saver health-checks (`SELECT 1`) before yielding each connection and replaces dead ones.

## Test plan

- [x] Lint + mypy + 128 tests pass in CI (https://github.com/rwlove/langgraph-agents/pull/17 — including the new postgres-backed regression test that verifies recovery after `pg_terminate_backend`).
- [ ] After Flux reconcile, verify new pod starts on 0.2.12: `kubectl get pod -n ai -l app.kubernetes.io/name=langgraph-agents -o yaml | grep image:`
- [ ] Trigger reporter task end-to-end; confirm 4 checkpoints land + `/inbox` returns:
  ```
  TASK=verify-bump-$(date +%s); kubectl exec -n ai deploy/langgraph-agents -c app -- /app/.venv/bin/python -c "import httpx; print(httpx.post('http://localhost:8765/inbox', json={'task_id':'$TASK','source':'test','content':\"generate today's digest\",'user':'rob'}, timeout=900).text)"
  kubectl exec -n databases postgres-langgraph-checkpoints-2 -c postgres -- psql -U postgres -d langgraph_checkpoints -c "SELECT COUNT(*) FROM checkpoints WHERE thread_id = '$TASK'"
  ```
- [ ] Soak 24h; track Phase 5 SLO criteria from the plan file (no idle-in-txn rows post-run, daily digest completes within 15 min, etc.).

## Follow-up

After this PR's soak passes, undraft + merge https://github.com/rwlove/home-ops/pull/11747 for the postgres timeouts (loud-failures-over-hangs safety net).

🤖 Generated with [Claude Code](https://claude.com/claude-code)