### PR TITLE
fix(automation/claude-runner): bump activeDeadlineSeconds 600 → 1800

### DIFF
--- a/kubernetes/apps/automation/claude-runner/app/cronjob-cost-cap-commentary.yaml
+++ b/kubernetes/apps/automation/claude-runner/app/cronjob-cost-cap-commentary.yaml
@@ -18,7 +18,10 @@ spec:
   jobTemplate:
     spec:
       backoffLimit: 1
-      activeDeadlineSeconds: 600
+      # 30 min hard cap (was 600s, too tight — Claude tool-call latency
+      # plus langgraph/Prometheus queries pushed this past 10 min on
+      # 2026-05-19's run).
+      activeDeadlineSeconds: 1800
       ttlSecondsAfterFinished: 86400
       template:
         metadata:

--- a/kubernetes/apps/automation/claude-runner/app/cronjob-pr-triage.yaml
+++ b/kubernetes/apps/automation/claude-runner/app/cronjob-pr-triage.yaml
@@ -17,10 +17,13 @@ spec:
     spec:
       # one retry then give up — preserves daily Claude budget
       backoffLimit: 1
-      # 10 min hard cap; PR triage is read-only and finishes well under this
-      # in normal runs. Avoids racing the litellm timeout pattern from
-      # HolmesGPT (see project_n8n_holmesgpt_timeout_workaround).
-      activeDeadlineSeconds: 600
+      # 30 min hard cap. The previous 10-min budget proved too tight:
+      # PR triage with `--max-turns 20` plus Claude Opus 4.7 thinking +
+      # tool-calls per turn routinely runs ~12-15 min, and any tail-
+      # latency spike trips DeadlineExceeded. 30 min covers normal +
+      # slow runs without risking runaway spend (backoffLimit:1 + the
+      # daily schedule cap the worst case to one over-budget run).
+      activeDeadlineSeconds: 1800
       ttlSecondsAfterFinished: 86400
       template:
         metadata:


### PR DESCRIPTION
## Summary

Both `claude-runner` CronJobs have hit `DeadlineExceeded` in the last 24h:

- `claude-runner-cost-cap-commentary-29653800` (2026-05-19, 22:00 UTC)
- `claude-runner-pr-triage-29654700` (2026-05-20, 13:00 UTC)

Same root cause: `activeDeadlineSeconds: 600` (10 min) is too tight for Claude Opus 4.7 thinking + tool calls over `--max-turns` 10-20 iterations, plus the supporting langgraph admin API + Prometheus queries each run touches.

Bump to 1800s (30 min). Runaway-spend protection is unchanged — `backoffLimit: 1` + the daily schedule cap the worst case to one over-budget run per day per CronJob.

## Test plan

- [ ] Flux reconciles both CronJobs
- [ ] `kubectl create job test --from=cronjob/claude-runner-pr-triage` completes within 30 min
- [ ] Next scheduled runs (pr-triage at 13:00 UTC, cost-cap at 22:00 UTC) succeed
- [ ] `KubeJobFailed{job_name=~"claude-runner-.*"}` does not recur

🤖 Generated with [Claude Code](https://claude.com/claude-code)