### PR TITLE
docs(agents): add orchestration-substrate status doc; document blast-radius, change windows, observer/guardian deferral

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,44 @@ edits, or to take an app offline for maintenance.
 a Flux Kustomization without explicit instruction. If a `Suspended:
 True` status shows up unexpectedly, ask before touching it.
 
+## Blast radius
+
+A single agent-authored PR touches at most 50 files. Larger sweeps —
+sorting, schema, security-context retrofits, mass renames — require
+the `sweep` label on the PR to bypass the limit. Even with the label,
+prefer to split if the change can be split.
+
+Per HOMELAB-SPEC Layer 5 blast-radius rules.
+
+## Maintenance windows
+
+Non-emergency disruptive changes wait for one of these windows
+(US Eastern):
+
+- **Routine** (internal services, langgraph-agents, Windmill,
+  MCP servers, observability, storage backends): any night,
+  02:00–05:00.
+- **Renee-facing** (Home Assistant, Music Assistant, Jellyfin,
+  Frigate, voice services, lighting / climate / locks): Tuesday
+  02:00–04:00 only.
+
+Emergency changes (security, data-loss prevention) bypass with Rob's
+explicit approval.
+
+Today these windows are advisory — there is no scheduler enforcing
+them. See `docs/src/orchestration_substrate.md` for why.
+
+## Observer and Guardian modes (deferred)
+
+HOMELAB-SPEC Layer 4 defines Observer and Guardian modes that watch
+cluster health and gate destructive operations through a queue with
+TTL. This cluster doesn't have the queue substrate yet, so both
+modes are aspirational. See `docs/src/orchestration_substrate.md`.
+
+Until the substrate lands, destructive operations follow the
+propose-then-execute pattern from `.agents/instructions/persona.md`
+with Rob as the human-in-the-loop gate.
+
 ## Common Operations
 
 - **Add app**: Create in `kubernetes/apps/` with kustomization + HelmRelease

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -20,6 +20,7 @@
 - [NetworkPolicy Rollout Plan](networkpolicy_rollout_plan.md)
 - [Egress Restriction Design Proposal](egress_restriction_design.md)
 - [Istio mTLS Rollout Design Proposal](mtls_rollout_design.md)
+- [Orchestration Substrate](orchestration_substrate.md)
 - [Pod Security Baseline Audit](pod_security_audit.md)
 - [Github Webhook](github_webhook.md)
 - [Resources: Limits and Requests Philosophy](limits.md)

