### PR TITLE
fix(kube-system): NFD skips nvidia toolkit DS on CRI-O nodes

### DIFF
--- a/kubernetes/apps/kube-system/node-feature-discovery/rules/gpu-operator-runtime-override.yaml
+++ b/kubernetes/apps/kube-system/node-feature-discovery/rules/gpu-operator-runtime-override.yaml
@@ -1,0 +1,41 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/nfd.k8s-sigs.io/nodefeaturerule_v1alpha1.json
+apiVersion: nfd.k8s-sigs.io/v1alpha1
+kind: NodeFeatureRule
+metadata:
+  name: gpu-operator-runtime-override
+spec:
+  # The cluster runs CRI-O on every node except Spark (Ubuntu 24.04 +
+  # containerd). gpu-operator's `nvidia-container-toolkit-daemonset`
+  # writes containerd-specific config (`/etc/containerd/conf.d/99-nvidia.toml`)
+  # and SIGHUPs containerd via `/run/containerd/containerd.sock` — both
+  # of which are meaningless on a CRI-O host (no socket → crashloop).
+  #
+  # GPU still works on CRI-O nodes (worker8 currently runs 8 GPU
+  # workloads via the existing host-level NVIDIA hook setup); the
+  # toolkit DS just has nothing useful to do there.
+  #
+  # Mark CRI-O nodes (proxied here by `system-os_release.ID` since the
+  # cluster's 1:1 mapping is centos/fedora/rhel → CRI-O, ubuntu/talos →
+  # containerd) as opted-out of the toolkit DS via the documented
+  # gpu-operator label `nvidia.com/gpu.deploy.container-toolkit=false`.
+  # The other gpu-operator DSes (device-plugin, dcgm-exporter,
+  # operator-validator, gpu-feature-discovery, node-status-exporter)
+  # don't depend on the toolkit's containerd configuration and stay
+  # enabled on CRI-O nodes.
+  #
+  # When a new GPU node is added with a different OS, audit the OS↔
+  # runtime mapping before relying on this rule.
+  rules:
+    - name: gpu-operator-crio-toolkit-skip
+      labels:
+        nvidia.com/gpu.deploy.container-toolkit: "false"
+      matchFeatures:
+        - feature: system.osrelease
+          matchExpressions:
+            ID:
+              op: In
+              value:
+                - centos
+                - fedora
+                - rhel

--- a/kubernetes/apps/kube-system/node-feature-discovery/rules/kustomization.yaml
+++ b/kubernetes/apps/kube-system/node-feature-discovery/rules/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 resources:
   - ./barcode-device.yaml
   - ./coral-device.yaml
+  - ./gpu-operator-runtime-override.yaml
   - ./intel-gpu.yaml
   - ./nvidia-gpu.yaml
   - ./skyconnect-device.yaml


### PR DESCRIPTION
## Summary

gpu-operator's `nvidia-container-toolkit-daemonset` is hardcoded to write `/etc/containerd/conf.d/99-nvidia.toml` and SIGHUP containerd via `/run/containerd/containerd.sock`. The cluster runs CRI-O on every node *except* Spark (Ubuntu 24.04 + containerd), so on the CRI-O majority the toolkit DS has nothing useful to do — it crashloops trying to dial a non-existent containerd socket.

worker8 has been firing `KubePodCrashLooping` on this DS while still hosting **8 GPU workloads** happily (comfyui, ollama, immich-machine-learning, immich-pet-tagger, av1corrector, whisper, pump-cv) — the host-level NVIDIA hook setup is independent of the toolkit DS on CRI-O.

Architectural fix via NFD:
- New NodeFeatureRule `gpu-operator-runtime-override`
- Matches OS ID `centos|fedora|rhel` (1:1 proxy for CRI-O in this cluster — see [[project_os_migration_program]])
- Applies the documented gpu-operator opt-out label `nvidia.com/gpu.deploy.container-toolkit=false`
- gpu-operator respects the label and skips the toolkit DS on labeled nodes
- Self-applying as new CRI-O GPU nodes get added; Spark (Ubuntu) keeps the toolkit DS

Other gpu-operator DSes (device-plugin, dcgm-exporter, operator-validator, gpu-feature-discovery, node-status-exporter) remain deployed on CRI-O nodes — they don't depend on the toolkit's containerd config writes.

## Test plan

- [ ] Flux reconciles the new NodeFeatureRule
- [ ] NFD applies `nvidia.com/gpu.deploy.container-toolkit=false` to worker8 (and any other GPU-enabled CRI-O node, currently none)
- [ ] gpu-operator removes `nvidia-container-toolkit-daemonset` pod from worker8
- [ ] `KubePodCrashLooping{pod=~"nvidia-container-toolkit-daemonset-.*"}` clears
- [ ] Spark keeps `container-toolkit=true` (OS ID = ubuntu, not matched) → toolkit DS still runs there
- [ ] Existing GPU workloads on worker8 continue to function (no regression)
- [ ] `kube_daemonset_status_number_ready{daemonset="nvidia-container-toolkit-daemonset"}` matches `desiredNumberScheduled` (1, only Spark)

## Caveats

When a new GPU node is added with a different OS, audit the OS↔runtime mapping before relying on this rule. Currently centos/fedora/rhel ↔ CRI-O, ubuntu/talos ↔ containerd is locked-in per the OS migration plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)