### PR TITLE
feat(observability/opentelemetry-collector): add OTel collector → Tempo pipeline

### DIFF
--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -29,6 +29,7 @@ resources:
   - ./kube-state-metrics/ks.yaml
   - ./loki/ks.yaml
   - ./netdata/ks.yaml
+  - ./opentelemetry-collector/ks.yaml
   - ./prometheus-operator-crds/ks.yaml
   - ./silence-operator/ks.yaml
   - ./vector/ks.yaml

--- a/kubernetes/apps/observability/opentelemetry-collector/app/cnp-allow.yaml
+++ b/kubernetes/apps/observability/opentelemetry-collector/app/cnp-allow.yaml
@@ -1,0 +1,49 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: opentelemetry-collector-allow
+spec:
+  # Chart deploys with `app.kubernetes.io/name: opentelemetry-collector`.
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: opentelemetry-collector
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # Cluster-wide OTLP ingress. Any pod (langgraph-agents, MCP
+    # backends, future OTel-instrumented apps) can push spans to the
+    # collector at :4317 (gRPC) or :4318 (HTTP). The k8sattributes
+    # processor in the pipeline tags every span with source pod
+    # metadata, so we don't lose attribution by accepting from
+    # `cluster` entities.
+    - fromEntities:
+        - cluster
+      toPorts:
+        - ports:
+            - port: "4317"
+              protocol: TCP
+            - port: "4318"
+              protocol: TCP
+  egress:
+    # Push to Tempo's OTLP gRPC receiver in the same namespace.
+    # Intra-ns is allowed by the baseline; this rule documents the
+    # dependency explicitly.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: observability
+            app.kubernetes.io/name: tempo
+      toPorts:
+        - ports:
+            - port: "4317"
+              protocol: TCP
+    # k8sattributes processor needs to query the kube-apiserver for
+    # pod metadata. Allow egress to the apiserver (kube-system).
+    - toEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "6443"
+              protocol: TCP

--- a/kubernetes/apps/observability/opentelemetry-collector/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/opentelemetry-collector/app/helmrelease.yaml
@@ -29,7 +29,10 @@ spec:
     mode: deployment
     replicaCount: 1
     image:
-      repository: otel/opentelemetry-collector-contrib
+      # Prefer ghcr.io publication per repo policy
+      # (.github/image-registry-allowlist.txt). The chart's default
+      # `otel/opentelemetry-collector-contrib` is Docker Hub.
+      repository: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
 
     # Chart presets — pre-baked config blocks. We enable the
     # kubernetesAttributes preset so spans get k8s.namespace.name,

--- a/kubernetes/apps/observability/opentelemetry-collector/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/opentelemetry-collector/app/helmrelease.yaml
@@ -1,0 +1,130 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: opentelemetry-collector
+spec:
+  chart:
+    spec:
+      # renovate: registryUrl=https://open-telemetry.github.io/opentelemetry-helm-charts
+      chart: opentelemetry-collector
+      sourceRef:
+        kind: HelmRepository
+        name: open-telemetry-charts
+        namespace: observability
+      version: 0.118.0
+  interval: 30m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    # Required by the chart (no default).
+    mode: deployment
+    replicaCount: 1
+    image:
+      repository: otel/opentelemetry-collector-contrib
+
+    # Chart presets — pre-baked config blocks. We enable the
+    # kubernetesAttributes preset so spans get k8s.namespace.name,
+    # k8s.pod.name, etc. attached automatically (uses the collector's
+    # `k8sattributes` processor and the chart's pre-built RBAC).
+    presets:
+      kubernetesAttributes:
+        enabled: true
+        extractAllPodLabels: false
+        extractAllPodAnnotations: false
+      # Logs go to Loki via Vector — we don't need OTel for log
+      # collection.
+      logsCollection:
+        enabled: false
+      # Host metrics handled by node-exporter; not OTel's job here.
+      hostMetrics:
+        enabled: false
+
+    # Override the chart's default config block with our own.
+    # `mode: deployment` + traces-only pipeline; no metrics/logs
+    # forwarding in this collector (those have their own paths via
+    # Prom scrape and Vector → Loki).
+    config:
+      receivers:
+        otlp:
+          protocols:
+            grpc:
+              endpoint: 0.0.0.0:4317
+            http:
+              endpoint: 0.0.0.0:4318
+
+      processors:
+        # `kubernetesAttributes` preset injects this; declared
+        # explicitly so the pipeline reference is unambiguous.
+        k8sattributes: {}
+
+        memory_limiter:
+          check_interval: 1s
+          limit_percentage: 75
+          spike_limit_percentage: 25
+
+        # Batch spans into ~1s batches; reduces Tempo write pressure.
+        batch:
+          timeout: 1s
+          send_batch_size: 1024
+
+      exporters:
+        # Push to the local Tempo SingleBinary OTLP receiver.
+        otlp/tempo:
+          endpoint: tempo.observability.svc.cluster.local:4317
+          tls:
+            insecure: true
+
+        debug:
+          verbosity: basic
+
+      service:
+        # Healthz + zpages for chart probes.
+        extensions: [health_check]
+        pipelines:
+          traces:
+            receivers: [otlp]
+            processors: [memory_limiter, k8sattributes, batch]
+            exporters: [otlp/tempo]
+        telemetry:
+          logs:
+            level: info
+
+      extensions:
+        health_check:
+          endpoint: 0.0.0.0:13133
+
+    # ServiceMonitor for the collector's own Prom metrics endpoint.
+    serviceMonitor:
+      enabled: true
+      interval: 30s
+
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        memory: 1Gi
+
+    # Per `.agents/instructions/helmrelease.security.md`.
+    securityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop:
+          - ALL
+      seccompProfile:
+        type: RuntimeDefault
+    podSecurityContext:
+      runAsNonRoot: true
+      runAsUser: 10001
+      runAsGroup: 10001
+      fsGroupChangePolicy: OnRootMismatch

