### PR TITLE
feat(mcp-system): Phase 1+2 — time-mcp + netbox-mcp cluster bumps

### DIFF
--- a/kubernetes/apps/mcp-system/netbox-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/netbox-mcp/app/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/netbox-mcp
-              tag: v0.1.1@sha256:13be693c3dbd9b623e975a9e2b00879b10967dba449e54d46b8d8fd0073c00e8
+              tag: v1.1.0@sha256:1cdfef3f51036ec888d83e059cf29be8931e35e1a4c31d565d3a9cb12c84e678
             env:
               NETBOX_URL: https://netbox.${SECRET_DOMAIN}
               TRANSPORT: http

--- a/kubernetes/apps/mcp-system/netbox-mcp/app/kustomization.yaml
+++ b/kubernetes/apps/mcp-system/netbox-mcp/app/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./servicemonitor.yaml

--- a/kubernetes/apps/mcp-system/netbox-mcp/app/servicemonitor.yaml
+++ b/kubernetes/apps/mcp-system/netbox-mcp/app/servicemonitor.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/servicemonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: netbox-mcp
+  labels:
+    app.kubernetes.io/name: netbox-mcp
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: netbox-mcp
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+  namespaceSelector:
+    matchNames:
+      - mcp-system

--- a/kubernetes/apps/mcp-system/observability/app/prometheusrule.yaml
+++ b/kubernetes/apps/mcp-system/observability/app/prometheusrule.yaml
@@ -29,3 +29,33 @@ spec:
           expr: sum by (status) (rate(memory_mcp_embed_calls_total[5m]))
           labels:
             backend: memory
+    - name: mcp.recording.time.rules
+      interval: 1m
+      rules:
+        - record: mcp:tool_calls:rate5m
+          expr: sum by (tool, status) (rate(time_mcp_tool_calls_total[5m]))
+          labels:
+            backend: time
+        - record: mcp:tool_call_duration:p99_5m
+          expr: |
+            histogram_quantile(
+              0.99,
+              sum by (le, tool) (rate(time_mcp_tool_call_duration_seconds_bucket[5m]))
+            )
+          labels:
+            backend: time
+    - name: mcp.recording.netbox.rules
+      interval: 1m
+      rules:
+        - record: mcp:tool_calls:rate5m
+          expr: sum by (tool, status) (rate(netbox_mcp_tool_calls_total[5m]))
+          labels:
+            backend: netbox
+        - record: mcp:tool_call_duration:p99_5m
+          expr: |
+            histogram_quantile(
+              0.99,
+              sum by (le, tool) (rate(netbox_mcp_tool_call_duration_seconds_bucket[5m]))
+            )
+          labels:
+            backend: netbox

--- a/kubernetes/apps/mcp-system/time-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/time-mcp/app/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/time-mcp
-              tag: v0.1.0@sha256:e14f8a504632b2b47cab13f6ff79a1898699cf7376f4c31984f9ca3a2b33a794
+              tag: v0.1.1@sha256:7e639c169104da809376a91fa6143504b0dacc7a40c53446494cad3b03fe6f04
             env:
               PORT: "8060"
               HOST: "0.0.0.0"

--- a/kubernetes/apps/mcp-system/time-mcp/app/kustomization.yaml
+++ b/kubernetes/apps/mcp-system/time-mcp/app/kustomization.yaml
@@ -6,3 +6,4 @@ components:
   - ../../../../components/repos/app-template
 resources:
   - ./helmrelease.yaml
+  - ./servicemonitor.yaml

--- a/kubernetes/apps/mcp-system/time-mcp/app/servicemonitor.yaml
+++ b/kubernetes/apps/mcp-system/time-mcp/app/servicemonitor.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/servicemonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: time-mcp
+  labels:
+    app.kubernetes.io/name: time-mcp
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: time-mcp
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+  namespaceSelector:
+    matchNames:
+      - mcp-system


