### PR TITLE
feat(ci): auto-bump README badges on push to main

### DIFF
--- a/.github/workflows/readme-autobump.yaml
+++ b/.github/workflows/readme-autobump.yaml
@@ -1,0 +1,85 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+
+# Auto-bump README.md badges on every push to main.
+#
+# Closes the race where every concurrent PR that touched the README
+# badges would drift the moment another PR merged. Authors no longer
+# need to bump badges manually — the bot does it as a follow-up
+# commit to main.
+#
+# Loop avoidance: the bot's commit only touches README.md, which
+# isn't in this workflow's `paths:` trigger, so its own push won't
+# re-fire the workflow.
+
+name: README autobump
+
+"on":
+  push:
+    branches: [main]
+    paths:
+      - "kubernetes/**"
+      - "tools/lint-readme-drift.py"
+      - ".github/workflows/readme-autobump.yaml"
+
+concurrency:
+  group: readme-autobump
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  autobump:
+    name: Auto-bump README badges
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate Token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          client-id: ${{ secrets.LOVENET_RENOVATE_OPERATOR_CLIENT_ID }}
+          private-key: ${{ secrets.LOVENET_RENOVATE_OPERATOR_PRIVATE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          # Need full history so the push isn't rejected for being
+          # behind the remote when concurrent pushes land.
+          fetch-depth: 0
+
+      - name: Run readme-drift --fix
+        id: fix
+        run: |
+          set -e
+          tools/lint-readme-drift.py --fix
+          if git diff --quiet README.md; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No drift — README already matches reality."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            git diff README.md | head -20
+          fi
+
+      - name: Commit and push
+        if: steps.fix.outputs.changed == 'true'
+        run: |
+          set -e
+          git config user.name "lovenet-renovate-operator[bot]"
+          git config user.email "lovenet-renovate-operator[bot]@users.noreply.github.com"
+          git add README.md
+          git commit \
+            -m "chore(readme): auto-bump badges to match repo reality" \
+            -m "Triggered by ${GITHUB_SHA::12} — see ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA}."
+          # Retry on push race: if another push landed while we were
+          # working, pull --rebase and try again. Up to 3 attempts.
+          for attempt in 1 2 3; do
+            if git push origin HEAD:main; then
+              exit 0
+            fi
+            echo "Push attempt $attempt failed; pulling rebase and retrying..."
+            git pull --rebase origin main
+          done
+          echo "Push failed after 3 retries."
+          exit 1

--- a/tools/lint-readme-drift.py
+++ b/tools/lint-readme-drift.py
@@ -19,8 +19,14 @@ it ensures a new hardware row is paired with a badge bump.
 
 Usage:
     tools/lint-readme-drift.py [README_PATH]
+    tools/lint-readme-drift.py --fix [README_PATH]
 
 Exits 0 if all badges match, 1 if any drift.
+
+With `--fix`, drift is corrected in-place and the script exits 0
+(or 2 if the only drift is the `k8s_nodes` badge — that one is
+operator-edited alongside the Hardware table, not auto-derivable from
+code, so we refuse to auto-rewrite it).
 """
 from __future__ import annotations
 
@@ -108,8 +114,26 @@ def parse_badges(readme_text: str) -> dict[str, str]:
     return out
 
 
+def rewrite_badge(text: str, label: str, new_value: str) -> str:
+    """Replace the value in a shields.io badge for `label` with `new_value`.
+
+    Operates on the exact pattern `/badge/<label>-<value>-` so we don't
+    touch the rest of the URL (color, style flags, logo, etc.).
+    """
+    pattern = re.compile(
+        rf"(/badge/{re.escape(label)}-)([^-]+)(-)",
+    )
+    return pattern.sub(rf"\g<1>{new_value}\g<3>", text, count=1)
+
+
 def main(argv: list[str]) -> int:
-    readme_path = Path(argv[1]) if len(argv) > 1 else REPO_ROOT / "README.md"
+    args = argv[1:]
+    fix = False
+    if args and args[0] == "--fix":
+        fix = True
+        args = args[1:]
+
+    readme_path = Path(args[0]) if args else REPO_ROOT / "README.md"
     text = readme_path.read_text()
     badges = parse_badges(text)
 
@@ -123,31 +147,60 @@ def main(argv: list[str]) -> int:
         "k8s_nodes": str(count_hardware_rows(text)),
     }
 
-    drift: list[str] = []
+    drift: list[tuple[str, str, str]] = []
     for label, expected in expectations.items():
         actual = badges.get(label)
         if actual is None:
-            drift.append(f"  - badge `{label}` not found in README")
+            drift.append((label, "<missing>", expected))
         elif actual != expected:
-            drift.append(
-                f"  - badge `{label}` says `{actual}`; repo reality is `{expected}`"
-            )
+            drift.append((label, actual, expected))
 
-    if drift:
-        print("❌ README.md is drifting from repo reality:")
-        for line in drift:
-            print(line)
-        print()
-        print("Update the badges + any matching body text in the same PR")
-        print("that changed the underlying counts, per CLAUDE.md:")
-        print('  "Repo README.md and docs/ are updated in the same PR as')
-        print('   the change they describe. Stale docs are bugs."')
-        return 1
+    if not drift:
+        print("✅ README badges match repo reality:")
+        for label, value in expectations.items():
+            print(f"   {label}: {value}")
+        return 0
 
-    print("✅ README badges match repo reality:")
-    for label, value in expectations.items():
-        print(f"   {label}: {value}")
-    return 0
+    if fix:
+        # Auto-fix all drift except `k8s_nodes` — that one is sourced
+        # from the README's own Hardware table, so fixing the badge
+        # would just paper over a stale table. Surface it instead.
+        unfixed: list[tuple[str, str, str]] = []
+        new_text = text
+        fixed = []
+        for label, actual, expected in drift:
+            if label == "k8s_nodes":
+                unfixed.append((label, actual, expected))
+                continue
+            if actual == "<missing>":
+                unfixed.append((label, actual, expected))
+                continue
+            new_text = rewrite_badge(new_text, label, expected)
+            fixed.append((label, actual, expected))
+
+        if fixed:
+            readme_path.write_text(new_text)
+            print("🛠  README badges auto-fixed:")
+            for label, actual, expected in fixed:
+                print(f"   {label}: {actual} → {expected}")
+        if unfixed:
+            print("⚠️  Drift NOT auto-fixed (requires manual edit):")
+            for label, actual, expected in unfixed:
+                print(f"   {label}: {actual} → {expected} (Hardware table or missing badge)")
+            return 2
+        return 0
+
+    print("❌ README.md is drifting from repo reality:")
+    for label, actual, expected in drift:
+        print(f"  - badge `{label}` says `{actual}`; repo reality is `{expected}`")
+    print()
+    print("Update the badges + any matching body text in the same PR")
+    print("that changed the underlying counts, per CLAUDE.md:")
+    print('  "Repo README.md and docs/ are updated in the same PR as')
+    print('   the change they describe. Stale docs are bugs."')
+    print()
+    print("Or run `tools/lint-readme-drift.py --fix` to auto-correct.")
+    return 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Closes the race where every concurrent PR touching the README badges drifts the moment another PR merges. Authors no longer hand-bump the apps / HelmReleases / secrets / Postgres badges — a post-merge GitHub Action runs the fixer and commits the result.

This session shipped 12 PRs end-to-end, and the readme-drift cascade caused at least 8 force-pushes across 5 PRs. The pattern is intrinsic to per-PR badge edits: whichever PR merges first wins, every other PR goes stale.

## Implementation

- **`tools/lint-readme-drift.py --fix`** — corrects drift in place. The `k8s_nodes` badge is refused — it's sourced from the README's own Hardware table, so auto-rewriting it would paper over a stale table.
- **`.github/workflows/readme-autobump.yaml`** — triggers on `push` to `main` when `kubernetes/**` or the script itself changes. Uses the existing `LOVENET_RENOVATE_OPERATOR` app token. Retries up to 3× on push race.
- **Loop avoidance**: the bot's commit only touches `README.md`, which isn't in the workflow's `paths:` trigger, so its own push won't re-fire.

## Verified locally

\`\`\`
$ sed -i 's|apps-179-|apps-100-|' README.md
$ tools/lint-readme-drift.py
❌ README.md is drifting from repo reality:
  - badge \`apps\` says \`100\`; repo reality is \`179\`

$ tools/lint-readme-drift.py --fix
🛠  README badges auto-fixed:
   apps: 100 → 179

$ tools/lint-readme-drift.py
✅ README badges match repo reality
\`\`\`

The PR-time \`readme-drift\` check stays in place — it still catches authors who deliberately tried to edit the badge and got the wrong value, and it documents intent. The auto-bump workflow is the safety net for the concurrent-PR race case.

## Test plan

- [ ] CI passes (yamllint + actionlint + readme-drift on this PR)
- [ ] After merge, the next PR that adds an app/HR/secret triggers the autobump workflow and lands a follow-up bot commit on main
- [ ] Watch for push-loops in the first few runs (shouldn't happen — paths filter excludes README.md changes)
- [ ] Concurrent PRs that both add apps: each merges normally, bot follows up after each merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)