### PR TITLE
feat: apiserver audit logging prep (Phase 5.P, cluster-side)

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -23,6 +23,7 @@
 - [Garage Substrate Restore Runbook](garage_restore.md)
 - [Frigate + direct-NFS DR Runbook](frigate_dr.md)
 - [master1 etcd Disk Swap](master1_etcd_disk_swap.md)
+- [Apiserver Audit Logging Runbook](apiserver_audit_logging.md)
 - [NetworkPolicy Rollout Plan](networkpolicy_rollout_plan.md)
 - [Egress Restriction Design Proposal](egress_restriction_design.md)
 - [Istio mTLS Rollout Design Proposal](mtls_rollout_design.md)

--- a/docs/src/apiserver_audit_logging.md
+++ b/docs/src/apiserver_audit_logging.md
@@ -1,0 +1,5 @@
+# Apiserver Audit Logging Runbook
+
+Moved to the vault: `~/vaults/claude/runbooks/home-ops/apiserver_audit_logging.md`
+
+See HOMELAB-SPEC Layer 2 #5: the vault is canonical for runbooks.

--- a/kubernetes/apps/observability/vector/agent/resources/vector.yaml
+++ b/kubernetes/apps/observability/vector/agent/resources/vector.yaml
@@ -25,6 +25,19 @@ sources:
     node_annotation_fields:
       node_labels: ""
 
+  # Phase 5.P — apiserver audit log. The file only exists on
+  # control-plane nodes (after the operator follows
+  # `~/vaults/claude/runbooks/home-ops/apiserver_audit_logging.md`
+  # per node); on worker nodes the file is absent and Vector's
+  # file source quietly tails nothing.
+  kube_apiserver_audit_source:
+    type: file
+    include:
+      - /var/log/kubernetes/audit.log
+    read_from: beginning
+    fingerprint:
+      strategy: device_and_inode
+
 # Sinks
 sinks:
   journald:
@@ -40,6 +53,13 @@ sinks:
     version: "2"
     address: vector-aggregator-app.observability.svc.cluster.local:6000
     inputs: ["kubernetes_source"]
+
+  kube_apiserver_audit:
+    type: vector
+    compression: true
+    version: "2"
+    address: vector-aggregator-app.observability.svc.cluster.local:6000
+    inputs: ["kube_apiserver_audit_source"]
 
   prometheus_metrics:
     type: prometheus_exporter

