### PR TITLE
chore(ai/langgraph-agents): bump 0.2.23 → 0.2.26

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/langgraph-agents
-              tag: 0.2.23@sha256:c9b5286f5e2039cc0298a0587b4968818b2ad1006f94b9c75efe751fddd95776
+              tag: 0.2.26@sha256:768a08dbef7f2b30220f12ea18f15cf6b8c4e6c46962011a7607b9a89486fef8
 
             env:
               # --- vault ---


### PR DESCRIPTION
Picks up the 5-PR follow-up batch (#43 docs, #44 structlog fix, #45 cost-cap, #46 repro harness, #47 specialists). 

Note: PR #47 wires the routing for the 5 specialists but `kubectl-mcp.kubectl_apply` is NOT in errand-runner's allowlist — execute-time will refuse cleanly until a separate security-review PR expands it.

Image: `ghcr.io/rwlove/langgraph-agents:0.2.26@sha256:768a08…`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)