### PR TITLE
feat(ai/langfuse): deploy Langfuse trace UI behind internal Gateway

### DIFF
--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
   - ./namespace.yaml
   - ./priority-class.yaml
   - ./comfyui/ks.yaml
+  - ./langfuse/ks.yaml
   - ./langgraph-agents/ks.yaml
   - ./ollama/ks.yaml
   - ./ollama-spark/ks.yaml

--- a/kubernetes/apps/ai/langfuse/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/langfuse/app/cnp-allow.yaml
@@ -1,0 +1,72 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: langfuse-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/instance: langfuse
+  ingress:
+    # Envoy Gateway → langfuse-web (the chart's user-facing service).
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "3000"
+              protocol: TCP
+            - port: "3030"
+              protocol: TCP
+
+    # langgraph-agents → langfuse-web for trace ingestion via the
+    # langfuse SDK (POST /api/public/ingestion). Same ai namespace
+    # but default-deny is enforced.
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: ai
+            app.kubernetes.io/name: langgraph-agents
+      toPorts:
+        - ports:
+            - port: "3000"
+              protocol: TCP
+
+    # Intra-app: web ↔ worker, web ↔ clickhouse, web ↔ redis,
+    # web ↔ minio. Allow all intra-instance traffic.
+    - fromEndpoints:
+        - matchLabels:
+            app.kubernetes.io/instance: langfuse
+
+  egress:
+    # Postgres (external CNPG cluster in databases ns).
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: databases
+            cnpg.io/cluster: postgres-langfuse
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+
+    # Intra-app components.
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/instance: langfuse
+
+    # kube-dns.
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s:k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+
+    # K8s API (chart hooks may issue API calls during install/upgrade).
+    - toEntities:
+        - kube-apiserver

--- a/kubernetes/apps/ai/langfuse/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/langfuse/app/externalsecret.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: langfuse
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: langfuse-secret
+    template:
+      engineVersion: v2
+      data:
+        # NextAuth shared secret — used to sign JWTs for langfuse's
+        # built-in user sessions. 32+ chars, random. Rotating this
+        # invalidates all active sessions.
+        NEXTAUTH_SECRET: "{{ .NEXTAUTH_SECRET }}"
+
+        # SALT — 32+ chars, random. Used to salt API key hashes; only
+        # rotate if you reissue every API key downstream.
+        SALT: "{{ .SALT }}"
+
+        # ENCRYPTION_KEY — exactly 64 hex chars (32 bytes). Used to
+        # encrypt stored secrets/integration credentials. Rotating
+        # invalidates stored secrets — leave alone unless required.
+        ENCRYPTION_KEY: "{{ .ENCRYPTION_KEY }}"
+
+        # First-boot bootstrap. Leave blank to use the langfuse UI to
+        # create the first user manually.
+        LANGFUSE_INIT_ORG_NAME: "{{ .LANGFUSE_INIT_ORG_NAME }}"
+        LANGFUSE_INIT_USER_NAME: "{{ .LANGFUSE_INIT_USER_NAME }}"
+        LANGFUSE_INIT_USER_EMAIL: "{{ .LANGFUSE_INIT_USER_EMAIL }}"
+        LANGFUSE_INIT_USER_PASSWORD: "{{ .LANGFUSE_INIT_USER_PASSWORD }}"
+  dataFrom:
+    - extract:
+        key: langfuse-app

