### PR TITLE
fix(media/soularr): enable Web UI on 8265, fix 502 at soularr.${SECRET_DOMAIN}

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ _Production-grade Kubernetes for a household._
 
 <br/>
 
-![apps](https://img.shields.io/badge/apps-176-blue?style=for-the-badge)
-![helmreleases](https://img.shields.io/badge/HelmReleases-186-326CE5?style=for-the-badge&logo=helm&logoColor=white)
+![apps](https://img.shields.io/badge/apps-177-blue?style=for-the-badge)
+![helmreleases](https://img.shields.io/badge/HelmReleases-187-326CE5?style=for-the-badge&logo=helm&logoColor=white)
 ![nodes](https://img.shields.io/badge/k8s_nodes-11-326CE5?style=for-the-badge&logo=kubernetes&logoColor=white)
 ![cnpg](https://img.shields.io/badge/Postgres_clusters-25-336791?style=for-the-badge&logo=postgresql&logoColor=white)
 ![secrets](https://img.shields.io/badge/secrets-111-0572EC?style=for-the-badge&logo=1password&logoColor=white)

--- a/kubernetes/apps/media/soularr-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/soularr-oauth2-proxy/app/cnp-allow.yaml
@@ -35,7 +35,7 @@ spec:
     # match cluster LB IPs) and NOT authelia:9091 directly (which
     # oauth2-proxy never connects to because of how it's configured).
     # Mirrors pump-oauth2-proxy PR #11559.
-    # Upstream → soularr.media:1000 is same-ns,
+    # Upstream → soularr.media:8265 is same-ns,
     # covered by baseline allow-intra-namespace.
     - toEndpoints:
         - matchLabels:

--- a/kubernetes/apps/media/soularr-oauth2-proxy/app/helmrelease.yaml
+++ b/kubernetes/apps/media/soularr-oauth2-proxy/app/helmrelease.yaml
@@ -51,7 +51,7 @@ spec:
               - --oidc-issuer-url=https://auth.${SECRET_DOMAIN}
               - --client-id=soularr-oauth2-proxy
               - --redirect-url=https://soularr.${SECRET_DOMAIN}/oauth2/callback
-              - --upstream=http://soularr.media.svc.cluster.local:1000
+              - --upstream=http://soularr.media.svc.cluster.local:8265
               - --http-address=0.0.0.0:4180
               - --cookie-name=_oauth2_proxy_soularr
               - --cookie-secure=true

--- a/kubernetes/apps/media/soularr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/soularr/app/helmrelease.yaml
@@ -46,6 +46,12 @@ spec:
               repository: ghcr.io/mrusse/soularr
               tag: 1.2.2@sha256:c4f97924fabfce4e0de539d821ea7d20519b95c4815a707bacfc9d7212597f20
 
+            env:
+              # Soularr v1.2.0+ ships a Web UI on port 8265, off by default.
+              # Pair with log_to_file=True in config.ini — the UI reads the
+              # rotated log file to render activity.
+              WEBUI_ENABLED: "true"
+
             resources:
               requests:
                 cpu: 10m
@@ -65,7 +71,9 @@ spec:
         controller: soularr
         ports:
           http:
-            port: 1000
+            # Soularr's Web UI listens on 8265 (mrusse/soularr v1.2.0+).
+            # Override via WEBUI_PORT env if you ever change it.
+            port: 8265
 
     route:
       app:

--- a/kubernetes/apps/media/soularr/app/resources/config.ini
+++ b/kubernetes/apps/media/soularr/app/resources/config.ini
@@ -37,3 +37,8 @@ search_source = missing
 level = DEBUG
 format = [%(levelname)s|%(module)s|L%(lineno)d] %(asctime)s: %(message)s
 datefmt = %Y-%m-%dT%H:%M:%S%z
+# log_to_file is required for the Web UI (port 8265) to render activity.
+log_to_file = True
+log_file = soularr.log
+max_bytes = 1048576
+backup_count = 3


### PR DESCRIPTION
## Summary

- `https://soularr.${SECRET_DOMAIN}` was returning **502** from oauth2-proxy because `Service soularr:1000` pointed at a port nothing was listening on. The pod was healthy; soularr was running its sync loop fine; it just had no HTTP listener.
- mrusse/soularr v1.2.0 (2026-04-23) added a Web UI on port **8265**, off by default. It requires two settings, both missing here: `WEBUI_ENABLED=true` (env) and `log_to_file=True` (config.ini, because the UI tails the log file).
- This PR turns the UI on, points the Service + oauth2-proxy at 8265, and adds the file-logging config the UI depends on.

## Changes

- `soularr/app/helmrelease.yaml` — `WEBUI_ENABLED=true` env, service port `1000 → 8265`.
- `soularr/app/resources/config.ini` — `log_to_file = True` + rotation defaults.
- `soularr-oauth2-proxy/app/helmrelease.yaml` — `--upstream` port `:1000 → :8265`.
- `soularr-oauth2-proxy/app/cnp-allow.yaml` — comment-only update for upstream port (same-ns ingress already covered by baseline).

No Authelia / 1P / Renovate changes.

## Test plan

- [ ] After Flux reconciles, pod stays `1/1 Running`.
- [ ] `https://soularr.${SECRET_DOMAIN}` redirects to Authelia.
- [ ] Post-auth, soularr Web UI renders (shows current sync activity + log tail).
- [ ] soularr → slskd `:5030` calls still work (no CNP regression — port change is on the inbound side only).
- [ ] soularr → lidarr `:8686` calls still work (intra-ns, baseline covered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)