### PR TITLE
chore(mcp-system/chrome-smoke-sweep): lower failedJobsHistory 7 → 1

### DIFF
--- a/kubernetes/apps/mcp-system/chrome-smoke-sweep/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/chrome-smoke-sweep/app/helmrelease.yaml
@@ -24,7 +24,12 @@ spec:
           schedule: "10 5 * * *"
           concurrencyPolicy: Forbid
           successfulJobsHistory: 3
-          failedJobsHistory: 7
+          # Keep only the most recent failure — every retained failed
+          # Job fires KubeJobFailed in KSM until rotated out. 7 was an
+          # iteration-era retention while the sweep was being built;
+          # the CronJob has stabilized and there's no need to keep
+          # debug history at that depth.
+          failedJobsHistory: 1
           backoffLimit: 1
           ttlSecondsAfterFinished: 86400
         annotations:


### PR DESCRIPTION
## Summary

The CronJob retained 7 failed Jobs (iteration-era setting from building the smoke sweep). Now that the sweep is stable, those retained failures keep firing `KubeJobFailed` indefinitely — they only rotate out via new failures, which in healthy state never happen.

Lower to `failedJobsHistory: 1`. Most recent failure is still retained for debugging; older debris automatically pruned.

## Test plan

- [ ] Flux reconciles `chrome-smoke-sweep` HelmRelease
- [ ] CronJob `chrome-smoke-sweep` spec shows `failedJobsHistoryLimit: 1`
- [ ] Next failure (whenever one happens) rotates out the prior failure
- [ ] `KubeJobFailed{namespace="mcp-system", job_name=~"chrome-smoke-sweep.*"}` no longer accumulates

🤖 Generated with [Claude Code](https://claude.com/claude-code)