### PR TITLE
chore(collab/glance): remove cruft and add Automation widget

### DIFF
--- a/kubernetes/apps/collab/glance/app/resources/glance.yml
+++ b/kubernetes/apps/collab/glance/app/resources/glance.yml
@@ -36,6 +36,13 @@ pages:
                 annotations["glance/id"] == "AI" and
                 ("glance/hide" in annotations || annotations["glance/show"] == "true")
           - <<: *apps-by-id
+            title: Automation
+            parameters:
+              show-if: |
+                namespace != "kube-system" and
+                annotations["glance/id"] == "Automation" and
+                ("glance/hide" in annotations || annotations["glance/show"] == "true")
+          - <<: *apps-by-id
             title: Collaboration
             parameters:
               show-if: |
@@ -55,13 +62,6 @@ pages:
               show-if: |
                 namespace != "kube-system" and
                 annotations["glance/id"] == "Downloads" and
-                ("glance/hide" in annotations || annotations["glance/show"] == "true")
-          - <<: *apps-by-id
-            title: Fitness
-            parameters:
-              show-if: |
-                namespace != "kube-system" and
-                annotations["glance/id"] == "Fitness" and
                 ("glance/hide" in annotations || annotations["glance/show"] == "true")
           - <<: *apps-by-id
             title: Home Automation
@@ -149,14 +149,8 @@ pages:
                   - title: Pi-Hole (Unbound)
                     url: https://pihole.${SECRET_DOMAIN}/admin/
                     icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/pi-hole-unbound.png
-                  # - title: News page
-                  #   url: https://glance.juno.moe/news
                   - title: Home-Ops Repo
                     url: https://github.com/rwlove/home-ops
-              # - title: Git Cleaner
-              #   url: https://gitcleaner.com
-              # - title: GitHub Folder Download
-              #   url: https://download-directory.github.io
 
               - title: Kubernetes
                 color: 115 60 30
@@ -174,32 +168,9 @@ pages:
                   - title: BGP View
                     url: https://bgp.he.net
 
-              # - title: Security Intelligence
-              #   color: 347 70 35
-              #   links:
-              #     - title: Shodan
-              #       url: https://shodan.io
-              #     - title: GreyNoise
-              #       url: https://greynoise.io
-              #     - title: Intel X
-              #       url: https://intelx.io
-              #     - title: GrayHatWarfare
-              #       url: https://grayhatwarfare.com
-
-              # - title: Personal
-              #   color: 160 50 50
-              #   links:
-              #     - title: Music (Squid)
-              #       url: https://tidal.squid.wtf/
-              #     - title: Diving Sites
-              #       url: https://divesites.com
-              #     - title: Selfhosted blog
-              #       url: https://selfh.st
               - title: Utilities
                 color: 270 50 50
                 links:
-                  # - title: Download book
-                  #   url: https://z-lib.gd/
                   - title: Dashboard Icons
                     url: https://dashboardicons.com/
 
@@ -224,10 +195,6 @@ pages:
         widgets:
           - type: group
             widgets:
-              # - type: hacker-news
-              #   sort-by: best
-              #   limit: 18
-              #   collapse-after: 10
               - type: lobsters
                 sort-by: hot
                 limit: 18
@@ -246,27 +213,6 @@ pages:
                 limit: 15
                 collapse-after: 10
                 comments-url-template: "https://redlib.lol/{POST-PATH}"
-              # - type: reddit
-              #   subreddit: europe
-              #   show-thumbnails: true
-              #   sort-by: "top"
-              #   limit: 15
-              #   collapse-after: 10
-              #   comments-url-template: "https://redlib.lol/{POST-PATH}"
-              # - type: reddit
-              #   subreddit: plex
-              #   show-thumbnails: true
-              #   sort-by: "top"
-              #   limit: 15
-              #   collapse-after: 10
-              #   comments-url-template: "https://redlib.lol/{POST-PATH}"
-              # - type: reddit
-              #   subreddit: chatgpt
-              #   show-thumbnails: true
-              #   sort-by: "top"
-              #   limit: 15
-              #   collapse-after: 10
-              #   comments-url-template: "https://redlib.lol/{POST-PATH}"
               - type: reddit
                 subreddit: NonCredibleDefense
                 show-thumbnails: true


### PR DESCRIPTION
## Summary

Audit of the admin Glance config found two real issues plus ~50 lines of stale commented-out content.

## Real issues

- **Add `Automation` widget.** `home/ntfy` and `home/windmill` already use `glance/id: \"Automation\"` but the config only had a `Home Automation` widget, so both apps were silently falling into the Uncategorized card.
- **Delete the `Fitness` widget.** No app annotates `glance/id: \"Fitness\"`, and there's no `kubernetes/apps/fitness/` namespace — the card was always empty.

## Commented-out content removed (~50 lines)

| Removed | Why |
|---|---|
| \"News page\" bookmark (juno.moe) | Third-party, never used |
| \"Git Cleaner\" + \"GitHub Folder Download\" bookmarks | Never enabled |
| Entire \"Security Intelligence\" group (Shodan, GreyNoise, Intel X, GrayHatWarfare) | 11 lines, never enabled |
| Entire \"Personal\" group (Squid music, divesites, selfh.st) | 9 lines, never enabled |
| Z-Lib \"Download book\" bookmark | Never enabled |
| `hacker-news` widget | Replaced by lobsters; commented for months |
| r/europe, r/plex, r/chatgpt reddit feeds | Never enabled |

Net diff: +7/-61 lines, YAML still parses.

## Test plan

- [ ] Flux reconciles the ConfigMap and Glance picks up the new config (no pod restart needed; Glance reloads on file change)
- [ ] `glance.${SECRET_DOMAIN}` renders the new `Automation` card with ntfy + windmill in it
- [ ] No empty `Fitness` card
- [ ] News page still shows lobsters + r/selfhosted + r/kubernetes + r/NonCredibleDefense

⚠️ **Blocked on #11848** until kyverno is fixed on main (CI's `helm template kyverno` still fails). After that PR lands, this one should clear next CI cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)