### PR TITLE
feat(ai/langgraph-agents): bump 0.2.17 → 0.2.18 (/admin/asyncio-tasks)

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/langgraph-agents
-              tag: 0.2.17@sha256:9e3f94606b9c06c7e6f88eb50d46db50fdf5131d4027cf172212d4abd0a38416
+              tag: 0.2.18@sha256:3c36ff7b20e472158270ad165fa6e7fe2b7cc5d6d09ff0bee280b3e76fa60ff7
 
             env:
               # --- vault ---


### PR DESCRIPTION
Diagnostic endpoint for rwlove/langgraph-agents#19. Dumps all asyncio Tasks + stacks so we can identify the actual parking await after 5 iterations of conn-pool fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)