--- a/docs/src/orchestration_substrate.md
+++ b/docs/src/orchestration_substrate.md
@@ -1,0 +1,141 @@
+# Orchestration substrate
+
+## Status
+
+**Not built as of 2026-05-20.** HOMELAB-SPEC Layer 5 references a task
+contract, queue substrate, DLQ, and per-mode workers that this cluster
+does not yet implement. This document names the gap, describes what
+exists today, and sketches the forward-looking shape so we don't lose
+the specs while we wait.
+
+## What exists today
+
+The closest things to a task pipeline in this cluster:
+
+- **AlertManager → HolmesGPT** for alert triage. AlertManager fires →
+  HolmesGPT investigates → result posts to Zulip / Pushover.
+- **Zulip Triager bot → Windmill → langgraph-agents `/inbox`** for
+  DM-shaped intents. The Triager outgoing-webhook converts DMs to
+  HTTP and Windmill brokers to langgraph. See memory entry
+  `project_zulip_triager_webhook_done`.
+- **ntfy → langgraph approval endpoint** for tap-to-approve actions
+  on Android. HMAC-signed, single-use. See memory entry
+  `project_ntfy_pushover_migration_done`.
+- **HA voice + ntfy notifications** for Renee-facing surfaces.
+  Currently end-user-driven, not agent-mediated.
+
+None of these speak a common task contract. None have a DLQ. None
+queue durably across a worker crash. None carry an OpenTelemetry
+trace_id end-to-end.
+
+## What would exist when built
+
+Per HOMELAB-SPEC Layer 5:
+
+- **Durable queue** with at-least-once delivery, DLQ, visibility
+  timeouts that return crashed-worker tasks within minutes.
+- **Ingress wrappers** that wrap raw user input (Open WebUI, HA voice,
+  Android, AlertManager) in a task envelope before enqueueing. Raw
+  surface input never reaches an agent.
+- **Per-mode workers** for the modes defined in HOMELAB-SPEC Layer 4:
+  planner, executor, reviewer, guardian, observer, historian,
+  upstream-watcher, router. Modes compose with personas
+  (`~/.claude-personal/agents/*.md`).
+- **Observability**: OpenTelemetry traces follow `trace_id` from
+  ingress through every mode hop to PR / CI / Flux reconcile /
+  historian summary. Structured logs carry `trace_id`, `task_id`,
+  `mode`, `persona`. Grafana dashboard with one panel per task.
+- **Human-in-the-loop queue** with `ttl` on destructive tasks. On
+  expiry the task does *not* auto-execute — it expires and notifies
+  Rob with a summary. Urgent tasks page; normal tasks wait.
+- **DLQ → review queue**: DLQ entries become tasks for Rob's review,
+  not silent failures.
+
+## Task envelope (forward-looking)
+
+When the substrate exists, every task carries:
+
+- `id` — ULID
+- `trace_id` — OpenTelemetry-compatible
+- `origin` — `open-webui` | `ha-voice` | `android` | `observer` |
+  `scheduled` | `manual`
+- `requester` — `rob` | `renee` | `system`
+- `intent` — natural-language string
+- `priority` — `low` | `normal` | `high` | `urgent`
+- `destructive` — bool, planner sets/confirms
+- `idempotency_key` — task handlers must be safe under at-least-once
+  delivery; this is how
+- `ttl` — after which guardian-queued tasks expire and notify Rob
+- `retry_policy`
+- `data_tier` — `public` | `internal` | `restricted`
+  (see `.agents/instructions/data-classification.md`)
+
+Tasks without this envelope are rejected at ingress.
+
+## Renee allowlist (forward-looking)
+
+When the substrate exists, Renee's intents are auto-approved when
+they fall into these categories:
+
+- Media playback (Jellyfin, Music Assistant, Kodi)
+- Lighting
+- Climate
+- Scenes
+- Locks-unlock-when-already-home (NOT from-away)
+
+Anything else from Renee routes to Rob's queue with a Renee-originated
+tag. Renee never sees admin output, stack traces, or restricted-tier
+data.
+
+Start narrow — easier to widen than retract.
+
+## Observer and Guardian modes (deferred)
+
+HOMELAB-SPEC Layer 4 defines Observer (watches cluster health, files
+tasks) and Guardian (owns human-approval gate with TTL). Both depend
+on the queue substrate. Until the substrate lands, observer
+responsibilities live in AlertManager + HolmesGPT, and guardian
+responsibilities live in Rob (the human) responding to ntfy /
+Pushover approval requests.
+
+## Token / cost budget (deferred)
+
+HOMELAB-SPEC Layer 6 asks for a daily + weekly MAX-phase budget. Not
+set today. Plan: ship the Grafana dashboard panel from Layer 6 first,
+collect a week of real spend, then pick numbers based on the data.
+Picking numbers cold would be guessing.
+
+## Substitutes / partial implementations
+
+These do *substrate-ish* work today but are not substitutes for the
+real thing:
+
+- **HolmesGPT** — single-task investigation per alert. No queue, no
+  envelope, no idempotency, no trace correlation.
+- **Zulip Triager → Windmill → langgraph** — DM ingress only. No DLQ,
+  no retry policy, no priority routing.
+- **ntfy approval flow** — one-off HMAC-signed approvals. Not a
+  generic guardian.
+- **AlertManager** — fires, doesn't reason. The piece closest to
+  observer-by-rule.
+
+When the substrate is built, each of these collapses into the
+appropriate mode worker.
+
+## What this is NOT
+
+- Not a design doc. The shape above is HOMELAB-SPEC's, not a
+  worked-through design for this cluster's specifics.
+- Not a roadmap. There's no commit date.
+- Not a list of substitutes that are good-enough. They aren't.
+
+## See also
+
+- HOMELAB-SPEC Layer 4 (Modes), Layer 5 (Task contract, Queueing,
+  Blast radius, HITL SLA, Self-healing loop), Layer 6 (Routing and
+  budget), Layer 7 (User surfaces).
+- `.agents/instructions/data-classification.md`
+- `.agents/skills/historian.md`
+- `.agents/skills/upstream-watcher.md`
+- memory `project_zulip_triager_webhook_done`
+- memory `project_ntfy_pushover_migration_done`


### PR DESCRIPTION
## Summary
- New `docs/src/orchestration_substrate.md` — documents the largest single gap between HOMELAB-SPEC and this cluster (the task contract + queue + DLQ + per-mode workers substrate doesn't exist).
- CLAUDE.md picks up explicit numbers for the blast-radius limit (50 files, `sweep` bypass) and the maintenance windows (nightly 02:00–05:00 ET; Tuesday 02:00–04:00 ET for Renee-facing).
- Observer/Guardian modes documented as deferred-until-substrate.

## Test plan
- [ ] mdBook builds with the new doc + SUMMARY entry.
- [ ] CLAUDE.md still renders as Claude Code auto-load.
- [ ] No k8s manifest changes — Flux unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)