### PR TITLE
fix(cnp): round-4 — Denon Telnet:23 + frigate RTMP via toEntities

### DIFF
--- a/kubernetes/apps/home/frigate/app/cnp-allow.yaml
+++ b/kubernetes/apps/home/frigate/app/cnp-allow.yaml
@@ -70,13 +70,18 @@ spec:
               protocol: TCP
     # go2rtc birdcam publish destination — RTMP to YouTube Live
     # (rtmp://a.rtmp.youtube.com/live2/{BIRDCAM_YOUTUBE_KEY} in
-    # snapshots/config.yml). The YouTube RTMP ingest uses a 142.x
-    # AWS-fronted load balancer pool — Cilium DNS proxy resolves
-    # a.rtmp.youtube.com to ~13+ rotating IPs. matchPattern is limited
-    # to one DNS label and the dest is always a single-label subdomain
-    # of rtmp.youtube.com, so no apex matchName needed.
-    - toFQDNs:
-        - matchPattern: "*.rtmp.youtube.com"
+    # snapshots/config.yml). YouTube ingest IPs are AWS-fronted Google
+    # load balancers (142.x).
+    #
+    # NOTE: A toFQDNs(matchPattern "*.rtmp.youtube.com") rule was tried
+    # first (PR #11786) but didn't take effect — frigate's long-lived
+    # DNS cache predates the Cilium DNS proxy interception, so the
+    # cached IPs are never bound to the FQDN policy. Falling back to
+    # toEntities:world+1935 is broader (any 1935 destination), but
+    # since 1935 is RTMP-specific and frigate doesn't have other RTMP
+    # destinations, the actual exposure is unchanged.
+    - toEntities:
+        - world
       toPorts:
         - ports:
             - port: "1935"

--- a/kubernetes/apps/home/home-assistant/app/cnp-allow.yaml
+++ b/kubernetes/apps/home/home-assistant/app/cnp-allow.yaml
@@ -154,6 +154,7 @@ spec:
               protocol: TCP
     # LAN integrations that poll over various TCP ports on the main
     # home subnet (192.168.1.0/24):
+    #   * 23    — Denon AVR Telnet control protocol (.1.12)
     #   * 8080  — Denon AVR HTTP (denon.thesteamedcrab.com / .1.12)
     #   * 60006 — Denon HEOS protocol (same host as 8080)
     #   * 8043  — Omada Controller HTTPS UI on brain (.1.1)
@@ -163,6 +164,8 @@ spec:
         - 192.168.1.0/24
       toPorts:
         - ports:
+            - port: "23"
+              protocol: TCP
             - port: "8080"
               protocol: TCP
             - port: "60006"


### PR DESCRIPTION
## Summary

Two post-merge findings from CNP round-3 (#11786):

### 1. home/home-assistant → 192.168.1.12:23 (Denon Telnet)

Round-3 added the Denon HEOS port (60006) but the Denon AVR *also* exposes a Telnet control protocol on TCP 23, which HA's `denon` integration uses. 9 drops/sample observed. Added 23 to HA's 192.168.1.0/24 LAN rule.

### 2. frigate → YouTube RTMP — toFQDNs didn't bind

The round-3 `toFQDNs: matchPattern "*.rtmp.youtube.com"` rule didn't take effect. Frigate's long-lived DNS cache predates Cilium DNS proxy interception, so the cached YouTube RTMP IPs are never bound to the FQDN policy. Drops continued at the same rate after the CNP applied at 14:11 UTC:

```
May 20 14:27:05  home/frigate-0 → 142.251.45.172:1935  Policy denied DROPPED
May 20 14:27:06  home/frigate-0 → 142.251.45.172:1935  Policy denied DROPPED
May 20 14:27:07  home/frigate-0 → 142.250.188.12:1935  Policy denied DROPPED
```

Falling back to `toEntities: world + 1935`. Broader, but 1935 is RTMP-specific and frigate has no other RTMP destinations, so actual exposure is unchanged.

## Test plan

- [ ] Flux reconciles `home-assistant-allow` + `frigate-allow`
- [ ] HA Denon integration Telnet control commands round-trip
- [ ] Birdcam YouTube Live stream is live again (no pod restart needed — the new rule is IP-agnostic)
- [ ] `CiliumPolicyDropsSustained` for `source_namespace=home` clears

## Follow-up

Worth documenting as a memory: Cilium toFQDNs requires DNS proxy interception of the lookup. Long-lived pods with pre-existing DNS cache may not benefit from a toFQDNs rule until they re-resolve. For known-stable destinations behind unstable IPs, `toEntities: world` + port narrowing is a reliable fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)