### PR TITLE
feat(grafana): extend langgraph-agents dashboard with per-task lineage + GPU busy

### DIFF
--- a/kubernetes/apps/observability/grafana/dashboards/langgraph-agents.json
+++ b/kubernetes/apps/observability/grafana/dashboards/langgraph-agents.json
@@ -1,5 +1,7 @@
 {
-  "annotations": { "list": [] },
+  "annotations": {
+    "list": []
+  },
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -11,7 +13,9 @@
       "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
@@ -21,26 +25,52 @@
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
-            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
             "lineInterpolation": "linear",
             "lineWidth": 2,
             "pointSize": 5,
-            "scaleDistribution": { "type": "linear" },
+            "scaleDistribution": {
+              "type": "linear"
+            },
             "showPoints": "never",
             "spanNulls": false,
-            "stacking": { "group": "A", "mode": "normal" },
-            "thresholdsStyle": { "mode": "off" }
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "mappings": [],
           "unit": "cps"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
       "id": 1,
       "options": {
-        "legend": { "displayMode": "table", "placement": "right", "showLegend": true, "calcs": ["sum"] },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "calcs": [
+            "sum"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
         {
@@ -59,27 +89,49 @@
       "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 1 },
-              { "color": "red", "value": 3 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 3
+              }
             ]
           },
           "unit": "currencyUSD"
         }
       },
-      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 0 },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
       "id": 2,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "auto"
       },
       "targets": [
@@ -99,16 +151,35 @@
       "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [
-            { "type": "value", "value": "NaN", "options": { "0": { "text": "—" } } }
+            {
+              "type": "value",
+              "value": "NaN",
+              "options": {
+                "0": {
+                  "text": "\u2014"
+                }
+              }
+            }
           ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "red", "value": null },
-              { "color": "yellow", "value": 0.9 },
-              { "color": "green", "value": 0.99 }
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.9
+              },
+              {
+                "color": "green",
+                "value": 0.99
+              }
             ]
           },
           "unit": "percentunit",
@@ -116,14 +187,25 @@
           "max": 1
         }
       },
