### PR TITLE
fix(cilium): cilium-config needs explicit dependsOn + wait: true

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ _Production-grade Kubernetes for a household._
 
 <br/>
 
-![apps](https://img.shields.io/badge/apps-175-blue?style=for-the-badge)
-![helmreleases](https://img.shields.io/badge/HelmReleases-185-326CE5?style=for-the-badge&logo=helm&logoColor=white)
+![apps](https://img.shields.io/badge/apps-176-blue?style=for-the-badge)
+![helmreleases](https://img.shields.io/badge/HelmReleases-186-326CE5?style=for-the-badge&logo=helm&logoColor=white)
 ![nodes](https://img.shields.io/badge/k8s_nodes-11-326CE5?style=for-the-badge&logo=kubernetes&logoColor=white)
 ![cnpg](https://img.shields.io/badge/Postgres_clusters-25-336791?style=for-the-badge&logo=postgresql&logoColor=white)
 ![secrets](https://img.shields.io/badge/secrets-111-0572EC?style=for-the-badge&logo=1password&logoColor=white)

--- a/kubernetes/apps/kube-system/cilium/ks.yaml
+++ b/kubernetes/apps/kube-system/cilium/ks.yaml
@@ -13,7 +13,11 @@ spec:
   interval: 1h
   timeout: 5m
   prune: true
-  wait: false
+  # `wait: true` is required for `cilium-config`'s `dependsOn` to
+  # honor readiness — without it, the dependent Kustomization fires
+  # as soon as this one's resources are applied, not when the chart
+  # has actually installed its CRDs. Mirrors cert-manager / kyverno.
+  wait: true
   sourceRef:
     kind: GitRepository
     name: home-ops-kubernetes
@@ -34,8 +38,15 @@ spec:
   interval: 1h
   timeout: 5m
   prune: true
-  wait: false
+  wait: true
   sourceRef:
     kind: GitRepository
     name: home-ops-kubernetes
     namespace: flux-system
+  # CiliumBGPAdvertisement + CiliumLoadBalancerIPPool here use CRDs
+  # the cilium chart provides. Without dependsOn, fresh deploys /
+  # full reconciles race the chart's CRD install (chicken-and-egg).
+  # Same pattern as cert-manager-issuers / kyverno-policies.
+  dependsOn:
+    - name: cilium
+      namespace: kube-system


### PR DESCRIPTION
## Summary

Audit of CRD-providing charts in the cluster (following #11861) found `cilium-config` as the **only** remaining \"self-deploying CRD chart with CRs in a separate Kustomization but no \`dependsOn\`\" case.

`cilium-config` applies \`CiliumBGPAdvertisement\` and \`CiliumLoadBalancerIPPool\` — CRs whose CRDs come from the cilium chart itself. On a fresh deploy or full Flux reconcile, the config Kustomization can race against the chart's CRD install and halt with \`no matches for kind \"...\"\` on the dry-run.

Today this only bites at bootstrap (CRDs already exist in the running cluster), but the pattern is latent and matches the kyverno chicken-and-egg that bit #11842/#11843 and got fixed in #11861.

## Audit results

Every other CRD-providing chart in the cluster is already guarded:

| App | Pattern |
|---|---|
| cert-manager / cert-manager-issuers | Split + \`dependsOn\` |
| kyverno / kyverno-policies | Split + \`dependsOn\` (#11861) |
| kube-prometheus-stack | Separate \`prometheus-operator-crds\` + \`dependsOn\` |
| rook-ceph / rook-ceph-cluster | Split + \`dependsOn\` |
| istio-base / istiod | Split + \`dependsOn\` |
| node-feature-discovery / node-feature-rules | Split + \`dependsOn\` |
| onepassword-connect | \`dependsOn: external-secrets\` |
| policy-reporter (#11865) | \`dependsOn: kyverno\` |
| **cilium / cilium-config** | **❌ Split, but no \`dependsOn\` — this PR** |

## Fix

Mirror the established pattern:

- \`cilium\` Kustomization: flip \`wait: false\` → \`wait: true\`. \`dependsOn\` only honors readiness when the upstream Kustomization waits for health; otherwise the downstream fires the moment resources are applied, not when the chart finishes installing.
- \`cilium-config\` Kustomization: add \`dependsOn: cilium\` + flip \`wait: false\` → \`wait: true\`.

## Bootstrap concern

cilium is the CNI and bootstrap-critical. \`wait: true\` means the Kustomization sits Pending until cilium pods are Ready. In practice this matches what happens implicitly today — every downstream app depends on cilium for pod-to-pod networking — and cilium pod startup is seconds.

## Test plan

- [ ] CI clears (diff is just two Kustomization specs, no chart render)
- [ ] After merge, \`kustomization.kustomize.toolkit.fluxcd.io/cilium -n flux-system\` reaches \`Ready=True\` (currently does already; the change is the eventual-Ready-on-health gating)
- [ ] \`kustomization.kustomize.toolkit.fluxcd.io/cilium-config\` shows \`dependsOn[0].name == cilium\` and \`Ready=True\` once \`cilium\` is Ready
- [ ] BGP peerings + LoadBalancer IP pool unchanged in observed behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)