### PR TITLE
fix(home/home-assistant): round-2 LAN egress (Glances/Hyperion/LG/Denon/Omada/Ollama)

### DIFF
--- a/kubernetes/apps/home/home-assistant/app/cnp-allow.yaml
+++ b/kubernetes/apps/home/home-assistant/app/cnp-allow.yaml
@@ -152,6 +152,43 @@ spec:
         - ports:
             - port: "631"
               protocol: TCP
+    # LAN integrations that poll over various TCP ports on the main
+    # home subnet (192.168.1.0/24):
+    #   * 8080 — Denon AVR (denon.thesteamedcrab.com / .1.12)
+    #   * 8043 — Omada Controller HTTPS UI on brain (.1.1)
+    #   * 19444 — Hyperion JSON-RPC on kodi-familyroom (.1.11)
+    #   * 61208 — Glances on brain (.1.1) + beast (.1.27)
+    - toCIDR:
+        - 192.168.1.0/24
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+            - port: "8043"
+              protocol: TCP
+            - port: "19444"
+              protocol: TCP
+            - port: "61208"
+              protocol: TCP
+    # LG webOS TVs on the management subnet expose the WebSocket API
+    # on TCP 3000. lg-familyroom (.5.44) + lg-bedroom (.5.26).
+    - toCIDR:
+        - 192.168.5.0/24
+      toPorts:
+        - ports:
+            - port: "3000"
+              protocol: TCP
+    # In-cluster Ollama (ai/ollama-0:11434). HA's `ollama` custom
+    # integration / template REST sensor calls the API for LLM-driven
+    # automations and sensor enrichment.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: ai
+            app.kubernetes.io/name: ollama
+      toPorts:
+        - ports:
+            - port: "11434"
+              protocol: TCP
     # NOTE: Home Assistant has multus-attached secondary NICs on the
     # IoT and SECURITY VLANs (hass-iot-static, hass-security-static).
     # Discovery (mDNS, broadcasts, device polling) over those NICs


### PR DESCRIPTION
## Summary

After PR #11736 cleared the Kodi/SNMP/IPP polling, hubble still showed `home/home-assistant-0 → various` TCP drops at ~1.21 pkt/s in the empty-`destination_namespace` bucket. Flow capture identified 7 more legitimate polling targets:

| Destination | Port | HA Integration |
|---|---|---|
| `192.168.5.44`, `192.168.5.26` | 3000 | webostv (lg-familyroom, lg-bedroom) |
| `192.168.1.12` | 8080 | denon (Denon AVR) |
| `192.168.1.27` (beast), `192.168.1.1` (brain) | 61208 | glances (3 integrations — `beast:61208`, `brain:61208`, `security-storage:61208`) |
| `192.168.1.1` (brain) | 8043 | omada (Omada Controller) |
| `192.168.1.11` (kodi-familyroom) | 19444 | hyperion |
| `ai/ollama-0` | 11434 | custom ollama integration / REST sensor |

All verified as configured HA integrations via `ha_get_integration`.

Three new egress rules:
- `192.168.1.0/24` → ports 8080, 8043, 19444, 61208 TCP
- `192.168.5.0/24` → 3000 TCP (LG TVs)
- `ai/ollama` Endpoints → 11434 TCP

## Test plan

- [ ] Flux reconciles `home-assistant-allow` CNP
- [ ] Hubble: HA → LG TVs, Denon, Glances, Omada, Hyperion all show `FORWARDED`
- [ ] glances integrations move from `setup_retry` → `loaded`
- [ ] hyperion integration moves from `setup_retry` → `loaded`
- [ ] omada integration moves out of `setup_in_progress`
- [ ] `CiliumPolicyDropsSustained{destination_namespace=""}` clears for the home source

🤖 Generated with [Claude Code](https://claude.com/claude-code)