### PR TITLE
fix(ai/langgraph-agents): bump 0.2.14 → 0.2.15 (TCP keepalives)

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/langgraph-agents
-              tag: v0.2.14@sha256:f93031853e46ca1833c2d8929154628e6dcc92bef21f7b147f8247d1155083d1
+              tag: v0.2.15@sha256:72848255c3267dbc89b6be3fd5daafd6fbd111927c1661afd45b0742f221cd88
 
             env:
               # --- vault ---


### PR DESCRIPTION
## Summary

- Bump langgraph-agents `0.2.14 → 0.2.15@sha256:72848255...`
- Upstream: rwlove/langgraph-agents#22 (closes #19)
- **Real fix for the post-reporter hang.** Adds TCP keepalives to the pool's `kwargs` so the kernel detects silently-half-open conns within ~60s. The previous deploys partially fixed adjacent issues but the hang itself was always a stale-conn problem — coincidentally hidden by PR #18's spark routing because the reporter LLM is now too fast for the conn to go idle.

## Why

In-cluster forensics on 2026-05-20:

1. First `/inbox` after pod boot lands cleanly: 4 checkpoints + reply.
2. Pod sits idle ~2 min.
3. Cilium conntrack (or similar) silently drops the pool's idle TCP conns. No FIN/RST on the wire — both sides still show ESTABLISHED.
4. Next `/inbox`: pool's `check=check_connection` issues `SELECT 1` on the half-open fd. The write goes (or pretends to); the recv never returns. Pool parks forever. Graph stalls at 0 checkpoints.

`check=AsyncConnectionPool.check_connection` handles hard closes (`pg_terminate_backend`) but not silent half-open. TCP keepalives are the kernel-level safety net.

## Test plan

- [ ] Apply, watch new pod start on 0.2.15
- [ ] Fire `/inbox` once; verify 4 checkpoints + reply.
- [ ] **Wait 3+ min**, fire `/inbox` again; verify 4 checkpoints again. This is the regression gate that v0.2.14 fails.

## Followup

After this PR's soak passes, undraft and merge https://github.com/rwlove/home-ops/pull/11747 (postgres timeouts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)