### PR TITLE
feat(home/windmill): Stream 3 — Paperless RAG ingest + tombstone

### DIFF
--- a/kubernetes/apps/home/windmill/app/cnp-allow.yaml
+++ b/kubernetes/apps/home/windmill/app/cnp-allow.yaml
@@ -152,6 +152,36 @@ spec:
         - ports:
             - port: "8080"
               protocol: TCP
+    # Paperless RAG ingest workflows
+    # (paperless-rag-ingest, paperless-rag-tombstone):
+    # - paperless (collab ns) for doc list + content
+    # - ollama-spark (ai ns) for bge-m3 embeddings
+    # - qdrant (databases ns) for point upsert + scroll
+    # Each scoped to its specific Service rather than ns-wide.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: collab
+            app.kubernetes.io/name: paperless
+      toPorts:
+        - ports:
+            - port: "8000"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: ai
+            app.kubernetes.io/name: ollama-spark
+      toPorts:
+        - ports:
+            - port: "11434"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
+            app.kubernetes.io/name: qdrant
+      toPorts:
+        - ports:
+            - port: "6333"
+              protocol: TCP
     # External APIs Windmill workflows hit: Pushover + Anthropic + GitHub.
     # Canonical FQDNs via toEntities:world+443 per memory
     # project_cilium_matchpattern_fqdn_limits (matchPattern silently

--- a/kubernetes/apps/home/windmill/app/externalsecret-workflows.yaml
+++ b/kubernetes/apps/home/windmill/app/externalsecret-workflows.yaml
@@ -39,6 +39,10 @@ spec:
         ZULIP_BOT_EMAIL: "{{ .ZULIP_BOT_EMAIL }}"
         ZULIP_BOT_API_KEY: "{{ .ZULIP_BOT_API_KEY }}"
         ROB_ZULIP_USER_ID: "{{ .ROB_ZULIP_USER_ID }}"
+        # Paperless RAG ingest / tombstone workflows. Same 1P item
+        # (`paperless` / field `mcp_token`) that mcp-system/paperless-mcp
+        # already uses — keeping a single token-rotation surface.
+        PAPERLESS_TOKEN: "{{ .paperless_mcp_token }}"
   dataFrom:
     # LANGGRAPH_APPROVAL_SIGNING_KEY
     - extract:
@@ -49,3 +53,11 @@ spec:
     # ZULIP_BOT_* + ROB_ZULIP_USER_ID
     - extract:
         key: zulip-n8n-bot
+    # PAPERLESS_TOKEN (field=mcp_token, prefixed to avoid colliding
+    # with other items extracted above).
+    - extract:
+        key: paperless
+      rewrite:
+        - regexp:
+            source: "(.*)"
+            target: "paperless_$1"

--- a/kubernetes/apps/home/windmill/app/helmrelease.yaml
+++ b/kubernetes/apps/home/windmill/app/helmrelease.yaml
@@ -74,7 +74,7 @@ spec:
           # an explicit allowlist).
           extraEnv: &workflow_secrets
             - name: WHITELIST_ENVS
-              value: LANGGRAPH_APPROVAL_SIGNING_KEY,NTFY_URL,NTFY_WRITE_TOKEN,ZULIP_API_URL,ZULIP_BOT_EMAIL,ZULIP_BOT_API_KEY,ROB_ZULIP_USER_ID
+              value: LANGGRAPH_APPROVAL_SIGNING_KEY,NTFY_URL,NTFY_WRITE_TOKEN,ZULIP_API_URL,ZULIP_BOT_EMAIL,ZULIP_BOT_API_KEY,ROB_ZULIP_USER_ID,PAPERLESS_TOKEN
             - name: LANGGRAPH_APPROVAL_SIGNING_KEY
               valueFrom:
                 secretKeyRef:
@@ -105,6 +105,11 @@ spec:
                 secretKeyRef:
                   name: windmill-workflows-secret
                   key: ZULIP_BOT_API_KEY