--- a/kubernetes/control-plane-config/audit-policy.yaml
+++ b/kubernetes/control-plane-config/audit-policy.yaml
@@ -1,0 +1,128 @@
+---
+# Audit policy for kube-apiserver — Phase 5.P (HOMELAB-SPEC Layer 5,
+# blast-radius PSA audit surface).
+#
+# Operator copies this file to /etc/kubernetes/audit-policy.yaml on
+# each control-plane node, then patches
+# /etc/kubernetes/manifests/kube-apiserver.yaml to add:
+#
+#   --audit-policy-file=/etc/kubernetes/audit-policy.yaml
+#   --audit-log-path=/var/log/kubernetes/audit.log
+#   --audit-log-maxage=14
+#   --audit-log-maxbackup=3
+#   --audit-log-maxsize=200
+#
+# See `~/vaults/claude/runbooks/home-ops/apiserver_audit_logging.md`
+# for the full per-node procedure (Inv 9 territory — operator runs
+# this; agents do not modify control-plane manifests autonomously).
+#
+# Volume: this policy aims at PSA-violation visibility + RBAC change
+# logging + cluster-state mutation traceability. NOT a complete
+# security-monitoring policy; tune as audit-data informs.
+
+apiVersion: audit.k8s.io/v1
+kind: Policy
+
+# Drop high-volume noise we know we don't care about (mostly read-only
+# leader-election + heartbeat traffic).
+omitStages:
+  - RequestReceived
+
+rules:
+  # ---- Tier 1: high-value security events at RequestResponse level ----
+
+  # PSA-violation events come back as Pod create/update audit entries
+  # with `pod-security.kubernetes.io/audit-violations` annotation.
+  # Recording at RequestResponse captures the full pod spec + admission
+  # decision; the size cost is acceptable at homelab volume.
+  - level: RequestResponse
+    verbs: ["create", "update", "patch"]
+    resources:
+      - group: ""
+        resources: ["pods"]
+
+  # RBAC changes (any role/binding mutation) — full payload so we can
+  # see what permissions changed.
+  - level: RequestResponse
+    verbs: ["create", "update", "patch", "delete"]
+    resources:
+      - group: "rbac.authorization.k8s.io"
+        resources:
+          - "roles"
+          - "rolebindings"
+          - "clusterroles"
+          - "clusterrolebindings"
+
+  # Secret access — full audit trail at metadata level. (Avoid
+  # RequestResponse on secrets; the value lands in the log.)
+  - level: Metadata
+    resources:
+      - group: ""
+        resources: ["secrets"]
+
+  # CRD lifecycle — major cluster-state change.
+  - level: RequestResponse
+    verbs: ["create", "update", "delete"]
+    resources:
+      - group: "apiextensions.k8s.io"
+        resources: ["customresourcedefinitions"]
+
+  # Namespace lifecycle — pairs with the Kyverno 5.O3 enforce policy.
+  - level: RequestResponse
+    verbs: ["create", "delete"]
+    resources:
+      - group: ""
+        resources: ["namespaces"]
+
+  # ---- Tier 2: cluster-state mutations at Metadata level ----
+
+  # Workload mutations (Deployments, StatefulSets, DaemonSets, Jobs,
+  # CronJobs) at Metadata — captures who-changed-what without the
+  # full spec.
+  - level: Metadata
+    verbs: ["create", "update", "patch", "delete"]
+    resources:
+      - group: "apps"
+      - group: "batch"
+
+  # NetworkPolicy + CiliumNetworkPolicy — security-adjacent.
+  - level: RequestResponse
+    verbs: ["create", "update", "patch", "delete"]
+    resources:
+      - group: "networking.k8s.io"
+        resources: ["networkpolicies"]
+      - group: "cilium.io"
+        resources: ["ciliumnetworkpolicies"]
+
+  # ---- Tier 3: everything else at Metadata, with high-volume drops ----
+
+  # Drop leader-election heartbeats (high volume, low value).
+  - level: None
+    users:
+      - "system:kube-controller-manager"
+      - "system:kube-scheduler"
+    resources:
+      - group: "coordination.k8s.io"
+        resources: ["leases"]
+
+  # Drop kubelet self-status updates (high volume).
+  - level: None
+    userGroups: ["system:nodes"]
+    resources:
+      - group: ""
+        resources: ["nodes/status", "pods/status"]
+
+  # Drop CSR approvals + cluster-info reads.
+  - level: None
+    nonResourceURLs:
+      - "/healthz*"
+      - "/readyz*"
+      - "/livez*"
+      - "/version"
+      - "/metrics"
+      - "/openapi/*"
+
+  # Everything else: Metadata.
+  - level: Metadata
+    omitStages:
+      - RequestReceived


### PR DESCRIPTION
## Summary

Per HOMELAB-SPEC **Layer 5** (PSA audit visibility) + **Inv 9** (core network infra not modified by agents). The rollout plan's **[5.P1/P2/P3]** item — **cluster-side prep only**.

The actual kubeadm static-pod manifest edit + apiserver restart per control-plane node is **operator-side work** documented in the vault runbook. Static-pod manifests live on disk on each master; they are not Flux-managed. Per Inv 9, agents do not modify them.

## What lands cluster-side

| File | Purpose |
|---|---|
| `kubernetes/control-plane-config/audit-policy.yaml` | Audit policy (RequestResponse on pods/RBAC/CRDs/namespaces; Metadata on apps+batch+NetworkPolicy; None on leader-election + health endpoints) |
| `kubernetes/apps/observability/vector/agent/resources/vector.yaml` | New `kube_apiserver_audit` file source + sink → Loki |
| `docs/src/apiserver_audit_logging.md` | Pointer stub |
| `~/vaults/claude/runbooks/home-ops/apiserver_audit_logging.md` | Per-node operator runbook |

## What the operator runs (5.P1 / P2 / P3)

Per the vault runbook. Per-node, in order:

1. `scp audit-policy.yaml root@masterN:/etc/kubernetes/audit-policy.yaml`
2. `mkdir -p /var/log/kubernetes && touch audit.log`
3. Edit `/etc/kubernetes/manifests/kube-apiserver.yaml` — add `--audit-policy-file` + `--audit-log-path` + volume + mount
4. Kubelet auto-restarts the apiserver static pod (~30-60s downtime on that one apiserver; other two keep serving)
5. Verify audit log writes; confirm Loki receives
6. Wait ≥1 day before doing the next master

Recovery path: `cp /root/kube-apiserver.yaml.pre-audit /etc/kubernetes/manifests/kube-apiserver.yaml` — kubelet reverts within ~10s.

## Pre-submit

- 4 files, 154 insertions
- yamllint clean on the new policy file + the Vector config
- Runbook is paper — paper per Q3 from earlier in the rollout
- Disk budget: ~800MB per master = ~2.4GB across 3 masters at default rotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)