### PR TITLE
fix(ai/langfuse): move salt/encryptionKey/nextauth.secret to chart-native paths

### DIFF
--- a/kubernetes/apps/ai/langfuse/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langfuse/app/helmrelease.yaml
@@ -48,33 +48,39 @@ spec:
       deploy: true
 
     # ----- Langfuse web + worker -----
+    # The chart's worker deployment template references
+    # `.Values.langfuse.salt` directly (along with
+    # `.Values.langfuse.nextauth.secret` and
+    # `.Values.langfuse.encryptionKey`). These MUST be set at the
+    # top-level langfuse.* paths with the chart's `secretKeyRef`
+    # shape — putting them in `additionalEnv` worked for the web
+    # pod but left the worker pod's template unrenderable
+    # (`no valid value, secretKeyRef, fieldRef, or resourceFieldRef
+    # provided for langfuse.salt`).
     langfuse:
       web:
         replicas: 1
       worker:
         replicas: 1
-      # NextAuth + crypto config + first-boot bootstrap come from the
-      # langfuse-secret created by externalsecret.yaml. The
-      # postgres-langfuse-app secret's `uri` key carries the full
-      # `DATABASE_URL` (CNPG's standard output format).
+      salt:
+        secretKeyRef:
+          name: langfuse-secret
+          key: SALT
+      encryptionKey:
+        secretKeyRef:
+          name: langfuse-secret
+          key: ENCRYPTION_KEY
+      nextauth:
+        url: https://langfuse.${SECRET_DOMAIN}
+        secret:
+          secretKeyRef:
+            name: langfuse-secret
+            key: NEXTAUTH_SECRET
+      # DATABASE_URL + optional first-boot bootstrap stay in
+      # additionalEnv because they aren't first-class chart values.
+      # CNPG exposes the full DSN at the `uri` key on the
+      # postgres-langfuse-app secret.
       additionalEnv:
-        - name: NEXTAUTH_URL
-          value: https://langfuse.${SECRET_DOMAIN}
-        - name: NEXTAUTH_SECRET
-          valueFrom:
-            secretKeyRef:
-              name: langfuse-secret
-              key: NEXTAUTH_SECRET
-        - name: SALT
-          valueFrom:
-            secretKeyRef:
-              name: langfuse-secret
-              key: SALT
-        - name: ENCRYPTION_KEY
-          valueFrom:
-            secretKeyRef:
-              name: langfuse-secret
-              key: ENCRYPTION_KEY
         - name: DATABASE_URL
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
## Summary

Bug fix for **PR #11796** — chart's worker deployment template references \`.Values.langfuse.salt\` (and \`encryptionKey\` / \`nextauth.secret\`) directly. I put them in \`langfuse.additionalEnv\` which worked for the web pod but left the worker pod's template unrenderable:

\`\`\`
execution error at (langfuse/templates/worker/deployment.yaml:72:16):
  no valid value, secretKeyRef, fieldRef, or resourceFieldRef
  provided for langfuse.salt
\`\`\`

flux-local CI caught this on PR #11800 (sibling alert PR).

## Fix

Per the chart's values.yaml, the three fields each accept either \`value:\` or \`secretKeyRef:\`. Moved to chart-native paths:

\`\`\`yaml
langfuse:
  salt:
    secretKeyRef: { name: langfuse-secret, key: SALT }
  encryptionKey:
    secretKeyRef: { name: langfuse-secret, key: ENCRYPTION_KEY }
  nextauth:
    url: https://langfuse.\${SECRET_DOMAIN}
    secret:
      secretKeyRef: { name: langfuse-secret, key: NEXTAUTH_SECRET }
\`\`\`

DATABASE_URL stays in \`additionalEnv\` (no chart-native path for an arbitrary connection-string env). Optional LANGFUSE_INIT_* bootstrap fields + TELEMETRY_ENABLED also stay there.

## Test plan

- [x] yaml parses, chart-native paths present
- [ ] Post-merge: flux-local CI passes on subsequent PRs
- [ ] Post-merge: \`langfuse-worker\` pod reaches Ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)