### PR TITLE
feat(mcp-system): Phase 5 alerts — scrape-failure + error-rate + latency + gateway-down

### DIFF
--- a/kubernetes/apps/mcp-system/observability/app/prometheusrule.yaml
+++ b/kubernetes/apps/mcp-system/observability/app/prometheusrule.yaml
@@ -59,3 +59,107 @@ spec:
             )
           labels:
             backend: netbox
+
+    # Alerts are deliberately minimal and recording-rule-driven so a
+    # new backend = adding one `mcp.recording.<x>.rules` group, no
+    # alert-rule edit. ScrapeFailed remains per-backend because each
+    # `absent()` clause is a separate selector; that's the documented
+    # exception in the plan.
+    - name: mcp.alerts.rules
+      interval: 1m
+      rules:
+        # --- Per-backend scrape failure (cluster convention:
+        # absent(up{...} == 1), not raw `up == 0`. Catches both
+        # "target unhealthy" and "target removed from discovery"). ---
+        - alert: MCPBackendScrapeFailed
+          expr: absent(up{namespace="mcp-system", service="memory-mcp"} == 1)
+          for: 15m
+          labels:
+            severity: warning
+            backend: memory
+          annotations:
+            summary: "MCP backend memory-mcp unscrapable for ≥15m"
+            description: >-
+              scrape target `up{namespace=mcp-system, service=memory-mcp}`
+              has been absent or unhealthy for 15+ minutes. Pod likely
+              down, SM mislabeled, or /metrics endpoint hung past the
+              10s scrapeTimeout. Tools served by memory-mcp will fail.
+        - alert: MCPBackendScrapeFailed
+          expr: absent(up{namespace="mcp-system", service="time-mcp"} == 1)
+          for: 15m
+          labels:
+            severity: warning
+            backend: time
+          annotations:
+            summary: "MCP backend time-mcp unscrapable for ≥15m"
+            description: >-
+              scrape target `up{namespace=mcp-system, service=time-mcp}`
+              has been absent or unhealthy for 15+ minutes. Pod likely
+              down, SM mislabeled, or /metrics endpoint hung past the
+              10s scrapeTimeout. Tools served by time-mcp will fail.
+        - alert: MCPBackendScrapeFailed
+          expr: absent(up{namespace="mcp-system", service="netbox-mcp"} == 1)
+          for: 15m
+          labels:
+            severity: warning
+            backend: netbox
+          annotations:
+            summary: "MCP backend netbox-mcp unscrapable for ≥15m"
+            description: >-
+              scrape target `up{namespace=mcp-system, service=netbox-mcp}`
+              has been absent or unhealthy for 15+ minutes. Pod likely
+              down, SM mislabeled, or /metrics endpoint hung past the
+              10s scrapeTimeout. Tools served by netbox-mcp will fail.
+
+        # --- High-error-rate alert via normalized recording rule.
+        # Adding a backend = adding its mcp.recording.<x>.rules group;
+        # this alert automatically fans out across all backends
+        # present in mcp:tool_calls:rate5m. ---
+        - alert: MCPBackendHighErrorRate
+          expr: |
+            (
+              sum by (backend) (mcp:tool_calls:rate5m{status="error"})
+              /
+              clamp_min(sum by (backend) (mcp:tool_calls:rate5m), 0.001)
+            ) > 0.10
+            and on (backend) sum by (backend) (mcp:tool_calls:rate5m) > 0.05
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "MCP backend {{ $labels.backend }} >10% tool-call errors"
+            description: >-
+              Backend `{{ $labels.backend }}` is returning errors on
+              >10% of tool calls over the last 5 minutes (gated on
+              ≥0.05 calls/sec so quiet backends don't false-positive).
+              Inspect logs and recent upstream changes.
+
+        # --- High-latency alert via normalized recording rule. ---
+        - alert: MCPBackendHighLatency
+          expr: max by (backend) (mcp:tool_call_duration:p99_5m) > 5
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "MCP backend {{ $labels.backend }} p99 latency >5s"
+            description: >-
+              Backend `{{ $labels.backend }}` p99 tool-call latency has
+              been >5s for 10 minutes. Either a slow downstream
+              (Ollama/Postgres/NetBox API) or a hot tool. Check the
+              dashboard's per-tool panel.
+
+        # --- Phase 5b: critical-tier gateway-down alert.
+        # Triggers HolmesGPT enrichment via the `windmill-investigate`
+        # AlertManager route. If the broker is down, all MCP traffic
+        # stops — worth a 5-min `for:` rather than 15m. ---
+        - alert: MCPGatewayDown
+          expr: absent(up{namespace="mcp-system", service="mcp-gateway-istio"} == 1)
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "MCP gateway down — all MCP tool traffic blocked"
+            description: >-
+              `mcp-gateway-istio` is unscrapable. All agents (langgraph,
+              HolmesGPT, Claude Code) lose access to the MCP fleet.
+              HolmesGPT triage will run via windmill-investigate.


### PR DESCRIPTION
## Summary
Activates alerts on the MCP fleet observability substrate. Soak gate cleared: 24h+ post-deploy, neither time-mcp nor netbox-mcp pod has restarted (same pod hash since 2026-05-19 23:33Z), `/metrics` still serves on both.

## What ships

Six alerts. Three of them share the `MCPBackendScrapeFailed` alertname (one per Class A backend) — the per-backend split is the documented exception in the plan because each `absent()` needs its own selector. Error-rate + latency are single fleet-wide alerts that fan out via the normalized recording rules.

### Warning tier (default → Pushover receiver, no HolmesGPT)
| Alert | Expression | `for:` |
|---|---|---|
| `MCPBackendScrapeFailed{backend=memory}` | `absent(up{namespace="mcp-system", service="memory-mcp"} == 1)` | 15m |
| `MCPBackendScrapeFailed{backend=time}` | `absent(up{namespace="mcp-system", service="time-mcp"} == 1)` | 15m |
| `MCPBackendScrapeFailed{backend=netbox}` | `absent(up{namespace="mcp-system", service="netbox-mcp"} == 1)` | 15m |
| `MCPBackendHighErrorRate` | `error_ratio > 0.10 AND total_rate > 0.05` (per backend) | 10m |
| `MCPBackendHighLatency` | `max by (backend) (mcp:tool_call_duration:p99_5m) > 5s` | 10m |

### Critical tier (routes via `windmill-investigate` → HolmesGPT)
| Alert | Expression | `for:` |
|---|---|---|
| `MCPGatewayDown` | `absent(up{namespace="mcp-system", service="mcp-gateway-istio"} == 1)` | 5m |

## Why this design

- **`absent(up == 1)`** matches the cluster's existing convention (`speedtest-prometheus`, `snmp-exporter-apc-ups`, kube-prometheus-stack/addons/flux). Catches both "target unhealthy" AND "target removed from discovery"; raw `up == 0` would miss the second.
- **Normalized recording rules**: `MCPBackendHighErrorRate` + `MCPBackendHighLatency` query `mcp:tool_calls:rate5m{backend, ...}` and `mcp:tool_call_duration:p99_5m{backend, ...}`. Adding a 4th instrumented backend in the future = one new `mcp.recording.<x>.rules` group; **zero** alert-rule edits.
- **Volume gate on error rate**: `and on (backend) sum by (backend) (mcp:tool_calls:rate5m) > 0.05` (≥3 calls/min) prevents a single tool error on a quiet backend from triggering a "100% error rate" page.
- **Pushover-compatible annotations**: every alert carries both `summary` AND `description` — alertmanagerconfig.yaml's template prefers `.Annotations.description`, falls back to `.summary`.
- **No Zulip receiver**: AlertManager config doesn't have one; the Zulip integration in this cluster is inbound triager-bot, not outbound alert→chat.

## Test plan
- [x] `kubectl kustomize kubernetes/apps/mcp-system/observability/app` renders 4 groups (3 recording + 1 alerts) with 6 alert rules.
- [x] PromQL expressions parse-validated against current `mcp:*` recording-rule output shape.
- [x] Per-backend ScrapeFailed alerts use the same label/expression shape as memory-mcp's working scrape (which `up{namespace=mcp-system, service=memory-mcp}` already returns 1 for).
- [ ] Post-merge: PrometheusRule reconciled by Flux within 30m (no pod restarts).
- [ ] Post-merge: alerts appear in AlertManager UI at `alertmanager.${SECRET_DOMAIN}` with state `inactive`.
- [ ] Optional destructive verification (pick a low-traffic window):
  ```
  kubectl scale -n mcp-system deploy/time-mcp --replicas=0
  # Wait 15m → MCPBackendScrapeFailed{backend="time"} fires → Pushover delivery.
  # Flux interval is 1h; restore within 45m or Flux flaps it.
  kubectl scale -n mcp-system deploy/time-mcp --replicas=1
  ```

## Refs
- Plan: `/home/rwlove/.claude-personal/plans/on-a-plan-to-adaptive-ripple.md` (v5, 4-pass adversarial audit)
- Phase 0c (substrate): #11741 (merged)
- Phase 1+2 (cluster bumps): #11749 (merged)
- Phase 3 sweep: `project_mcp_phase3_metrics_sweep.md` (all 9 third-party backends → Class D, no /metrics)
- Remaining phases: 6 (tag-pin paperless+immich `:latest`), 7 (operator runbook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)