### PR TITLE
feat(kube-system/kyverno): promote namespace-delete to Enforce (5.O3)

### DIFF
--- a/kubernetes/apps/kube-system/kyverno/app/policies/disallow-namespace-deletion-without-approval.yaml
+++ b/kubernetes/apps/kube-system/kyverno/app/policies/disallow-namespace-deletion-without-approval.yaml
@@ -14,11 +14,14 @@ metadata:
       deletion requires an explicit two-person approval annotation
       `blast-radius.lovenet.io/two-person-approved: <approver>`.
 
-      Audit mode: violations land in PolicyReport CRs and Prometheus
-      metrics for review. Promotion to enforce is the 5.O3 step,
-      gated to a follow-on session per the 2026-05-20 D-A decision.
+      ENFORCE mode (Phase 5.O3, 2026-05-20): admission rejections
+      are now active. Adding the
+      `blast-radius.lovenet.io/two-person-approved: <approver>`
+      annotation is required to delete a non-system namespace.
+
+      Rollback: flip back to `validationFailureAction: Audit`.
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: Enforce
   background: false
   rules:
     - name: namespace-delete-needs-approval


### PR DESCRIPTION
## Summary

**DESTRUCTIVE — at-moment approval by operator 2026-05-20 ("finish everything in this session" overrides D-A's prior deferral).**

Per HOMELAB-SPEC Layer 5 blast-radius enforcement and the rollout plan's **[5.O3]** item.

Flips `disallow-namespace-deletion-without-approval` from `Audit` → `Enforce`. Admission rejections are now active. Deleting a non-system namespace without the `blast-radius.lovenet.io/two-person-approved: <approver>` annotation will fail at admission.

## Caveat — minimal soak

The audit-mode soak from 5.O2 (#11843) only had ~hours of operational data before this promotion (same-session). If a legitimate namespace-delete fails post-merge, the rollback is one line — flip `Enforce` → `Audit`.

## Fail-open backstop

`failurePolicy: Ignore` on the Kyverno webhook (from 5.O1) means that if Kyverno itself goes unhealthy, admission passes — namespace deletes succeed without the annotation check. Per-policy `failurePolicy: Fail` can be set later once soak confirms zero false-positives.

## Rollback recipe

```yaml
spec:
  validationFailureAction: Audit  # was: Enforce
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)