### PR TITLE
feat(observability/tempo): add Tempo SingleBinary HelmRelease

### DIFF
--- a/.github/image-registry-allowlist.txt
+++ b/.github/image-registry-allowlist.txt
@@ -38,6 +38,7 @@ docker.io/rhasspy/wyoming-openwakeword
 docker.io/rhasspy/wyoming-piper
 docker.io/rhasspy/wyoming-whisper
 docker.io/grafana/mcp-grafana
+docker.io/grafana/tempo                # Grafana project canonical; ghcr publication missing
 docker.io/jmtvms/tplink-omada-mcp
 docker.io/isokoliuk/mcp-searxng
 docker.io/mekayelanik/time-mcp               # wraps yokingma stdio time-mcp; ghcr.io mirror exists but docker.io is primary

--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -31,4 +31,5 @@ resources:
   - ./netdata/ks.yaml
   - ./prometheus-operator-crds/ks.yaml
   - ./silence-operator/ks.yaml
+  - ./tempo/ks.yaml
   - ./vector/ks.yaml

--- a/kubernetes/apps/observability/tempo/app/cnp-allow.yaml
+++ b/kubernetes/apps/observability/tempo/app/cnp-allow.yaml
@@ -1,0 +1,43 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: tempo-allow
+spec:
+  # The single-binary chart deploys with `app.kubernetes.io/name: tempo`.
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: tempo
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # Grafana queries Tempo for trace data at port 3100 (HTTP).
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: observability
+            app.kubernetes.io/name: grafana
+      toPorts:
+        - ports:
+            - port: "3100"
+              protocol: TCP
+    # OTel collector (also in observability ns) pushes spans via OTLP
+    # gRPC 4317 and HTTP 4318. Cross-ns ingestion from ai/ namespace
+    # (langgraph-agents direct-OTLP path) covered by the same
+    # endpoint-selector match; we intentionally allow OTLP from any
+    # pod in the cluster to simplify Phase 3.K rollout. Tighten when
+    # the OTel collector becomes the canonical path.
+    - fromEntities:
+        - cluster
+      toPorts:
+        - ports:
+            - port: "4317"
+              protocol: TCP
+            - port: "4318"
+              protocol: TCP
+  egress:
+    # No external egress needed — single-binary mode with local
+    # storage. If metricsGenerator gets enabled later, add an egress
+    # rule to Prometheus remote-write endpoint.
+    []

--- a/kubernetes/apps/observability/tempo/app/configmap-grafana-datasource.yaml
+++ b/kubernetes/apps/observability/tempo/app/configmap-grafana-datasource.yaml
@@ -1,0 +1,42 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/configmap-v1.json
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tempo-grafana-datasource
+  labels:
+    # Picked up by Grafana's sidecar discovery (label key configured via
+    # the grafana HelmRelease's sidecar.datasources.label/labelValue;
+    # see `kubernetes/apps/observability/grafana/app/helmrelease.yaml`).
+    grafana_datasource: "1"
+data:
+  tempo-datasource.yaml: |
+    apiVersion: 1
+    datasources:
+      - name: Tempo
+        type: tempo
+        uid: tempo
+        access: proxy
+        url: http://tempo.observability.svc.cluster.local:3100
+        jsonData:
+          # Link traces ↔ logs ↔ metrics via these data sources.
+          tracesToLogsV2:
+            datasourceUid: loki
+            tags:
+              - key: service.name
+                value: service_name
+              - key: task_id
+                value: task_id
+          tracesToMetrics:
+            datasourceUid: prometheus
+            tags:
+              - key: service.name
+                value: service_name
+          serviceMap:
+            datasourceUid: prometheus
+          nodeGraph:
+            enabled: true
+          search:
+            hide: false
+          lokiSearch:
+            datasourceUid: loki

