### PR TITLE
fix(home/frigate): snapshot CronJob — pre-baked git image + dedicated CNP

### DIFF
--- a/kubernetes/apps/home/frigate/app/kustomization.yaml
+++ b/kubernetes/apps/home/frigate/app/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - ./longhorn-pvc.yaml
   - ./nfs-pvc.yaml
   - ./prometheusrule.yaml
+  - ./snapshot-cnp.yaml
   - ./snapshot-cronjob.yaml
   - ./snapshot-externalsecret.yaml
   - ./snapshot-rbac.yaml

--- a/kubernetes/apps/home/frigate/app/snapshot-cnp.yaml
+++ b/kubernetes/apps/home/frigate/app/snapshot-cnp.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: frigate-snapshot-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: frigate-snapshot
+  # Additive — default-deny in `home` ns is what triggers the lockdown;
+  # this rule punches a hole for the nightly snapshot run (init
+  # container kubectl-execs into frigate-0, main container pushes to
+  # github via SSH).
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  egress:
+    # SSH to github.com to commit + push the config snapshot. world:22
+    # is narrow enough for this single-purpose pod (mirrors the
+    # home-assistant-config-sync-allow pattern).
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "22"
+              protocol: TCP
+    # kubectl-exec from the init container hits kube-apiserver — that
+    # is covered by the baseline allow-apiserver component (intra-
+    # cluster control plane access). No explicit rule needed here.

--- a/kubernetes/apps/home/frigate/app/snapshot-cronjob.yaml
+++ b/kubernetes/apps/home/frigate/app/snapshot-cronjob.yaml
@@ -15,6 +15,11 @@ spec:
     spec:
       backoffLimit: 1
       template:
+        metadata:
+          # Label is the endpointSelector key for the dedicated
+          # frigate-snapshot-allow CNP (egress to world:22 for git push).
+          labels:
+            app.kubernetes.io/name: frigate-snapshot
         spec:
           serviceAccountName: frigate-snapshot
           restartPolicy: OnFailure
@@ -43,7 +48,11 @@ spec:
                   memory: 128Mi
           containers:
             - name: snapshot
-              image: docker.io/library/alpine:3.23
+              # Pre-baked git + openssh image — avoids the alpine:3.23
+              # `apk add git openssh-client` at runtime, which fails
+              # under home-ns default-deny (no egress to dl-cdn.alpine
+              # linux.org). Same pattern as ha-config-sync (PR #11710).
+              image: docker.io/alpine/git:v2.52.0
               command: ["/bin/sh", "/opt/snapshot/snapshot.sh"]
               env:
                 - name: CONFIG_FILE

--- a/kubernetes/apps/home/frigate/app/snapshot-script-cm.yaml
+++ b/kubernetes/apps/home/frigate/app/snapshot-script-cm.yaml
@@ -32,7 +32,9 @@ data:
     snapshot_attempt() {
       set -e
 
-      apk add --no-cache --quiet git openssh-client > /dev/null
+      # git + openssh-client are pre-baked into the alpine/git image;
+      # no runtime apk add needed (which would fail under default-deny
+      # since dl-cdn.alpinelinux.org egress isn't allowed from this pod).
 
       if [ "$WAIT_BEFORE" -gt 0 ]; then
         echo "Waiting ${WAIT_BEFORE}s for Frigate to finish startup migrations..."


### PR DESCRIPTION
## Summary

The `frigate-snapshot` CronJob has been failing since 2026-05-08 (per [`project_frigate_snapshot_cronjob_broken`]). Two compounding issues:

1. The snapshot container uses `docker.io/library/alpine:3.23` and runs `apk add git openssh-client` at runtime. Under home-ns default-deny (PR #11592, 2026-05-18) that fails because there's no egress to `dl-cdn.alpinelinux.org`.
2. Even if `apk` succeeded, `git push` would fail — no CNP allows world:22 from this pod.

Same fix pattern as the ha-config-sync CronJob (PR #11710):

| Change | Where |
|---|---|
| Swap `alpine:3.23` → `alpine/git:v2.52.0` (git + openssh pre-baked) | `snapshot-cronjob.yaml` |
| Drop the runtime `apk add` line | `snapshot-script-cm.yaml` |
| Add `frigate-snapshot-allow` CNP — egress to `world:22` | new `snapshot-cnp.yaml` |
| Add `app.kubernetes.io/name: frigate-snapshot` label to the jobTemplate (CNP selector) | `snapshot-cronjob.yaml` |

`kubectl-exec` from the init container hits kube-apiserver — already covered by the baseline `allow-apiserver` component.

## Test plan

- [ ] Flux reconciles `home/frigate` app Kustomization
- [ ] Next 03:00 America/New_York run of `frigate-snapshot` completes successfully
- [ ] OR `kubectl create job frigate-snapshot-manual --from=cronjob/frigate-snapshot -n home` succeeds
- [ ] `KubeJobFailed{job_name=~"frigate-snapshot.*"}` clears
- [ ] `FrigateSnapshotJobFailed` clears
- [ ] If config.yml changed since last successful snapshot (15+ days ago), a new commit lands on `main` with the latest contents

🤖 Generated with [Claude Code](https://claude.com/claude-code)