### PR TITLE
chore(ai/langgraph-agents): bump 0.2.20 → 0.2.21

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/langgraph-agents
-              tag: 0.2.20@sha256:1cbf2e59ee9c4efa075366d81a718dab32ba33f535dac6feffb54c9e428bee67
+              tag: 0.2.21@sha256:a9a548a8b9843b5b292ddf7d9fe87930b4fd52d42a417419ccb56ab1479b75ff
 
             env:
               # --- vault ---


### PR DESCRIPTION
## Summary

Bumps the deployed langgraph-agents image from 0.2.20 → 0.2.21 to pick up all 11 PRs since v0.2.20 (memory-ollama-url). New image: \`ghcr.io/rwlove/langgraph-agents:0.2.21@sha256:a9a548…\`.

With the matching LANGFUSE_HOST / PUBLIC_KEY / SECRET_KEY already in the 1P \`langgraph-agents\` item, the SDK starts emitting traces immediately on next reconcile.

## Test plan

- [x] Tag + digest verified
- [ ] Post-merge: rollout completes
- [ ] Trace appears in langfuse UI on next /inbox call

🤖 Generated with [Claude Code](https://claude.com/claude-code)