--- a/kubernetes/apps/observability/tempo/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/tempo/app/helmrelease.yaml
@@ -1,0 +1,115 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: tempo
+spec:
+  chart:
+    spec:
+      # renovate: registryUrl=https://grafana.github.io/helm-charts
+      chart: tempo
+      sourceRef:
+        kind: HelmRepository
+        name: grafana-charts
+        namespace: observability
+      version: 1.18.3
+  interval: 30m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    # Single-binary mode — distributed mode is unnecessary at home-ops
+    # scale. The chart deploys a single StatefulSet pod with embedded
+    # ingester, querier, compactor.
+
+    tempo:
+      # 14-day retention — long enough to investigate weekly patterns,
+      # short enough that the PVC stays sized at 50Gi.
+      retention: 336h
+
+      # OTLP receivers — Phase 3.K propagates `trace_id` from
+      # langgraph-agents (and any other OTel-instrumented workload)
+      # via the OTel collector deployed alongside (2.J2). Tempo accepts
+      # OTLP directly so a single-app pipeline (skip-collector) also
+      # works for early debugging.
+      receivers:
+        otlp:
+          protocols:
+            grpc:
+              endpoint: 0.0.0.0:4317
+            http:
+              endpoint: 0.0.0.0:4318
+        jaeger:
+          protocols: {}
+
+      # Metrics-generator OFF — adds Prom remote-write of trace-derived
+      # metrics. Useful long-term; not needed for the initial deploy.
+      # Enable when there's a concrete dashboard that needs it.
+      metricsGenerator:
+        enabled: false
+
+      # `local` backend writes blocks + WAL to the mounted PVC. The
+      # alternative is Garage-S3; using ceph-block keeps Tempo
+      # independent of Garage (which would otherwise be in the trace
+      # pipeline for its own observability — circular).
+      storage:
+        trace:
+          backend: local
+          local:
+            path: /var/tempo/traces
+          wal:
+            path: /var/tempo/wal
+
+      # Disable upstream Grafana telemetry / usage reporting.
+      reportingEnabled: false
+
+      # Per `.agents/instructions/helmrelease.security.md` defaults.
+      # Container-level securityContext; the chart's `tempo:` block
+      # wraps both runtime config and container security.
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop:
+            - ALL
+        seccompProfile:
+          type: RuntimeDefault
+
+      resources:
+        requests:
+          cpu: 100m
+          memory: 512Mi
+        limits:
+          memory: 2Gi
+
+    persistence:
+      enabled: true
+      storageClassName: ceph-block
+      size: 50Gi
+      accessModes:
+        - ReadWriteOnce
+
+    # ServiceMonitor for Prometheus scrape.
+    serviceMonitor:
+      enabled: true
+      interval: 30s
+
+    # Tempo is internal-only — no HTTPRoute. Grafana queries via the
+    # in-cluster Service.
+    tempoQuery:
+      enabled: false
+
+    # Pod-level security context.
+    podSecurityContext:
+      runAsNonRoot: true
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+      fsGroupChangePolicy: OnRootMismatch

--- a/kubernetes/apps/observability/tempo/app/kustomization.yaml
+++ b/kubernetes/apps/observability/tempo/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./cnp-allow.yaml
+  - ./configmap-grafana-datasource.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/observability/tempo/ks.yaml
+++ b/kubernetes/apps/observability/tempo/ks.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app tempo
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: observability
+  path: ./kubernetes/apps/observability/tempo/app
+  interval: 30m
+  timeout: 5m
+  prune: true
+  wait: false
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: kube-prometheus-stack
+      namespace: observability
+    - name: rook-ceph-cluster
+      namespace: rook-ceph


### PR DESCRIPTION
## Summary

Per HOMELAB-SPEC Layer 5 (OTel/Tempo trace destination) and the rollout plan's **[2.J1]** item. Lands the trace storage tier so Phase 3.K (`trace_id` propagation in langgraph-agents) has somewhere to send spans. 2.J2 (OTel collector) follows.

## What lands

| File | Purpose |
|---|---|
| `tempo/ks.yaml` | Flux Kustomization; depends on kube-prometheus-stack (ServiceMonitor CRD) + rook-ceph-cluster (ceph-block PVC) |
| `tempo/app/helmrelease.yaml` | grafana/tempo 1.18.3 SingleBinary, 14d retention, OTLP gRPC + HTTP receivers, local backend, 50Gi ceph-block PVC, ServiceMonitor, security defaults |
| `tempo/app/cnp-allow.yaml` | Grafana → :3100 + cluster-wide → :4317/:4318 OTLP |
| `tempo/app/configmap-grafana-datasource.yaml` | Grafana sidecar discovers; registers Tempo with trace↔log↔metric links |
| `tempo/app/kustomization.yaml` | Resource list |
| `observability/kustomization.yaml` | + `./tempo/ks.yaml` |

## Storage choice

`local` backend on ceph-block, **not** S3 via Garage.

1. **Independence** — Garage is itself a workload Tempo will trace. A trace pipeline that depends on Garage to investigate Garage incidents is circular.
2. **Simplicity** — local backend on a single-binary chart is the smallest moving part. S3 migration is a values change later if scale demands it.

## Retention + sizing

- Retention: 336h (14d)
- PVC: 50Gi
- Both are initial guesses; Prom alerts on PVC fill catch the wrong estimate well before exhaustion.

## Pre-submit

- `yamllint --strict .yamllint.yaml`: clean (caught a duplicate `tempo:` key before push; fixed)
- File-count: 6, well under 50
- Memory grep: aligns with `[[reference_predict_linear_sparse_data_false_positives]]` (new PVC has 0% used initially; the disk-fill alerting rule scopes correctly post-PR #11755)
- Data classification: internal-tier; no restricted names in any file

## Open follow-ups (separate PRs)

- **2.J2** OTel collector deploy (pushes to this Tempo)
- PrometheusRule for Tempo health (slow-query alerts, ingester saturation, PVC fill) — defer until first signal lands
- Migration to Garage-S3 backend — defer until storage signals demand it

🤖 Generated with [Claude Code](https://claude.com/claude-code)