### PR TITLE
chore: add CODEOWNERS pinning @rwlove on critical paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,48 @@
+# CODEOWNERS — home-ops
+#
+# Solo-owner per HOMELAB-SPEC review-protection intent. Pins @rwlove
+# on the critical paths where an unintended change carries outsized
+# blast radius. Branch-protection enforcement (require-reviews) is
+# configured in GitHub repo settings; this file documents the
+# intent + supplies the reviewer hint to PR tooling.
+#
+# Catch-all default keeps the same owner — solo repo today. Specific
+# blocks below are documented mostly for future readers.
+
+* @rwlove
+
+# Flux GitOps root + cluster definitions — touching these reshapes
+# what reconciles where.
+/kubernetes/flux/                           @rwlove
+/kubernetes/apps/kustomization.yaml         @rwlove
+
+# Storage critical paths (HOMELAB-SPEC Inv 4 / spec storage tier).
+/kubernetes/apps/rook-ceph/                 @rwlove
+/kubernetes/apps/longhorn-system/           @rwlove
+/kubernetes/apps/storage/garage/            @rwlove
+
+# Database / data-bearing paths (CNPG clusters + backups).
+/kubernetes/apps/databases/                 @rwlove
+
+# Network critical paths (HOMELAB-SPEC Inv 9 territory — adjacent;
+# brain/beast live in lovenet-network-configuration, not here).
+/kubernetes/apps/network/                   @rwlove
+/kubernetes/apps/cilium-secrets/            @rwlove
+/kubernetes/apps/kube-system/cilium/        @rwlove
+
+# Secret + auth pipeline.
+/kubernetes/apps/external-secrets/          @rwlove
+/kubernetes/apps/cert-manager/              @rwlove
+/kubernetes/apps/auth/                      @rwlove
+
+# Policy / admission / blast-radius enforcement (Phase 5 territory).
+/kubernetes/apps/kube-system/kyverno/       @rwlove
+/kubernetes/components/network-policy/      @rwlove
+
+# Agent guidance — changes here change every future PR.
+/.agents/                                   @rwlove
+/CLAUDE.md                                  @rwlove
+
+# CI definitions — changing what CI enforces changes what reaches main.
+/.github/workflows/                         @rwlove
+/.github/CODEOWNERS                         @rwlove


### PR DESCRIPTION
## Summary

Solo-owner CODEOWNERS per HOMELAB-SPEC review-protection intent and the rollout plan's [1.E1] item.

## Critical paths pinned to @rwlove

- Flux GitOps root + apps kustomization
- Storage (rook-ceph, longhorn, garage)
- Databases (CNPG clusters + backups)
- Network (network/, cilium-secrets, kube-system/cilium)
- Secret + auth pipeline (external-secrets, cert-manager, auth)
- Policy / admission targets (kyverno path, network-policy)
- Agent guidance (.agents/, CLAUDE.md)
- CI definitions (.github/workflows/, CODEOWNERS)

Catch-all `*` keeps the same owner — solo repo today. Specific blocks document intent for future readers.

## Out of scope

Branch-protection "require reviews" is configured separately in GitHub repo settings (not file-driven). Without that, CODEOWNERS is advisory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)