### PR TITLE
feat(ai/langgraph-agents): CNP egress to Dragonfly for Phase 3.G dedup

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/cnp-allow.yaml
@@ -89,6 +89,19 @@ spec:
         - ports:
             - port: "80"
               protocol: TCP
+    # Dragonfly in databases ns — idempotency-key dedup store backing
+    # the /inbox handler. Phase 3.G; see
+    # langgraph-agents `src/agents/idempotency.py`. Dragonfly pods carry
+    # `app.kubernetes.io/part-of: dragonfly` (set by the operator from
+    # the Dragonfly CR's topology selector).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
+            app.kubernetes.io/part-of: dragonfly
+      toPorts:
+        - ports:
+            - port: "6379"
+              protocol: TCP
     # External APIs: api.pushover.net for Tier-1 alert escalations,
     # api.anthropic.com for the Claude API gated on ENABLE_CLAUDE_API.
     #


### PR DESCRIPTION
## Summary

Wire-side companion to langgraph-agents [#51](https://github.com/rwlove/langgraph-agents/pull/51) (idempotency dedup at /inbox).

The DedupStore connects to `dragonfly.databases.svc.cluster.local:6379` — without this CNP egress allow, the connection silently fails and the store gracefully degrades (returning None for every `check_and_set` call). This PR ships the allow so dedup actually works.

## What changed

One new egress block in `kubernetes/apps/ai/langgraph-agents/app/cnp-allow.yaml`:

```yaml
- toEndpoints:
    - matchLabels:
        io.kubernetes.pod.namespace: databases
        app.kubernetes.io/part-of: dragonfly
  toPorts:
    - ports:
        - port: "6379"
          protocol: TCP
```

Selector: `app.kubernetes.io/part-of: dragonfly` — matches the operator's pod label per the Dragonfly CR's `topologySpreadConstraints`.

## Behavior without this PR

Pods running the new `feat/spec-3g-idempotency` lga build still serve requests; they just under-dedup. The DedupStore's PING fails on first connection, logs a structured `dedup_store_unavailable` warning, and `check_and_set` returns None thereafter. No /inbox failures.

## Pre-submit

- 1 file changed
- yamllint clean
- Aligned with existing CNP comment-style + Pattern B (cross-ns endpoint match)

🤖 Generated with [Claude Code](https://claude.com/claude-code)