### PR TITLE
feat(lidarr-sab-autoimport): workaround for develop-branch queue tracker regression

### DIFF
--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -33,6 +33,7 @@ resources:
   - ./lidarr/ks.yaml
   - ./lidarr-bridge/ks.yaml
   - ./lidarr-oauth2-proxy/ks.yaml
+  - ./lidarr-sab-autoimport/ks.yaml
   - ./medialyze/ks.yaml
   - ./medialyze-oauth2-proxy/ks.yaml
   - ./music-assistant/ks.yaml

--- a/kubernetes/apps/media/lidarr-sab-autoimport/app/helmrelease.yaml
+++ b/kubernetes/apps/media/lidarr-sab-autoimport/app/helmrelease.yaml
@@ -1,0 +1,73 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app lidarr-sab-autoimport
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 1h
+  values:
+    defaultPodOptions:
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile: {type: RuntimeDefault}
+
+    controllers:
+      lidarr-sab-autoimport:
+        pod:
+          automountServiceAccountToken: false
+          restartPolicy: Never
+        cronjob:
+          schedule: "*/5 * * * *"
+          concurrencyPolicy: Forbid
+          successfulJobsHistory: 1
+          failedJobsHistory: 3
+          backoffLimit: 0
+          activeDeadlineSeconds: 300
+          ttlSecondsAfterFinished: 86400
+        type: cronjob
+        containers:
+          app:
+            image:
+              repository: python
+              tag: 3.14-alpine
+
+            command:
+              - python3
+              - /script/scan.py
+
+            env:
+              LIDARR_URL: http://lidarr.media.svc.cluster.local:8686
+
+            envFrom:
+              - secretRef:
+                  name: lidarr
+
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32M
+              limits:
+                memory: 64M
+
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: {drop: ["ALL"]}
+
+    persistence:
+      script:
+        type: configMap
+        name: lidarr-sab-autoimport-script
+        defaultMode: 0555
+        globalMounts:
+          - path: /script/scan.py
+            subPath: scan.py
+            readOnly: true

--- a/kubernetes/apps/media/lidarr-sab-autoimport/app/kustomization.yaml
+++ b/kubernetes/apps/media/lidarr-sab-autoimport/app/kustomization.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../components/repos/app-template
+resources:
+  - ./helmrelease.yaml
+
+configMapGenerator:
+  - name: lidarr-sab-autoimport-script
+    files:
+      - scan.py=./resources/scan.py
+
+generatorOptions:
+  disableNameSuffixHash: true
+  annotations:
+    kustomize.toolkit.fluxcd.io/substitute: disabled

--- a/kubernetes/apps/media/lidarr-sab-autoimport/app/resources/scan.py
+++ b/kubernetes/apps/media/lidarr-sab-autoimport/app/resources/scan.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""
+Workaround for Lidarr 3.1.2.4938 (develop) queue-tracker regression.
+
+Lidarr's `Refresh Monitored Downloads` task is supposed to fire
+DownloadedAlbumsScan for sab downloads that finish in /sabnzbd/complete/.
+In 3.1.2.4938 it doesn't — items sit in the queue with
+status=completed, trackedDownloadState=importing forever, the actual
+files pile up in /sabnzbd/complete, and the user has to manually
+trigger the scan in the Lidarr UI.
+
+This cron kicks Lidarr by POSTing DownloadedAlbumsScan for each stuck
+queue item's outputPath. Lidarr's normal import logic does the rest
+(match score, move into /media library, etc.). The queue entry then
+drops once the import completes.
+
+Remove this whole app when upstream Lidarr fixes the regression — we'll
+know because new sab completions will start clearing on their own
+within ~1 min of the next `Refresh Monitored Downloads` cycle.
+"""
+import json
+import os
+import urllib.parse
+import urllib.request
+
+LIDARR_URL = os.environ.get("LIDARR_URL", "http://lidarr.media.svc.cluster.local:8686")
+LIDARR_API_KEY = os.environ["LIDARR__API_KEY"]
+
+
+def call_api(method, path, params=None, body=None):
+    url = f"{LIDARR_URL}{path}"
+    if params:
+        url += "?" + urllib.parse.urlencode(params)
+    headers = {"X-Api-Key": LIDARR_API_KEY}
+    data = None
+    if body is not None:
+        data = json.dumps(body).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return json.loads(resp.read())
+
+
+def main():
+    q = call_api("GET", "/api/v1/queue", params={"pageSize": 100})
+    stuck = [
+        r for r in q.get("records", [])
+        if r.get("status") == "completed"
+        and r.get("trackedDownloadState") == "importing"
+        and r.get("outputPath")
+    ]
+    if not stuck:
+        print("no stuck queue items")
+        return
+
+    seen = set()
+    for r in stuck:
+        path = r["outputPath"]
+        if path in seen:
+            continue
+        seen.add(path)
+        cmd = call_api(
+            "POST",
+            "/api/v1/command",
+            body={"name": "DownloadedAlbumsScan", "path": path, "importMode": "auto"},
+        )
+        print(f"  scan id={cmd.get('id')} path={path}")
+    print(f"queued {len(seen)} scans")
+
+
+if __name__ == "__main__":
+    main()

--- a/kubernetes/apps/media/lidarr-sab-autoimport/ks.yaml
+++ b/kubernetes/apps/media/lidarr-sab-autoimport/ks.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app lidarr-sab-autoimport
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: media
+  path: ./kubernetes/apps/media/lidarr-sab-autoimport/app
+  interval: 1h
+  timeout: 5m
+  prune: true
+  wait: false
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: lidarr
+      namespace: media
+  retryInterval: 2m


### PR DESCRIPTION
## Summary

Lidarr 3.1.2.4938 (develop, the latest released build — all 3.x are prereleases) has a queue-tracker regression. sab downloads that finish in `/sabnzbd/complete/` get stuck in the queue forever with `status=completed, trackedDownloadState=importing`. The `Refresh Monitored Downloads` task runs every minute but doesn't fire `DownloadedAlbumsScan` for these items, so they pile up. Manually POSTing `DownloadedAlbumsScan` via the API does work and imports cleanly.

This CronJob (every 5 min) lists Lidarr's queue, finds stuck items, and POSTs `DownloadedAlbumsScan` for each `outputPath`. Lidarr's normal import logic handles the rest.

## Why a new sibling app, not folded into `lidarr-bridge`

- `lidarr-bridge` is scoped to slskd's `failed_imports/` via `ManualImport` (bypassing the match-score gate). Its docstring is explicit about that.
- This kicks Lidarr's normal scan path for healthy sab downloads to work around a temporary upstream bug.
- When Lidarr fixes the regression, `git rm -r kubernetes/apps/media/lidarr-sab-autoimport/` + one line out of the parent kustomization = clean revert.

## Test plan

- [ ] Flux reconciles, CronJob created in `media` namespace.
- [ ] First scheduled fire (`*/5 * * * *`) runs without error.
- [ ] When stuck queue items exist, log shows `queued N scans` and Lidarr's history shows `trackFileImported` events shortly after.
- [ ] Queue items drop to 0 once imports complete.
- [ ] Idle cycles log `no stuck queue items` and exit cleanly.

## Rollback

`git rm -r kubernetes/apps/media/lidarr-sab-autoimport/` + remove the parent kustomization line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)