### PR TITLE
feat(kube-system/kyverno): deploy Kyverno admission controller (5.O1)

### DIFF
--- a/kubernetes/apps/kube-system/kustomization.yaml
+++ b/kubernetes/apps/kube-system/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
   - ./intel-device-plugin/ks.yaml
   - ./k8tz/ks.yaml
   - ./kubelet-csr-approver/ks.yaml
+  - ./kyverno/ks.yaml
   - ./metrics-server/ks.yaml
   - ./node-feature-discovery/ks.yaml
   - ./node-problem-detector/ks.yaml

--- a/kubernetes/apps/kube-system/kyverno/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/kyverno/app/helmrelease.yaml
@@ -1,0 +1,94 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kyverno
+spec:
+  chart:
+    spec:
+      # renovate: registryUrl=https://kyverno.github.io/kyverno
+      chart: kyverno
+      sourceRef:
+        kind: HelmRepository
+        name: kyverno-charts
+        namespace: kube-system
+      version: 3.3.7
+  interval: 30m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    # Per HOMELAB-SPEC Layer 5 (blast-radius enforcement) and the
+    # rollout plan's [5.O1] item. This PR ships the controller; the
+    # rules ride along separately in [5.O2] in audit mode. Promotion
+    # to enforce mode (5.O3) is a separate destructive PR per the
+    # 2026-05-20 decision (D-A).
+
+    # Single-replica admission controller — homelab scale. The chart
+    # supports HA (3+ replicas with leader election) but it's overkill
+    # here and adds restart-time complexity during upgrades.
+    admissionController:
+      replicas: 1
+      container:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            memory: 512Mi
+      serviceMonitor:
+        enabled: true
+
+    backgroundController:
+      replicas: 1
+      resources:
+        requests:
+          cpu: 50m
+          memory: 128Mi
+        limits:
+          memory: 256Mi
+
+    cleanupController:
+      replicas: 1
+      resources:
+        requests:
+          cpu: 50m
+          memory: 128Mi
+        limits:
+          memory: 256Mi
+
+    reportsController:
+      replicas: 1
+      resources:
+        requests:
+          cpu: 50m
+          memory: 128Mi
+        limits:
+          memory: 256Mi
+
+    # CRDs install with the chart. Subsequent chart upgrades update
+    # them per the upstream releaseclass.
+    crds:
+      install: true
+
+    # Fail-open at the webhook level: if the admission controller
+    # itself is unhealthy, requests pass rather than fail. This is
+    # the safer default for an initial deploy where Kyverno owning
+    # admission is new territory. Per-policy `failurePolicy` can be
+    # tightened later for specific rules.
+    config:
+      webhooks:
+        - failurePolicy: Ignore
+
+    # Policy reports — Kyverno generates `PolicyReport` CRs that
+    # ServiceMonitor + Grafana can scrape. Audit-mode rules in 5.O2
+    # write to these.
+    reports-server:
+      enabled: false  # using built-in reports controller

--- a/kubernetes/apps/kube-system/kyverno/app/helmrepository.yaml
+++ b/kubernetes/apps/kube-system/kyverno/app/helmrepository.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: kyverno-charts
+spec:
+  interval: 2h
+  url: https://kyverno.github.io/kyverno
+  timeout: 3m

--- a/kubernetes/apps/kube-system/kyverno/app/kustomization.yaml
+++ b/kubernetes/apps/kube-system/kyverno/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./helmrepository.yaml

--- a/kubernetes/apps/kube-system/kyverno/ks.yaml
+++ b/kubernetes/apps/kube-system/kyverno/ks.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app kyverno
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: kube-system
+  path: ./kubernetes/apps/kube-system/kyverno/app
+  interval: 30m
+  timeout: 5m
+  prune: true
+  wait: false
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system


### PR DESCRIPTION
## Summary

Per HOMELAB-SPEC **Layer 5 blast-radius enforcement** and the rollout plan's **[5.O1]** item. Closes step 1 of the audit-flagged "no blast-radius enforcement" gap.

**Controller only — no policies.** The audit-mode rule set lands separately in [5.O2]; promotion to enforce mode (5.O3) is destructive and gated to a follow-on session per the 2026-05-20 D-A decision.

## What lands

| File | Purpose |
|---|---|
| `kyverno/ks.yaml` | Flux Kustomization, kube-system targetNamespace |
| `kyverno/app/helmrepository.yaml` | `kyverno-charts` HelmRepository |
| `kyverno/app/helmrelease.yaml` | Chart 3.3.7, single-replica controllers, fail-open webhook |
| `kyverno/app/kustomization.yaml` | Resource list |
| `kube-system/kustomization.yaml` | + `./kyverno/ks.yaml` |

## Configuration choices

- **Single-replica** admission / background / cleanup / reports controllers — homelab scale; HA mode is overkill
- **`failurePolicy: Ignore`** at the webhook level — fail-OPEN initially. If Kyverno itself is unhealthy, admission requests pass rather than fail. Per-policy `failurePolicy` can be tightened later for specific rules
- **ServiceMonitor enabled** on admission controller
- **CRDs install with the chart** — subsequent upgrades update them per upstream releaseclass

Resources: ~250m CPU + 1Gi memory aggregate across the four controllers. Well within kube-system budget.

## Pre-submit

- yamllint clean (caught a duplicate `admissionController:` key pre-push; consolidated)
- 5 files, 1 modify
- Data classification: internal-tier only

## Followup (5.O2)

Audit-mode ClusterPolicy rules per blast-radius spec:
- Namespace-delete requires explicit annotation
- (Other rules per soak data later)

🤖 Generated with [Claude Code](https://claude.com/claude-code)