### PR TITLE
feat(databases): provision postgres-langfuse CNPG cluster

### DIFF
--- a/kubernetes/apps/databases/cloudnative-pg/config/langfuse/cluster.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/langfuse/cluster.yaml
@@ -1,0 +1,77 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/cluster_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgres-langfuse
+spec:
+  instances: 3
+
+  imageName: ghcr.io/cloudnative-pg/postgresql:17.7
+
+  primaryUpdateStrategy: unsupervised
+
+  failoverDelay: 30
+
+  replicationSlots:
+    highAvailability:
+      enabled: true
+
+  postgresql:
+    parameters:
+      timezone: "America/New_York"
+
+  storage:
+    size: 8Gi
+    storageClass: ceph-block
+
+  walStorage:
+    size: 4Gi
+    storageClass: ceph-block
+
+  resources:
+    requests:
+      cpu: 50m
+      memory: 256Mi
+    limits:
+      memory: 512Mi
+
+  enableSuperuserAccess: true
+  superuserSecret:
+    name: cloudnative-pg
+
+  bootstrap:
+    initdb:
+      database: langfuse
+      owner: langfuse
+
+  # Langfuse runs in the ai namespace; CNPG generates
+  # `postgres-langfuse-app` in databases ns. Mirror cross-namespace via
+  # emberstack reflector. Sibling of postgres-langgraph-memory pattern.
+  inheritedMetadata:
+    annotations:
+      reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: ai
+      reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: ai
+
+  monitoring:
+    enablePodMonitor: true
+
+  plugins:
+    - enabled: true
+      isWALArchiver: true
+      name: barman-cloud.cloudnative-pg.io
+      parameters:
+        barmanObjectName: garage-langfuse
+        serverName: postgres-langfuse-backup
+
+  externalClusters:
+    - name: postgres-langfuse-backup
+      plugin:
+        enabled: true
+        isWALArchiver: false
+        name: barman-cloud.cloudnative-pg.io
+        parameters:
+          barmanObjectName: garage-langfuse
+          serverName: postgres-langfuse-backup

--- a/kubernetes/apps/databases/cloudnative-pg/config/langfuse/kustomization.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/langfuse/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../../components/cnpg-app-database
+resources:
+  - ./cluster.yaml

--- a/kubernetes/apps/databases/cloudnative-pg/ks.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/ks.yaml
@@ -963,3 +963,41 @@ spec:
     - apiVersion: postgresql.cnpg.io/v1
       kind: Cluster
       current: status.phase in ['Cluster in healthy state']
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app langfuse
+  labels:
+    substitution.flux.home.arpa/enabled: "true"
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: databases
+  path: ./kubernetes/apps/databases/cloudnative-pg/config/langfuse
+  interval: 30m
+  timeout: 5m
+  prune: true
+  wait: true
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: cloudnative-pg
+      namespace: databases
+    - name: cloudnative-pg-plugin-barman-cloud
+      namespace: databases
+    - name: garage
+      namespace: storage
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  postBuild:
+    substitute:
+      APP: *app
+  healthCheckExprs:
+    - apiVersion: postgresql.cnpg.io/v1
+      kind: Cluster
+      current: status.phase in ['Cluster in healthy state']


### PR DESCRIPTION
## Summary

First half of the langfuse self-hosted deploy (audit plan **P2.1** / the "visualize where my request is in the pipeline" headline ask).

Provisions the Postgres cluster the langfuse app will consume; the langfuse HelmRelease + ClickHouse/Redis/MinIO + HTTPRoute behind Authelia land in a follow-up PR.

## Why split

The langfuse-k8s helm chart deploys 5+ components. The repo's pattern for stateful durable storage is "use the cluster's CNPG + Barman, not the chart's embedded Postgres" — same pattern as `postgres-langgraph-checkpoints`, `postgres-langgraph-memory`, `postgres-windmill`. Splitting lets the CNPG cluster healthcheck cleanly before the HelmRelease tries to bind the secret.

## What lands

- 3-replica CNPG cluster on `cnpg-postgresql:17.7`, 8Gi data + 4Gi WAL on ceph-block, no special extensions (langfuse uses Prisma migrations).
- Shared `cnpg-app-database` component (ExternalSecret + Barman ObjectStore → Garage + ScheduledBackup).
- `inheritedMetadata` reflects `postgres-langfuse-app` into the `ai` namespace via the emberstack reflector. Sibling of the postgres-langgraph-memory pattern.
- New Flux Kustomization entry in `cloudnative-pg/ks.yaml`.

## Prereqs the user lands separately

Before merging the follow-up langfuse app PR (or before backups go green on this PR):

1. **1Password entry `langfuse`** (Kubernetes vault) with `GARAGE_AWS_ACCESS_KEY_ID` + `GARAGE_AWS_SECRET_ACCESS_KEY` — mirrors the existing `langgraph-memory` entry.
2. **Garage bucket `postgres-langfuse-backup`** — create via Garage UI or CLI.

Without these the cluster still comes up on its data/WAL volumes; the Barman archiver retries when creds + bucket land.

## Test plan

- [x] YAML parses (cluster.yaml + kustomization.yaml + ks.yaml round-trip cleanly)
- [x] ks.yaml is a 27-doc stream including the new \`langfuse\` entry
- [ ] Post-merge: \`kubectl get cluster -n databases postgres-langfuse\` → "Cluster in healthy state" within ~5 min
- [ ] Post-merge: \`kubectl get secret -n ai postgres-langfuse-app\` (reflector copy)
- [ ] Post-merge once 1P + Garage land: \`kubectl get objectstore -n databases garage-langfuse\` → Healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)