### PR TITLE
feat(ai/langfuse): externalsecret carries subchart auth keys

### DIFF
--- a/kubernetes/apps/ai/langfuse/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/langfuse/app/externalsecret.yaml
@@ -28,6 +28,18 @@ spec:
         # invalidates stored secrets — leave alone unless required.
         ENCRYPTION_KEY: "{{ .ENCRYPTION_KEY }}"
 
+        # Subchart auth — the bundled bitnami clickhouse / valkey
+        # (redis) / minio (s3) each hard-require an existingSecret
+        # with a known key name. The helmrelease.yaml points all
+        # three at `langfuse-secret` with these specific key names;
+        # the values must be present here for the chart's pods to
+        # start. Rotating any of these requires restarting the
+        # matching subchart pods.
+        CLICKHOUSE_PASSWORD: "{{ .CLICKHOUSE_PASSWORD }}"
+        REDIS_PASSWORD: "{{ .REDIS_PASSWORD }}"
+        S3_ROOT_USER: "{{ .S3_ROOT_USER }}"
+        S3_ROOT_PASSWORD: "{{ .S3_ROOT_PASSWORD }}"
+
         # First-boot bootstrap. Leave blank to use the langfuse UI to
         # create the first user manually.
         LANGFUSE_INIT_ORG_NAME: "{{ .LANGFUSE_INIT_ORG_NAME }}"


### PR DESCRIPTION
## Summary

PR #11802 wired the langfuse chart's bundled clickhouse / valkey / minio subcharts to \`auth.existingSecret: langfuse-secret\` with explicit key names. It called the matching ExternalSecret extension out as a follow-up — without it the subchart pods can't start.

Adds CLICKHOUSE_PASSWORD, REDIS_PASSWORD, S3_ROOT_USER, S3_ROOT_PASSWORD to the langfuse ExternalSecret template. 1P \`langfuse-app\` item already carries these (provisioned today with random 24-byte hex values).

## Test plan

- [x] YAML parses
- [x] 1P \`langfuse-app\` item carries the 4 new keys
- [ ] Post-merge: \`kubectl get secret -n ai langfuse-secret\` has all 11 keys
- [ ] Post-merge: langfuse-clickhouse / langfuse-redis-master / langfuse-minio pods Ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)