### PR TITLE
fix(collab/paperless): allow windmill-workers ingress on :8000

### DIFF
--- a/kubernetes/apps/collab/paperless/app/cnp-allow.yaml
+++ b/kubernetes/apps/collab/paperless/app/cnp-allow.yaml
@@ -35,6 +35,18 @@ spec:
         - ports:
             - port: "8000"
               protocol: TCP
+    # Cross-ns: home/windmill-workers run the Spark-unblocks-RAG
+    # ingest workflows (paperless-rag-ingest, paperless-rag-tombstone
+    # — see PR #11774). The workers' egress side already permits
+    # this connection; this is the symmetric ingress entry.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: home
+            app.kubernetes.io/name: windmill-workers
+      toPorts:
+        - ports:
+            - port: "8000"
+              protocol: TCP
     # Cross-ns: paperless-mcp's PAPERLESS_URL points at the external
     # FQDN which traverses envoy back to paperless. Internal callers
     # speaking directly to paperless:8000 (if any are added later)


### PR DESCRIPTION
## Summary

Stream 3 follow-up. The Windmill workers in `home` ns run the
Spark-unblocks-RAG ingest workflows (shipped in #11774). The workers'
**egress** side already permits the connection to `paperless:8000`,
but the symmetric **ingress** entry on paperless was missing — the
first ingest run timed out at the paperless API call.

## Evidence

From a `windmill-workers-default` pod:

```text
$ wget paperless.collab.svc.cluster.local:8000/api/documents/
Connecting to paperless.collab.svc.cluster.local:8000... failed:
Connection timed out.
```

DNS resolves to the right IP (`10.43.8.153`). The TCP SYN gets
dropped by Cilium because paperless's CNP `ingress` rules name
`network/envoy` and `ai/paperless-ai` but not `home/windmill-workers`.

The first scheduled ingest fired at 13:43 UTC and hung on the first
Paperless list call until Deno's `AbortSignal.timeout(60_000)` cut
the request.

## Fix

Add a matching ingress entry mirroring the existing `paperless-ai`
shape: `fromEndpoints: { namespace: home, name: windmill-workers }`
→ `toPorts: [8000]`. Narrow scope; no `world` egress, no FQDN
fragility.

## Test plan

- [ ] CI green
- [ ] Re-run `f/lovenet/paperless-rag-ingest` manually from the
      Windmill UI — should ingest all 168 docs
- [ ] `paperless` Qdrant collection populates (`points_count` > 0)
- [ ] The cron-scheduled next run succeeds without intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)