### PR TITLE
feat: DLQ watcher + queue dashboard (Phase 4.M3 home-ops side)

### DIFF
--- a/kubernetes/apps/home/windmill/workflows/langgraph-dlq-watcher.ts
+++ b/kubernetes/apps/home/windmill/workflows/langgraph-dlq-watcher.ts
@@ -1,0 +1,122 @@
+// Cron: every 5 minutes.
+//
+// Phase 4.M3 — DLQ surface. Polls langgraph-agents `/admin/dlq` and
+// posts new entries to Zulip `operations` topic with action buttons
+// (ack / inspect). Tracks last-seen ULID via Windmill state to avoid
+// re-posting.
+//
+// Companion to lga 4.M3 (`/admin/dlq` endpoints + Phase 4.M2 worker
+// that writes to task_dlq on terminal failure).
+
+import * as wmill from "https://deno.land/x/wmill@v1.470.0/mod.ts";
+
+type DlqEntry = {
+    id: string;
+    envelope: Record<string, unknown>;
+    attempts: number;
+    last_error: string | null;
+    dlq_at: string | null;
+};
+
+const LG_BASE = "http://langgraph-agents.ai.svc.cluster.local:8765";
+const STATE_KEY = "f/lovenet/langgraph_dlq_last_seen_id";
+
+export async function main() {
+    const lastSeen = await getLastSeen();
+
+    const url = lastSeen
+        ? `${LG_BASE}/admin/dlq?since_id=${encodeURIComponent(lastSeen)}&limit=20`
+        : `${LG_BASE}/admin/dlq?limit=20`;
+    const resp = await fetch(url, { signal: AbortSignal.timeout(15_000) });
+    if (!resp.ok) {
+        return { skip: true, reason: `GET /admin/dlq returned HTTP ${resp.status}` };
+    }
+    const entries = (await resp.json().catch(() => [])) as DlqEntry[];
+    if (!Array.isArray(entries) || entries.length === 0) {
+        return { posted: 0, last_seen: lastSeen };
+    }
+
+    // Entries arrive newest-first. We need to post oldest-first so the
+    // operator reads them in chronological order; reverse before iterating.
+    const ordered = [...entries].reverse();
+    let postedCount = 0;
+    let newestId = lastSeen ?? "";
+
+    for (const e of ordered) {
+        await postToZulip(e);
+        postedCount += 1;
+        if (e.id > newestId) newestId = e.id;
+    }
+
+    await setLastSeen(newestId);
+    return { posted: postedCount, last_seen: newestId };
+}
+
+async function getLastSeen(): Promise<string | null> {
+    try {
+        const value = await wmill.getState();
+        if (typeof value === "string" && value.length > 0) return value;
+        if (value && typeof value === "object" && "last_id" in value) {
+            return (value as { last_id: string }).last_id;
+        }
+        return null;
+    } catch {
+        return null;
+    }
+}
+
+async function setLastSeen(id: string): Promise<void> {
+    try {
+        await wmill.setState({ last_id: id, updated_at: new Date().toISOString() });
+    } catch {
+        // Non-fatal — next run picks up newer entries via the SQL `since_id`
+        // filter regardless.
+    }
+}
+
+async function postToZulip(entry: DlqEntry): Promise<void> {
+    const email = Deno.env.get("ZULIP_BOT_EMAIL");
+    const apiKey = Deno.env.get("ZULIP_BOT_API_KEY");
+    if (!email || !apiKey) {
+        console.error("zulip creds not configured; skipping post");
+        return;
+    }
+    const auth = "Basic " + btoa(`${email}:${apiKey}`);
+    const zulipApiUrl = Deno.env.get("ZULIP_API_URL") ?? "http://zulip.collab.svc.cluster.local";
+
+    const env = entry.envelope;
+    const taskIdHint = (env.task_id as string) ?? entry.id;
+    const source = (env.source as string) ?? "unknown";
+    const user = (env.user as string) ?? "unknown";
+    const errSnippet = (entry.last_error ?? "").slice(0, 1200);
+
+    const content = [
+        `🪦 **DLQ task** \`${entry.id}\``,
+        `Client task_id: \`${taskIdHint}\``,
+        `Source: \`${source}\` · User: \`${user}\` · Attempts: ${entry.attempts}`,
+        `Failed at: ${entry.dlq_at ?? "(unknown)"}`,
+        ``,
+        `\`\`\``,
+        errSnippet || "(no error message)",
+        `\`\`\``,
+        ``,
+        `Ack and drop:`,
+        `  \`curl -X DELETE ${LG_BASE}/admin/dlq/${entry.id}\``,
+    ].join("\n");
+
+    const form = new URLSearchParams({
+        type: "stream",
+        to: "operations",
+        topic: `dlq-${(entry.dlq_at ?? "").slice(0, 10) || "unknown"}`,
+        content,
+    });
+    await fetch(`${zulipApiUrl}/api/v1/messages`, {
+        method: "POST",
+        headers: {
+            Authorization: auth,
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: form,
+        signal: AbortSignal.timeout(15_000),
+    }).catch(() => {});
+}

--- a/kubernetes/apps/observability/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/grafana/app/helmrelease.yaml
@@ -123,6 +123,11 @@ spec:
         langgraph-agents:
           datasource: Prometheus
           url: https://raw.githubusercontent.com/rwlove/home-ops/main/kubernetes/apps/observability/grafana/dashboards/langgraph-agents.json
+        task-queue:
+          # Phase 4.M3 — queue lifecycle + DLQ rollup. Loki-sourced;
+          # event labels emitted by `agents.queue.{store,worker}`.
+          datasource: Loki
+          url: https://raw.githubusercontent.com/rwlove/home-ops/main/kubernetes/apps/observability/grafana/dashboards/task-queue.json
       cert-manager:
         overview:
           url: https://raw.githubusercontent.com/monitoring-mixins/website/refs/heads/master/assets/cert-manager/dashboards/cert-manager-overview.json

--- a/kubernetes/apps/observability/grafana/dashboards/task-queue.json
+++ b/kubernetes/apps/observability/grafana/dashboards/task-queue.json
@@ -1,0 +1,200 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "description": "Task lifecycle events emitted by langgraph-agents (structlog → Vector → Loki). Per HOMELAB-SPEC Layer 5 task queue.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "sum by (event) (rate({namespace=\"ai\", app=\"langgraph-agents\"} |~ \"task_(enqueued|dequeued|acked|nacked|to_dlq|completed)\" | json | __error__ != \"JSONParserErr\" [5m]))",
+          "legendFormat": "{{event}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Task lifecycle event rate (5m)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "description": "DLQ landings — terminal failures past retry policy. Each event is one task moved to task_dlq.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 5 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "sum(count_over_time({namespace=\"ai\", app=\"langgraph-agents\"} |= \"task_to_dlq\" [1h]))",
+          "refId": "A"
+        }
+      ],
+      "title": "DLQ in last 1h",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "description": "Most-recent dequeue events with worker_id + attempts.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 18,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "{namespace=\"ai\", app=\"langgraph-agents\"} |= \"task_to_dlq\" | json",
+          "refId": "A"
+        }
+      ],
+      "title": "Recent DLQ entries (log scroll)",
+      "type": "logs"
+    }
+  ],
+  "preload": false,
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["langgraph-agents", "queue"],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Task Queue",
+  "uid": "langgraph-task-queue",
+  "version": 1,
+  "weekStart": ""
+}


