### PR TITLE
chore: annotate longhorn + pod-gateway workarounds per workarounds.md

### DIFF
--- a/kubernetes/apps/downloads/jdownloader2/app/cnp-allow.yaml
+++ b/kubernetes/apps/downloads/jdownloader2/app/cnp-allow.yaml
@@ -34,11 +34,12 @@ spec:
         - ports:
             - port: "4789"
               protocol: UDP
-    # ICMP echo to the pod-gateway. The gateway-sidecar init container
-    # (angelnu/pod-gateway client_init.sh v7+) runs an ICMP liveness
-    # check against the gateway pod IP before declaring the tunnel up.
-    # Without this, init fails → CrashLoopBackOff under default-deny.
-    # See memory project_pod_gateway_upstream_issues.md (#414).
+    # workaround: https://github.com/angelnu/pod-gateway/issues/414 — drop this ICMP-echo allow when pod-gateway liveness mechanic changes or pod-gateway is replaced
+    # Tracking: home-ops#11829
+    # The gateway-sidecar init container (angelnu/pod-gateway
+    # client_init.sh v7+) runs an ICMP liveness check against the
+    # gateway pod IP before declaring the tunnel up. Without this,
+    # init fails → CrashLoopBackOff under default-deny.
     - toEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: vpn

--- a/kubernetes/apps/downloads/kustomization.yaml
+++ b/kubernetes/apps/downloads/kustomization.yaml
@@ -5,18 +5,18 @@ kind: Kustomization
 namespace: downloads
 components:
   - ../../components/network-policy/baseline
-  # default-deny intentionally OMITTED for downloads ns. The pod-gateway
-  # sidecar's init container brings up a VXLAN tunnel to vpn/pod-gateway
-  # then runs `udhcpc` on vxlan0 to lease an IP. The DHCP discover is a
-  # 255.255.255.255 broadcast encapsulated inside the VXLAN unicast tunnel.
-  # Under cilium default-deny the broadcast return path (DHCP OFFER) is
-  # silently dropped — cilium's identity for the broadcast frame inside
-  # the tunnel doesn't match vpn/pod-gateway's identity. ICMP allow
-  # (PR #11548) was necessary but not sufficient: VXLAN tunnel comes
-  # up, then DHCP times out and the init container crashloops.
-  # Tracked in #11493 / pod-gateway upstream issues #414-#416.
-  # Revisit when cilium broadcast-identity handling improves or we
-  # replace pod-gateway with static-IP wireguard.
+  # workaround: https://github.com/angelnu/pod-gateway/issues/414 — re-add default-deny when pod-gateway DHCP-over-VXLAN works under Cilium default-deny (or when pod-gateway is replaced with a static-IP wireguard pattern)
+  # Tracking: home-ops#11829
+  # Detail: the pod-gateway sidecar's init container brings up a VXLAN
+  # tunnel to vpn/pod-gateway then runs `udhcpc` on vxlan0 to lease an
+  # IP. The DHCP discover is a 255.255.255.255 broadcast encapsulated
+  # inside the VXLAN unicast tunnel. Under cilium default-deny the
+  # broadcast return path (DHCP OFFER) is silently dropped — cilium's
+  # identity for the broadcast frame inside the tunnel doesn't match
+  # vpn/pod-gateway's identity. ICMP allow (PR #11548) was necessary
+  # but not sufficient: VXLAN tunnel comes up, then DHCP times out and
+  # the init container crashloops. Tracked in #11493 / pod-gateway
+  # upstream issues #414-#416.
 resources:
   - ./namespace.yaml
   - ./jdownloader2/ks.yaml

--- a/kubernetes/apps/downloads/prowlarr/app/cnp-allow.yaml
+++ b/kubernetes/apps/downloads/prowlarr/app/cnp-allow.yaml
@@ -54,11 +54,12 @@ spec:
         - ports:
             - port: "4789"
               protocol: UDP
-    # ICMP echo to the pod-gateway. The gateway-sidecar init container
-    # (angelnu/pod-gateway client_init.sh v7+) runs an ICMP liveness
-    # check against the gateway pod IP before declaring the tunnel up.
-    # Without this, init fails → CrashLoopBackOff under default-deny.
-    # See memory project_pod_gateway_upstream_issues.md (#414).
+    # workaround: https://github.com/angelnu/pod-gateway/issues/414 — drop this ICMP-echo allow when pod-gateway liveness mechanic changes or pod-gateway is replaced
+    # Tracking: home-ops#11829
+    # The gateway-sidecar init container (angelnu/pod-gateway
+    # client_init.sh v7+) runs an ICMP liveness check against the
+    # gateway pod IP before declaring the tunnel up. Without this,
+    # init fails → CrashLoopBackOff under default-deny.
     - toEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: vpn

--- a/kubernetes/apps/downloads/qbittorrent/app/cnp-allow.yaml
+++ b/kubernetes/apps/downloads/qbittorrent/app/cnp-allow.yaml
@@ -54,11 +54,12 @@ spec:
         - ports:
             - port: "4789"
               protocol: UDP
