### PR TITLE
feat(ai/langgraph-agents): bump 0.2.20 → 0.2.21 + activate qwen2.5-coder:32b

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/langgraph-agents
-              tag: 0.2.20@sha256:1cbf2e59ee9c4efa075366d81a718dab32ba33f535dac6feffb54c9e428bee67
+              tag: 0.2.21@sha256:a9a548a8b9843b5b292ddf7d9fe87930b4fd52d42a417419ccb56ab1479b75ff
 
             env:
               # --- vault ---


### PR DESCRIPTION
## Summary

Bumps `ghcr.io/rwlove/langgraph-agents` from `0.2.20` → `0.2.21`, bundling two upstream changes:

- [rwlove/langgraph-agents#38](https://github.com/rwlove/langgraph-agents/pull/38) — add `local-spark-coder` group routing `coder` + `reviewer` agents to `qwen2.5-coder:32b` on `ollama-spark` instead of the general `qwen2.5:32b`. Same Spark Ollama instance; only the model name differs. Tier 1.2 of the GPU rebalance plan.
- [rwlove/langgraph-agents#39](https://github.com/rwlove/langgraph-agents/pull/39) — `smart_home_operator` composes `ApprovalRequest` and routes to `errand-runner`.

## Why this is safe

- Tagged release v0.2.21 (build #26175022996, 1m34s, success) — image digest `sha256:a9a548a8…` pinned.
- The 19 GB `qwen2.5-coder:32b` blob is already pulled on `ollama-spark` (verified via `ollama list`). No first-call download latency.
- Tests on the upstream PR: 143 passed, 2 integration tests skipped (POSTGRES_TEST_URL not set; pre-existing).
- The Spark-down → P40 7b degrade path collapses both Spark-flavored groups to the same fallback; a Spark outage doesn't make coder/reviewer worse off than today.
- Reloader picks up the digest change → rolling restart on the single langgraph-agents pod; OpenWebUI traffic gaps for ~30s during pod swap.

## Test plan

- [ ] Pod restarts cleanly post-Flux reconcile (reloader picks up the new digest).
- [ ] Invoke `coder` via OpenWebUI; verify `langgraph_calls_total{group="local-spark-coder",model="qwen2.5-coder:32b"}` increments in Grafana.
- [ ] Confirm `ollama-spark` keeps both `qwen2.5:32b` + `qwen2.5-coder:32b` loaded after a few rounds (MAX_LOADED_MODELS=3).
- [ ] Spot-check `smart_home_operator` → `errand-runner` flow via a Zulip triager test message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)