### PR TITLE
feat(ai/ollama-spark): Phase 0 — bump MAX_LOADED_MODELS + Pod-down alert

### DIFF
--- a/kubernetes/apps/ai/ollama-spark/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/ollama-spark/app/helmrelease.yaml
@@ -59,8 +59,11 @@ spec:
               OLLAMA_CONTEXT_LENGTH: 16384
               OLLAMA_NUM_PARALLEL: 4
               # Spark's 128 GB unified memory comfortably runs 30b-class
-              # models concurrently. P40-era cap of 1 lifted.
-              OLLAMA_MAX_LOADED_MODELS: 2
+              # models concurrently. P40-era cap of 1 lifted. Bumped
+              # 2 → 3 to leave headroom during the Spark-unblocks-RAG
+              # embedder benchmark (chat + two candidate embedders
+              # loaded concurrently).
+              OLLAMA_MAX_LOADED_MODELS: 3
 
             resources:
               requests:

--- a/kubernetes/apps/ai/ollama-spark/app/kustomization.yaml
+++ b/kubernetes/apps/ai/ollama-spark/app/kustomization.yaml
@@ -9,4 +9,5 @@ components:
 resources:
   - ./cnp-allow.yaml
   - ./helmrelease.yaml
+  - ./prometheusrule.yaml
   - ./pvc.yaml

--- a/kubernetes/apps/ai/ollama-spark/app/prometheusrule.yaml
+++ b/kubernetes/apps/ai/ollama-spark/app/prometheusrule.yaml
@@ -1,0 +1,37 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: ollama-spark-rules
+spec:
+  groups:
+    # GB10 traditional DCGM utilization counters (GPU_UTIL,
+    # GR_ENGINE_ACTIVE, FB_USED, MEM_COPY_UTIL) are broken on this
+    # arch — see reference_dcgm_gb10_broken_counters.md. The only
+    # signals that reliably report on GB10 are POWER_USAGE and
+    # SM_CLOCK. A "GPU is wedged" alert that depends on POWER_USAGE
+    # (idle <12 W while Pod Ready for >10 min) is planned for the
+    # Stream 1d cleanup PR; it'd cry wolf right now because no
+    # consumer routes to ollama-spark yet and POWER sits at the
+    # ~10 W idle floor.
+    - name: ollama-spark.availability
+      rules:
+        # Pod-level failure — covers OOM, image-pull, scheduling,
+        # crash-loop. High-precision pager. Once Stream 1 routes
+        # langgraph / HolmesGPT / Open WebUI to Spark, a dead Pod
+        # means the cluster's chat surface is degraded to the P40
+        # fallback.
+        - alert: SparkOllamaPodDown
+          annotations:
+            summary: ollama-spark Pod not Ready (Spark inference unavailable)
+            description: |
+              Pod {{ $labels.namespace }}/{{ $labels.pod }} on Spark
+              has been not-Ready for >5 minutes. Inspect with
+              `kubectl -n ai describe pod {{ $labels.pod }}` and
+              `kubectl -n ai logs {{ $labels.pod }} --previous`.
+          expr: |-
+            kube_pod_status_ready{namespace="ai",pod=~"ollama-spark-.*",condition="true"} == 0
+          for: 5m
+          labels:
+            severity: critical


### PR DESCRIPTION
## Summary

Phase 0 prerequisite work for the Spark-unblocks-RAG cutover plan
(`~/.claude-personal/plans/let-s-examine-the-spark-unblocks-rag-pure-dongarra.md`).
Low-blast-radius: no consumer routes to ollama-spark yet (langgraph,
HolmesGPT, Open WebUI still talk to the P40 `ollama` service), so
neither change touches the live inference path.

- `OLLAMA_MAX_LOADED_MODELS` 2 → 3 so chat (qwen2.5:32b) + two candidate
  embedders (nomic-embed-text, bge-m3) can be loaded concurrently
  during the Phase A embedder benchmark.
- New `PrometheusRule` (`kubernetes/apps/ai/ollama-spark/app/prometheusrule.yaml`)
  with `SparkOllamaPodDown` (`kube_pod_status_ready`, critical, 5 min).
- New rule added to `kustomization.yaml`.

## What's deferred to Stream 1d

The plan also called for a POWER<12W "wedged" alert. It'd fire
continuously today — Spark sits at ~10 W idle because no consumer
routes there yet. Deferred to the Stream 1d cleanup PR, after the
routing cutover lands.

## GB10 quirk recap

GB10 DCGM utilization counters are broken (`GPU_UTIL` / `FB_USED` /
`GR_ENGINE_ACTIVE` / `MEM_COPY_UTIL` all 0 or empty). The deferred
wedged-alert will use `DCGM_FI_DEV_POWER_USAGE` as the activity proxy
per `reference_dcgm_gb10_broken_counters.md`. Only `SparkOllamaPodDown`
ships here and it uses standard kube-state-metrics.

## Test plan

- [ ] CI green (flux-local + image-registry-check + lint)
- [ ] On merge: Flux reconciles ollama-spark Kustomization; `kubectl -n ai get sts ollama-spark -o yaml | grep MAX_LOADED` shows `3`
- [ ] `kubectl -n ai get prometheusrules ollama-spark-rules` exists
- [ ] Prom rule loaded: `curl prometheus.../api/v1/rules | jq '.data.groups[] | select(.name=="ollama-spark.availability")'`
- [ ] Pod restarts cleanly with new env (reloader picks it up)
- [ ] Follow-up: pull `nomic-embed-text` + `bge-m3` on ollama-spark via `POST /api/pull` (Phase 0.2, live)

🤖 Generated with [Claude Code](https://claude.com/claude-code)