-    # ICMP echo to the pod-gateway. The gateway-sidecar init container
-    # (angelnu/pod-gateway client_init.sh v7+) runs an ICMP liveness
-    # check against the gateway pod IP before declaring the tunnel up.
-    # Without this, init fails → CrashLoopBackOff under default-deny.
-    # See memory project_pod_gateway_upstream_issues.md (#414).
+    # workaround: https://github.com/angelnu/pod-gateway/issues/414 — drop this ICMP-echo allow when pod-gateway liveness mechanic changes or pod-gateway is replaced
+    # Tracking: home-ops#11829
+    # The gateway-sidecar init container (angelnu/pod-gateway
+    # client_init.sh v7+) runs an ICMP liveness check against the
+    # gateway pod IP before declaring the tunnel up. Without this,
+    # init fails → CrashLoopBackOff under default-deny.
     - toEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: vpn

--- a/kubernetes/apps/downloads/sabnzbd/app/cnp-allow.yaml
+++ b/kubernetes/apps/downloads/sabnzbd/app/cnp-allow.yaml
@@ -48,11 +48,12 @@ spec:
         - ports:
             - port: "4789"
               protocol: UDP
-    # ICMP echo to the pod-gateway. The gateway-sidecar init container
-    # (angelnu/pod-gateway client_init.sh v7+) runs an ICMP liveness
-    # check against the gateway pod IP before declaring the tunnel up.
-    # Without this, init fails → CrashLoopBackOff under default-deny.
-    # See memory project_pod_gateway_upstream_issues.md (#414).
+    # workaround: https://github.com/angelnu/pod-gateway/issues/414 — drop this ICMP-echo allow when pod-gateway liveness mechanic changes or pod-gateway is replaced
+    # Tracking: home-ops#11829
+    # The gateway-sidecar init container (angelnu/pod-gateway
+    # client_init.sh v7+) runs an ICMP liveness check against the
+    # gateway pod IP before declaring the tunnel up. Without this,
+    # init fails → CrashLoopBackOff under default-deny.
     - toEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: vpn

--- a/kubernetes/apps/downloads/slskd/app/cnp-allow.yaml
+++ b/kubernetes/apps/downloads/slskd/app/cnp-allow.yaml
@@ -40,11 +40,12 @@ spec:
         - ports:
             - port: "4789"
               protocol: UDP
-    # ICMP echo to the pod-gateway. The gateway-sidecar init container
-    # (angelnu/pod-gateway client_init.sh v7+) runs an ICMP liveness
-    # check against the gateway pod IP before declaring the tunnel up.
-    # Without this, init fails → CrashLoopBackOff under default-deny.
-    # See memory project_pod_gateway_upstream_issues.md (#414).
+    # workaround: https://github.com/angelnu/pod-gateway/issues/414 — drop this ICMP-echo allow when pod-gateway liveness mechanic changes or pod-gateway is replaced
+    # Tracking: home-ops#11829
+    # The gateway-sidecar init container (angelnu/pod-gateway
+    # client_init.sh v7+) runs an ICMP liveness check against the
+    # gateway pod IP before declaring the tunnel up. Without this,
+    # init fails → CrashLoopBackOff under default-deny.
     - toEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: vpn

--- a/kubernetes/apps/longhorn-system/longhorn/app/helmrelease.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn/app/helmrelease.yaml
@@ -15,8 +15,8 @@ spec:
       version: 1.11.2
   interval: 30m
   values:
-    # preUpgradeChecker and image sections are workarounds until 1.11.1 is released
-    # https://github.com/longhorn/longhorn/issues/12573
+    # workaround: https://github.com/longhorn/longhorn/issues/12573 — remove preUpgradeChecker disables + v1.11.0-hotfix-1 image pins when longhorn v1.11.1 lands as a chart release
+    # Tracking: home-ops#11828
     defaultSettings:
       backupTarget: "nfs://beast:/mnt/mass_storage/longhorn-backups"
       createDefaultDiskLabeledNodes: true


### PR DESCRIPTION
## Summary

Initial sweep applying the `# workaround:` annotation convention established in `.agents/instructions/workarounds.md` (#11810).

## Workarounds annotated

| Upstream | Tracking | Files |
|---|---|---|
| [longhorn/longhorn#12573](https://github.com/longhorn/longhorn/issues/12573) | #11828 | `kubernetes/apps/longhorn-system/longhorn/app/helmrelease.yaml` |
| [angelnu/pod-gateway#414](https://github.com/angelnu/pod-gateway/issues/414) | #11829 | `kubernetes/apps/downloads/kustomization.yaml` + 5 `cnp-allow.yaml` files |

## Why the partial sweep

The convention requires a checkable upstream URL. Several other repo-known workarounds (immich-pet-tagger P40 fork, lidarr-sab-autoimport sidecar, renovate-operator Cilium toFQDNs) need a bit of upstream-issue research before they meet the convention's bar. Follow-up PRs will cover them as the URLs are pinned down.

## Pre-submit

- 7 files / 50 file-count limit
- yamllint: pass locally
- markdownlint: N/A (yaml-only changes)
- gitleaks: pass
- Data classification: download-namespace manifests are exempt per `.agents/instructions/data-classification.md` (the manifests stay; only narrative artifacts get redacted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)