### PR TITLE
feat(kyverno): add Policy Reporter UI dashboard

### DIFF
--- a/kubernetes/apps/kyverno/policy-reporter/app/cnp-allow.yaml
+++ b/kubernetes/apps/kyverno/policy-reporter/app/cnp-allow.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: policy-reporter-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/instance: policy-reporter
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal gateway → policy-reporter-ui:8080.
+    # Intra-namespace UI ↔ core API ↔ kyverno-plugin traffic is
+    # covered by the kyverno-ns baseline allow-intra-namespace
+    # CNP (added when default-deny lands for this ns).
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP

--- a/kubernetes/apps/kyverno/policy-reporter/app/helmrelease.yaml
+++ b/kubernetes/apps/kyverno/policy-reporter/app/helmrelease.yaml
@@ -1,0 +1,67 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: policy-reporter
+spec:
+  chart:
+    spec:
+      # renovate: registryUrl=https://kyverno.github.io/policy-reporter
+      chart: policy-reporter
+      sourceRef:
+        kind: HelmRepository
+        name: policy-reporter-charts
+        namespace: kyverno
+      version: 3.7.4
+  interval: 30m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    # Core API reads PolicyReport CRs from the cluster and exposes
+    # them on http://policy-reporter:8080.
+    replicaCount: 1
+    resources:
+      requests:
+        cpu: 10m
+        memory: 64Mi
+      limits:
+        memory: 256Mi
+
+    # In-memory storage — fine at homelab scale (single replica, no
+    # need for SQLite/Postgres). Trades historical data on pod
+    # restart for one less stateful component.
+
+    # UI subchart — the dashboard at policy-reporter.${SECRET_DOMAIN}.
+    # Cluster target points at the core API service. Adding a second
+    # cluster would let one UI serve PolicyReports from multiple
+    # clusters, but homelab is single-cluster.
+    ui:
+      enabled: true
+      replicaCount: 1
+      resources:
+        requests:
+          cpu: 10m
+          memory: 64Mi
+        limits:
+          memory: 128Mi
+
+    # Kyverno plugin — adds the "Kyverno" tab to the UI showing
+    # ClusterPolicy / Policy CRs alongside the report data.
+    plugin:
+      kyverno:
+        enabled: true
+        replicaCount: 1
+        resources:
+          requests:
+            cpu: 10m
+            memory: 64Mi
+          limits:
+            memory: 128Mi

--- a/kubernetes/apps/kyverno/policy-reporter/app/helmrepository.yaml
+++ b/kubernetes/apps/kyverno/policy-reporter/app/helmrepository.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: policy-reporter-charts
+spec:
+  interval: 2h
+  url: https://kyverno.github.io/policy-reporter
+  timeout: 3m

--- a/kubernetes/apps/kyverno/policy-reporter/app/httproute.yaml
+++ b/kubernetes/apps/kyverno/policy-reporter/app/httproute.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: policy-reporter
+  annotations:
+    glance/name: "Policy Reporter"
+    glance/show: "true"
+    glance/id: "Security"
+spec:
+  hostnames:
+    - "policy-reporter.${SECRET_DOMAIN}"
+  parentRefs:
+    # Internal-only: policy-reporter.${SECRET_DOMAIN} resolves via
+    # bind9 to an internal LB IP. The dashboard exposes cluster-wide
+    # PolicyReport data (which workloads violate which policies) —
+    # operator-facing only. LAN/Tailscale access is sufficient;
+    # avoids the oauth2-proxy sidecar dependency. If wider exposure
+    # is needed later, add a policy-reporter-oauth2-proxy sibling
+    # following the holmesgpt-oauth2-proxy pattern.
+    - name: internal
+      namespace: network
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: policy-reporter-ui
+          port: 8080

