### PR TITLE
feat(collab/glance-user): add BentoPDF to Manage group

### DIFF
--- a/kubernetes/apps/collab/glance-user/app/resources/glance.yml
+++ b/kubernetes/apps/collab/glance-user/app/resources/glance.yml
@@ -20,6 +20,9 @@ pages:
 
               - title: Manage
                 links:
+                  - title: BentoPDF (PDF toolkit)
+                    url: https://bentopdf.${SECRET_DOMAIN}/
+                    icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/bentopdf.png
                   - title: Home Assistant
                     url: https://home-assistant.${SECRET_DOMAIN}/
                     icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/home-assistant.png


### PR DESCRIPTION
## Summary

- Add BentoPDF bookmark to `glance-user` (Rob + Renee's `start.${SECRET_DOMAIN}` page) under the **Manage** group, next to Paperless / KitchenOwl.
- `glance-user` is a static bookmarks list — it doesn't auto-discover from `glance/show` annotations. Follow-up to #11779.

## Test plan

- [ ] Flux reconciles glance-user; configmap reloads via reloader
- [ ] `https://start.${SECRET_DOMAIN}/` shows "BentoPDF (PDF toolkit)" at the top of the Manage group
- [ ] Clicking the entry opens `https://bentopdf.${SECRET_DOMAIN}/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)