### PR TITLE
feat(glance): add missing dashboard entries for 7 services

### DIFF
--- a/kubernetes/apps/ai/khoj-oauth2-proxy/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/khoj-oauth2-proxy/app/helmrelease.yaml
@@ -82,6 +82,10 @@ spec:
             port: 4180
     route:
       app:
+        annotations:
+          glance/name: "Khoj"
+          glance/show: "true"
+          glance/id: "AI"
         hostnames:
           - khoj.${SECRET_DOMAIN}
         parentRefs:

--- a/kubernetes/apps/ai/langfuse/app/route.yaml
+++ b/kubernetes/apps/ai/langfuse/app/route.yaml
@@ -4,6 +4,10 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: langfuse
+  annotations:
+    glance/name: "Langfuse"
+    glance/show: "true"
+    glance/id: "AI"
 spec:
   hostnames:
     - "langfuse.${SECRET_DOMAIN}"

--- a/kubernetes/apps/auth/authelia/app/helmrelease.yaml
+++ b/kubernetes/apps/auth/authelia/app/helmrelease.yaml
@@ -90,6 +90,11 @@ spec:
             port: 9959
     route:
       app:
+        annotations:
+          glance/name: "Authelia"
+          glance/show: "true"
+          glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/authelia.png"
+          glance/id: "Security"
         hostnames:
           - "auth.${SECRET_DOMAIN}"
         parentRefs:

--- a/kubernetes/apps/auth/lldap/app/helmrelease.yaml
+++ b/kubernetes/apps/auth/lldap/app/helmrelease.yaml
@@ -73,6 +73,11 @@ spec:
 
     route:
       app:
+        annotations:
+          glance/name: "LLDAP"
+          glance/show: "true"
+          glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/lldap.png"
+          glance/id: "Security"
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
         parentRefs:

--- a/kubernetes/apps/media/soularr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/soularr/app/helmrelease.yaml
@@ -69,6 +69,10 @@ spec:
 
     route:
       app:
+        annotations:
+          glance/name: "Soularr"
+          glance/show: "true"
+          glance/id: "Media"
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
         parentRefs:

--- a/kubernetes/apps/network/wg-easy/app/helmrelease.yaml
+++ b/kubernetes/apps/network/wg-easy/app/helmrelease.yaml
@@ -87,6 +87,11 @@ spec:
 
     route:
       web:
+        annotations:
+          glance/name: "WireGuard Easy"
+          glance/show: "true"
+          glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/wireguard.png"
+          glance/id: "Network"
         hostnames:
           - "wg-easy.${SECRET_DOMAIN}"
         parentRefs:

--- a/kubernetes/apps/observability/holmesgpt/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/holmesgpt/app/helmrelease.yaml
@@ -79,6 +79,10 @@ spec:
             port: 8080
     route:
       app:
+        annotations:
+          glance/name: "HolmesGPT"
+          glance/show: "true"
+          glance/id: "Observability"
         hostnames:
           - "holmesgpt.${SECRET_DOMAIN}"
         parentRefs:


### PR DESCRIPTION
## Summary

Adds `glance/show: \"true\"` (plus `glance/name`, `glance/id`, and `glance/icon` where available) to seven HTTPRoutes so the admin Glance auto-discovery extension surfaces them on `glance.${SECRET_DOMAIN}`.

These were the seven user-facing UIs found by an audit of all HTTPRoutes against the `glance-k8s-extension`'s annotation triplet — they all have UIs but were silently missing from the dashboard.

## Entries added

| App | Category | Icon |
|---|---|---|
| khoj | AI | — (not in homarr-labs catalog) |
| langfuse | AI | — (not in homarr-labs catalog) |
| authelia | Security | authelia.png |
| lldap | Security | lldap.png |
| soularr | Media | — (not in homarr-labs catalog) |
| wg-easy | Network | wireguard.png |
| holmesgpt | Observability | — (not in homarr-labs catalog) |

## Explicitly excluded

- `start.${SECRET_DOMAIN}` (glance-user) — that's Renee's curated start page; including it on admin Glance would be circular.
- MCP servers (`*.mcp.local`, 16 entries), gateway plumbing, programmatic webhooks, and pure-API endpoints (atuin sync, obsidian-couchdb, ollama, kromgo) — not dashboard candidates.

## Follow-up (not in this PR)

- The 10 apps with `glance/show: \"true\"` but no `glance/icon` (medikeep, nametag, pump, av1corrector, cutvideo, medialyze, videodupfinder, whoami, blackbox-exporter, kube-ops-view) — most are local/custom so homarr-labs doesn't have icons. Worth a separate sweep with `selfh.st` or upstream-favicon fallbacks.
- `home/ntfy` and `home/windmill` use `glance/id: \"Automation\"` but the admin Glance config only has a `Home Automation` widget — they currently fall into the Uncategorized card. Fix is one annotation rename or one widget addition.

## Test plan

- [ ] Flux reconciles each app's `HelmRelease` / `HTTPRoute` without rollout (annotations are metadata-only — no pod restart)
- [ ] `kubectl get httproute -n <ns> <name> -o jsonpath='{.metadata.annotations}'` shows the new annotations
- [ ] Admin Glance at `glance.${SECRET_DOMAIN}` shows each new tile under the expected category card
- [ ] Icons render for authelia / lldap / wg-easy

🤖 Generated with [Claude Code](https://claude.com/claude-code)