-      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 0 },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
       "id": 3,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "auto"
       },
       "targets": [
@@ -143,23 +225,43 @@
       "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisLabel": "tokens/s",
             "drawStyle": "line",
             "fillOpacity": 10,
             "lineWidth": 2,
             "showPoints": "never",
-            "stacking": { "group": "A", "mode": "normal" }
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
           },
           "unit": "short"
         }
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
       "id": 4,
       "options": {
-        "legend": { "displayMode": "table", "placement": "right", "showLegend": true, "calcs": ["sum"] },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "calcs": [
+            "sum"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
         {
@@ -178,7 +280,9 @@
       "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "continuous-BlYlRd" },
+          "color": {
+            "mode": "continuous-BlYlRd"
+          },
           "custom": {
             "axisLabel": "p95 (s)",
             "drawStyle": "line",
@@ -189,11 +293,27 @@
           "unit": "s"
         }
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
       "id": 5,
       "options": {
-        "legend": { "displayMode": "table", "placement": "right", "showLegend": true, "calcs": ["mean", "max"] },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
         {
@@ -212,23 +332,43 @@
       "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisLabel": "calls",
             "drawStyle": "bars",
             "fillOpacity": 80,
             "lineWidth": 1,
             "showPoints": "never",
-            "stacking": { "group": "A", "mode": "normal" }
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
           },
           "unit": "short"
         }
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
       "id": 6,
       "options": {
-        "legend": { "displayMode": "table", "placement": "right", "showLegend": true, "calcs": ["sum"] },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "calcs": [
+            "sum"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
         {
@@ -247,7 +387,9 @@
       "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisLabel": "calls",
             "drawStyle": "line",
@@ -258,11 +400,26 @@
           "unit": "short"
         }
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
       "id": 7,
       "options": {
-        "legend": { "displayMode": "table", "placement": "right", "showLegend": true, "calcs": ["sum"] },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "calcs": [
+            "sum"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
         {
@@ -276,16 +433,196 @@
       ],
       "title": "Claude escalations by trigger (degraded_mode / requires_cloud)",
       "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Error rate per agent over the last 5 min. Errors are LLM/tool failures captured by the metrics callback's `on_llm_error` path.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "errors/sec",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "unit": "cps"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "calcs": [
+            "sum"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "sum by (agent) (rate(langgraph_calls_total{outcome=\"error\",agent=~\"$agent\",group=~\"$group\"}[5m]))",
+          "legendFormat": "{{agent}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Errors/sec by agent",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Spark (GB10) GPU power draw \u2014 used as a busy-proxy because DCGM_FI_DEV_GPU_UTIL is broken on GB10 (reports 0 even when SM_CLOCK ramps). The other working counter is SM_CLOCK; POWER_USAGE is the more legible busy signal.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-BlYlRd"
+          },
+          "custom": {
+            "axisLabel": "watts",
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "unit": "watt"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "DCGM_FI_DEV_POWER_USAGE",
+          "legendFormat": "{{Hostname}} gpu={{gpu}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "GPU power (Spark/P40) \u2014 busy proxy",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "loki",
+      "description": "Recent structlog activity from the langgraph-agents pod. Each log line carries `task_id` + `agent` + the event name \u2014 gives a live feed of which agent is doing what right now. Filter to a specific task by setting the `task_id` dashboard variable.",
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 32
+      },
+      "id": 10,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "targets": [
+        {
+          "datasource": "loki",
+          "editorMode": "code",
+          "expr": "{namespace=\"ai\", app_kubernetes_io_name=\"langgraph-agents\"} | json | line_format \"{{if .agent}}agent={{.agent}} {{end}}{{if .task_id}}task={{.task_id}} {{end}}{{if .event}}event={{.event}} {{end}}{{.msg}}\"",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Live activity feed (Loki) \u2014 set $task_id to narrow",
+      "type": "logs"
+    },
+    {
+      "datasource": "loki",
+      "description": "Per-task agent trail. Shows the sequence of agents that handled a specific task \u2014 answer to 'which agent is working on this and what came before / what's next.' Set the `task_id` dashboard variable to the thread/task you want to inspect.",
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 42
+      },
+      "id": 11,
+      "options": {
+        "dedupStrategy": "exact",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Ascending",
+        "wrapLogMessage": true
+      },
+      "targets": [
+        {
+          "datasource": "loki",
+          "editorMode": "code",
+          "expr": "{namespace=\"ai\", app_kubernetes_io_name=\"langgraph-agents\"} | json | task_id != \"\" | task_id =~ \"$task_id\" | line_format \"[{{.agent}}] {{.event}} \u2014 {{.msg}}\"",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Task trail viewer (set $task_id)",
+      "type": "logs"
     }
   ],
   "refresh": "30s",
   "schemaVersion": 38,
   "style": "dark",
-  "tags": ["langgraph-agents", "ai"],
+  "tags": [
+    "langgraph-agents",
+    "ai"
+  ],
   "templating": {
     "list": [
       {
-        "current": { "selected": false, "text": "All", "value": "$__all" },
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
         "datasource": "Prometheus",
         "definition": "label_values(langgraph_calls_total, agent)",
         "hide": 0,
@@ -294,7 +631,10 @@
         "multi": true,
         "name": "agent",
         "options": [],
-        "query": { "query": "label_values(langgraph_calls_total, agent)", "refId": "StandardVariableQuery" },
+        "query": {
+          "query": "label_values(langgraph_calls_total, agent)",
+          "refId": "StandardVariableQuery"
+        },
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -302,7 +642,11 @@
         "type": "query"
       },
       {
-        "current": { "selected": false, "text": "All", "value": "$__all" },
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
         "datasource": "Prometheus",
         "definition": "label_values(langgraph_calls_total, group)",
         "hide": 0,
@@ -311,7 +655,10 @@
         "multi": true,
         "name": "group",
         "options": [],
-        "query": { "query": "label_values(langgraph_calls_total, group)", "refId": "StandardVariableQuery" },
+        "query": {
+          "query": "label_values(langgraph_calls_total, group)",
+          "refId": "StandardVariableQuery"
+        },
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -319,7 +666,11 @@
         "type": "query"
       },
       {
-        "current": { "selected": false, "text": "All", "value": "$__all" },
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
         "datasource": "Prometheus",
         "definition": "label_values(langgraph_calls_total, outcome)",
         "hide": 0,
@@ -328,20 +679,47 @@
         "multi": true,
         "name": "outcome",
         "options": [],
-        "query": { "query": "label_values(langgraph_calls_total, outcome)", "refId": "StandardVariableQuery" },
+        "query": {
+          "query": "label_values(langgraph_calls_total, outcome)",
+          "refId": "StandardVariableQuery"
+        },
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 1,
         "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": ".*",
+          "value": ".*"
+        },
+        "hide": 0,
+        "label": "task_id (Loki filter)",
+        "name": "task_id",
+        "options": [
+          {
+            "selected": true,
+            "text": ".*",
+            "value": ".*"
+          }
+        ],
+        "query": ".*",
+        "skipUrlSync": false,
+        "type": "textbox",
+        "description": "Free-text task_id to narrow the Loki panels. Leave empty to show all tasks."
       }
     ]
   },
-  "time": { "from": "now-6h", "to": "now" },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
   "timepicker": {},
   "timezone": "America/New_York",
   "title": "LangGraph Agents",
   "uid": "langgraph-agents",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }


### PR DESCRIPTION
## Summary

The existing `LangGraph Agents` Grafana dashboard covers RED-style aggregate metrics but doesn't answer the user's headline ask: **"where is my request right now, which agent is working on it, and what came before / what's next."**

Adds 4 new panels + 1 templating variable to the existing dashboard JSON:

| Panel | Source | Why |
|---|---|---|
| Errors/sec by agent | Prom (`langgraph_calls_total{outcome="error"}`) | Existing dashboard only has *global* success rate; this surfaces *which* agent is dropping calls. |
| GPU power (Spark/P40) — busy proxy | Prom (`DCGM_FI_DEV_POWER_USAGE`) | Stand-in for "is the GPU busy?" because `DCGM_FI_DEV_GPU_UTIL` is broken on GB10 (caveat in panel description). |
| Live activity feed | Loki (`{namespace="ai", app_kubernetes_io_name="langgraph-agents"} \| json`) | Tails pod structlog. `line_format` uses `{{if .field}}` guards so it gracefully degrades on lifecycle-only logs today. |
| Task trail viewer | Loki, filtered by `$task_id` var | Renders the ordered `[agent] event` trail for one task. Activates as soon as the langgraph-agents follow-up (below) lands. |

New `task_id` templating variable: free-text, defaults to `.*` so the live feed isn't blank by default.

## Follow-up needed in langgraph-agents

The trail viewer needs the runtime to bind `task_id` on the structlog `BoundLogger` per request. `observability.get_logger()` documents the contract (`Callers should .bind(task_id=...) per request`) but no node actually calls it. The dashboard ships now — metrics panels are backed by working data and Loki queries are tolerant of missing fields. Trail viewer comes alive once a small `langgraph-agents` PR adds:

1. A middleware/wrapper binding `task_id` on `structlog.contextvars` at graph invocation time.
2. One structlog line per node entry (so the trail has data to render).

## Diff is noisier than it looks

476 line diff for ~4 panels — `python -m json.tool`'s pretty-printer reflowed the original hand-formatted JSON. No semantic changes outside the new panels + variable + `version: 1 → 2`. Panel summary:

```
id=1  y=0  : LLM calls/sec by agent              (existing)
id=2  y=0  : Claude spend (24h)                  (existing)
id=3  y=0  : Success rate (5m)                   (existing)
id=4  y=8  : Token rate (in/out)                 (existing)
id=5  y=8  : LLM duration p95 by agent           (existing)
id=6  y=16 : Calls per hour by group split       (existing)
id=7  y=16 : Claude escalations by trigger       (existing)
id=8  y=24 : Errors/sec by agent                 NEW
id=9  y=24 : GPU power (Spark/P40) — busy proxy  NEW
id=10 y=32 : Live activity feed (Loki)           NEW
id=11 y=42 : Task trail viewer (Loki)            NEW
```

## Test plan

- [x] `python3 -c "import json; json.load(open(...))"` — 11 panels, 4 templating vars, version 2
- [x] Panel grid: no overlaps; 3 new rows at y=24/32/42
- [x] Existing `$agent`, `$group`, `$outcome` variables unchanged
- [ ] Post-merge: Grafana sidecar picks up the update (label `grafana_dashboard: "1"` is set on the ConfigMap via the kustomization)
- [ ] Post-merge: Spark + P40 GPU series appear in panel 9 with their `Hostname` labels
- [ ] Once langgraph-agents follow-up lands: trail viewer renders agent sequence for a real task_id

🤖 Generated with [Claude Code](https://claude.com/claude-code)