--- a/kubernetes/apps/observability/opentelemetry-collector/app/helmrepository.yaml
+++ b/kubernetes/apps/observability/opentelemetry-collector/app/helmrepository.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: open-telemetry-charts
+spec:
+  interval: 2h
+  url: https://open-telemetry.github.io/opentelemetry-helm-charts
+  timeout: 3m

--- a/kubernetes/apps/observability/opentelemetry-collector/app/kustomization.yaml
+++ b/kubernetes/apps/observability/opentelemetry-collector/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./cnp-allow.yaml
+  - ./helmrelease.yaml
+  - ./helmrepository.yaml

--- a/kubernetes/apps/observability/opentelemetry-collector/ks.yaml
+++ b/kubernetes/apps/observability/opentelemetry-collector/ks.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app opentelemetry-collector
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: observability
+  path: ./kubernetes/apps/observability/opentelemetry-collector/app
+  interval: 30m
+  timeout: 5m
+  prune: true
+  wait: false
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: kube-prometheus-stack
+      namespace: observability
+    - name: tempo
+      namespace: observability


### PR DESCRIPTION
## Summary

Per HOMELAB-SPEC Layer 5 (OTel pipeline) and the rollout plan's **[2.J2]** item. Stands up the OTLP collector that Phase 3.K wires langgraph-agents into. Pairs with 2.J1 (Tempo, #11833).

## Pipeline shape

```
langgraph-agents → otel-collector :4317
                     → memory_limiter (75% / 25%)
                     → k8sattributes (tag with k8s.* metadata)
                     → batch (1s, 1024 spans)
                   → tempo :4317 (OTLP gRPC)
```

Other observability sources (Prometheus scrape, Vector → Loki for logs) keep their existing paths. This collector exists **for traces only**; metrics + logs collection presets are explicitly disabled.

## What lands

| File | Purpose |
|---|---|
| `opentelemetry-collector/ks.yaml` | Flux Kustomization; depends on kube-prometheus-stack + tempo |
| `opentelemetry-collector/app/helmrepository.yaml` | New HelmRepository for `open-telemetry/opentelemetry-helm-charts` |
| `opentelemetry-collector/app/helmrelease.yaml` | Chart 0.118.0, Deployment mode (single replica), `kubernetesAttributes` preset enabled, custom traces-only pipeline, ServiceMonitor, security defaults |
| `opentelemetry-collector/app/cnp-allow.yaml` | Cluster-wide OTLP ingress at :4317/:4318; egress to Tempo + kube-apiserver (for k8sattributes processor) |
| `opentelemetry-collector/app/kustomization.yaml` | Resource list |
| `observability/kustomization.yaml` | Adds the entry |

## Coordination with #11833

Both PRs edit `observability/kustomization.yaml`. Trivial merge conflict — whichever lands first leaves the second one a rebase.

## Pre-submit

- `yamllint --strict .yamllint.yaml`: clean
- File-count: 6 + 1 modify, under 50
- Data classification: internal-tier only

## Open follow-ups

- Phase 3.K wires langgraph-agents to push spans here. Endpoint will be `opentelemetry-collector.observability.svc.cluster.local:4317`.
- Once 3.K shows real traces, tighten `cnp-allow.yaml` from `fromEntities: cluster` to specific source namespaces (ai, mcp-system, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)