### PR TITLE
fix(network/external-dns-bind): bump memory limit 140M → 256M

### DIFF
--- a/kubernetes/apps/network/external-dns/app/bind/helmrelease.yaml
+++ b/kubernetes/apps/network/external-dns/app/bind/helmrelease.yaml
@@ -86,11 +86,19 @@ spec:
               startup:
                 enabled: false
             resources:
+              # Bumped 140M → 256M after observed peak hit 135M (96%
+              # of the previous limit). Memory pressure was stalling
+              # the Go GC enough that RFC2136 calls to brain:53 dialed
+              # tcp-timeout, external-dns treats that as fatal and
+              # exits → kubelet restart → on the next sync the orphan
+              # ownership TXT makes external-dns skip republishing the
+              # actual CNAME. The langfuse half-state on 2026-05-20
+              # was a symptom of this loop.
               requests:
                 cpu: 10m
-                memory: 140M
+                memory: 256M
               limits:
-                memory: 140M
+                memory: 256M
             securityContext:
               allowPrivilegeEscalation: false
               capabilities: {drop: ["ALL"]}


### PR DESCRIPTION
## Summary

bind-flavor external-dns has been restarting ~every 15 hours (19 restarts in 12 days). Same fatal exit every time:

\`\`\`
warn in dns.Client.Exchange: dial tcp 192.168.1.1:53: i/o timeout
RFC2136 update record failed: dial tcp 192.168.1.1:53: i/o timeout
fatal: Failed to do run once: RFC2136 had errors in one or more of its batches: [dial tcp 192.168.1.1:53: i/o timeout]
\`\`\`

The "i/o timeout" reads like a network issue but isn't — **peak memory over the last 14d hit 135 MB against the 140 MB limit (96%)**. Under that pressure Go's GC stalls long enough that scheduled RFC2136 calls miss their dial deadline. external-dns treats the failed batch as fatal and exits 1; kubelet restarts.

## Why this matters beyond cosmetic restart count

external-dns processes batches as `RemoveRecord → AddRecord` pairs. When the TCP times out **partway through**, some records land (e.g. the ownership TXT) and others don't (the actual CNAME). On the next sync the orphan TXT makes external-dns think "I already own that hostname" and it skips republishing — leaving the record half-published in bind.

The **langfuse half-state observed 2026-05-20** (`langfuse.thesteamedcrab.com` had the `k8s.*` ownership TXT in bind but no CNAME, so Pi-hole cached NXDOMAIN) was a direct symptom of this loop. Required manual investigation + Pi-hole cache flush to recover.

## Fix

Bump memory request + limit `140M → 256M`. Roughly 2× headroom over the observed peak. Should keep GC out of the way and let RFC2136 dials complete on time.

## Test plan

- [ ] After Flux reconciles, new pod stays `1/1 Running`.
- [ ] No restarts over the next ~24h.
- [ ] `container_memory_working_set_bytes{namespace="network",pod=~"external-dns-bind.*"}` stays comfortably below 256M.
- [ ] Newly-created internal HTTPRoutes publish to bind on first sync (no orphan TXT half-state).

## Out of scope

The underlying upstream design issue — that external-dns fatal-exits on a single batch failure and leaves bind half-state — is still there even with extra memory. Worth filing upstream separately. This PR removes the trigger; doesn't fix the trap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)