### PR TITLE
fix(ai/langgraph-agents): bump 0.2.16 → 0.2.17 (max_idle + memory pool)

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/langgraph-agents
-              tag: v0.2.16@sha256:740edfe5ebb11052102e69639a9263927a949f65b00d815298dfbfb28cada161
+              tag: v0.2.17@sha256:9e3f94606b9c06c7e6f88eb50d46db50fdf5131d4027cf172212d4abd0a38416
 
             env:
               # --- vault ---


### PR DESCRIPTION
## Summary
- Bump 0.2.16 → 0.2.17@sha256:9e3f9460...
- Upstream: rwlove/langgraph-agents#24

## Why
v0.2.16's tcp_user_timeout doesn't fire — in-cluster failure is "postgres backend gone, OS still ACKs at TCP layer." v0.2.17 adds `max_idle=60` to both pools (preemptive recycling, well below Cilium conntrack expiry) and brings the memory_store pool to parity with the checkpointer.

## Regression gate
1. /inbox → 4 checkpoints
2. Wait 3+ min
3. /inbox → 4 checkpoints (this is what v0.2.16 fails)

🤖 Generated with [Claude Code](https://claude.com/claude-code)