### PR TITLE
ci(lychee): add explicit contents:read permissions

### DIFF
--- a/.github/workflows/lychee.yaml
+++ b/.github/workflows/lychee.yaml
@@ -10,6 +10,9 @@ on:
     branches: ["main"]
     paths: [".github/workflows/lychee.yaml"]
 
+permissions:
+  contents: read
+
 jobs:
   check:
     name: Check


### PR DESCRIPTION
## Summary

- Resolves the CodeQL "Workflow does not contain permissions" alert (CWE-275) on `.github/workflows/lychee.yaml` (alert #17381).
- Adds top-level `permissions: contents: read`, matching the convention already used by `labeler.yaml`, `gitleaks.yaml`, `flux-local.yaml`, `lint.yaml`, etc.
- Lychee uses the default `GITHUB_TOKEN` only for API rate-limit auth (read-only); issue creation uses the GitHub App token via the `token:` input, so the workflow token itself doesn't need any write scope.

## Test plan

- [ ] CI passes (workflow itself only triggers on changes to its own path)
- [ ] CodeQL alert #17381 closes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)