### PR TITLE
feat(ai/langgraph-agents): bump 0.2.19 → 0.2.20 + route memory embeds to Spark

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/langgraph-agents
-              tag: 0.2.19@sha256:390e9b3e0daad150bcb2b110a2dbb0045cd1dd0f78bcae671ce31c2ea604946e
+              tag: 0.2.20@sha256:1cbf2e59ee9c4efa075366d81a718dab32ba33f535dac6feffb54c9e428bee67
 
             env:
               # --- vault ---
@@ -39,14 +39,13 @@ spec:
               # MCPMemoryStore writes via direct SQL to
               # kg.observations (langgraph_memory DB). Column type is
               # vector(1024) per the Phase A bge-m3 cutover
-              # (home-ops #11792). bge-m3 was pulled onto ollama
-              # (P40) so MCPMemoryStore's hardcoded ollama_p40_url
-              # path keeps working — embedding swaps qwen2.5:7b out
-              # briefly per memory write, but writes are rare. A
-              # follow-up langgraph-agents release can plumb
-              # MEMORY_OLLAMA_URL → ollama_spark_url for less swap
-              # churn; not blocking.
+              # (home-ops #11792). MEMORY_OLLAMA_URL was added in
+              # langgraph-agents v0.2.20 (PR #32) so memory embeds
+              # can target ollama-spark — avoids the P40
+              # MAX_LOADED=1 swap churn between bge-m3 and
+              # qwen2.5:7b on every memory write.
               MEMORY_EMBED_MODEL: bge-m3
+              MEMORY_OLLAMA_URL: http://ollama-spark.ai.svc.cluster.local:11434
 
               # --- MCP gateway ---
               MCP_GATEWAY_URL: http://mcp-gateway-istio.mcp-system.svc.cluster.local:8080


### PR DESCRIPTION
## Summary

Picks up [rwlove/langgraph-agents#32](https://github.com/rwlove/langgraph-agents/pull/32)
(`MEMORY_OLLAMA_URL` plumbing). Sets the env so `MCPMemoryStore`
embeddings hit `ollama-spark` instead of the P40, eliminating the
model-swap churn (`bge-m3` + `qwen2.5:7b` can't co-resident on P40
with `MAX_LOADED=1` — every memory write would evict the chat
model).

## Changes

- Image: `0.2.19` → `0.2.20`
- Env: add `MEMORY_OLLAMA_URL: http://ollama-spark.ai.svc.cluster.local:11434`
- Comment cleanup: the "follow-up release pending" note is no
  longer relevant.

## What this finishes

- Phase A's spark→memory routing optimization (last cosmetic
  follow-up after the KG re-embed cutover).
- P40 keeps its `qwen2.5:7b` slot warm for HolmesGPT / light agents
  without re-running every embed call as a swap.

## Test plan

- [ ] CI green
- [ ] Pod restarts with new env + image (reloader picks up)
- [ ] Trigger a memory write (e.g., specialist agent invocation) —
      Spark `POWER_USAGE` rises (bge-m3 already loaded; no new
      load latency)
- [ ] P40 `OLLAMA_LOADED_MODELS=qwen2.5:7b` stays steady through
      memory writes (no swap to bge-m3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)