### PR TITLE
feat(databases/qdrant): Stream 3a — memory bump + ServiceMonitor

### DIFF
--- a/kubernetes/apps/databases/qdrant/app/helmrelease.yaml
+++ b/kubernetes/apps/databases/qdrant/app/helmrelease.yaml
@@ -48,9 +48,15 @@ spec:
             resources:
               requests:
                 cpu: 50m
-                memory: 256Mi
+                # Sized for the initial Paperless ingest + Phase A
+                # dual-collection benchmark (200 docs × 2 embedders).
+                # Pre-Spark-unblocks-RAG sizing (256Mi/512Mi) was fine
+                # for 0 collections but will OOM during ingest. Revisit
+                # downward after the first full ingest measures resident
+                # set in steady state.
+                memory: 1Gi
               limits:
-                memory: 512Mi
+                memory: 4Gi
     service:
       app:
         controller: qdrant

--- a/kubernetes/apps/databases/qdrant/app/kustomization.yaml
+++ b/kubernetes/apps/databases/qdrant/app/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - ./cnp-allow.yaml
   - ./helmrelease.yaml
   - ./pvc.yaml
+  - ./servicemonitor.yaml

--- a/kubernetes/apps/databases/qdrant/app/servicemonitor.yaml
+++ b/kubernetes/apps/databases/qdrant/app/servicemonitor.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/servicemonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: qdrant
+  labels:
+    app.kubernetes.io/name: qdrant
+spec:
+  endpoints:
+    - interval: 30s
+      path: /metrics
+      port: http
+      scrapeTimeout: 10s
+  namespaceSelector:
+    matchNames:
+      - databases
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: qdrant


### PR DESCRIPTION
## Summary

Stream 3a of the Spark-unblocks-RAG plan. Two pre-ingest changes so
the cluster's vector store can carry the RAG workload that's about
to land on it.

## Changes

1. **Memory: 256 Mi req / 512 Mi limit → 1 Gi req / 4 Gi limit.**
   Sized for the Phase A dual-collection embedder benchmark (200 docs
   × two embedders concurrent) and the initial Paperless ingest. The
   pre-ingest 512 Mi limit was fine while collections were empty but
   OOMs the moment real ingest starts. Revisit downward after the
   first full ingest measures resident set in steady state.

2. **ServiceMonitor scraping `:6333/metrics`.** Verified live —
   `curl /metrics` returns 200, Prometheus format, ~2.7 KB
   (collection count, vector totals, request histograms). Matches the
   memory-mcp ServiceMonitor shape (interval 30 s, scrapeTimeout 10 s).

## What's NOT in scope

- Grafana dashboard row — planned for a follow-up once we have
  real ingest traffic to chart against.
- Qdrant HA / multi-replica — single-replica still capacity-fine;
  HA needs `QDRANT__CLUSTER__P2P_ENABLED` + headless svc + much
  more thought. Deferred per the v2 plan.

## CNP check

Existing CNP uses `fromEntities: cluster` for ingress on 6333/6334,
so Prometheus' scrape is already permitted. No network-policy
changes.

## Test plan

- [ ] CI green
- [ ] Pod restarts cleanly (rolling deployment; PVC reuse)
- [ ] ServiceMonitor picked up by Prometheus
      (`curl prometheus.../api/v1/targets` shows qdrant target Up)
- [ ] `qdrant_collections_total` metric exposed
- [ ] After Phase A starts: memory headroom remains positive during
      dual-collection ingest
- [ ] Follow-up: when Stream 3 ingest lands, observe peak memory and
      tighten the limit if 4 Gi proves over-provisioned

🤖 Generated with [Claude Code](https://claude.com/claude-code)