+            - name: PAPERLESS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: windmill-workflows-secret
+                  key: PAPERLESS_TOKEN
             - name: ROB_ZULIP_USER_ID
               valueFrom:
                 secretKeyRef:

--- a/kubernetes/apps/home/windmill/workflows/README.md
+++ b/kubernetes/apps/home/windmill/workflows/README.md
@@ -1,6 +1,6 @@
 # Windmill workflow source
 
-These TypeScript scripts are the source-of-truth for the 7 Windmill
+These TypeScript scripts are the source-of-truth for the Windmill
 flows that replaced n8n in the `lovenet` workspace.
 
 Runtime lives in the Windmill DB; this directory is the *checked-in
@@ -29,6 +29,7 @@ or the inline curl in the README two levels up).
 | `ZULIP_BOT_EMAIL` | `zulip-n8n-bot.ZULIP_BOT_EMAIL` |
 | `ZULIP_BOT_API_KEY` | `zulip-n8n-bot.ZULIP_BOT_API_KEY` |
 | `ROB_ZULIP_USER_ID` | `zulip-n8n-bot.ROB_ZULIP_USER_ID` |
+| `PAPERLESS_TOKEN` | `paperless.mcp_token` (shared with paperless-mcp) |
 
 ## Approval-token signing (pre-sign at post-time)
 

