### PR TITLE
feat(observability/holmesgpt): Stream 1b — Spark + qwen2.5:32b

### DIFF
--- a/kubernetes/apps/observability/holmesgpt/app/cnp-allow.yaml
+++ b/kubernetes/apps/observability/holmesgpt/app/cnp-allow.yaml
@@ -31,11 +31,17 @@ spec:
             - port: "8080"
               protocol: TCP
   egress:
-    # LLM backend — ollama in ai ns (Pattern E).
+    # LLM backend — ollama (P40) + ollama-spark (Blackwell) in ai ns
+    # (Pattern E). Both endpoints selected for parallel-routing readiness;
+    # current MODEL/OLLAMA_API_BASE target ollama-spark, but the rollback
+    # path is a one-env-flip back to ollama — keep both reachable.
     - toEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: ai
             app.kubernetes.io/name: ollama
+        - matchLabels:
+            io.kubernetes.pod.namespace: ai
+            app.kubernetes.io/name: ollama-spark
       toPorts:
         - ports:
             - port: "11434"

--- a/kubernetes/apps/observability/holmesgpt/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/holmesgpt/app/helmrelease.yaml
@@ -42,16 +42,19 @@ spec:
               - python
               - /app/server.py
             env:
-              MODEL: ollama/qwen2.5:7b
-              OLLAMA_API_BASE: http://ollama.ai.svc.cluster.local:11434
+              MODEL: ollama/qwen2.5:32b
+              OLLAMA_API_BASE: http://ollama-spark.ai.svc.cluster.local:11434
               OVERRIDE_MAX_CONTENT_SIZE: "16384"
               OVERRIDE_MAX_OUTPUT_TOKEN: "4096"
-              # Default litellm timeout is 600s — tool-calling investigations
-              # against qwen2.5:7b on P40 frequently exceed it (verified
-              # 2026-05-19 via direct /api/chat probe; investigation timed out
-              # at 600s with `litellm.Timeout: Connection timed out`). Align
-              # with the n8n outer-timeout of 1500s per
-              # `project_n8n_holmesgpt_timeout_workaround` memory.
+              # Default litellm timeout is 600s; tool-calling
+              # investigations against qwen2.5:7b on P40 routinely
+              # exceeded it (1500s band-aid landed in PR #11651). On
+              # Spark qwen2.5:32b the per-token latency drops but the
+              # total tool-orchestration budget for a complex
+              # investigation can still rival 1500s. Keep the band-aid
+              # through the 48 h soak; revert to 600s in the Stream
+              # 1d cleanup PR once p95 alert latency is observed back
+              # under 5 min in Grafana.
               LITELLM_REQUEST_TIMEOUT: "1500"
               LITELLM_TIMEOUT: "1500"
               HOLMES_HOST: 0.0.0.0


### PR DESCRIPTION
## Summary

HolmesGPT cuts from P40 `qwen2.5:7b` to Spark `qwen2.5:32b` per Stream 1b
of the Spark-unblocks-RAG plan. HolmesGPT is the highest-volume Ollama
consumer in the cluster (every AlertManager → windmill investigation
fires `/api/chat`), so this PR is the strongest signal that Spark
inference is healthy in production.

## Changes

- `MODEL: ollama/qwen2.5:7b` → `ollama/qwen2.5:32b`
- `OLLAMA_API_BASE: ollama.ai` → `ollama-spark.ai`
- CNP egress: add `ollama-spark` selector (kept `ollama` for rollback)
- `LITELLM_REQUEST_TIMEOUT`/`LITELLM_TIMEOUT`: **deliberately left at
  1500 s** for the 48 h soak. Revert to 600 s in the Stream 1d cleanup
  PR after observing alert latency p95 settles back under 5 min.

## Test plan

- [ ] CI green (yamllint, flux-local, cnp-empty-rules)
- [ ] Post-merge: Pod restarts (`reloader` picks up env), `kubectl -n
      observability logs deployment/holmesgpt` shows litellm calling
      `http://ollama-spark...`
- [ ] Trigger one synthetic alert (or wait for next real one) and watch:
      - investigation completes within 1500 s
      - response posted to Zulip/ntfy contains no raw OpenAI tool-call
        JSON descriptors leaking into the body (the open audit from
        `project_langgraph_activation_gated_on_spark`)
      - Spark `POWER_USAGE` rises above the ~10 W idle floor during
        the run (the v2 plan's Wedged alert will activate post-Stream
        1d if traffic still doesn't reach Spark)
- [ ] 48 h soak with HolmesGPT alert latency in Grafana

## Rollback

`git revert` this commit. CNP keeps both selectors so a faster
env-only rollback (`MODEL` / `OLLAMA_API_BASE` back to P40) works
without a second PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)