### PR TITLE
feat(ai/langgraph-agents): Stream 1a — bump 0.2.12 → 0.2.13 + drop dead OLLAMA_BASE_URL

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
@@ -20,14 +20,19 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/langgraph-agents
-              tag: 0.2.12@sha256:1e2e97c01a20048f0fb46a9159054abc9e8b77799bb2f3c5a70931bf900dda6f
+              tag: 0.2.13@sha256:9f15316ade75ea71c4a4729840d57f575ad9ce10c1ca07e8c5f94b10a8696e29
 
             env:
               # --- vault ---
               VAULT_ROOT: /vault
 
               # --- model providers ---
-              OLLAMA_BASE_URL: http://ollama.ai.svc.cluster.local:11434/v1
+              # Routing happens in code via AGENT_GROUP in
+              # src/agents/llm.py — settings.ollama_p40_url and
+              # settings.ollama_spark_url default to the right cluster
+              # Services so no overrides are needed here. The legacy
+              # OLLAMA_BASE_URL setting was deprecated in v0.2.x and
+              # removed in this PR.
               ENABLE_CLAUDE_API: "false"  # flip to true once Claude key is in 1Password
 
               # --- MCP gateway ---


### PR DESCRIPTION
## Summary

Stream 1a of the Spark-unblocks-RAG plan. Two related changes in one
PR because they belong together:

1. **Image bump 0.2.12 → 0.2.13** picks up
   [rwlove/langgraph-agents#18](https://github.com/rwlove/langgraph-agents/pull/18):
   `reporter`, `researcher`, and `supervisor` move from `local-p40`
   (qwen2.5:7b) to `local-spark` (qwen2.5:32b) in `AGENT_GROUP`, with
   matching updates to the OpenAI-surface `_PER_AGENT_MODEL` table.

2. **Removes the deprecated `OLLAMA_BASE_URL` env.** The settings
   field has been marked DEPRECATED in `src/agents/settings.py` since
   the `ollama_p40_url` + `ollama_spark_url` split landed; nothing in
   the factory path or the chat-completions API reads it anymore.
   Keeping it around with a P40 URL was actively misleading —
   operators reading the HelmRelease would conclude (wrongly) that
   *all* routing went to the P40. The routing is fully
   `AGENT_GROUP`-driven, with the defaults in `settings.py`
   already pointing at the right cluster Services.

## Routing as of this PR

| Group | Agents | Model |
|---|---|---|
| `local-spark` | reporter, researcher, supervisor, coder, reviewer, homelab-engineer, network-operator, storage-operator, smart-home-operator, ml-operator, observability-operator | qwen2.5:32b |
| `local-p40` | triager, note-maker, errand-runner, property-coordinator, health-tracker (hard-pinned), doc-writer | qwen2.5:7b |

11 of 17 agents on Spark now, 6 still on P40.

## Test plan

- [ ] CI green
- [ ] Pod restarts cleanly with new image + missing env (reloader
      picks it up)
- [ ] Trigger reporter via Windmill daily-digest cron (or wait for
      natural fire) — verify it routes to ollama-spark and produces
      a coherent digest
- [ ] Trigger researcher via /inbox with a real query — verify it
      routes to ollama-spark
- [ ] Spark POWER_USAGE rises above the ~10W idle floor during the
      runs (the v2 plan's Wedged alert will activate post-Stream 1d
      once routing is live and exercised)
- [ ] Tool-call-JSON leakage audit (Windmill TS workflows
      `langgraph-approval-post.ts` + `langgraph-daily-digest.ts`):
      check Zulip / ntfy bodies for raw tool-call JSON descriptors —
      decide between option A (per-channel detectors) vs option B
      (sanitize in rwlove/langgraph-agents) per the open audit memo

🤖 Generated with [Claude Code](https://claude.com/claude-code)