### PR TITLE
feat(collab/bentopdf): privacy-first PDF toolkit on internal gateway

### DIFF
--- a/kubernetes/apps/collab/bentopdf/app/cnp-allow.yaml
+++ b/kubernetes/apps/collab/bentopdf/app/cnp-allow.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: bentopdf-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: bentopdf
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal gateway (bentopdf.${SECRET_DOMAIN}) →
+    # bentopdf:8080
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+  # No egress holes needed — BentoPDF is a pure client-side toolkit
+  # (PDF processing via WASM: pymupdf, ghostscript, cpdf, tesseract
+  # OCR). The container only serves static assets. DNS + apiserver
+  # are covered by baseline.

--- a/kubernetes/apps/collab/bentopdf/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/bentopdf/app/helmrelease.yaml
@@ -1,0 +1,113 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app bentopdf
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+
+  interval: 30m
+  values:
+    controllers:
+      bentopdf:
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 101
+            runAsGroup: 101
+            fsGroup: 101
+            fsGroupChangePolicy: OnRootMismatch
+        annotations:
+          reloader.stakater.com/auto: "true"
+        type: statefulset
+        containers:
+          app:
+            image:
+              repository: ghcr.io/alam00000/bentopdf
+              tag: 2.8.4@sha256:f54b9ed9c56b767e0098b525468206689b666323c2b500b9686c3cf41cdfa348
+
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: &port 8080
+                  initialDelaySeconds: 10
+                  periodSeconds: 30
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: *port
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
+              limits:
+                memory: 128Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+              seccompProfile:
+                type: RuntimeDefault
+
+    service:
+      app:
+        controller: *app
+        ports:
+          http:
+            port: 80
+            targetPort: *port
+
+    route:
+      app:
+        annotations:
+          glance/name: "BentoPDF"
+          glance/show: "true"
+          glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/bentopdf.png"
+          glance/id: "Collaboration"
+        hostnames:
+          - bentopdf.${SECRET_DOMAIN}
+        parentRefs:
+          - name: internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: 80
+
+    # nginx-unprivileged needs writable temp paths under a read-only
+    # rootfs. Mirrors the bentopdf upstream chart's volumes:
+    # /etc/nginx/tmp (pid file), /var/cache/nginx, /var/run.
+    persistence:
+      nginx-tmp:
+        type: emptyDir
+        advancedMounts:
+          bentopdf:
+            app:
+              - path: /etc/nginx/tmp
+      nginx-cache:
+        type: emptyDir
+        advancedMounts:
+          bentopdf:
+            app:
+              - path: /var/cache/nginx
+      nginx-run:
+        type: emptyDir
+        advancedMounts:
+          bentopdf:
+            app:
+              - path: /var/run

--- a/kubernetes/apps/collab/bentopdf/app/kustomization.yaml
+++ b/kubernetes/apps/collab/bentopdf/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../components/repos/app-template
+resources:
+  - ./cnp-allow.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/collab/bentopdf/ks.yaml
+++ b/kubernetes/apps/collab/bentopdf/ks.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app bentopdf
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: collab
+  path: ./kubernetes/apps/collab/bentopdf/app
+  interval: 30m
+  timeout: 5m
+  prune: true
+  wait: false # no flux ks dependents
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system

--- a/kubernetes/apps/collab/kustomization.yaml
+++ b/kubernetes/apps/collab/kustomization.yaml
@@ -15,6 +15,7 @@ components:
 resources:
   - ./namespace.yaml
   - ./atuin/ks.yaml
+  - ./bentopdf/ks.yaml
   - ./glance/ks.yaml
   - ./glance-oauth2-proxy/ks.yaml
   - ./glance-user/ks.yaml


### PR DESCRIPTION
## Summary

- Install **BentoPDF** (https://github.com/alam00000/bentopdf) — a privacy-first PDF toolkit — in the `collab` namespace.
- All PDF processing runs client-side in the browser via WASM (pymupdf, ghostscript, cpdf, tesseract OCR). The container is just nginx-unprivileged serving static assets, so the shape closely mirrors `it-tools`.
- Routed at `bentopdf.${SECRET_DOMAIN}` on the **internal** gateway (LAN-only); no Authelia/oauth2-proxy.
- Image pinned by digest: `ghcr.io/alam00000/bentopdf:2.8.4@sha256:f54b9ed9c56b…`
- Security context per `helmrelease.security.md` defaults; readOnlyRootFilesystem with tmpfs at `/etc/nginx/tmp`, `/var/cache/nginx`, `/var/run` (matches the upstream chart's nginx volumes).
- CiliumNetworkPolicy: ingress from `network/envoy` on 8080 only; **no egress holes** — the app makes no outbound calls.
- Glance tile added to the "Collaboration" group.

## Test plan

- [ ] Flux reconciles `collab/bentopdf` Kustomization without errors
- [ ] Pod reaches Ready (liveness + readiness on `/` succeed)
- [ ] `https://bentopdf.${SECRET_DOMAIN}` resolves and loads from the LAN
- [ ] Upload a PDF and run at least one transform (compress / OCR / split) — verify it completes entirely in-browser with no outbound network requests from the container (Hubble flow check, no new egress)
- [ ] Glance shows the BentoPDF tile in the Collaboration group

🤖 Generated with [Claude Code](https://claude.com/claude-code)