### PR TITLE
docs(agents): add data-classification, workarounds, gpu-routing + 3 skills

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -13,13 +13,16 @@ context window space on every turn.
 | File | What it does |
 |------|--------------|
 | `configmap.resources.instructions.md` | ConfigMap source files live under `app/resources/`; file names match the in-container basename. |
+| `data-classification.md` | Public / Internal / Restricted tiers for narrative artifacts (PR text, docs, summaries, prompts to remote models). |
 | `flux.sorting.instructions.md` | Field ordering for Flux-managed YAML (Kustomization, dependsOn, sourceRef). |
+| `gpu-routing.md` | Pointer to langgraph-agents' canonical `hardware-routing.md` plus home-ops-local GPU facts (P40, GB10, runtime split). |
 | `helmfile.sorting.instructions.md` | Field ordering for HelmRelease YAML, especially app-template-based releases. |
 | `helmrelease.security.md` | Pod-securityContext defaults (runAsNonRoot, readOnlyRootFilesystem, etc.) for new HelmReleases. |
 | `kustomize.config.sorting.instructions.md` | Field ordering for kustomize `kustomization.yaml` files. |
 | `persona.md` | Repo-specific persona — role framing, tone, decision bias. |
 | `schema.correction.md` | apiVersion + kind → `# yaml-language-server: $schema=…` mappings used in this repo. |
 | `storage-class.instructions.md` | When to pick Rook/Ceph vs Longhorn vs Garage vs direct NFS. |
+| `workarounds.md` | `# workaround:` annotation format + `workaround` GitHub label convention; pairs with the upstream-watcher skill. |
 
 When you add a new instructions file, also add an `@`-import line at
 the top of `CLAUDE.md` so it gets loaded.
@@ -39,7 +42,10 @@ skills can discover them.
 | `dependency-mapper.md` | Build and validate the Flux Kustomization dependency graph. |
 | `expose-app.md` | Attach an HTTPRoute to a per-app Gateway listener with shim-managed TLS. |
 | `flux-suspend.md` | Document the suspend / unsuspend workflow and the `disable-<app>` commit pattern. |
+| `historian.md` | Produce a weekly summary of this repo's work, written to the vault. |
+| `pre-submit.md` | Author-time checklist gating agent-authored PRs before push. |
 | `pr-review.md` | Apply the repo's PR review standards to a Renovate or manual PR. |
+| `upstream-watcher.md` | Re-check `workaround`-labeled issues against upstream; open removal PRs when upstream catches up. |
 
 ## Conventions
 