--- a/kubernetes/apps/home/windmill/workflows/paperless-rag-ingest.ts
+++ b/kubernetes/apps/home/windmill/workflows/paperless-rag-ingest.ts
@@ -1,0 +1,284 @@
+// Cron: every 15 min.
+//
+// Streams modified Paperless documents into Qdrant `paperless` so the
+// Open WebUI Knowledge Base can retrieve against them. Idempotent —
+// safe to re-run with the same modified__gt cutoff.
+//
+// Sequencing per doc:
+//   1. fetch full content from Paperless
+//   2. chunk to ~1500 chars / ~200-char overlap (rough 350-tok target,
+//      fits bge-m3's 8192-token ceiling with a wide margin)
+//   3. delete any pre-existing chunks for this paperless_id (so
+//      updates replace cleanly — point IDs derive from paperless_id +
+//      chunk_index, but we still wipe by filter to handle docs whose
+//      chunk count shrinks)
+//   4. embed each chunk via Spark Ollama bge-m3 (1024-dim)
+//   5. upsert all chunks at once with full payload
+//
+// Watermark: read max(modified) across the live collection. If the
+// collection is empty, start from epoch (initial backfill). Save the
+// max(modified) observed in this run for the next iteration; we don't
+// persist it externally — re-deriving from Qdrant on each run keeps
+// the function stateless.
+//
+// Collection schema (lazy-created on first run):
+//   vectors:  size=1024 distance=Cosine
+//   payload:  paperless_id, title, correspondent, tags, last_modified,
+//             chunk_index, chunk_total, content
+
+type PaperlessDoc = {
+    id: number;
+    title: string;
+    content: string;
+    modified: string;
+    correspondent: { id: number; name: string } | null;
+    tags: { id: number; name: string }[];
+};
+
+type PaperlessList = {
+    count: number;
+    next: string | null;
+    results: PaperlessDoc[];
+};
+
+type QdrantPoint = {
+    id: number;
+    vector: number[];
+    payload: Record<string, unknown>;
+};
+
+const QDRANT = Deno.env.get("QDRANT_URL") ??
+    "http://qdrant.databases.svc.cluster.local:6333";
+const OLLAMA = Deno.env.get("OLLAMA_URL") ??
+    "http://ollama-spark.ai.svc.cluster.local:11434";
+const PAPERLESS = Deno.env.get("PAPERLESS_URL") ??
+    "http://paperless.collab.svc.cluster.local:8000";
+const EMBED_MODEL = Deno.env.get("EMBED_MODEL") ?? "bge-m3";
+const COLLECTION = "paperless";
+const EMBED_DIM = 1024;
+const CHUNK_CHARS = 1500;
+const CHUNK_OVERLAP = 200;
+const PAGE_SIZE = 50;
+const MAX_DOC_CHARS = 200_000; // safety: refuse runaway PDFs
+
+export async function main() {
+    const token = Deno.env.get("PAPERLESS_TOKEN");
+    if (!token) throw new Error("PAPERLESS_TOKEN env not set");
+
+    const started = new Date().toISOString();
+    await ensureCollection();
+    const watermark = await readWatermark();
+    console.log(`[ingest] watermark=${watermark} collection=${COLLECTION}`);
+
+    let touched = 0;
+    let chunks_written = 0;
+    let max_modified = watermark;
+    let page = 1;
+
+    while (true) {
+        const list = await paperlessList(token, watermark, page);
+        if (list.results.length === 0) break;
+        for (const doc of list.results) {
+            if (doc.modified > max_modified) max_modified = doc.modified;
+            const written = await ingestDoc(doc);
+            chunks_written += written;
+            touched += 1;
+        }
+        if (!list.next) break;
+        page += 1;
+    }
+
+    return {
+        started,
+        finished: new Date().toISOString(),
+        watermark_in: watermark,
+        watermark_out: max_modified,
+        docs_touched: touched,
+        chunks_written,
+    };
+}
+
+async function ensureCollection(): Promise<void> {
+    const r = await fetch(`${QDRANT}/collections/${COLLECTION}`);
+    if (r.status === 200) return;
+    if (r.status !== 404) {
+        throw new Error(`qdrant probe ${r.status}: ${await r.text()}`);
+    }
+    const create = await fetch(`${QDRANT}/collections/${COLLECTION}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+            vectors: { size: EMBED_DIM, distance: "Cosine" },
+        }),
+    });
+    if (!create.ok) {
+        throw new Error(`qdrant create ${create.status}: ${await create.text()}`);
+    }
+    // Payload index for tombstone filter + per-doc deletes.
+    const idx = await fetch(
+        `${QDRANT}/collections/${COLLECTION}/index?wait=true`,
+        {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                field_name: "paperless_id",
+                field_schema: "integer",
+            }),
+        },
+    );
+    if (!idx.ok) {
+        console.warn(
+            `qdrant payload-index paperless_id failed ${idx.status}: ${await idx.text()}`,
+        );
+    }
+    console.log(`[ingest] created collection ${COLLECTION} dim=${EMBED_DIM}`);
+}
+
+async function readWatermark(): Promise<string> {
+    // Scroll the collection for the max last_modified payload. The
+    // collection is small enough (target ~1k chunks for 200 docs) that
+    // a single scroll is fine; switch to a payload-indexed range query
+    // later if it grows past ~10k.
+    const r = await fetch(
+        `${QDRANT}/collections/${COLLECTION}/points/scroll`,
+        {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                limit: 10_000,
+                with_payload: ["last_modified"],
+                with_vector: false,
+            }),
+        },
+    );
+    if (!r.ok) return "1970-01-01T00:00:00Z";
+    const body = await r.json() as { result: { points: { payload: { last_modified: string } }[] } };
+    if (!body.result?.points?.length) return "1970-01-01T00:00:00Z";
+    let max = "1970-01-01T00:00:00Z";
+    for (const p of body.result.points) {
+        const lm = p.payload?.last_modified ?? "";
+        if (lm > max) max = lm;
+    }
+    return max;
+}
+
+async function paperlessList(
+    token: string,
+    modified_gt: string,
+    page: number,
+): Promise<PaperlessList> {
+    const url = new URL(`${PAPERLESS}/api/documents/`);
+    url.searchParams.set("page", String(page));
+    url.searchParams.set("page_size", String(PAGE_SIZE));
+    url.searchParams.set("ordering", "modified");
+    url.searchParams.set("modified__gt", modified_gt);
+    const r = await fetch(url, {
+        headers: { Authorization: `Token ${token}` },
+        signal: AbortSignal.timeout(60_000),
+    });
+    if (!r.ok) throw new Error(`paperless list ${r.status}: ${await r.text()}`);
+    return await r.json() as PaperlessList;
+}
+
+async function ingestDoc(doc: PaperlessDoc): Promise<number> {
+    const text = (doc.content ?? "").slice(0, MAX_DOC_CHARS).trim();
+    if (text.length < 50) {
+        console.log(`[ingest] skip doc ${doc.id} (${JSON.stringify(doc.title)}) — too short`);
+        return 0;
+    }
+    const chunks = chunk(text, CHUNK_CHARS, CHUNK_OVERLAP);
+    await deleteDocPoints(doc.id);
+    const points: QdrantPoint[] = [];
+    for (let i = 0; i < chunks.length; i++) {
+        const vector = await embed(chunks[i]);
+        points.push({
+            id: pointId(doc.id, i),
+            vector,
+            payload: {
+                paperless_id: doc.id,
+                title: doc.title,
+                correspondent: doc.correspondent?.name ?? null,
+                tags: (doc.tags ?? []).map((t) => t.name),
+                last_modified: doc.modified,
+                chunk_index: i,
+                chunk_total: chunks.length,
+                content: chunks[i],
+            },
+        });
+    }
+    await upsert(points);
+    console.log(
+        `[ingest] doc ${doc.id} (${JSON.stringify(doc.title)}) → ${points.length} chunks`,
+    );
+    return points.length;
+}
+
+// Stable integer point IDs derived from paperless_id × chunk_index.
+// Qdrant accepts arbitrary u64; we encode (paperless_id * 1024 +
+// chunk_index) so reads/deletes are deterministic without a hash.
+function pointId(paperless_id: number, chunk_index: number): number {
+    return paperless_id * 1024 + chunk_index;
+}
+
+async function deleteDocPoints(paperless_id: number): Promise<void> {
+    const r = await fetch(
+        `${QDRANT}/collections/${COLLECTION}/points/delete?wait=true`,
+        {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                filter: {
+                    must: [{
+                        key: "paperless_id",
+                        match: { value: paperless_id },
+                    }],
+                },
+            }),
+        },
+    );
+    if (!r.ok) {
+        const t = await r.text();
+        // 404 means no points matched — fine.
+        if (r.status !== 404) {
+            throw new Error(`qdrant delete-by-filter ${r.status}: ${t}`);
+        }
+    }
+}
+
+function chunk(text: string, size: number, overlap: number): string[] {
+    if (text.length <= size) return [text];
+    const out: string[] = [];
+    let pos = 0;
+    while (pos < text.length) {
+        const end = Math.min(pos + size, text.length);
+        out.push(text.slice(pos, end));
+        if (end === text.length) break;
+        pos = end - overlap;
+    }
+    return out;
+}
+
+async function embed(text: string): Promise<number[]> {
+    const r = await fetch(`${OLLAMA}/api/embed`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ model: EMBED_MODEL, input: text }),
+        signal: AbortSignal.timeout(120_000),
+    });
+    if (!r.ok) throw new Error(`ollama embed ${r.status}: ${await r.text()}`);
+    const body = await r.json() as { embeddings: number[][] };
+    return body.embeddings[0];
+}
+
+async function upsert(points: QdrantPoint[]): Promise<void> {
+    if (!points.length) return;
+    const r = await fetch(
+        `${QDRANT}/collections/${COLLECTION}/points?wait=true`,
+        {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ points }),
+        },
+    );
+    if (!r.ok) throw new Error(`qdrant upsert ${r.status}: ${await r.text()}`);
+}

--- a/kubernetes/apps/home/windmill/workflows/paperless-rag-tombstone.ts
+++ b/kubernetes/apps/home/windmill/workflows/paperless-rag-tombstone.ts
@@ -1,0 +1,137 @@
+// Cron: nightly at 03:00 America/New_York.
+//
+// Reconciles the Qdrant `paperless` collection against the
+// authoritative Paperless doc set. For every paperless_id present in
+// Qdrant but absent from Paperless, deletes all chunks. Idempotent.
+
+const QDRANT = Deno.env.get("QDRANT_URL") ??
+    "http://qdrant.databases.svc.cluster.local:6333";
+const PAPERLESS = Deno.env.get("PAPERLESS_URL") ??
+    "http://paperless.collab.svc.cluster.local:8000";
+const COLLECTION = "paperless";
+const PAGE_SIZE = 200;
+const SCROLL_LIMIT = 10_000;
+
+export async function main() {
+    const token = Deno.env.get("PAPERLESS_TOKEN");
+    if (!token) throw new Error("PAPERLESS_TOKEN env not set");
+
+    const started = new Date().toISOString();
+    const liveIds = await fetchPaperlessIds(token);
+    const indexedIds = await scrollIndexedIds();
+    const orphans = [...indexedIds].filter((id) => !liveIds.has(id));
+
+    console.log(
+        `[tombstone] paperless=${liveIds.size} indexed=${indexedIds.size} orphans=${orphans.length}`,
+    );
+
+    let deleted_docs = 0;
+    let deleted_points = 0;
+    for (const id of orphans) {
+        const n = await deleteDocPoints(id);
+        deleted_points += n;
+        deleted_docs += 1;
+        console.log(`[tombstone] purged paperless_id=${id} (${n} chunks)`);
+    }
+
+    return {
+        started,
+        finished: new Date().toISOString(),
+        paperless_total: liveIds.size,
+        indexed_total: indexedIds.size,
+        deleted_docs,
+        deleted_points,
+    };
+}
+
+async function fetchPaperlessIds(token: string): Promise<Set<number>> {
+    const ids = new Set<number>();
+    let page = 1;
+    while (true) {
+        const url = new URL(`${PAPERLESS}/api/documents/`);
+        url.searchParams.set("page", String(page));
+        url.searchParams.set("page_size", String(PAGE_SIZE));
+        url.searchParams.set("fields", "id");
+        const r = await fetch(url, {
+            headers: { Authorization: `Token ${token}` },
+            signal: AbortSignal.timeout(60_000),
+        });
+        if (!r.ok) {
+            throw new Error(`paperless list ${r.status}: ${await r.text()}`);
+        }
+        const body = await r.json() as {
+            next: string | null;
+            results: { id: number }[];
+        };
+        for (const row of body.results) ids.add(row.id);
+        if (!body.next) break;
+        page += 1;
+    }
+    return ids;
+}
+
+async function scrollIndexedIds(): Promise<Set<number>> {
+    const ids = new Set<number>();
+    let offset: number | undefined = undefined;
+    while (true) {
+        const body: Record<string, unknown> = {
+            limit: SCROLL_LIMIT,
+            with_payload: ["paperless_id"],
+            with_vector: false,
+        };
+        if (offset !== undefined) body.offset = offset;
+        const r = await fetch(
+            `${QDRANT}/collections/${COLLECTION}/points/scroll`,
+            {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(body),
+            },
+        );
+        if (r.status === 404) return ids; // collection doesn't exist yet
+        if (!r.ok) {
+            throw new Error(`qdrant scroll ${r.status}: ${await r.text()}`);
+        }
+        const out = await r.json() as {
+            result: {
+                points: { payload: { paperless_id: number } }[];
+                next_page_offset: number | null;
+            };
+        };
+        for (const p of out.result.points) {
+            if (p.payload?.paperless_id !== undefined) {
+                ids.add(p.payload.paperless_id);
+            }
+        }
+        if (out.result.next_page_offset === null) break;
+        offset = out.result.next_page_offset;
+    }
+    return ids;
+}
+
+async function deleteDocPoints(paperless_id: number): Promise<number> {
+    const r = await fetch(
+        `${QDRANT}/collections/${COLLECTION}/points/delete?wait=true`,
+        {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                filter: {
+                    must: [{
+                        key: "paperless_id",
+                        match: { value: paperless_id },
+                    }],
+                },
+            }),
+        },
+    );
+    if (!r.ok) {
+        if (r.status === 404) return 0;
+        throw new Error(`qdrant delete ${r.status}: ${await r.text()}`);
+    }
+    const body = await r.json() as { result?: { operation_id?: number } };
+    // Qdrant doesn't return the deleted-count in this response shape;
+    // we report 0 as "unknown but completed". The collection-level
+    // diff against indexed_total surfaces real deltas in run logs.
+    return body.result ? 0 : 0;
+}


### PR DESCRIPTION
## Summary

Stream 3 of the Spark-unblocks-RAG plan. Lights up the Paperless RAG
ingest path that's been blocked since the v2 plan locked the embedder
via Phase A (bge-m3 won by +23 MRR@10 — see
[[phase-a-embedder-decision-bge-m3]]).

Two new Windmill TS workflows plus CNP egress and secret plumbing.

## Workflows

### `paperless-rag-ingest.ts`

Target schedule: every 15 min.

- Reads watermark = `max(payload.last_modified)` across the live
  Qdrant collection (stateless — no external state to keep in sync).
- Pulls Paperless docs `modified__gt=<watermark>` page-by-page.
- Chunks ~1500 chars × ~200 overlap (~350 tokens; bge-m3 ceiling is
  8192 tokens so per-chunk has wide margin).
- For each doc:
  1. Delete pre-existing chunks by `paperless_id` filter (clean
     updates even if the new chunk count shrinks).
  2. Embed each chunk via Spark Ollama `bge-m3` (1024-dim).
  3. Upsert all chunks with full payload at once.
- Lazy-creates the `paperless` collection on first run with a payload
  index on `paperless_id` (for tombstone + per-doc deletes).

### `paperless-rag-tombstone.ts`

Target schedule: nightly at 03:00 America/New_York.

- Builds the set of live paperless_ids from `/api/documents/?fields=id`.
- Scrolls the Qdrant collection, builds the set of indexed
  paperless_ids.
- Deletes (by filter) any indexed paperless_id absent from Paperless.
- Idempotent — no-op when in sync.

## Plumbing

- **CNP egress** (narrowly scoped, not ns-wide):
  - `collab/paperless:8000`
  - `ai/ollama-spark:11434`
  - `databases/qdrant:6333`
- **ExternalSecret**: pulls `paperless.mcp_token` into
  `windmill-workflows-secret.PAPERLESS_TOKEN` via the same 1P item
  that paperless-mcp already uses. One rotation surface.
- **HelmRelease workers**: adds `PAPERLESS_TOKEN` to workers' env
  and to `WHITELIST_ENVS` (Windmill workers' env passthrough cap).

## What this does NOT do (call-outs)

- **Does not schedule the workflows automatically.** After merge:
  1. Sync workflow source to Windmill (via `tools/wmill-sync.sh`
     or the UI).
  2. Set the cron schedules from the Windmill UI:
     - `paperless-rag-ingest`: `*/15 * * * *`
     - `paperless-rag-tombstone`: `0 3 * * *` (America/New_York)
- **Does not wire Open WebUI's Knowledge Base.** That's a UI step
  post-ingest — Knowledge Base settings live in Open WebUI's SQLite
  DB, not in GitOps.
- **Does not re-embed memory-mcp's KG** (still on nomic-embed-text
  768-dim). Tracked as a follow-up — see Phase A decision memo.

## Test plan

- [ ] CI green
- [ ] Pod restart: windmill-workers picks up `PAPERLESS_TOKEN`
- [ ] CNP test from a `windmill-workers` Pod:
      `curl paperless.collab.svc.cluster.local:8000/api/documents/`
      returns 401 (auth required, not connection refused)
- [ ] Manual first-run via Windmill UI: all 168 docs ingest, the
      `paperless` collection has ~500-1500 chunks
- [ ] Verify a known doc by `paperless_id` via Qdrant points/search
- [ ] Wire Open WebUI Knowledge Base against the `paperless`
      collection (UI step); end-to-end RAG retrieval works

🤖 Generated with [Claude Code](https://claude.com/claude-code)