### PR TITLE
feat(ai/ollama-spark): Stream 1d.B — SparkOllamaWedged alert

### DIFF
--- a/kubernetes/apps/ai/ollama-spark/app/prometheusrule.yaml
+++ b/kubernetes/apps/ai/ollama-spark/app/prometheusrule.yaml
@@ -10,15 +10,11 @@ spec:
     # GR_ENGINE_ACTIVE, FB_USED, MEM_COPY_UTIL) are broken on this
     # arch — see reference_dcgm_gb10_broken_counters.md. The only
     # signals that reliably report on GB10 are POWER_USAGE and
-    # SM_CLOCK. A "GPU is wedged" alert that depends on POWER_USAGE
-    # (idle <12 W while Pod Ready for >10 min) is planned for the
-    # Stream 1d cleanup PR; it'd cry wolf right now because no
-    # consumer routes to ollama-spark yet and POWER sits at the
-    # ~10 W idle floor.
+    # SM_CLOCK. POWER_USAGE is the activity proxy.
     - name: ollama-spark.availability
       rules:
         # Pod-level failure — covers OOM, image-pull, scheduling,
-        # crash-loop. High-precision pager. Once Stream 1 routes
+        # crash-loop. High-precision pager. With Stream 1 routing
         # langgraph / HolmesGPT / Open WebUI to Spark, a dead Pod
         # means the cluster's chat surface is degraded to the P40
         # fallback.
@@ -35,3 +31,42 @@ spec:
           for: 5m
           labels:
             severity: critical
+        # Pod is Ready but GPU power is at idle floor for an
+        # extended window. Sustained idle while the Pod claims
+        # Ready strongly suggests one of:
+        #   1. No consumer is actually routing here (env regression
+        #      on langgraph-agents / HolmesGPT / Open WebUI).
+        #   2. The Ollama worker is hung — restart sts.
+        #   3. Traffic legitimately stopped (low usage period).
+        # `for: 1h` (rather than the v2 plan's original 10m) keeps
+        # this from crying wolf during quiet stretches between
+        # paperless-rag-ingest ticks and human chat sessions.
+        # Tighten / loosen based on observed cry-wolf rate.
+        - alert: SparkOllamaWedged
+          annotations:
+            summary: ollama-spark Pod Ready but GPU idle >1h — possibly wedged or unrouted
+            description: |
+              Spark GPU power draw has been <12 W (idle floor is
+              ~10 W; inference is 60-150 W) for the past 1 hour
+              while ollama-spark-0 reports Ready. Common causes:
+              (1) routing regression — verify
+                  langgraph-agents/HolmesGPT/Open WebUI env still
+                  points at ollama-spark;
+              (2) Ollama worker hung — try
+                  `kubectl -n ai rollout restart sts ollama-spark`;
+              (3) traffic legitimately stopped (quiet hours / no
+                  paperless ingest hits). If (3), the alert tuning
+                  needs adjusting.
+              GPU_UTIL/MEM_COPY_UTIL/FB_USED are broken on GB10 so
+              POWER is the only reliable activity signal.
+          expr: |-
+            (
+              avg_over_time(DCGM_FI_DEV_POWER_USAGE{Hostname="spark.thesteamedcrab.com"}[10m]) < 12
+            )
+            and on()
+            (
+              kube_pod_status_ready{namespace="ai",pod=~"ollama-spark-.*",condition="true"} == 1
+            )
+          for: 1h
+          labels:
+            severity: warning


### PR DESCRIPTION
## Summary

Stream 1d.B of the Spark-unblocks-RAG plan. Adds the POWER-based
"Spark is up but stalled" alert that was deferred in Phase 0 because
Spark had no routed consumers at the time.

With Stream 1 (HolmesGPT, Open WebUI multi-endpoint, langgraph
AGENT_GROUP) and Stream 3 (Paperless RAG ingest every 15 min)
landed, Spark is now exercised periodically. `POWER < 12 W for > 1 h`
while Pod Ready is a legitimate "wedged or unrouted" signal.

## Threshold rationale

- **12 W**: ~10 W is the GB10 idle floor; inference draws 60-150 W.
  Anything < 12 W = no GPU work.
- **`for: 1h`**: the v2 plan called for 10 min, but observed traffic
  is bursty (15-min cron + sporadic human chat + sporadic alerts).
  10 min would cry wolf during quiet stretches; 1 h still catches
  the real failure modes (env regression, hung worker) without
  pageable false positives. Tighten / loosen based on observed
  cry-wolf rate.
- **severity: warning**: false-positive cost > pageability benefit
  on a soft-SPOF that has a P40 fallback.

## Out of scope (Stream 1d.A)

The HolmesGPT `LITELLM_TIMEOUT 1500s → 600s` revert stays deferred
until the 48 h soak window completes. Independent change; this PR
only adds the alert.

## Test plan

- [ ] CI green
- [ ] Prometheus loads the rule (check `prometheus_rule_evaluations_total`)
- [ ] Alert does NOT fire during normal operation (15-min ingest +
      sporadic Holmes/chat traffic keeps POWER above the threshold
      most of the time)
- [ ] If it fires during a verified routed-but-idle window: tighten
      `for:` to match operational reality

🤖 Generated with [Claude Code](https://claude.com/claude-code)