### PR TITLE
feat(collab/pump-cv): bump v0.4.2 → v0.5.0 + pin to Spark/Blackwell

### DIFF
--- a/kubernetes/apps/collab/pump-cv/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump-cv/app/helmrelease.yaml
@@ -21,11 +21,28 @@ spec:
           reloader.stakater.com/auto: "true"
 
         pod:
-          # The yolo backend uses cuda:0; only worker8 has the
-          # nvidia.com/gpu resource via the gpu-operator. nodeSelector
-          # is belt-and-suspenders alongside the resource request below.
+          # Pinned to Spark/GB10 (Blackwell, arm64) after the multi-arch
+          # rebase (pump-cv v0.5.0 / pump-cv-base on nvcr.io/nvidia/pytorch).
+          # Previously bound to worker8 (Pascal P40, amd64); the cu121
+          # Pascal pin was dropped along with the base swap. One-way
+          # cutover — the new image won't run on P40 (sm_61 isn't in
+          # TORCH_CUDA_ARCH_LIST for the nvcr.io stack).
           nodeSelector:
-            nvidia.com/gpu.present: "true"
+            node-role.kubernetes.io/gpu: blackwell
+
+          tolerations:
+            # Spark is tainted kubernetes.io/arch=arm64:NoSchedule to
+            # keep amd64-only workloads off it. pump-cv v0.5.0 is
+            # multi-arch (linux/arm64 + linux/amd64) so tolerate
+            # explicitly.
+            - key: kubernetes.io/arch
+              operator: Equal
+              value: arm64
+              effect: NoSchedule
+            - key: nvidia.com/gpu
+              operator: Equal
+              value: "true"
+              effect: NoSchedule
 
         initContainers:
           # pump-cv config.py does not interpolate env vars in YAML, so
@@ -58,7 +75,7 @@ spec:
           pump-cv:
             image:
               repository: ghcr.io/rwlove/pump-cv
-              tag: v0.4.2@sha256:96f91875639e3d909bddf71711b267790ee775ce743e51e4e94c12c474ffad04
+              tag: v0.5.0@sha256:fed0360395bd65f86a7bde12183303a96fe2bbb6de0d388ce5d2ee21a6c03d38
 
             # Image's default ENTRYPOINT calls bare `python`, which doesn't
             # exist in PATH (only python3 is installed). Use the console-script


### PR DESCRIPTION
## Summary

Picks up the multi-arch image from [rwlove/PUMP#27](https://github.com/rwlove/PUMP/pull/27) (pump-cv v0.5.0 — first build against `nvcr.io/nvidia/pytorch:25.04-py3`, multi-arch amd64 + arm64, CUDA 12.9, Blackwell sm_120 supported). Moves pump-cv off worker8/P40 onto Spark/GB10.

Third P40 slot freed by the rebalance (after av1corrector and pet-tagger in-flight).

## One-way cutover

The new image dropped the Pascal sm_61 pin — pump-cv won't run on P40 with v0.5.0+. That's intentional, but flagged: rolling back means rebuilding the v0.4.x line (which still uses cu121 wheels).

## Changes

- Image tag `v0.4.2` → `v0.5.0@sha256:fed03603...` (digest-pinned).
- `nodeSelector: nvidia.com/gpu.present: "true"` → `node-role.kubernetes.io/gpu: blackwell`.
- Add arm64 + `nvidia.com/gpu` tolerations.
- Comment updated: replaced the worker8-only rationale with the Blackwell cutover note.

## Test plan

- [ ] Pod schedules on `spark.thesteamedcrab.com` (`kubectl get pod -n collab pump-cv-0 -o wide`).
- [ ] YOLO model loads (`/cache/yolov8m-pose.pt` weights re-downloaded on first run; ~2-3 s).
- [ ] Camera capture round-trip works via healthd `/api/v1/cameras` + a live snapshot.
- [ ] Watch for any CUDA/torch.compile regressions vs v0.4.2 — `torch.cuda.get_arch_list()` now starts at sm_70.

🤖 Generated with [Claude Code](https://claude.com/claude-code)