--- a/kubernetes/apps/ai/langfuse/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langfuse/app/helmrelease.yaml
@@ -1,0 +1,114 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: langfuse
+spec:
+  chart:
+    spec:
+      chart: langfuse
+      sourceRef:
+        kind: HelmRepository
+        name: langfuse
+      version: 1.5.31
+  interval: 30m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+      strategy: rollback
+  values:
+    # ----- External Postgres -----
+    # Use the CNPG-managed `postgres-langfuse` cluster instead of the
+    # chart's bundled bitnami postgresql. The CNPG-generated secret is
+    # mirrored into the ai namespace by emberstack reflector (see
+    # databases/cloudnative-pg/config/langfuse/cluster.yaml).
+    postgresql:
+      deploy: false
+      auth:
+        existingSecret: postgres-langfuse-app
+        secretKeys:
+          # CNPG exposes the full DSN at key `uri`.
+          userPasswordKey: uri
+
+    # ----- Bundled dependencies the chart deploys in-namespace -----
+    # ClickHouse, Valkey (Redis), MinIO (S3) are all required by
+    # langfuse v3 — the chart deploys them with sane defaults.
+    # Persistent storage uses the cluster default (ceph-block via
+    # the rook-ceph default StorageClass).
+    clickhouse:
+      deploy: true
+    redis:
+      deploy: true
+    s3:
+      deploy: true
+
+    # ----- Langfuse web + worker -----
+    langfuse:
+      web:
+        replicas: 1
+      worker:
+        replicas: 1
+      # NextAuth + crypto config + first-boot bootstrap come from the
+      # langfuse-secret created by externalsecret.yaml. The
+      # postgres-langfuse-app secret's `uri` key carries the full
+      # `DATABASE_URL` (CNPG's standard output format).
+      additionalEnv:
+        - name: NEXTAUTH_URL
+          value: https://langfuse.${SECRET_DOMAIN}
+        - name: NEXTAUTH_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: langfuse-secret
+              key: NEXTAUTH_SECRET
+        - name: SALT
+          valueFrom:
+            secretKeyRef:
+              name: langfuse-secret
+              key: SALT
+        - name: ENCRYPTION_KEY
+          valueFrom:
+            secretKeyRef:
+              name: langfuse-secret
+              key: ENCRYPTION_KEY
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: postgres-langfuse-app
+              key: uri
+        - name: LANGFUSE_INIT_ORG_NAME
+          valueFrom:
+            secretKeyRef:
+              name: langfuse-secret
+              key: LANGFUSE_INIT_ORG_NAME
+              optional: true
+        - name: LANGFUSE_INIT_USER_NAME
+          valueFrom:
+            secretKeyRef:
+              name: langfuse-secret
+              key: LANGFUSE_INIT_USER_NAME
+              optional: true
+        - name: LANGFUSE_INIT_USER_EMAIL
+          valueFrom:
+            secretKeyRef:
+              name: langfuse-secret
+              key: LANGFUSE_INIT_USER_EMAIL
+              optional: true
+        - name: LANGFUSE_INIT_USER_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: langfuse-secret
+              key: LANGFUSE_INIT_USER_PASSWORD
+              optional: true
+        - name: TELEMETRY_ENABLED
+          value: "false"
+
+    # ----- Native Ingress is disabled; we wire Gateway API HTTPRoute
+    # in a sibling route.yaml so the cluster's existing Envoy Gateway
+    # handles the edge.
+    ingress:
+      enabled: false

--- a/kubernetes/apps/ai/langfuse/app/helmrepository.yaml
+++ b/kubernetes/apps/ai/langfuse/app/helmrepository.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: langfuse
+spec:
+  interval: 2h
+  url: https://langfuse.github.io/langfuse-k8s

--- a/kubernetes/apps/ai/langfuse/app/kustomization.yaml
+++ b/kubernetes/apps/ai/langfuse/app/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./cnp-allow.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./helmrepository.yaml
+  - ./route.yaml

--- a/kubernetes/apps/ai/langfuse/app/route.yaml
+++ b/kubernetes/apps/ai/langfuse/app/route.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: langfuse
+spec:
+  hostnames:
+    - "langfuse.${SECRET_DOMAIN}"
+  parentRefs:
+    # Internal-only: langfuse.${SECRET_DOMAIN} resolves via bind9 to
+    # an internal LB IP. The trace UI is operator-facing; LAN access
+    # via Tailscale or the home network is sufficient and avoids the
+    # added complexity of a dedicated oauth2-proxy sidecar.
+    # Langfuse's built-in auth (email + password) handles the user
+    # gate. Public exposure can be added later via a langfuse-oauth2-
+    # proxy sibling, same pattern as khoj-oauth2-proxy.
+    - name: internal
+      namespace: network
+      sectionName: https
+  rules:
+    - backendRefs:
+        # Web frontend exposed by the chart as `langfuse-web` on port
+        # 3000 (chart default). Confirm with `kubectl get svc -n ai`
+        # post-deploy in case the chart renames.
+        - name: langfuse-web
+          port: 3000

--- a/kubernetes/apps/ai/langfuse/ks.yaml
+++ b/kubernetes/apps/ai/langfuse/ks.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app langfuse
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: ai
+  path: ./kubernetes/apps/ai/langfuse/app
+  interval: 1h
+  timeout: 10m
+  prune: true
+  wait: false
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: langfuse
+      namespace: databases
+    - name: longhorn
+      namespace: longhorn-system
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+    - name: onepassword-connect
+      namespace: external-secrets
+  retryInterval: 2m


