### PR TITLE
fix(ai): temporarily unwire langfuse pending chart-values completion

### DIFF
--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -15,7 +15,22 @@ resources:
   - ./namespace.yaml
   - ./priority-class.yaml
   - ./comfyui/ks.yaml
-  - ./langfuse/ks.yaml
+  # ./langfuse/ks.yaml — TEMPORARILY UNWIRED 2026-05-20.
+  # The chart's helm template path fails because PR #11796's values
+  # configure SALT/ENCRYPTION_KEY/NextAuth as additionalEnv only —
+  # the chart's worker/deployment.yaml ALSO requires values-level
+  # `langfuse.salt.{value | secretKeyRef}` (and similar for
+  # `langfuse.encryptionKey` + `langfuse.nextauth.secret`), and
+  # bitnami subchart auth (`clickhouse.auth`, `redis.auth`, `s3.auth`)
+  # need either an `existingSecret` or an inline password. With
+  # this line uncommented, flux-local CI fails on every PR cluster-
+  # wide. The runtime HelmRelease wasn't installing for the same
+  # reason — verified `kubectl get hr -n ai langfuse` returns
+  # NotFound, so unwiring doesn't undeploy anything.
+  #
+  # Re-enable: re-comment-in this line once the langfuse HelmRelease
+  # values are extended to fully render. The langfuse/ tree under
+  # apps/ai/ is preserved for the next iteration.
   - ./langgraph-agents/ks.yaml
   - ./ollama/ks.yaml
   - ./ollama-spark/ks.yaml


### PR DESCRIPTION
## Summary

The `langfuse` HelmRelease added in #11796 fails `helm template`
in every CI run because the chart requires values-level secret
plumbing that the initial PR didn't include:

- `langfuse.salt.secretKeyRef.{name, key}` (chart aborts if absent)
- `langfuse.encryptionKey.secretKeyRef.{name, key}`
- `langfuse.nextauth.secret.secretKeyRef.{name, key}`
- `clickhouse.auth` — `existingSecret` or inline `password`
- `redis.auth` — same
- `s3.auth` — same

PR #11796 only set SALT / ENCRYPTION_KEY / NextAuth as
`additionalEnv`, which is the runtime-env path but **not** the
chart's secret-rendering path.

## Blast radius

This failure is blocking flux-local CI across the cluster's PR
queue:

- [#11799](https://github.com/rwlove/home-ops/pull/11799) — SparkOllamaWedged tune
- [#11800](https://github.com/rwlove/home-ops/pull/11800) — langgraph stale-paused alert
- Likely any future PR until langfuse renders

## Runtime impact: zero

`kubectl get hr -n ai langfuse` returns NotFound — the HelmRelease
isn't installing because Flux hits the same render failure. So
unwiring removes no running workload, only unblocks the CI queue.

## Fix

Comment out `./langfuse/ks.yaml` in
`kubernetes/apps/ai/kustomization.yaml`. The entire
`kubernetes/apps/ai/langfuse/` tree is preserved verbatim for the
next iteration; the line stays as a `#` comment with a re-enable
note in-line.

## What the langfuse author needs to do to re-enable

In `kubernetes/apps/ai/langfuse/app/helmrelease.yaml`, add under
`spec.values.langfuse`:

```yaml
salt:
  secretKeyRef:
    name: langfuse-secret
    key: SALT
encryptionKey:
  secretKeyRef:
    name: langfuse-secret
    key: ENCRYPTION_KEY
nextauth:
  url: https://langfuse.${SECRET_DOMAIN}
  secret:
    secretKeyRef:
      name: langfuse-secret
      key: NEXTAUTH_SECRET
```

And under top-level `spec.values`, for each bundled subchart
(`clickhouse`, `redis`, `s3`), point `.auth.existingSecret` at a
secret that contains the right `*_PASSWORD` keys (extend the
`langfuse` ExternalSecret or create a sibling).

Then revert this PR (uncomment the kustomization line).

## Test plan

- [ ] CI green (specifically `Extract images` + `Flux Local Test`)
- [ ] After merge, blocked PRs' CI clears with `gh pr update-branch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)