--- a/kubernetes/apps/kyverno/policy-reporter/app/kustomization.yaml
+++ b/kubernetes/apps/kyverno/policy-reporter/app/kustomization.yaml
@@ -2,10 +2,8 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: kyverno
-components:
-  - ../../components/alerts
 resources:
-  - ./namespace.yaml
-  - ./kyverno/ks.yaml
-  - ./policy-reporter/ks.yaml
+  - ./helmrelease.yaml
+  - ./helmrepository.yaml
+  - ./httproute.yaml
+  - ./cnp-allow.yaml

--- a/kubernetes/apps/kyverno/policy-reporter/ks.yaml
+++ b/kubernetes/apps/kyverno/policy-reporter/ks.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app policy-reporter
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: kyverno
+  path: ./kubernetes/apps/kyverno/policy-reporter/app
+  interval: 30m
+  timeout: 5m
+  prune: true
+  wait: true
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: kyverno
+      namespace: kyverno


### PR DESCRIPTION
## Summary

Adds [kyverno/policy-reporter](https://github.com/kyverno/policy-reporter) — a web dashboard for the `PolicyReport` / `ClusterPolicyReport` CRs that the kyverno admission controller generates. Filtered views by namespace, severity, policy, rule, and a Kyverno-specific tab showing ClusterPolicy / Policy CRs alongside the report data.

Accessible at `policy-reporter.${SECRET_DOMAIN}` (internal-only).

## Components (chart 3.7.4)

| Service | Port | Purpose |
|---|---|---|
| `policy-reporter` | 8080 | Core API — reads PolicyReport CRs cluster-wide |
| `policy-reporter-ui` | 8080 | Vue.js dashboard (HTTPRoute target) |
| `policy-reporter-kyverno-plugin` | 8080 | Kyverno tab — ClusterPolicy / Policy CRs |

## Architecture

- **Third Flux Kustomization** in the `kyverno` namespace, sibling to `kyverno` and `kyverno-policies`, with `dependsOn: kyverno` (needs the PolicyReport CRD that kyverno provides).
- **Storage**: in-memory default. Trades history-across-restarts for one less stateful component; reasonable at homelab single-replica scale. Swap to SQLite or Postgres later if retention matters.
- **No oauth2-proxy in this PR.** Dashboard is operator-facing only — LAN/Tailscale via the internal gateway is sufficient. If wider exposure becomes needed, add a `policy-reporter-oauth2-proxy` sibling following the `holmesgpt-oauth2-proxy` pattern (1Password item + Authelia OIDC client + sibling HelmRelease).
- **CNP** allows envoy → `policy-reporter-ui:8080` ingress.
- **Glance**: `Security` category. No icon — homarr-labs catalog has neither `policy-reporter` nor `kyverno`.

## Verified

\`\`\`bash
$ kubectl kustomize kubernetes/apps/kyverno/policy-reporter/app
$ echo $?
0

$ helm template policy-reporter policy-reporter-charts/policy-reporter \\
    --version 3.7.4 -f values.yaml --namespace kyverno --skip-crds --skip-tests
$ echo $?
0
\`\`\`

Renders 3 expected Services: `policy-reporter`, `policy-reporter-ui`, `policy-reporter-kyverno-plugin`.

## Test plan

- [ ] CI clears
- [ ] Once merged, \`kustomization.kustomize.toolkit.fluxcd.io/policy-reporter -n kyverno\` reaches \`Ready=True\` (after \`kyverno\` is healthy)
- [ ] \`kubectl get pods -n kyverno\` shows the 3 policy-reporter pods (core + ui + kyverno-plugin) Running
- [ ] \`policy-reporter.${SECRET_DOMAIN}\` loads the UI and shows PolicyReport data
- [ ] The Kyverno tab in the UI lists \`disallow-namespace-deletion-without-approval\` (the only ClusterPolicy today)
- [ ] Glance shows a "Policy Reporter" tile in the Security card

🤖 Generated with [Claude Code](https://claude.com/claude-code)