### PR DESCRIPTION
## Summary
- Phases 1+2 of the MCP fleet observability rollout (Plan v5).
- Bumps **time-mcp** to v0.1.1 (instrumented in containers#19) and **netbox-mcp** to v1.1.0 (instrumented in containers#20) — both images now expose `/metrics` with per-tool counters + latency histograms.
- Adds two ServiceMonitors (cloned verbatim from memory-mcp's) and appends two recording-rule groups to `mcp-system-rules` PrometheusRule (landed in #11741).

Combined into one PR because both touch `prometheusrule.yaml`'s `groups:` list — splitting would conflict on merge. Rollback is still per-backend (revert specific files).

## Image digests
- `ghcr.io/rwlove/time-mcp:v0.1.1@sha256:7e639c169104da809376a91fa6143504b0dacc7a40c53446494cad3b03fe6f04`
- `ghcr.io/rwlove/netbox-mcp:v1.1.0@sha256:1cdfef3f51036ec888d83e059cf29be8931e35e1a4c31d565d3a9cb12c84e678`

Note: netbox-mcp jumps `v0.1.1 → v1.1.0` — upstream pyproject.toml already had `version = "1.0.0"` (stale w.r.t. image tags), so `v1.1.0` follows the source-of-truth in the upstream repo. No `v1.0.0` image exists.

## What lands per backend

### time-mcp
- HelmRelease image tag bump (v0.1.0 → v0.1.1).
- New `app/servicemonitor.yaml` (port `http`, path `/metrics`, 30s interval).
- New `mcp.recording.time.rules` group in the central PrometheusRule.

### netbox-mcp
- HelmRelease image tag bump (v0.1.1 → v1.1.0).
- New `app/servicemonitor.yaml` (port `http`, path `/metrics`, 30s interval).
- New `mcp.recording.netbox.rules` group in the central PrometheusRule.

## After merge — verification
Both backends share the same soak protocol:
```
count_over_time((up{namespace="mcp-system", service="time-mcp"}   == 0)[24h:30s]) == 0
count_over_time((up{namespace="mcp-system", service="netbox-mcp"} == 0)[24h:30s]) == 0
```
And spot-check that `mcp:tool_calls:rate5m{backend="time"}` / `{backend="netbox"}` populate within ~2 min of Flux reconcile.

## Test plan
- [x] `kubectl kustomize kubernetes/apps/mcp-system/observability/app` renders all 3 recording-rule groups (memory/time/netbox).
- [x] `kubectl kustomize kubernetes/apps/mcp-system/{time,netbox}-mcp/app` renders both ServiceMonitors.
- [x] Both upstream images built successfully via `gh workflow run` (digests pinned above).
- [x] Local tests passed on both upstream PRs (containers#19, containers#20) — all metrics emit correctly.
- [ ] Post-merge: `up{namespace="mcp-system", service="time-mcp"}` returns 1 within 60s of Flux reconcile.
- [ ] Post-merge: `up{namespace="mcp-system", service="netbox-mcp"}` returns 1 within 60s.
- [ ] Post-merge: `mcp:tool_calls:rate5m{backend="time"}` queryable within ~2 min.
- [ ] Post-merge: `mcp:tool_calls:rate5m{backend="netbox"}` queryable within ~2 min.
- [ ] Dashboard `$backend` template variable shows memory/time/netbox after panels load.

## Refs
- Plan: `/home/rwlove/.claude-personal/plans/on-a-plan-to-adaptive-ripple.md` (v5, 4-pass adversarial audit)
- Phase 0c substrate: #11741 (merged)
- Upstream instrumentation: rwlove/containers#19 (time-mcp), rwlove/containers#20 (netbox-mcp)
- Phase 3 status: see `project_mcp_phase3_metrics_sweep.md` memory (9 third-party backends → Class D)
- Phase 5 (alerts) queued after both 24h soaks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)