### PR TITLE
fix(ai/ollama-spark): SparkOllamaWedged for: 1h → 4h

### DIFF
--- a/kubernetes/apps/ai/ollama-spark/app/prometheusrule.yaml
+++ b/kubernetes/apps/ai/ollama-spark/app/prometheusrule.yaml
@@ -38,25 +38,31 @@ spec:
         #      on langgraph-agents / HolmesGPT / Open WebUI).
         #   2. The Ollama worker is hung — restart sts.
         #   3. Traffic legitimately stopped (low usage period).
-        # `for: 1h` (rather than the v2 plan's original 10m) keeps
-        # this from crying wolf during quiet stretches between
-        # paperless-rag-ingest ticks and human chat sessions.
-        # Tighten / loosen based on observed cry-wolf rate.
+        # Threshold tuning history:
+        #   - v2 plan: 10 min. Would cry wolf during quiet hours.
+        #   - First ship: 1 h. Caught in PENDING during a quiet
+        #     window — incremental cron ingest finds 0 new docs and
+        #     completes in <5 s, leaving Spark at the ~10 W idle
+        #     floor for the rest of the 15-min window.
+        #   - Current: 4 h. Real wedged states (routing regression,
+        #     hung worker) won't recover on their own and will
+        #     trivially exceed 4 h. Quiet stretches up to half a
+        #     workday are normal for a homelab.
         - alert: SparkOllamaWedged
           annotations:
-            summary: ollama-spark Pod Ready but GPU idle >1h — possibly wedged or unrouted
+            summary: ollama-spark Pod Ready but GPU idle >4h — possibly wedged or unrouted
             description: |
               Spark GPU power draw has been <12 W (idle floor is
-              ~10 W; inference is 60-150 W) for the past 1 hour
+              ~10 W; inference is 60-150 W) for the past 4 hours
               while ollama-spark-0 reports Ready. Common causes:
               (1) routing regression — verify
                   langgraph-agents/HolmesGPT/Open WebUI env still
                   points at ollama-spark;
               (2) Ollama worker hung — try
                   `kubectl -n ai rollout restart sts ollama-spark`;
-              (3) traffic legitimately stopped (quiet hours / no
-                  paperless ingest hits). If (3), the alert tuning
-                  needs adjusting.
+              (3) traffic legitimately stopped (overnight / no
+                  paperless ingest hits). If (3) is recurring,
+                  consider adding a heartbeat embedding cron.
               GPU_UTIL/MEM_COPY_UTIL/FB_USED are broken on GB10 so
               POWER is the only reliable activity signal.
           expr: |-
@@ -67,6 +73,6 @@ spec:
             (
               kube_pod_status_ready{namespace="ai",pod=~"ollama-spark-.*",condition="true"} == 1
             )
-          for: 1h
+          for: 4h
           labels:
             severity: warning


### PR DESCRIPTION
## Summary

The `SparkOllamaWedged` alert (shipped in #11790 with `for: 1h`)
was caught in PENDING within hours of landing. Root cause:

- Incremental `paperless-rag-ingest` cron finds 0 new docs in
  steady state, completes in ~5 s, leaves Spark at the ~10 W idle
  floor for the remaining ~14 minutes of every 15-min window.
- With no HolmesGPT alerts firing right now and no human chat
  traffic, Spark legitimately sits below the 12 W threshold for
  hours.

## Fix

`for: 1h` → `4h`. Real wedged states (routing regression, hung
worker) won't self-heal and will easily exceed 4 h. Quiet stretches
up to half a workday are normal for a homelab.

If overnight idle pushes it to fire regularly, the next move is a
heartbeat embedding cron (cheap on Spark) rather than tighter
tuning of the threshold.

## Test plan

- [ ] CI green
- [ ] Alert moves from PENDING → INACTIVE on reconcile
- [ ] Verify over 24 h that it doesn't fire under normal traffic
      patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)