### PR TITLE
fix(observability/blackbox-exporter): use toEntities: cluster for synthetic probers

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ _Production-grade Kubernetes for a household._
 
 <br/>
 
-![apps](https://img.shields.io/badge/apps-176-blue?style=for-the-badge)
-![helmreleases](https://img.shields.io/badge/HelmReleases-186-326CE5?style=for-the-badge&logo=helm&logoColor=white)
+![apps](https://img.shields.io/badge/apps-177-blue?style=for-the-badge)
+![helmreleases](https://img.shields.io/badge/HelmReleases-187-326CE5?style=for-the-badge&logo=helm&logoColor=white)
 ![nodes](https://img.shields.io/badge/k8s_nodes-11-326CE5?style=for-the-badge&logo=kubernetes&logoColor=white)
 ![cnpg](https://img.shields.io/badge/Postgres_clusters-25-336791?style=for-the-badge&logo=postgresql&logoColor=white)
 ![secrets](https://img.shields.io/badge/secrets-111-0572EC?style=for-the-badge&logo=1password&logoColor=white)

--- a/kubernetes/apps/observability/exporters/blackbox-exporter/app/cnp-allow.yaml
+++ b/kubernetes/apps/observability/exporters/blackbox-exporter/app/cnp-allow.yaml
@@ -27,36 +27,23 @@ spec:
             - port: "9115"
               protocol: TCP
   egress:
-    # Blackbox probes LAN hosts (~60 devices: cameras, UPSes, iDRAC,
-    # ESPHome devices, WLED, Roborock, Kodi, voice satellites, NFS
-    # servers, etc.) with ICMP + tcp_connect + http_2xx modules.
-    # Targets are short LAN hostnames resolved via DNS to RFC1918
-    # addresses scattered across the home LAN — `world` is the
-    # simplest correct identity here (LAN-only because there's no
-    # default route to public internet at the pod level after this
-    # policy). Future tightening could restrict to ICMP + a small
-    # TCP/HTTP port set but the surface is wide and stable.
+    # Blackbox probes a mix of LAN hosts (~60 devices: cameras, UPSes,
+    # iDRAC, ESPHome devices, WLED, Roborock, Kodi, voice satellites,
+    # NFS servers, etc.) with ICMP + tcp_connect + http_2xx modules,
+    # plus in-cluster synthetic probers (ollama-spark-embed,
+    # ollama-embed) that POST against /api/embed. `cluster` covers
+    # the in-cluster targets; `world` + `host` + `remote-node` covers
+    # the LAN devices reached via the home DNS + RFC1918 routing.
+    #
+    # NB: targeted `toEndpoints + toPorts: 11434` rules for ai/ollama
+    # were attempted (PRs #11859, #11862) but Cilium 1.19 did not
+    # realize them in the endpoint's allowed-egress-identities even
+    # though the selector → identity resolution succeeded. Using
+    # `toEntities: cluster` (the prometheus-allow pattern) sidesteps
+    # that. Tradeoff: any port to any in-cluster pod from blackbox.
+    # Blackbox is a sealed prober — the broader surface is acceptable.
     - toEntities:
-        - world
+        - cluster
         - host
         - remote-node
-    # Synthetic embed prober target (Probe: ollama-spark-embed).
-    # Cluster-internal POST to /api/embed on bge-m3.
-    - toEndpoints:
-        - matchLabels:
-            io.kubernetes.pod.namespace: ai
-            app.kubernetes.io/name: ollama-spark
-      toPorts:
-        - ports:
-            - port: "11434"
-              protocol: TCP
-    # Synthetic embed prober target (Probe: ollama-embed) — P40
-    # ollama on worker8. Same module, different pod.
-    - toEndpoints:
-        - matchLabels:
-            io.kubernetes.pod.namespace: ai
-            app.kubernetes.io/name: ollama
-      toPorts:
-        - ports:
-            - port: "11434"
-              protocol: TCP
+        - world


### PR DESCRIPTION
## Summary

PRs #11859 (ollama-spark synthetic embed probe) and #11862 (P40 ollama sister) added per-target `toEndpoints + toPorts: 11434` egress rules to `blackbox-exporter-allow`. Both probes fail at runtime — Cilium 1.19 drops the egress despite the CNP being correctly deployed.

Switches to the `toEntities: cluster` pattern that works for `prometheus-allow`.

## What I verified on the cluster

| Check | Result |
|---|---|
| CNP source ↔ deployed spec | match |
| `cilium-dbg policy selectors \| grep ollama` | resolves to identities `61545` (ollama) + `51456` (ollama-spark) ✓ |
| `cilium endpoint get <blackbox-id>` realized allowed-egress-identities | excludes `61545` and `51456` ✗ |
| Hubble verdict | `policy-verdict:none ... DENIED` (no allow matched) |

The selector → identity resolution succeeds; the BPF policy realization on the endpoint does not include those identities. Suggests an interaction in Cilium 1.19 between `toEndpoints + toPorts` and the namespace's `default-deny` CNP using `egressDeny: [{}]` to opt into non-default-deny mode.

## Fix

Mirror `prometheus-allow`. Replace the two targeted `toEndpoints + toPorts` rules with `toEntities: cluster`.

```diff
   egress:
-    - toEntities:
-        - world
-        - host
-        - remote-node
-    - toEndpoints:
-        - matchLabels:
-            io.kubernetes.pod.namespace: ai
-            app.kubernetes.io/name: ollama-spark
-      toPorts:
-        - ports:
-            - port: "11434"
-              protocol: TCP
-    - toEndpoints:
-        - matchLabels:
-            io.kubernetes.pod.namespace: ai
-            app.kubernetes.io/name: ollama
-      toPorts:
-        - ports:
-            - port: "11434"
-              protocol: TCP
+    - toEntities:
+        - cluster
+        - host
+        - remote-node
+        - world
```

## Tradeoff

- **Lost**: L4 restriction to `:11434` on the `ai/ollama*` targets.
- **Gained**: probes work, which is the whole point of #11859 + #11862. Without this, `OllamaWedged` + `SparkOllamaWedged` fire as permanent false positives — worse than where we started.
- **Acceptable because**: blackbox is a sealed prober. Egress traffic is determined by what's in `Probe` CRs + the module config, not by the pod freely choosing destinations.

The comment block in the file records the prior attempt and the Cilium issue, so a future tightened `toEndpoints` allow can come back when the realization problem is understood.

## Test plan

- [ ] Flux reconciles the CNP.
- [ ] `probe_success{instance=~"https?://ollama.*"}` flips 0 → 1 within ~5 min.
- [ ] Hubble: `hubble observe --from-pod observability/blackbox-exporter-... --to-namespace ai --type drop` shows no new drops.
- [ ] `OllamaWedged` and `SparkOllamaWedged` clear in AlertManager.

🤖 Generated with [Claude Code](https://claude.com/claude-code)