### PR TITLE
feat(ai/langgraph-agents): MEMORY_EMBED_MODEL=bge-m3

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
@@ -35,6 +35,19 @@ spec:
               # removed in this PR.
               ENABLE_CLAUDE_API: "false"  # flip to true once Claude key is in 1Password
 
+              # --- memory embedder ---
+              # MCPMemoryStore writes via direct SQL to
+              # kg.observations (langgraph_memory DB). Column type is
+              # vector(1024) per the Phase A bge-m3 cutover
+              # (home-ops #11792). bge-m3 was pulled onto ollama
+              # (P40) so MCPMemoryStore's hardcoded ollama_p40_url
+              # path keeps working — embedding swaps qwen2.5:7b out
+              # briefly per memory write, but writes are rare. A
+              # follow-up langgraph-agents release can plumb
+              # MEMORY_OLLAMA_URL → ollama_spark_url for less swap
+              # churn; not blocking.
+              MEMORY_EMBED_MODEL: bge-m3
+
               # --- MCP gateway ---
               MCP_GATEWAY_URL: http://mcp-gateway-istio.mcp-system.svc.cluster.local:8080
 


### PR DESCRIPTION
## Summary

Phase A follow-up. After home-ops #11792 migrated
`kg.observations.embedding` from `vector(768)` → `vector(1024)`,
langgraph-agents' `MCPMemoryStore` (which writes via **direct SQL**)
would 400 on any INSERT because it still embeds via
`nomic-embed-text` (768-dim).

Fix: set `MEMORY_EMBED_MODEL=bge-m3` — picked up by
`agents.settings.memory_embed_model`. `bge-m3` has been pulled onto
`ollama` (P40) so `MCPMemoryStore`'s hardcoded `ollama_p40_url`
path keeps working. The trade-off is `qwen2.5:7b` gets briefly
swapped out per memory write (writes are rare; swap cost is
bounded).

## Cleaner fix (follow-up, not blocking)

Plumb `MEMORY_OLLAMA_URL → ollama_spark_url` to avoid the P40 swap
entirely. Needs a langgraph-agents code change (add a settings
field + use it in `main.py`). Filed as follow-up; not blocking.

## Test plan

- [ ] CI green
- [ ] Pod restarts with new env (`MEMORY_EMBED_MODEL=bge-m3`
      visible in env)
- [ ] A langgraph specialist task that writes to memory succeeds
      (the INSERT lands as 1024-dim, matches the new column type)
- [ ] If the swap churn on P40 is observable in p95 chat latency,
      open the follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)