### PR TITLE
fix(cnp): round-3 — windmill→ollama-spark + frigate YouTube RTMP + HA Denon HEOS

### DIFF
--- a/kubernetes/apps/ai/ollama-spark/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/ollama-spark/app/cnp-allow.yaml
@@ -31,6 +31,9 @@ spec:
             io.kubernetes.pod.namespace: home
             app.kubernetes.io/name: home-assistant
         - matchLabels:
+            io.kubernetes.pod.namespace: home
+            app.kubernetes.io/name: windmill-workers
+        - matchLabels:
             io.kubernetes.pod.namespace: media
             app.kubernetes.io/name: suggestarr
         - matchLabels:

--- a/kubernetes/apps/ai/ollama/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/ollama/app/cnp-allow.yaml
@@ -26,6 +26,7 @@ spec:
               protocol: TCP
     # Cross-ns callers observed via Hubble + helmrelease survey:
     #   home/home-assistant   — voice assist / conversation agent
+    #   home/windmill-workers — Windmill flows that hit Ollama API
     #   media/suggestarr      — LLM-driven recommendation enrichment
     #   collab/open-webui     — primary OLLAMA_BASE_URL
     #   mcp-system/*          — some MCP servers may proxy ollama calls
@@ -35,6 +36,9 @@ spec:
         - matchLabels:
             io.kubernetes.pod.namespace: home
             app.kubernetes.io/name: home-assistant
+        - matchLabels:
+            io.kubernetes.pod.namespace: home
+            app.kubernetes.io/name: windmill-workers
         - matchLabels:
             io.kubernetes.pod.namespace: media
             app.kubernetes.io/name: suggestarr

--- a/kubernetes/apps/home/frigate/app/cnp-allow.yaml
+++ b/kubernetes/apps/home/frigate/app/cnp-allow.yaml
@@ -68,3 +68,16 @@ spec:
         - ports:
             - port: "443"
               protocol: TCP
+    # go2rtc birdcam publish destination — RTMP to YouTube Live
+    # (rtmp://a.rtmp.youtube.com/live2/{BIRDCAM_YOUTUBE_KEY} in
+    # snapshots/config.yml). The YouTube RTMP ingest uses a 142.x
+    # AWS-fronted load balancer pool — Cilium DNS proxy resolves
+    # a.rtmp.youtube.com to ~13+ rotating IPs. matchPattern is limited
+    # to one DNS label and the dest is always a single-label subdomain
+    # of rtmp.youtube.com, so no apex matchName needed.
+    - toFQDNs:
+        - matchPattern: "*.rtmp.youtube.com"
+      toPorts:
+        - ports:
+            - port: "1935"
+              protocol: TCP

--- a/kubernetes/apps/home/home-assistant/app/cnp-allow.yaml
+++ b/kubernetes/apps/home/home-assistant/app/cnp-allow.yaml
@@ -154,8 +154,9 @@ spec:
               protocol: TCP
     # LAN integrations that poll over various TCP ports on the main
     # home subnet (192.168.1.0/24):
-    #   * 8080 — Denon AVR (denon.thesteamedcrab.com / .1.12)
-    #   * 8043 — Omada Controller HTTPS UI on brain (.1.1)
+    #   * 8080  — Denon AVR HTTP (denon.thesteamedcrab.com / .1.12)
+    #   * 60006 — Denon HEOS protocol (same host as 8080)
+    #   * 8043  — Omada Controller HTTPS UI on brain (.1.1)
     #   * 19444 — Hyperion JSON-RPC on kodi-familyroom (.1.11)
     #   * 61208 — Glances on brain (.1.1) + beast (.1.27)
     - toCIDR:
@@ -163,6 +164,8 @@ spec:
       toPorts:
         - ports:
             - port: "8080"
+              protocol: TCP
+            - port: "60006"
               protocol: TCP
             - port: "8043"
               protocol: TCP


### PR DESCRIPTION
## Summary

After CNP rounds 1+2 (#11729 through #11772) cleared most of the `CiliumPolicyDropsSustained` surface, Hubble flow capture still showed ~0.83 pkt/s of home/TCP drops. Three more legitimate flows:

| Drop | Fix |
|---|---|
| `home/windmill-workers → ai/ollama-spark:11434` (14/sample) | Add `windmill-workers` to `ollama-allow` + `ollama-spark-allow` ingress (egress was already allowed) |
| `home/frigate-0 → a.rtmp.youtube.com:1935` (~100/sample to 13+ rotating Google IPs) | Add `toFQDNs: "*.rtmp.youtube.com":1935` to `frigate-allow`. go2rtc birdcam `publish:` streams to YouTube Live |
| `home/home-assistant-0 → 192.168.1.12:60006` (6/sample) | Add port 60006 (Denon HEOS protocol) to HA's 192.168.1.0/24 LAN rule. PR #11772 only added 8080 (HTTP) |

## Test plan

- [ ] Flux reconciles ai/ollama, ai/ollama-spark, home/frigate, home/home-assistant
- [ ] Hubble: windmill-workers → ollama-spark:11434 FORWARDED
- [ ] Hubble: frigate-0 → *.rtmp.youtube.com:1935 FORWARDED
- [ ] Hubble: home-assistant → 192.168.1.12:60006 FORWARDED
- [ ] HA Denon integration (HEOS sub-features) work
- [ ] Birdcam YouTube Live stream is live again
- [ ] `CiliumPolicyDropsSustained{destination_namespace=""}` clears (final tail of the bucket)

🤖 Generated with [Claude Code](https://claude.com/claude-code)