### PR TITLE
feat(mcp-system): add cilium-mcp (Azure mcp-kubernetes, Cilium/Hubble readonly)

### DIFF
--- a/kubernetes/apps/mcp-system/cilium-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/cilium-mcp/app/helmrelease.yaml
@@ -1,0 +1,107 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: cilium-mcp
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 1h
+  values:
+    defaultPodOptions:
+      automountServiceAccountToken: true
+    controllers:
+      cilium-mcp:
+        pod:
+          annotations:
+            reloader.stakater.com/auto: "true"
+            sidecar.istio.io/inject: "true"
+          securityContext:
+            runAsGroup: 1000
+            runAsNonRoot: true
+            runAsUser: 1000
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/azure/mcp-kubernetes
+              tag: v0.0.13@sha256:9490d69a7550f58593ca120a60921ce165cf012337ef99925149a73d6e2f91cb
+            args:
+              - --transport=streamable-http
+              - --additional-tools=cilium,hubble
+              - --access-level=readonly
+              - --host=0.0.0.0
+              - --port=8000
+            resources:
+              requests:
+                cpu: 50m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities: {drop: ["ALL"]}
+              readOnlyRootFilesystem: true
+              seccompProfile:
+                type: RuntimeDefault
+    service:
+      app:
+        controller: cilium-mcp
+        ports:
+          http:
+            port: 8000
+    route:
+      app:
+        hostnames:
+          - "cilium-mcp.mcp.local"
+        parentRefs:
+          - name: mcp-gateway
+            namespace: mcp-system
+            sectionName: mcps
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /mcp
+            backendRefs:
+              - identifier: app
+                port: 8000
+    rbac:
+      bindings:
+        cilium-mcp-read:
+          type: ClusterRoleBinding
+          roleRef:
+            identifier: cilium-mcp-read
+          subjects:
+            - identifier: cilium-mcp
+              serviceAccount: cilium-mcp
+      roles:
+        cilium-mcp-read:
+          type: ClusterRole
+          rules:
+            - apiGroups: ["cilium.io"]
+              resources:
+                - ciliumnetworkpolicies
+                - ciliumclusterwidenetworkpolicies
+                - ciliumendpoints
+                - ciliumidentities
+                - ciliumnodes
+                - ciliumloadbalancerippools
+                - ciliumbgpclusterconfigs
+                - ciliumbgppeerconfigs
+                - ciliumbgpadvertisements
+              verbs: ["get", "list", "watch"]
+            - apiGroups: [""]
+              resources: ["pods", "services", "namespaces", "nodes", "endpoints"]
+              verbs: ["get", "list", "watch"]
+            - apiGroups: [""]
+              resources: ["pods/log"]
+              verbs: ["get", "list"]
+            - apiGroups: ["apps"]
+              resources: ["daemonsets", "deployments"]
+              verbs: ["get", "list", "watch"]
+    serviceAccount:
+      cilium-mcp: {}

--- a/kubernetes/apps/mcp-system/cilium-mcp/app/kustomization.yaml
+++ b/kubernetes/apps/mcp-system/cilium-mcp/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../components/repos/app-template
+resources:
+  - ./helmrelease.yaml
+  - ./rbac.yaml

--- a/kubernetes/apps/mcp-system/cilium-mcp/app/rbac.yaml
+++ b/kubernetes/apps/mcp-system/cilium-mcp/app/rbac.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/role-rbac-v1.json
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cilium-mcp-exec
+  namespace: kube-system
+rules:
+  # Hubble queries run as `kubectl exec cilium-agent -- hubble observe ...`,
+  # and pods/exec doesn't honor resourceNames — namespace-scoped to kube-system
+  # is the tightest k8s RBAC allows.
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/rolebinding-rbac-v1.json
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cilium-mcp-exec
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cilium-mcp-exec
+subjects:
+  - kind: ServiceAccount
+    name: cilium-mcp
+    namespace: mcp-system

--- a/kubernetes/apps/mcp-system/cilium-mcp/ks.yaml
+++ b/kubernetes/apps/mcp-system/cilium-mcp/ks.yaml
@@ -1,0 +1,48 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app cilium-mcp
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: mcp-system
+  path: ./kubernetes/apps/mcp-system/cilium-mcp/app
+  interval: 1h
+  timeout: 5m
+  prune: true
+  wait: false
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: mcp-gateway
+      namespace: mcp-system
+  retryInterval: 2m
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app cilium-mcp-mcpserverregistration
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: mcp-system
+  path: ./kubernetes/apps/mcp-system/cilium-mcp/mcp
+  interval: 1h
+  timeout: 5m
+  prune: true
+  wait: false
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: cilium-mcp
+      namespace: mcp-system
+  retryInterval: 2m

