### PR TITLE
fix(databases/postgres-windmill): bump memory 512Mi → 1Gi

### DIFF
--- a/kubernetes/apps/databases/cloudnative-pg/config/windmill/cluster.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/windmill/cluster.yaml
@@ -32,9 +32,9 @@ spec:
   resources:
     requests:
       cpu: 50m
-      memory: 256Mi
-    limits:
       memory: 512Mi
+    limits:
+      memory: 1Gi
 
   enableSuperuserAccess: true
   superuserSecret:


### PR DESCRIPTION
## Summary

`postgres-windmill-1` has restarted **31 times in 8 hours** since the n8n → Windmill cutover ([memory: project_n8n_to_windmill_migration_done](https://github.com/rwlove/home-ops)). Container is firing `OOMKilled` — `limits.memory: 512Mi` is not enough for an actively-used Windmill backend.

- Current steady-state usage: **333 MiB** (65% of the 512 Mi limit)
- Peak workload spikes blow past the limit → OOM → restart

Aligning sizing with `postgres-paperless` (similar workload profile):
- `requests.memory`: 256Mi → **512Mi**
- `limits.memory`: 512Mi → **1Gi**

| Cluster | request | limit |
|---|---|---|
| postgres-home-assistant | 1536Mi | 3Gi |
| postgres-immich | 1Gi | 2Gi |
| **postgres-paperless** | 512Mi | 1Gi |
| **postgres-windmill (new)** | 512Mi | 1Gi |
| postgres-windmill (old) | 256Mi | 512Mi ← OOM source |

## Test plan

- [ ] Flux reconciles Cluster CR (CNPG operator rolls instances one at a time)
- [ ] `kubectl -n databases get cluster postgres-windmill -o jsonpath='{.spec.resources.limits.memory}'` shows `1Gi`
- [ ] Pods restart with new limits applied (`kubectl describe`)
- [ ] OOMKilled alert clears + no new container restarts after rollout completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)