### PR TITLE
feat(mcp-system): add windmill-mcp (HTTPRoute → windmill-server MCP gateway)

### DIFF
--- a/kubernetes/apps/home/windmill/app/cnp-allow.yaml
+++ b/kubernetes/apps/home/windmill/app/cnp-allow.yaml
@@ -40,6 +40,11 @@ spec:
         - matchLabels:
             io.kubernetes.pod.namespace: collab
             app.kubernetes.io/name: zulip
+        # windmill-mcp (mcp-system) reverse-proxies /api/mcp/w/lovenet/mcp
+        # with a Bearer token injected from windmill-mcp-secret.
+        - matchLabels:
+            io.kubernetes.pod.namespace: mcp-system
+            app.kubernetes.io/name: windmill-mcp
       toPorts:
         - ports:
             - port: "8000"

--- a/kubernetes/apps/mcp-system/kustomization.yaml
+++ b/kubernetes/apps/mcp-system/kustomization.yaml
@@ -30,3 +30,4 @@ resources:
   - ./prometheus-mcp/ks.yaml
   - ./searxng-mcp/ks.yaml
   - ./time-mcp/ks.yaml
+  - ./windmill-mcp/ks.yaml

--- a/kubernetes/apps/mcp-system/windmill-mcp/app/cnp-allow.yaml
+++ b/kubernetes/apps/mcp-system/windmill-mcp/app/cnp-allow.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: windmill-mcp-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: windmill-mcp
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it. Ingress from same-ns mcp-gateway broker is
+  # covered by baseline allow-intra-namespace.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  egress:
+    # windmill-app in home ns. The matching ingress rule on
+    # `home/windmill-allow` will need to permit mcp-system → 8000;
+    # that side is owned by the windmill HelmRelease and updated in
+    # a separate PR if not already covered.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: home
+            app.kubernetes.io/name: windmill-app
+      toPorts:
+        - ports:
+            - port: "8000"
+              protocol: TCP

--- a/kubernetes/apps/mcp-system/windmill-mcp/app/externalsecret.yaml
+++ b/kubernetes/apps/mcp-system/windmill-mcp/app/externalsecret.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: windmill-mcp
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: windmill-mcp-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        # Consumed by the nginx envsubst-on-startup template to set
+        # `Authorization: Bearer <token>` on every request proxied
+        # through to windmill-app.home.svc.cluster.local:8000.
+        WINDMILL_TOKEN: "{{ .mcp_token }}"
+  dataFrom:
+    # 1P item `windmill` in vault `Kubernetes`. Required field for
+    # this ExternalSecret: `mcp_token` — a Windmill API token created
+    # by an operator with at least the `lovenet` workspace MCP scopes.
+    # See `kubernetes/apps/home/windmill/README.md` for the windmill
+    # item bootstrap recipe; this MCP token is added separately.
+    - extract:
+        key: windmill

--- a/kubernetes/apps/mcp-system/windmill-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/windmill-mcp/app/helmrelease.yaml
@@ -1,0 +1,118 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: windmill-mcp
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 1h
+  values:
+    defaultPodOptions:
+      securityContext:
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 101
+        runAsNonRoot: true
+        runAsUser: 101
+    controllers:
+      windmill-mcp:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        pod:
+          annotations:
+            sidecar.istio.io/inject: "true"
+        containers:
+          app:
+            # nginx-unprivileged: stock nginx + runs as UID 101 on port
+            # 8080 (no root, no NET_BIND_SERVICE needed). The image's
+            # entrypoint runs `envsubst` on /etc/nginx/templates/*.template
+            # and writes the rendered config to /etc/nginx/conf.d/.
+            # We supply `default.conf.template` via the templates configMap,
+            # and the rendered output lands in the writable conf-d emptyDir.
+            image:
+              repository: docker.io/nginxinc/nginx-unprivileged
+              tag: 1.27.5-alpine
+            env:
+              # envsubst replaces ${WINDMILL_TOKEN} in the template; the
+              # secret is materialized by the windmill-mcp ExternalSecret.
+              WINDMILL_TOKEN:
+                valueFrom:
+                  secretKeyRef:
+                    name: windmill-mcp-secret
+                    key: WINDMILL_TOKEN
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
+              limits:
+                memory: 128Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop: ["ALL"]
+              seccompProfile:
+                type: RuntimeDefault
+    service:
+      app:
+        controller: windmill-mcp
+        ports:
+          http:
+            port: 8080
+    route:
+      app:
+        hostnames:
+          - "windmill-mcp.mcp.local"
+        parentRefs:
+          - name: mcp-gateway
+            namespace: mcp-system
+            sectionName: mcps
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /mcp
+            backendRefs:
+              - identifier: app
+                port: 8080
+    persistence:
+      # Source nginx template — envsubst rewrites this into conf.d
+      # at container start. Mounted read-only.
+      nginx-templates:
+        type: configMap
+        name: windmill-mcp-nginx-config
+        advancedMounts:
+          windmill-mcp:
+            app:
+              - path: /etc/nginx/templates/default.conf.template
+                subPath: default.conf.template
+                readOnly: true
+      # nginx writes the rendered config + pid + cache here. With
+      # readOnlyRootFilesystem: true these must be emptyDirs.
+      nginx-conf-d:
+        type: emptyDir
+        advancedMounts:
+          windmill-mcp:
+            app:
+              - path: /etc/nginx/conf.d
+      nginx-cache:
+        type: emptyDir
+        advancedMounts:
+          windmill-mcp:
+            app:
+              - path: /var/cache/nginx
+      nginx-tmp:
+        type: emptyDir
+        advancedMounts:
+          windmill-mcp:
+            app:
+              - path: /tmp
+      nginx-run:
+        type: emptyDir
+        advancedMounts:
+          windmill-mcp:
+            app:
+              - path: /var/run