--- a/.agents/instructions/data-classification.md
+++ b/.agents/instructions/data-classification.md
@@ -1,0 +1,65 @@
+# Data classification
+
+Every narrative artifact this repo produces — PR descriptions, README
+content, mdBook chapters, memory entries, prompts sent to remote
+models, summaries, blog drafts — carries an implicit data tier. Pick
+the tier before you emit. Per HOMELAB-SPEC Layer 5.
+
+## Tiers
+
+- **Public** — May appear in published docs, summaries, external-facing
+  artifacts (repo READMEs, mdBook output rendered at
+  <https://rwlove.github.io/home-ops/>, anything Anthropic or other
+  external readers see).
+- **Internal** — Cluster internals, runbooks, decisions. Vault and repo.
+  Not external.
+- **Restricted** — Secrets, the arr stack and stash, anything Rob has
+  flagged restricted. Never summarized, never indexed for retrieval,
+  never emitted to remote models.
+
+## Restricted patterns in this repo
+
+- Secrets — any 1Password reference values, key material, API tokens,
+  OIDC client secrets, htpasswd content. If it's behind an
+  `ExternalSecret`, the resolved value is restricted.
+- **Do not name the arr stack or stash in PR descriptions, READMEs,
+  mdBook output, or any artifact a third party could see** (per
+  HOMELAB-SPEC Layer 2 #2). They exist in `kubernetes/apps/media/`
+  but narrative artifacts treat them as "the media stack."
+- Anything under `kubernetes/apps/security/` — this namespace exists
+  for hardening / audit work; assume restricted unless proven
+  otherwise.
+- Specific hostnames, internal IPs, MAC addresses unless required for
+  the technical content. Prefer roles (`the gateway`, `the storage
+  node`) over names in external artifacts.
+
+## When to check
+
+- Before opening a PR — review the title, body, and any new doc
+  content.
+- Before writing or updating anything in `docs/src/`.
+- Before sending content to a remote model (Anthropic API, etc.).
+- Before writing memory entries that might be surfaced elsewhere
+  (vault, summaries, indexed retrieval).
+- Before producing any external artifact (LinkedIn post, blog draft,
+  conference abstract).
+
+## How to redact
+
+- Replace specific names with category descriptors ("the media stack"
+  not the actual app names).
+- Replace internal hostnames with `<hostname>` or the role (`the
+  gateway`, `the storage node`).
+- For secrets: do not redact — refuse to emit at all. If a secret has
+  to appear in narrative, you're producing the wrong artifact.
+
+## What this is NOT
+
+- Not a substitute for ExternalSecrets. That's a separate layer — don't
+  commit plaintext secrets to Git regardless of tier.
+- Not a code-review rule for inline credentials — gitleaks + pre-commit
+  hooks catch those, and they apply to every commit regardless of
+  classification.
+- This is about **narrative artifacts** — descriptions, summaries,
+  prose — that humans or LLMs produce *about* the cluster. The cluster
+  manifests themselves follow their own (separate) rules.

--- a/.agents/instructions/gpu-routing.md
+++ b/.agents/instructions/gpu-routing.md
@@ -1,0 +1,53 @@
+# GPU routing
+
+This file is a pointer plus a small set of home-ops-local facts.
+Model-to-GPU routing decisions don't live here.
+
+## Canonical source
+
+The cross-repo authority lives in
+`~/workspace/claude-workspace/langgraph-agents/.agents/instructions/hardware-routing.md`.
+Read that before scheduling model work in this cluster.
+
+## Local cluster GPU inventory
+
+- **P40** (Pascal, 24GB VRAM) — currently on a worker node. Used for
+  ≤8b-class inference; bge-m3 + nomic embedders; Ollama-served.
+  Pre-Spark generation.
+- **DGX Spark** (NVIDIA GB10, Grace-Blackwell) — on its own host
+  running Ubuntu 24.04 / containerd (the lone non-CRI-O node — see
+  `reference_cluster_runtime_inventory` in memory). Used for larger
+  inference; the Spark migration is in progress and specific model
+  assignments live in `hardware-routing.md` upstream.
+
+## Runtime split matters for gpu-operator
+
+- The cluster is mostly CRI-O on CentOS Stream 9; Spark is the lone
+  containerd outlier.
+- gpu-operator's `container-toolkit` DaemonSet is containerd-only.
+- PR #11760 installed a `NodeFeatureRule` that auto-labels CRI-O nodes
+  (`OS ID = centos/fedora/rhel`) with
+  `nvidia.com/gpu.deploy.container-toolkit=false`, skipping the
+  toolkit DS on those nodes.
+- When the OS migration completes (everything on Ubuntu/containerd),
+  the NFD rule flips off naturally — no manual cleanup.
+
+## DCGM counters on GB10
+
+- Most DCGM counters are broken on GB10 — `GPU_UTIL` and
+  `MEM_COPY_UTIL` stuck at 0; `GR_ENGINE_ACTIVE` and `FB_USED` empty.
+- Only `POWER_USAGE` and `SM_CLOCK` report.
+- Use power draw as proxy for "is GB10 busy" in dashboards and alerts.
+
+## Routing decisions
+
+- Defer to `hardware-routing.md` in langgraph-agents — don't replicate
+  model-to-GPU mappings here.
+- Local rule of thumb: ≤8b → P40; larger → Spark (until the Spark
+  migration is documented as complete).
+
+## What this is NOT
+
+- Not the canonical GPU routing doc — that's in langgraph-agents.
+- Not a snapshot of every node's hardware — `kubectl get nodes -o yaml
+  | grep nvidia` is the source of truth.

--- a/.agents/instructions/workarounds.md
+++ b/.agents/instructions/workarounds.md
@@ -7,7 +7,7 @@ catches up. Per HOMELAB-SPEC Layer 5 Workaround tracking.
 
 ## Annotation format
 
-```
+```text
 # workaround: <upstream-url> — remove when <condition>
 ```
 
@@ -19,7 +19,7 @@ catches up. Per HOMELAB-SPEC Layer 5 Workaround tracking.
   merged PR, a behavior change. "Eventually" is not a condition.
 - Example:
 
-  ```
+  ```text
   # workaround: https://github.com/cloudnative-pg/cloudnative-pg/issues/5489 — remove when v1.27 lands
   ```
 

--- a/.agents/instructions/workarounds.md
+++ b/.agents/instructions/workarounds.md
@@ -1,0 +1,65 @@
+# Workarounds
+
+When this repo carries code that compensates for an upstream gap —
+version pin, custom CNP, sidecar, disabled default — it must be
+annotated so the upstream-watcher skill can retire it when upstream
+catches up. Per HOMELAB-SPEC Layer 5 Workaround tracking.
+
+## Annotation format
+
+```
+# workaround: <upstream-url> — remove when <condition>
+```
+
+- The `# workaround:` prefix is fixed. Don't invent variants (no
+  `# WORKAROUND`, no `// workaround:`, no `# HACK:`).
+- The upstream URL must point at a specific issue or PR, not a generic
+  project page.
+- The "remove when" condition should be checkable — a version, a
+  merged PR, a behavior change. "Eventually" is not a condition.
+- Example:
+
+  ```
+  # workaround: https://github.com/cloudnative-pg/cloudnative-pg/issues/5489 — remove when v1.27 lands
+  ```
+
+## When to apply
+
+- Pinning to a known-broken version waiting for an upstream fix.
+- Custom CNP / RBAC / config to compensate for a missing upstream
+  feature.
+- Sidecar containers that exist only to work around an upstream gap
+  (e.g., `lidarr-sab-autoimport`).
+- Disabling default behavior that's known-broken (e.g., gpu-operator
+  NFD override for CRI-O nodes).
+
+## GitHub label
+
+Every workaround in code also has a tracking issue with the
+`workaround` label:
+
+- The label name is exactly `workaround` — do not invent variants.
+- The issue links to the upstream issue/PR and the file(s) containing
+  the annotation.
+- One issue per upstream item, not per occurrence. One upstream bug
+  touching three files → one `workaround`-labeled issue.
+
+## How to retire
+
+- When upstream resolves: file a PR that removes the workaround code
+  and references the upstream resolution.
+- Close the `workaround`-labeled tracking issue from the PR
+  (`Closes #N`).
+- This is what `.agents/skills/upstream-watcher.md` exists to find.
+
+## What this is NOT
+
+- Bug fixes against this repo's own code are not workarounds — fix
+  them directly.
+- Technical debt with no upstream gate is not a workaround — use
+  `# TODO:` instead.
+- A workaround needs an explicit upstream link. If you can't link,
+  you don't have a workaround — you have an unjustified hack.
+
+Pairs with the `upstream-watcher` skill, which scans
+`workaround`-labeled issues weekly.

