### PR TITLE
feat(ai/langfuse): wire LANGFUSE_INIT_ORG_ID + project keys for first-boot init

### DIFF
--- a/kubernetes/apps/ai/langfuse/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/langfuse/app/externalsecret.yaml
@@ -40,9 +40,21 @@ spec:
         S3_ROOT_USER: "{{ .S3_ROOT_USER }}"
         S3_ROOT_PASSWORD: "{{ .S3_ROOT_PASSWORD }}"
 
-        # First-boot bootstrap. Leave blank to use the langfuse UI to
-        # create the first user manually.
+        # First-boot bootstrap. Langfuse's init script only fires when
+        # LANGFUSE_INIT_ORG_ID + _PROJECT_ID are both set — missing
+        # ORG_ID silently skips user/project creation (warning in web
+        # pod logs: `LANGFUSE_INIT_ORG_ID is not set but other
+        # LANGFUSE_INIT_* variables are configured...`). Pre-generated
+        # public/secret keys (pk-lf-…/sk-lf-…) flow straight into the
+        # 1P `langgraph-agents` item as LANGFUSE_PUBLIC_KEY /
+        # _SECRET_KEY, so the SDK wiring picks them up on next
+        # reconcile without a manual UI bootstrap step.
+        LANGFUSE_INIT_ORG_ID: "{{ .LANGFUSE_INIT_ORG_ID }}"
         LANGFUSE_INIT_ORG_NAME: "{{ .LANGFUSE_INIT_ORG_NAME }}"
+        LANGFUSE_INIT_PROJECT_ID: "{{ .LANGFUSE_INIT_PROJECT_ID }}"
+        LANGFUSE_INIT_PROJECT_NAME: "{{ .LANGFUSE_INIT_PROJECT_NAME }}"
+        LANGFUSE_INIT_PROJECT_PUBLIC_KEY: "{{ .LANGFUSE_INIT_PROJECT_PUBLIC_KEY }}"
+        LANGFUSE_INIT_PROJECT_SECRET_KEY: "{{ .LANGFUSE_INIT_PROJECT_SECRET_KEY }}"
         LANGFUSE_INIT_USER_NAME: "{{ .LANGFUSE_INIT_USER_NAME }}"
         LANGFUSE_INIT_USER_EMAIL: "{{ .LANGFUSE_INIT_USER_EMAIL }}"
         LANGFUSE_INIT_USER_PASSWORD: "{{ .LANGFUSE_INIT_USER_PASSWORD }}"

--- a/kubernetes/apps/ai/langfuse/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langfuse/app/helmrelease.yaml
@@ -106,11 +106,54 @@ spec:
             secretKeyRef:
               name: postgres-langfuse-app
               key: uri
+        # First-boot bootstrap. Langfuse's init script only fires when
+        # LANGFUSE_INIT_ORG_ID is set; missing ORG_ID silently skips
+        # user/project creation even when the other LANGFUSE_INIT_*
+        # vars are present (warning in web pod logs:
+        # `LANGFUSE_INIT_ORG_ID is not set but other LANGFUSE_INIT_*
+        # variables are configured. The following variables will be
+        # ignored: ...`). Adding all six required keys here.
+        #
+        # Setting PROJECT_PUBLIC_KEY + PROJECT_SECRET_KEY at init means
+        # the langgraph-agents pod can be wired to traces without a
+        # manual UI bootstrap step — the same pk/sk land in the 1P
+        # `langgraph-agents` item and feed the Langfuse SDK on next
+        # reconcile.
+        - name: LANGFUSE_INIT_ORG_ID
+          valueFrom:
+            secretKeyRef:
+              name: langfuse-secret
+              key: LANGFUSE_INIT_ORG_ID
+              optional: true
         - name: LANGFUSE_INIT_ORG_NAME
           valueFrom:
             secretKeyRef:
               name: langfuse-secret
               key: LANGFUSE_INIT_ORG_NAME
+              optional: true
+        - name: LANGFUSE_INIT_PROJECT_ID
+          valueFrom:
+            secretKeyRef:
+              name: langfuse-secret
+              key: LANGFUSE_INIT_PROJECT_ID
+              optional: true
+        - name: LANGFUSE_INIT_PROJECT_NAME
+          valueFrom:
+            secretKeyRef:
+              name: langfuse-secret
+              key: LANGFUSE_INIT_PROJECT_NAME
+              optional: true
+        - name: LANGFUSE_INIT_PROJECT_PUBLIC_KEY
+          valueFrom:
+            secretKeyRef:
+              name: langfuse-secret
+              key: LANGFUSE_INIT_PROJECT_PUBLIC_KEY
+              optional: true
+        - name: LANGFUSE_INIT_PROJECT_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: langfuse-secret
+              key: LANGFUSE_INIT_PROJECT_SECRET_KEY
               optional: true
         - name: LANGFUSE_INIT_USER_NAME
           valueFrom:


### PR DESCRIPTION
## Summary

Langfuse v3 init only fires when both \`LANGFUSE_INIT_ORG_ID\` + \`LANGFUSE_INIT_PROJECT_ID\` are set. Without them the chart silently ignores all other LANGFUSE_INIT_* vars (warning visible in web pod logs).

Adds the 5 missing keys to both the helmrelease's \`additionalEnv\` (container env vars) and the ExternalSecret template (so they land in \`langfuse-secret\`):

- \`LANGFUSE_INIT_ORG_ID\` (the gatekeeper)
- \`LANGFUSE_INIT_PROJECT_ID\`
- \`LANGFUSE_INIT_PROJECT_NAME\`
- \`LANGFUSE_INIT_PROJECT_PUBLIC_KEY\` (\`pk-lf-…\`)
- \`LANGFUSE_INIT_PROJECT_SECRET_KEY\` (\`sk-lf-…\`)

## Why pre-generate keys

The same \`pk-lf-…\`/\`sk-lf-…\` pair is already populated in the 1P \`langgraph-agents\` item under \`LANGFUSE_PUBLIC_KEY\`/\`_SECRET_KEY\` so the SDK starts emitting traces on its next ESO refresh + pod restart — no manual UI bootstrap step.

## 1P state (already populated)

- \`langfuse-app\` item carries all 9 LANGFUSE_INIT_* fields
- \`langgraph-agents\` item: LANGFUSE_HOST + PUBLIC_KEY + SECRET_KEY filled

## Test plan

- [x] YAML parses
- [ ] Post-merge: \`langfuse-secret\` gets 5 new keys
- [ ] Web pod restart → init log no longer warns about missing ORG_ID
- [ ] langgraph-agents pod restart → trace lands in UI on next /inbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)