### PR TITLE
feat(ai/langgraph-agents): rate-limit public /approval at 5 RPS

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/backendtrafficpolicy.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/backendtrafficpolicy.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/gateway.envoyproxy.io/backendtrafficpolicy_v1alpha1.json
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: langgraph-agents-approval
+spec:
+  # Public /approval is HMAC-only auth — anyone with a leaked token can
+  # still only issue a single verdict on a single paused task — but
+  # there's no rate ceiling on an attacker grinding the endpoint with
+  # bogus tokens, each of which costs us an HMAC verification + a
+  # Postgres checkpoint read. 5 RPS is well above any human ntfy
+  # tapping pattern and well below an abuse load.
+  rateLimit:
+    local:
+      rules:
+        - limit:
+            requests: 5
+            unit: Second
+    type: Local
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: langgraph-agents-approval

--- a/kubernetes/apps/ai/langgraph-agents/app/kustomization.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./backendtrafficpolicy.yaml
   - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml


### PR DESCRIPTION
## Summary

Adds an Envoy Gateway `BackendTrafficPolicy` bound to the `langgraph-agents-approval` HTTPRoute that caps that public route at 5 RPS local-rate-limit.

The /approval endpoint is publicly reachable through cloudflared and accepts HMAC-signed verdicts from ntfy action buttons. HMAC + single-use is the auth model; an attacker with a leaked token can only issue one verdict on one paused task. But there was nothing between cloudflared and FastAPI that capped request rate, so a bogus-token grinder cost us an HMAC verification + an AsyncPostgresSaver state read per request.

5 RPS is the audit's recommended ceiling — well above any human-tapping pattern and well below abuse load.

## Why Local over Global

- The global rate-limit service is not deployed in this cluster.
- The limit needs per-route enforcement, not gateway-wide.
- A single envoy-gateway pod handles all /approval traffic, so Local's per-pod counter is the same as per-route in this topology.

## Test plan

- [x] YAML parses; targetRefs name matches the HTTPRoute name
- [x] kustomization.yaml lists the new resource (alphabetic sort preserved)
- [x] Schema validates against the bjw-s `backendtrafficpolicy_v1alpha1.json`
- [ ] Post-merge: `kubectl get backendtrafficpolicy -n ai langgraph-agents-approval` shows `Accepted=True`
- [ ] Post-merge: `for i in {1..10}; do curl -sw "%{http_code}\\n" -X POST "https://langgraph.${SECRET_DOMAIN}/approval" -d '{}' -H 'content-type:application/json'; done` — once burst exceeds the bucket, returns 429

🤖 Generated with [Claude Code](https://claude.com/claude-code)