--- a/.agents/skills/historian.md
+++ b/.agents/skills/historian.md
@@ -1,0 +1,56 @@
+---
+name: historian
+description: Produce a weekly summary of this repo's work, written to the vault
+---
+
+# Historian
+
+Produces vault summaries per HOMELAB-SPEC Layer 4 Historian + Layer 3
+Documentation/Summaries.
+
+## When to use
+
+Manually, when rolling up the week. Daily/monthly/yearly will roll up
+from weeklies once that's automated; only weekly is implemented today.
+
+## Inputs
+
+- `git log --since="1 week ago" --pretty=format:"%h %s"` — commits to
+  main.
+- `gh pr list --state merged --search "merged:>=$(date -d '7 days ago' +%Y-%m-%d)"`
+  — PRs merged this week.
+- Memory deltas: new files under
+  `~/.claude-personal/projects/-home-rwlove-workspace-claude-workspace-home-ops/memory/`
+  in the past week.
+- Alert volume: query Prometheus for `ALERTS{alertstate="firing"}`
+  deltas.
+- Open work: `gh pr list --state open` + `gh issue list --label workaround`.
+
+## Output
+
+`~/vaults/claude/summaries/weekly/YYYY-WW.md` (ISO week number).
+
+## Structure
+
+- **Highlights** (3-5 bullets, top-of-mind).
+- **Notable PRs** (merged this week; group by area).
+- **Memory deltas** (what got learned/codified).
+- **Alert weather** (deltas vs prior week).
+- **Open / unresolved** (workarounds still in place, PRs still open).
+
+## Data classification
+
+- The vault is internal-tier. Memory and summary content is internal.
+- But: the historian's summaries sometimes feed external surfaces
+  (LinkedIn writeups, conference abstracts). Apply
+  `.agents/instructions/data-classification.md` redaction *as if* the
+  output might be external — better to redact at write time than scrub
+  later.
+- Restricted patterns from `data-classification.md` apply: never name
+  the arr stack / stash; never emit secrets.
+
+## What this is NOT
+
+- Not a release-note generator — those belong in PR descriptions.
+- Not a per-PR summary — operates at the week-scale.
+- Not the canonical history — `git log` is. The summary is a digest.

