### PR TITLE
fix(ai/langfuse): chart values — salt + encryptionKey + nextauth + subchart auth

### DIFF
--- a/kubernetes/apps/ai/langfuse/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langfuse/app/helmrelease.yaml
@@ -40,12 +40,30 @@ spec:
     # langfuse v3 — the chart deploys them with sane defaults.
     # Persistent storage uses the cluster default (ceph-block via
     # the rook-ceph default StorageClass).
+    #
+    # Each subchart hard-requires either an inline `auth.password`
+    # or an `auth.existingSecret`. Point them at `langfuse-secret`
+    # with explicit key names; the ExternalSecret extension that
+    # populates those keys is a follow-up (the keys must be present
+    # in the 1P `langfuse-app` item before Flux can install the
+    # HelmRelease, but CI's `helm template` doesn't validate that —
+    # the render passes as long as the values structure is correct).
     clickhouse:
       deploy: true
+      auth:
+        existingSecret: langfuse-secret
+        existingSecretKey: CLICKHOUSE_PASSWORD
     redis:
       deploy: true
+      auth:
+        existingSecret: langfuse-secret
+        existingSecretPasswordKey: REDIS_PASSWORD
     s3:
       deploy: true
+      auth:
+        existingSecret: langfuse-secret
+        rootUserSecretKey: S3_ROOT_USER
+        rootPasswordSecretKey: S3_ROOT_PASSWORD
 
     # ----- Langfuse web + worker -----
     langfuse:
@@ -53,28 +71,36 @@ spec:
         replicas: 1
       worker:
         replicas: 1
-      # NextAuth + crypto config + first-boot bootstrap come from the
-      # langfuse-secret created by externalsecret.yaml. The
-      # postgres-langfuse-app secret's `uri` key carries the full
-      # `DATABASE_URL` (CNPG's standard output format).
+      # SALT / ENCRYPTION_KEY / NextAuth must use the chart's native
+      # `secretKeyRef` plumbing — the chart's worker/deployment.yaml
+      # renders these as secret env refs and aborts `helm template`
+      # if the values-side path is empty. (PR #11796 set them only
+      # via `additionalEnv` which is the pod-runtime path but does
+      # not satisfy the chart template's rendering.)
+      salt:
+        secretKeyRef:
+          name: langfuse-secret
+          key: SALT
+      encryptionKey:
+        secretKeyRef:
+          name: langfuse-secret
+          key: ENCRYPTION_KEY
+      nextauth:
+        url: https://langfuse.${SECRET_DOMAIN}
+        secret:
+          secretKeyRef:
+            name: langfuse-secret
+            key: NEXTAUTH_SECRET
+      features:
+        # Chart-side telemetry off (mirrors the old TELEMETRY_ENABLED
+        # additionalEnv entry; can't set both — chart validates).
+        telemetryEnabled: false
+      # DATABASE_URL stays in additionalEnv because the CNPG `uri`
+      # carries the full DSN, while the chart's
+      # `postgresql.auth.existingSecret` path only handles a
+      # username/password pair. First-boot bootstrap fields stay
+      # here too — the chart has no native value paths for those.
       additionalEnv:
-        - name: NEXTAUTH_URL
-          value: https://langfuse.${SECRET_DOMAIN}
-        - name: NEXTAUTH_SECRET
-          valueFrom:
-            secretKeyRef:
-              name: langfuse-secret
-              key: NEXTAUTH_SECRET
-        - name: SALT
-          valueFrom:
-            secretKeyRef:
-              name: langfuse-secret
-              key: SALT
-        - name: ENCRYPTION_KEY
-          valueFrom:
-            secretKeyRef:
-              name: langfuse-secret
-              key: ENCRYPTION_KEY
         - name: DATABASE_URL
           valueFrom:
             secretKeyRef:
@@ -104,8 +130,6 @@ spec:
               name: langfuse-secret
               key: LANGFUSE_INIT_USER_PASSWORD
               optional: true
