### PR TITLE
feat(collab/open-webui): switch RAG embedder nomic-embed-text → bge-m3

### DIFF
--- a/kubernetes/apps/collab/open-webui/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/open-webui/app/helmrelease.yaml
@@ -46,7 +46,16 @@ spec:
               OPENAI_API_KEYS: sk-langgraph-agents-cluster-internal
               ENABLE_RAG_WEB_SEARCH: true
               RAG_EMBEDDING_ENGINE: ollama
-              RAG_EMBEDDING_MODEL: nomic-embed-text
+              # Phase A benchmark (2026-05-20, 50-doc Paperless eval)
+              # showed bge-m3 (1024-dim) beats nomic-embed-text (768) by
+              # +23 MRR@10 pts. The cluster moves to bge-m3 for new
+              # embedding work; both models live on ollama-spark.
+              # Note: this is destructive to any existing Open WebUI
+              # Knowledge Base collection embedded with nomic — those
+              # need a re-embed from the UI. The first such collection
+              # (Paperless) doesn't exist yet, so this PR has no
+              # in-flight re-index cost.
+              RAG_EMBEDDING_MODEL: bge-m3
               # Cross-encoder reranker — runs in-process via sentence-transformers
               # on CPU. Adds ~2.5GiB to the pod's resident set (model weights);
               # latency is ~hundreds of ms per batch which is fine for homelab


### PR DESCRIPTION
## Summary

Phase A of the Spark-unblocks-RAG plan ran a 50-doc Paperless
retrieval eval; **bge-m3 (1024-dim) beat nomic-embed-text (768-dim) by
+23 MRR@10 points** (0.8380 vs 0.6071) and +15 hits@1 (39 vs 24). Far
past the 5-pt decision threshold from the v2 plan.

| Embedder | MRR@10 | hits@1 | recall@10 |
|---|---|---|---|
| nomic-embed-text | 0.6071 | 24/50 | 86% |
| **bge-m3** | **0.8380** | **39/50** | **94%** |

This flip is a prerequisite for Stream 3 (Paperless RAG ingest): the
Knowledge Base needs Open WebUI to embed queries with the same model
that indexed the documents.

## Prereqs already in place

- `bge-m3` pulled onto `ollama-spark` in Phase 0.2 (verified live with
  a 1024-dim smoke test).
- `RAG_EMBEDDING_ENGINE=ollama` already routes via
  `OLLAMA_BASE_URLS`, which is Spark-first after Stream 1c — so
  embeddings land on Spark.

## Destructive caveat

Any existing Open WebUI Knowledge Base collection embedded with nomic
needs a re-index from the UI (dim mismatch). **None exist today**
(the Paperless KB doesn't land until Stream 3 ships), so this PR has
no in-flight re-index cost.

## Test plan

- [ ] CI green
- [ ] Pod reloads with new env (reloader picks it up)
- [ ] Open WebUI Knowledge Base creation prompt shows bge-m3 as the
      embedder; a small test KB can be uploaded + queried

## Followups (separate PRs)

- memory-mcp KG re-embedding 768→1024 dim (schema migration + ~67-row
  back-fill; see Phase A decision memory)
- Stream 3 Paperless ingest pipeline (Windmill TS scripts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)