--- a/.agents/skills/pre-submit.md
+++ b/.agents/skills/pre-submit.md
@@ -1,0 +1,54 @@
+---
+name: pre-submit
+description: Pre-submit checklist for agent-authored PRs in this repo
+---
+
+# Pre-submit
+
+Agents do not open PRs that haven't passed local pre-submit
+(HOMELAB-SPEC Layer 2 #6). This is the author-time gate.
+
+## When to use
+
+Before pushing a branch and opening a PR. Pairs with
+`.agents/skills/pr-review.md` (the matching review-time gate run by an
+independent agent).
+
+## Checks
+
+1. **Flux render diff** — run `flux-local diff` (or the repo's
+   wrapper) against `main` and verify the rendered manifest changes
+   match what you expect. Unexpected diffs usually mean an upstream
+   chart bumped under you.
+2. **YAML schema validation** — every YAML in `kubernetes/` should
+   have the right `# yaml-language-server: $schema=` comment on line
+   2 per `.agents/instructions/schema.correction.md`. Open each
+   new/changed file and confirm.
+3. **Image pull check** — for any new image reference, confirm it
+   pulls (or is set to sync via ZOT). `crane manifest <ref>` is one
+   way.
+4. **Lint** — match whatever CI runs (markdownlint, yamllint,
+   `kustomize build`).
+5. **File-count** — see `CLAUDE.md` "Blast radius". 50-file ceiling;
+   `sweep` label required to bypass. If you're above 50 and not
+   labeling `sweep`, split.
+6. **Memory grep** — search
+   `~/.claude-personal/projects/-home-rwlove-workspace-claude-workspace-home-ops/memory/`
+   for any prior decisions that contradict the change. Cross-namespace
+   grep too (per global `CLAUDE.md` "Cross-namespace memory").
+7. **Data classification** — review the diff and PR description per
+   `.agents/instructions/data-classification.md`. Refuse to emit
+   restricted content to external surfaces.
+
+## Why
+
+HOMELAB-SPEC Layer 2 #6: "The PR is the artifact of a passing local
+run."
+
+## What this is NOT
+
+- Not a substitute for CI. CI still runs post-PR.
+- Not a code review — see `.agents/skills/pr-review.md` for that.
+- Not a strict checklist that blocks every PR — judgment call when the
+  changes are obviously safe (renovate digest bumps, doc-only PRs).
+  Document the skip reason in the PR body.

--- a/.agents/skills/upstream-watcher.md
+++ b/.agents/skills/upstream-watcher.md
@@ -1,0 +1,46 @@
+---
+name: upstream-watcher
+description: Re-check tracked workarounds against upstream and open removal PRs
+---
+
+# Upstream watcher
+
+Per HOMELAB-SPEC Layer 4 Upstream-watcher + Layer 5 Workaround
+tracking, periodically re-check that workarounds we've adopted are
+still necessary upstream.
+
+## When to use
+
+Manually, ~weekly. Future: scheduled.
+
+## Inputs
+
+- `gh issue list --label workaround --state open` — tracking issues.
+- `grep -rn '# workaround:' .` — annotated source (see
+  `.agents/instructions/workarounds.md` for the format).
+- For each tracked workaround: the upstream URL it points at.
+
+## Workflow
+
+1. List all open issues labeled `workaround` and gather their upstream
+   URLs.
+2. For each upstream URL:
+   - Fetch via `gh issue view <upstream>` or `gh pr view <upstream>`
+     (note: cross-repo for most).
+   - If the upstream is closed/merged: collect for removal.
+   - If still open: optionally post a status comment on the home-ops
+     tracking issue.
+3. For each removable workaround, open a PR that:
+   - Removes the `# workaround:` annotation block.
+   - Removes any compensating code (sidecar, custom CNP, version pin).
+   - References the upstream resolution in the PR body.
+   - Closes the home-ops tracking issue (`Closes #N`).
+4. Use the sweep pattern from `CLAUDE.md` "Blast radius" if multiple
+   workarounds retire at once (label `sweep`).
+
+## What this is NOT
+
+- Not a general bug-watcher — only tracks code we've explicitly
+  annotated with `# workaround:` and labeled `workaround` in issues.
+- Not a renovate replacement — version bumps are renovate's job. This
+  is for behavior workarounds, not dep updates.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,11 +1,14 @@
 @.agents/instructions/configmap.resources.instructions.md
+@.agents/instructions/data-classification.md
 @.agents/instructions/flux.sorting.instructions.md
+@.agents/instructions/gpu-routing.md
 @.agents/instructions/helmfile.sorting.instructions.md
 @.agents/instructions/helmrelease.security.md
 @.agents/instructions/kustomize.config.sorting.instructions.md
 @.agents/instructions/persona.md
 @.agents/instructions/schema.correction.md
 @.agents/instructions/storage-class.instructions.md
+@.agents/instructions/workarounds.md
 
 # Home Operations - AI Assistant Guide
 


### PR DESCRIPTION
## Summary
Adds three auto-loaded instructions (data-classification, workarounds, gpu-routing) and three on-demand skills (pre-submit, historian, upstream-watcher) to align the repo with HOMELAB-SPEC Layers 2, 3, 4, and 5.

## Test plan
- [ ] CLAUDE.md @-imports resolve (no broken @-references).
- [ ] .agents/README.md tables match the files on disk.
- [ ] No k8s manifest changes — Flux unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)