### PR TITLE
feat(collab/open-webui): Stream 1c — multi-endpoint Ollama (Spark default, P40 fallback)

### DIFF
--- a/kubernetes/apps/collab/open-webui/app/cnp-allow.yaml
+++ b/kubernetes/apps/collab/open-webui/app/cnp-allow.yaml
@@ -25,11 +25,15 @@ spec:
             - port: "8080"
               protocol: TCP
   egress:
-    # ai/ollama — primary LLM backend (OLLAMA_BASE_URL).
+    # ai/ollama + ai/ollama-spark — LLM backends (OLLAMA_BASE_URLS
+    # advertises both endpoints; Spark is default, P40 selectable).
     - toEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: ai
             app.kubernetes.io/name: ollama
+        - matchLabels:
+            io.kubernetes.pod.namespace: ai
+            app.kubernetes.io/name: ollama-spark
       toPorts:
         - ports:
             - port: "11434"

--- a/kubernetes/apps/collab/open-webui/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/open-webui/app/helmrelease.yaml
@@ -32,7 +32,13 @@ spec:
               tag: v0.9.5
 
             env:
-              OLLAMA_BASE_URL: http://ollama.ai.svc.cluster.local:11434
+              # Multi-endpoint: Spark (qwen2.5:32b) is the new default,
+              # P40 (qwen2.5:7b) remains user-selectable per
+              # conversation. Open WebUI parses this as `;`-separated
+              # endpoints and exposes each model under its own provider
+              # label in the model picker. First entry is the default
+              # for new chats.
+              OLLAMA_BASE_URLS: http://ollama-spark.ai.svc.cluster.local:11434;http://ollama.ai.svc.cluster.local:11434
               # langgraph-agents exposes an OpenAI-compatible surface; each
               # agent id is registered as a model. The key is a placeholder —
               # the langgraph-agents Service has no auth (cluster-internal only).


### PR DESCRIPTION
## Summary

Open WebUI's chat path now advertises both Spark and P40 endpoints per
Stream 1c of the Spark-unblocks-RAG plan. Spark (`qwen2.5:32b`) is the
default for new conversations; P40 (`qwen2.5:7b`/`qwen3:8b`) remains
user-selectable in the model picker.

## Changes

- `OLLAMA_BASE_URL` (singular) → `OLLAMA_BASE_URLS` (plural,
  `;`-separated): `ollama-spark;ollama`. First entry is the default for
  new chats per Open WebUI's documented behavior.
- CNP egress: add `ollama-spark` selector alongside the existing
  `ollama` selector.

## Scope kept narrow

- **No RAG embedding change** — `RAG_EMBEDDING_MODEL: nomic-embed-text`
  still goes through Open WebUI's own embedding client; that routing
  is a Phase A (embedder benchmark) decision and not touched here.
- **No reranker change** — `bge-reranker-v2-m3` stays in-process for
  now; the move to TEI on Spark is Stream 2.

## Test plan

- [ ] CI green (yamllint, flux-local, cnp-empty-rules)
- [ ] Post-merge: model picker in Open WebUI shows `qwen2.5:32b`
      alongside the existing 7b / 8b options
- [ ] New conversation defaults to qwen2.5:32b (first endpoint, first
      model)
- [ ] P40 models still selectable and respond
- [ ] Spark `POWER_USAGE` rises during a 32b conversation

## Rollback

`git revert` this commit. Both endpoints remain in the CNP egress so
an even-faster env-only rollback (`OLLAMA_BASE_URLS` → single P40
URL) is also viable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)