### PR TITLE
chore(ai/langgraph-agents): bump 0.2.22 → 0.2.23 (startup sweep OFF)

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/langgraph-agents
-              tag: 0.2.22@sha256:f49105759ce8a9f65f8ac7a00dbefd0a202698b5f8e3932e9cf6ac45b96f4f64
+              tag: 0.2.23@sha256:c9b5286f5e2039cc0298a0587b4968818b2ad1006f94b9c75efe751fddd95776
 
             env:
               # --- vault ---


### PR DESCRIPTION
Default startup paused-threads sweep to OFF (langgraph-agents PR #42). v0.2.22's backgrounded sweep still starved the Postgres pool when checkpoint history is days deep. Opt back in per-deploy via `STARTUP_SWEEP_ENABLED=true` once class-C/D nodes actually pause. Image: `ghcr.io/rwlove/langgraph-agents:0.2.23@sha256:c9b5286…`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)