### PR TITLE
fix(ai/ollama-spark): allow home/windmill-workers ingress on :11434

### DIFF
--- a/kubernetes/apps/ai/ollama-spark/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/ollama-spark/app/cnp-allow.yaml
@@ -31,6 +31,9 @@ spec:
             io.kubernetes.pod.namespace: home
             app.kubernetes.io/name: home-assistant
         - matchLabels:
+            io.kubernetes.pod.namespace: home
+            app.kubernetes.io/name: windmill-workers
+        - matchLabels:
             io.kubernetes.pod.namespace: media
             app.kubernetes.io/name: suggestarr
         - matchLabels:


### PR DESCRIPTION
## Summary

Stream 3 follow-up. Mirror of #11781 one hop downstream. The
Spark-unblocks-RAG ingest workflow (`paperless-rag-ingest`, PR
#11774) embeds chunks via `bge-m3` on `ollama-spark`. The Windmill
workers' egress CNP already permits the connection; the symmetric
ingress on `ollama-spark` was missing.

After #11781 fixed paperless ingress, the next ingest attempt timed
out at 120 s on the first embed call against ollama-spark — same
root cause, one hop further down the pipeline.

## Diagnostic trail

1. PR #11774 (Stream 3): added ingest TS, opened windmill workers'
   egress to paperless/ollama-spark/qdrant.
2. First manual run: 60 s timeout at paperless. Root cause:
   paperless ingress missing windmill-workers entry.
3. PR #11781: added paperless ingress for windmill-workers. Verified:
   TCP now connects, paperless returns 401.
4. Second manual run: 120 s timeout at the embed call. Same class
   of root cause one hop downstream.
5. This PR: add ollama-spark ingress for windmill-workers.

`qdrant`'s ingress is already `fromEntities: cluster` so it's fine
— no third PR needed.

## Test plan

- [ ] CI green
- [ ] Manual re-run of `f/lovenet/paperless-rag-ingest`
- [ ] Qdrant `paperless` collection populates with ~500-1500
      chunks for 168 docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)