### PR TITLE
fix(ai/langgraph-agents): bump 0.2.15 → 0.2.16 (tcp_user_timeout)

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/langgraph-agents
-              tag: v0.2.15@sha256:72848255c3267dbc89b6be3fd5daafd6fbd111927c1661afd45b0742f221cd88
+              tag: v0.2.16@sha256:740edfe5ebb11052102e69639a9263927a949f65b00d815298dfbfb28cada161
 
             env:
               # --- vault ---


### PR DESCRIPTION
## Summary

- Bump `0.2.15 → 0.2.16@sha256:740edfe5...`
- Upstream: rwlove/langgraph-agents#23

## Why

v0.2.15's TCP keepalives only fire after `keepalives_idle` seconds of TRUE idle. When the pool's `check=` does `SELECT 1` and the socket is half-open mid-write, the kernel waits forever for the ACK. Verified in cluster: 3+ min idle → next /inbox hangs at 0 checkpoints.

v0.2.16 adds `tcp_user_timeout=15000ms`. Kernel-level: gives up on a connection if outgoing data has been unacked for 15s, regardless of keepalive cadence. SELECT 1 on a half-open conn now raises within 15s; pool catches & replaces.

## Test plan (post-deploy regression gate)

1. Fire `/inbox` once, verify 4 checkpoints
2. Wait 3+ min
3. Fire `/inbox` again, verify 4 checkpoints within ~30s wall over LLM-call duration. Without this fix, step 3 hangs indefinitely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)