### PR DESCRIPTION
## Summary

Second half of the langfuse self-hosted deploy — delivers the audit's **headline ask**: a visual pipeline inspector showing "where my request is right now, which agent, what came before / what's next."

PR #11794 ships the external CNPG cluster (postgres-langfuse); this PR ships the langfuse app + its bundled deps (ClickHouse, Valkey/Redis, MinIO/S3) using the official chart at chart version **1.5.31** (appVersion **3.174.1**).

## Architecture decisions

- **External Postgres via CNPG** — same pattern as postgres-langgraph-checkpoints + postgres-langgraph-memory + postgres-windmill. Disables the chart's bundled bitnami postgres.
- **ClickHouse / Valkey / MinIO bundled by chart** — required by langfuse v3 architecture, no good external substitute in this cluster for ClickHouse. Resource footprint ~3-4 GiB total.
- **Internal Gateway only** — `langfuse.${SECRET_DOMAIN}` resolves via bind9 to internal envoy LB. Trace UI is operator-facing; LAN/Tailscale access is sufficient. Public exposure can be added later via a `langfuse-oauth2-proxy` sibling (same pattern as khoj-oauth2-proxy) without touching this app.
- **Langfuse built-in auth** — email/password handled by the langfuse UI itself; user gating happens at the app, not via oauth2-proxy.

## What lands

- `kubernetes/apps/ai/langfuse/ks.yaml` — Flux Kustomization
- `kubernetes/apps/ai/langfuse/app/helmrepository.yaml` — chart source
- `kubernetes/apps/ai/langfuse/app/helmrelease.yaml` — pinned chart 1.5.31, external DB, in-chart ClickHouse/Redis/MinIO, additionalEnv from the langfuse-secret + postgres-langfuse-app secret
- `kubernetes/apps/ai/langfuse/app/externalsecret.yaml` — pulls NEXTAUTH_SECRET / SALT / ENCRYPTION_KEY (+ optional bootstrap fields) from 1P
- `kubernetes/apps/ai/langfuse/app/route.yaml` — internal HTTPRoute
- `kubernetes/apps/ai/langfuse/app/cnp-allow.yaml` — net policy (envoy→web, langgraph-agents→web SDK path, intra-instance allow-all, egress to postgres + DNS + kube-apiserver)
- `kubernetes/apps/ai/kustomization.yaml` adds `./langfuse/ks.yaml`

## Prereqs the user lands separately

1. **PR #11794 merged + postgres-langfuse healthy** (this PR's dependsOn blocks until then).
2. **1Password item \`langfuse-app\`** in the Kubernetes vault:
   - \`NEXTAUTH_SECRET\` — 32+ char random
   - \`SALT\` — 32+ char random
   - \`ENCRYPTION_KEY\` — exactly 64 hex chars (32 bytes)
   - Optional: \`LANGFUSE_INIT_ORG_NAME\`, \`LANGFUSE_INIT_USER_NAME\`, \`LANGFUSE_INIT_USER_EMAIL\`, \`LANGFUSE_INIT_USER_PASSWORD\`
3. **DNS entry** in bind9 for \`langfuse.${SECRET_DOMAIN}\` → internal envoy LB IP (standard pattern).

## Wiring downstream

The existing langgraph-agents externalsecret.yaml already carries placeholders for \`LANGFUSE_HOST\`, \`LANGFUSE_PUBLIC_KEY\`, \`LANGFUSE_SECRET_KEY\`. Once this PR is live: user creates a Langfuse project in the UI, copies the keys to the 1P \`langgraph-agents\` item, ESO delivers them to the pod. The langgraph SDK-wiring PR (P2.2) lands separately to actually emit traces — the langfuse dep is already in \`pyproject.toml\`.

## Test plan

- [x] YAML parses for all 7 files (ks.yaml + 5 app files + ai/kustomization.yaml)
- [x] HelmRepository URL returns chart 1.5.31 metadata
- [ ] Post-merge: \`kubectl get helmrelease -n ai langfuse\` → Ready=True
- [ ] Post-merge: \`kubectl get httproute -n ai langfuse\` → Accepted
- [ ] Post-merge: \`https://langfuse.${SECRET_DOMAIN}\` from LAN renders login
- [ ] Post-merge: all 5 sub-pods reach Ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)