### PR TITLE
chore(ai/langgraph-agents): bump 0.2.21 → 0.2.22 (sweep-bound fix)

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/langgraph-agents
-              tag: 0.2.21@sha256:a9a548a8b9843b5b292ddf7d9fe87930b4fd52d42a417419ccb56ab1479b75ff
+              tag: 0.2.22@sha256:f49105759ce8a9f65f8ac7a00dbefd0a202698b5f8e3932e9cf6ac45b96f4f64
 
             env:
               # --- vault ---


### PR DESCRIPTION
v0.2.21 rollout failed Flux's 5m HR upgrade timeout — startup sweep blocked lifespan. v0.2.22 (langgraph-agents PR #41) caps the sweep + runs it as a background asyncio task. Image: `ghcr.io/rwlove/langgraph-agents:0.2.22@sha256:f49105…`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)