--- a/kubernetes/apps/mcp-system/windmill-mcp/app/kustomization.yaml
+++ b/kubernetes/apps/mcp-system/windmill-mcp/app/kustomization.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../components/repos/app-template
+resources:
+  - ./cnp-allow.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+configMapGenerator:
+  - name: windmill-mcp-nginx-config
+    files:
+      - default.conf.template=./resources/default.conf.template
+generatorOptions:
+  disableNameSuffixHash: true

--- a/kubernetes/apps/mcp-system/windmill-mcp/app/resources/default.conf.template
+++ b/kubernetes/apps/mcp-system/windmill-mcp/app/resources/default.conf.template
@@ -1,0 +1,40 @@
+# nginx reverse-proxy for windmill-mcp.
+#
+# The mcp-gateway broker delivers MCP traffic to this proxy at /mcp.
+# We rewrite to Windmill's workspace-scoped MCP endpoint and inject
+# the Authorization: Bearer header from $WINDMILL_TOKEN (set via env
+# from the windmill-mcp-secret ExternalSecret).
+#
+# Windmill's MCP route is HTTP streamable + SSE. Disable proxy
+# buffering and set generous timeouts so long-running tool calls
+# survive.
+
+server {
+    listen 8080;
+    server_name _;
+
+    # /healthz — simple liveness/readiness target. No auth, no proxy.
+    location = /healthz {
+        access_log off;
+        return 200 "ok\n";
+        default_type text/plain;
+    }
+
+    # /mcp — broker entrypoint. Rewrite to Windmill's workspace MCP
+    # route and inject the Bearer token.
+    location = /mcp {
+        proxy_pass http://windmill-app.home.svc.cluster.local:8000/api/mcp/w/lovenet/mcp;
+
+        proxy_http_version 1.1;
+        proxy_set_header Host windmill-app.home.svc.cluster.local;
+        proxy_set_header Connection "";
+        proxy_set_header Authorization "Bearer ${WINDMILL_TOKEN}";
+
+        # SSE / streamable-HTTP friendliness — Windmill MCP streams.
+        proxy_buffering off;
+        proxy_request_buffering off;
+        proxy_read_timeout 1h;
+        proxy_send_timeout 1h;
+        chunked_transfer_encoding on;
+    }
+}

--- a/kubernetes/apps/mcp-system/windmill-mcp/ks.yaml
+++ b/kubernetes/apps/mcp-system/windmill-mcp/ks.yaml
@@ -1,0 +1,48 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app windmill-mcp
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: mcp-system
+  path: ./kubernetes/apps/mcp-system/windmill-mcp/app
+  interval: 1h
+  timeout: 5m
+  prune: true
+  wait: false
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: mcp-gateway
+      namespace: mcp-system
+  retryInterval: 2m
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app windmill-mcp-mcpserverregistration
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: mcp-system
+  path: ./kubernetes/apps/mcp-system/windmill-mcp/mcp
+  interval: 1h
+  timeout: 5m
+  prune: true
+  wait: false
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: windmill-mcp
+      namespace: mcp-system
+  retryInterval: 2m

--- a/kubernetes/apps/mcp-system/windmill-mcp/mcp/kustomization.yaml
+++ b/kubernetes/apps/mcp-system/windmill-mcp/mcp/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./mcpserverregistration.yaml

--- a/kubernetes/apps/mcp-system/windmill-mcp/mcp/mcpserverregistration.yaml
+++ b/kubernetes/apps/mcp-system/windmill-mcp/mcp/mcpserverregistration.yaml
@@ -1,0 +1,14 @@
+---
+# TODO: apply schema
+apiVersion: mcp.kuadrant.io/v1alpha1
+kind: MCPServerRegistration
+metadata:
+  name: windmill-tools
+  labels:
+    mcp.kuadrant.io/managed: "true"
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: windmill-mcp
+  toolPrefix: windmill_