--- a/kubernetes/apps/mcp-system/cilium-mcp/mcp/kustomization.yaml
+++ b/kubernetes/apps/mcp-system/cilium-mcp/mcp/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./mcpserverregistration.yaml

--- a/kubernetes/apps/mcp-system/cilium-mcp/mcp/mcpserverregistration.yaml
+++ b/kubernetes/apps/mcp-system/cilium-mcp/mcp/mcpserverregistration.yaml
@@ -1,0 +1,14 @@
+---
+# TODO: apply schema
+apiVersion: mcp.kuadrant.io/v1alpha1
+kind: MCPServerRegistration
+metadata:
+  name: cilium-hubble-tools
+  labels:
+    mcp.kuadrant.io/managed: "true"
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: cilium-mcp
+  toolPrefix: cilium_

--- a/kubernetes/apps/mcp-system/kustomization.yaml
+++ b/kubernetes/apps/mcp-system/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
   - ./arr-mcp/ks.yaml
   - ./chrome-mcp/ks.yaml
   - ./chrome-smoke-sweep/ks.yaml
+  - ./cilium-mcp/ks.yaml
   - ./github-mcp/ks.yaml
   - ./grafana-mcp/ks.yaml
   - ./ha-mcp/ks.yaml


### PR DESCRIPTION
## Summary

Adds `kubernetes/apps/mcp-system/cilium-mcp/` — a new MCP server that
surfaces Cilium policy resources and Hubble flow observability to
agents. The existing `kubectl-mcp` covers core / apps / Flux / etc.
but doesn't carry `cilium.io/*` read perms or `cilium-agent` exec,
which is what's needed for policy triage and `hubble observe`.

Server is Azure's `ghcr.io/azure/mcp-kubernetes` at `v0.0.13`, pinned
by sha256 digest. Launched with `--access-level=readonly` and
`--additional-tools=cilium,hubble`. RBAC is narrowed in two pieces:

- **ClusterRoleBinding** to a ClusterRole granting `get,list,watch`
  on the `cilium.io` kinds we actually observe (CNPs, CCNPs,
  CiliumEndpoint, CiliumIdentity, CiliumNode, the LB pool, and the
  three-resource BGP model: ClusterConfig / PeerConfig /
  Advertisement) plus a minimal `""` + `apps` read set so Hubble
  flows can be enriched with pod / service / DaemonSet context.
- **RoleBinding scoped to `kube-system`** granting `pods/exec` only —
  Hubble queries are issued as `kubectl exec cilium-agent -- hubble
  observe ...`, and `pods/exec` doesn't honor `resourceNames`, so
  namespace-scoped to where the cilium-agent DaemonSet lives is the
  tightest the API allows.

Pod hardening matches `helmrelease.security.md` defaults (non-root
1000, no priv-esc, read-only rootfs, drop ALL caps, seccomp
RuntimeDefault). Istio sidecar injection is on. HTTPRoute attaches to
`mcp-gateway/mcps` exactly like `kubectl-mcp`.

Two Flux Kustomizations mirror the `kubectl-mcp` shape — `app/`
depends on `mcp-gateway`; `mcp/` depends on the app Kustomization so
the MCPServerRegistration only lands once the HTTPRoute exists.

**Tool overlap, accepted:** Azure's `mcp-kubernetes` always exposes
its kubectl-shaped tools — they can't be disabled. Those will show up
under the `cilium_` `toolPrefix` from the MCPServerRegistration. We
take the overlap with `kubectl-mcp`'s `kubectl_` surface for the
benefit of first-class `cilium_*` / `hubble_*` tools.

## Test plan

- [x] `kubectl kustomize kubernetes/apps/mcp-system/cilium-mcp/app/` succeeds locally
- [x] `kubectl kustomize kubernetes/apps/mcp-system/cilium-mcp/mcp/` succeeds locally
- [x] `kubectl kustomize kubernetes/apps/mcp-system/` succeeds locally
- [ ] Flux reconciles `cilium-mcp` Kustomization after merge
- [ ] `cilium-mcp` pod reaches Ready
- [ ] `cilium-mcp-mcpserverregistration` Kustomization reconciles
- [ ] At least one `cilium_*` tool surfaces via the MCPServerRegistration

Generated with [Claude Code](https://claude.com/claude-code)