-        - name: TELEMETRY_ENABLED
-          value: "false"
 
     # ----- Native Ingress is disabled; we wire Gateway API HTTPRoute
     # in a sibling route.yaml so the cluster's existing Envoy Gateway


### PR DESCRIPTION
## Summary

PR [#11796](https://github.com/rwlove/home-ops/pull/11796) set
`SALT` / `ENCRYPTION_KEY` / `NEXTAUTH_SECRET` only as
`additionalEnv`, which feeds them to the runtime pod env but does
**not** satisfy the chart's `worker/deployment.yaml` template, which
hard-requires `langfuse.salt.{value | secretKeyRef}` (and similar
for `encryptionKey` + `nextauth.secret`). Bundled subcharts
(`clickhouse`, `redis`, `s3`) also each require an
`auth.existingSecret` or inline password.

**Result**: every CI run since #11796 merged fails `helm template`
on this chart. Verified blocking [#11799](https://github.com/rwlove/home-ops/pull/11799)
(my SparkOllamaWedged tune),
[#11800](https://github.com/rwlove/home-ops/pull/11800)
(langgraph stale-paused alert), and would block any future PR
cluster-wide.

**Runtime impact**: zero. `kubectl get hr -n ai langfuse` returns
NotFound — Flux hits the same render failure CI does, so the
HelmRelease was never installed. This PR makes the render succeed;
Flux can then attempt install, but it'll wait on the follow-up
(ExternalSecret extension) before it actually starts pods.

## Changes (helmrelease values)

| Was | Now |
|---|---|
| `langfuse.salt` unset → chart aborts | `secretKeyRef: langfuse-secret/SALT` |
| `langfuse.encryptionKey` unset → chart aborts | `secretKeyRef: langfuse-secret/ENCRYPTION_KEY` |
| `langfuse.nextauth.secret` unset → chart aborts | `secretKeyRef: langfuse-secret/NEXTAUTH_SECRET` |
| `langfuse.nextauth.url` unset (default `http://localhost:3000`) | `https://langfuse.${SECRET_DOMAIN}` |
| `additionalEnv[TELEMETRY_ENABLED]` (chart aborts when mixed with new structure) | `langfuse.features.telemetryEnabled: false` |
| `clickhouse.auth` unset → chart aborts | `existingSecret: langfuse-secret`, key `CLICKHOUSE_PASSWORD` |
| `redis.auth` unset → chart aborts | `existingSecret: langfuse-secret`, key `REDIS_PASSWORD` |
| `s3.auth` unset → chart aborts | `existingSecret: langfuse-secret`, keys `S3_ROOT_USER` + `S3_ROOT_PASSWORD` |

Dropped from `additionalEnv` (chart re-injects them via its own
templates now that the values-side refs are set):
`NEXTAUTH_URL`, `NEXTAUTH_SECRET`, `SALT`, `ENCRYPTION_KEY`.

`DATABASE_URL` and the `LANGFUSE_INIT_*` bootstrap fields stay in
`additionalEnv` — DATABASE_URL because the CNPG `uri` carries the
full DSN (the chart's `postgresql.auth.existingSecret` path only
plumbs username + password); `LANGFUSE_INIT_*` because the chart
has no native value paths for first-boot bootstrap.

## Verified locally

```sh
helm template lf-test ai-langfuse/langfuse --version 1.5.31 \\
    --values <rendered helmrelease.yaml values>
# → 2072 lines of manifests, 0 errors
```

## Follow-up (operator, before Flux can install)

The `langfuse` ExternalSecret must be extended to materialize the
new keys (`CLICKHOUSE_PASSWORD`, `REDIS_PASSWORD`, `S3_ROOT_USER`,
`S3_ROOT_PASSWORD`), and the 1P item `langfuse-app` needs those
fields populated. CI passes without that step because `helm
template` doesn't validate secret-key existence — only structure.

## Test plan

- [ ] CI green on `Extract images` + `Flux Local Test` + `Flux Local Diff`
- [ ] Once merged: `gh pr update-branch` on #11799 + #11800; both
      should clear their CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)