### PR DESCRIPTION
## Summary

Wires Windmill's built-in MCP gateway (`POST /api/mcp/w/lovenet/mcp` on `windmill-app.home.svc:8000`) into `mcp-gateway` via a small nginx reverse-proxy that injects `Authorization: Bearer <token>` from a 1Password-backed ExternalSecret. Lets agents and Claude dispatch Windmill scripts/flows from chat without round-tripping through the Windmill admin API recipe.

## Auth-injection approach

Investigated Windmill's source first:

- `backend/windmill-api/src/lib.rs` mounts the workspaced MCP router under `route_layer(from_extractor::<ApiAuthed>())`.
- `backend/windmill-api-auth/src/auth.rs::extract_token` extracts auth in order: `Authorization: Bearer <token>` header → cookie → `?token=` query param. **The Bearer header is the preferred form**.

So the goal is a Bearer-header-injecting layer between mcp-gateway and Windmill. Options considered:

1. **Envoy Gateway `HTTPRouteFilter` with `credentialInjection`** — exists, reads a Bearer token from a Secret, and is exactly the right shape — but it only binds to routes on `gatewayClassName: envoy`. `mcp-gateway` uses `gatewayClassName: istio`, so the filter does nothing. ❌
2. **HTTPRoute `RequestHeaderModifier`** — value must be a literal in the HTTPRoute YAML; no Secret-ref support. Token-in-Git is a non-starter. ❌
3. **Small nginx reverse-proxy** — reads `WINDMILL_TOKEN` from env (Secret-mounted), template-rendered via the image's `envsubst`-on-startup entrypoint, `proxy_set_header Authorization "Bearer $WINDMILL_TOKEN"`, proxies `/mcp` → `/api/mcp/w/lovenet/mcp`. ✅

Picked option 3. Mirrors the existing app-template + bjw-s hardening pattern in mcp-system, supports SSE / streamable-HTTP semantics (buffering off, 1h timeouts), and the Bearer-only token never leaves the cluster Secret store.

## File layout

- `kubernetes/apps/mcp-system/windmill-mcp/ks.yaml` — two Flux Kustomizations (app then mcp, with `dependsOn`).
- `app/helmrelease.yaml` — `nginxinc/nginx-unprivileged:1.27.5-alpine` (UID 101, port 8080), `readOnlyRootFilesystem`, `drop: ALL`, `seccompProfile: RuntimeDefault`, emptyDirs for `/etc/nginx/conf.d`, `/var/cache/nginx`, `/var/run`, `/tmp`.
- `app/externalsecret.yaml` — pulls `mcp_token` from 1P item `windmill` (vault `Kubernetes`) into a `WINDMILL_TOKEN` env-shape Secret.
- `app/resources/default.conf.template` — nginx template; mounted via `configMapGenerator` at `/etc/nginx/templates/default.conf.template` and rendered into `conf.d` at startup.
- `app/cnp-allow.yaml` — egress to `home/windmill-app:8000`.
- `mcp/mcpserverregistration.yaml` — `windmill-tools`, `toolPrefix: windmill_`, targets the HTTPRoute.

## Other touched files

- `kubernetes/apps/mcp-system/kustomization.yaml` — append `./windmill-mcp/ks.yaml`.
- `kubernetes/apps/home/windmill/app/cnp-allow.yaml` — permit ingress from `mcp-system/windmill-mcp` on port 8000.

The Windmill HelmRelease itself is **not** modified.

## Manual step (operator, before merge)

Create a Windmill API token in the `lovenet` workspace UI (Settings → Account → Tokens) with at least the MCP scopes, then add it to 1Password:

```sh
op item edit "windmill" --vault Kubernetes "mcp_token[password]=<TOKEN>"
```

The ExternalSecret refreshes hourly; the reloader annotation rolls the nginx proxy on Secret change.

## Test plan

- [x] `kubectl kustomize kubernetes/apps/mcp-system/windmill-mcp/app/` renders cleanly.
- [x] `kubectl kustomize kubernetes/apps/mcp-system/windmill-mcp/mcp/` renders cleanly.
- [x] Windmill source confirms `Authorization: Bearer` accepted (extract_token in windmill-api-auth/src/auth.rs).
- [ ] Operator creates 1P `windmill.mcp_token` field.
- [ ] Flux reconciles; `kubectl -n mcp-system get pod -l app.kubernetes.io/name=windmill-mcp` Running.
- [ ] From the mcp-gateway broker, an MCP `initialize` POST to `http://windmill-mcp.mcp-system.svc.cluster.local:8080/mcp` returns a Windmill MCP response.
- [ ] `windmill_*` tools surface via MCPServerRegistration on the mcp-gateway tool list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)