### PR DESCRIPTION
## Summary

Companion to lga [#57](https://github.com/rwlove/langgraph-agents/pull/57) which adds `GET /admin/dlq` + `DELETE /admin/dlq/<id>` endpoints. Closes Phase 4.

## What lands

### `kubernetes/apps/home/windmill/workflows/langgraph-dlq-watcher.ts`

- Cron every 5 min
- Polls `/admin/dlq?since_id=<state>&limit=20`
- Posts new entries to Zulip stream `operations`, topic `dlq-YYYY-MM-DD`
- Tracks last-seen ULID via `wmill.getState/setState` so re-runs don't re-post

### `kubernetes/apps/observability/grafana/dashboards/task-queue.json`

Three panels (Loki-sourced; events emitted by `agents.queue.{store,worker}`):

- Task lifecycle event rate (5m)
- DLQ count in last 1h (stat)
- Recent DLQ entries (log scroll)

### `kubernetes/apps/observability/grafana/app/helmrelease.yaml`

New `ai/task-queue` dashboard entry pulling from `raw.githubusercontent.com/.../task-queue.json` (same pattern the existing `langgraph-agents.json` dashboard uses).

## Deploy

1. This PR + lga #57 merge
2. Flux reconciles grafana → loads `task-queue.json` from main
3. Operator runs `tools/wmill-sync.sh` to push DLQ-watcher to Windmill's `lovenet` workspace + sets the 5-min cron

🤖 Generated with [Claude Code](https://claude.com/claude-code)