### PR TITLE
fix(kube-system/zot): expand zot-data-ceph PVC 200Gi → 500Gi

### DIFF
--- a/kubernetes/apps/kube-system/zot/app/pvc.yaml
+++ b/kubernetes/apps/kube-system/zot/app/pvc.yaml
@@ -9,6 +9,6 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 200Gi
+      storage: 500Gi
   storageClassName: ceph-block
   volumeMode: Filesystem


### PR DESCRIPTION
## Summary

After the Phase 1 cache rollout ([#11704](https://github.com/rwlove/home-ops/pull/11704), `project_zot_chart_cache_phase1_done`) ZOT's pull-through cache is filling rapidly during the post-migration backfill:

- Current: **130 GiB used / 200 Gi (65%)**
- Growth: **~17 GiB/day** per `predict_linear` over trailing 2 days
- Projected fill: **~4 days**

Expanding to 500 Gi gives ~22 days of margin at the current rate. Growth is expected to level off once the post-warmup backfill is done (ZOT only re-pulls when a tag moves or a new chart is referenced).

`ceph-block` PVCs are online-resizable — no pod restart required.

## Test plan

- [ ] Flux reconciles PVC
- [ ] `kubectl get pvc -n kube-system zot-data-ceph` shows 500Gi (Bound)
- [ ] Filesystem inside the ZOT pod (`kubectl -n kube-system exec zot-0 -- df -h /var/lib/registry`) reports 500 GiB
- [ ] `node_filesystem_size_bytes{instance="worker7.thesteamedcrab.com:9100",device="/dev/rbd8"}` doubles to ~500 GiB
- [ ] `CephNodeDiskspaceWarning` for worker7/rbd8 clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)