### PR TITLE
fix(rook-ceph): scope CephNodeDiskspaceWarning to exclude CSI mounts

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -9,6 +9,35 @@ spec:
     kind: OCIRepository
     name: rook-ceph-cluster
   interval: 1h
+  postRenderers:
+    # The rook-ceph cluster chart ships CephNodeDiskspaceWarning with
+    # `device=~"/.*"` — which matches every block device on the node,
+    # including CSI plugin mounts (/dev/rbd*, /dev/longhorn/*). That
+    # turns the rule into a noisy "any PVC filling up" alert with
+    # `predict_linear < 0` regardless of actual fill %.
+    #
+    # Scope the matcher to actual node disks. Real OSD-node disks (sd*,
+    # nvme*, mapper/ when used as OSD LVM) still alert; transient and
+    # legitimate PVC growth is covered by the kube-prometheus-stack
+    # NodeFilesystemSpaceFillingUp rule (stricter: requires both
+    # <15% free AND fills in 24h).
+    #
+    # Index path is the current chart layout — `test` op verifies it
+    # before `replace`, so a chart upgrade that reorders rules will
+    # fail loudly here rather than silently mis-patch a different rule.
+    - kustomize:
+        patches:
+          - patch: |-
+              - op: test
+                path: /spec/groups/6/rules/4/alert
+                value: CephNodeDiskspaceWarning
+              - op: replace
+                path: /spec/groups/6/rules/4/expr
+                value: |
+                  predict_linear(node_filesystem_free_bytes{device=~"/.*",device!~"/dev/(rbd|longhorn).*"}[2d], 3600 * 24 * 5) *on(instance) group_left(nodename) node_uname_info < 0
+            target:
+              kind: PrometheusRule
+              name: prometheus-ceph-rules
   values:
     cephBlockPools:
       - name: ceph-blockpool


### PR DESCRIPTION
## Summary

The rook-ceph cluster chart ships `CephNodeDiskspaceWarning` with `device=~"/.*"` — which catches every block device on the node, including CSI plugin mounts (`/dev/rbd*` for Ceph PVCs, `/dev/longhorn/*` for Longhorn PVCs). The rule then fires as a noisy "any PVC trending downward" alert regardless of actual fill %.

**Today's 4 firing instances**:

| Alert | Reality |
|---|---|
| worker7/rbd8 (zot-data-ceph, 130/200 GiB) | **Real** — addressed by #11754 expansion |
| spark/rbd1 (ollama-spark-models, 100Gi) | False positive — 0% used; `predict_linear` extrapolated from sparse data → `-1008G in 5d` |
| worker3/rbd0 (zot image stale) | False positive — RBD detached, metric stale |
| worker3/longhorn/slskd-config-xfs (5Gi, 17%) | False positive — positive trend |

Three of four are false positives that `NodeFilesystemSpaceFillingUp` (kube-prometheus-stack default) wouldn't fire on — it requires **both** <15% free AND fills in 24h, which is much stricter.

Adds a HelmRelease `postRenderer` JSON Patch to scope the matcher to `device!~"/dev/(rbd|longhorn).*"`. Real OSD-node disks (`sd*`, `nvme*`, `mapper/*` when used as OSD LVM) still alert.

The patch uses a `test` op before `replace` — a chart upgrade that reorders rules fails loudly rather than silently mis-patching a different rule.

## Test plan

- [ ] Flux reconciles `rook-ceph-cluster` HelmRelease
- [ ] `prometheus-ceph-rules` PrometheusRule has the scoped expression
- [ ] Spark/rbd1 + worker3/rbd0 + worker3/longhorn/slskd-config-xfs alerts clear
- [ ] worker7/rbd8 alert clears once #11754 lands and expansion completes
- [ ] `NodeFilesystemSpaceFillingUp` doesn't pick up any new false positives (it never has on these volumes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)