### PR TITLE
chore(ai/langgraph-agents): bump 0.2.13 → 0.2.14 (msgpack allowlist)

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/langgraph-agents
-              tag: 0.2.13@sha256:9f15316ade75ea71c4a4729840d57f575ad9ce10c1ca07e8c5f94b10a8696e29
+              tag: 0.2.14@sha256:f93031853e46ca1833c2d8929154628e6dcc92bef21f7b147f8247d1155083d1
 
             env:
               # --- vault ---


### PR DESCRIPTION
## Summary

- Bump langgraph-agents `0.2.13 → 0.2.14@sha256:f9303185...`
- Upstream: rwlove/langgraph-agents#20 + #21 (both merged)

## Why

v0.2.14 = v0.2.13 (reporter/researcher/supervisor routing → spark/qwen2.5:32b) + register `agents.state` Pydantic types with `JsonPlusSerializer.allowed_msgpack_modules`. Clears the deprecation warning observed during reporter's initial `aget_tuple` on the cluster.

Investigating rwlove/langgraph-agents#19 (post-reporter hang). Pure serde hygiene — does **NOT** change runtime behavior of deserialization (the default already succeeds with a warning). Expected outcome: quieter log, no behavioral change. If the hang resolves anyway, that's evidence serde was load-bearing somehow — useful negative result either way.

## Test plan

- [ ] Apply, watch new pod start on 0.2.14
- [ ] Fire reporter `/inbox` test, observe post-reporter checkpoint behavior
- [ ] If hang persists: next experiment is async-def conversion (separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)