### PR TITLE
ci(pre-commit): pre-push readme-drift check vs origin/main

### DIFF
--- a/.agents/skills/pre-submit.md
+++ b/.agents/skills/pre-submit.md
@@ -28,7 +28,13 @@ independent agent).
    pulls (or is set to sync via ZOT). `crane manifest <ref>` is one
    way.
 4. **Lint** — match whatever CI runs (markdownlint, yamllint,
-   `kustomize build`).
+   `kustomize build`, `tools/lint-readme-drift.py`,
+   `tools/lint-cnp-empty-rules.py`). With `pre-commit install
+   --hook-type pre-commit --hook-type pre-push` the commit-time +
+   push-time hooks in `.pre-commit-config.yaml` cover this
+   automatically — the push-stage `readme-drift-vs-main` also catches
+   "main moved past my branch" drift that the commit-time hook can't
+   see.
 5. **File-count** — see `CLAUDE.md` "Blast radius". 50-file ceiling;
    `sweep` label required to bypass. If you're above 50 and not
    labeling `sweep`, split.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,6 +68,13 @@ repos:
   # cnp-empty-rules catches CiliumNetworkPolicies with an
   # `endpointSelector` but no `ingress:` / `egress:` rules — Cilium
   # 1.19 silently rejects them at apply time.
+  #
+  # readme-drift-vs-main is the push-time companion: the commit-time
+  # check sees only the local tree, so it can't catch "main moved past
+  # my branch" drift (another PR added an app and bumped the badges
+  # while this branch sat). The push-stage hook fetches origin/main,
+  # simulates the merge, and runs the linter on the merged tree —
+  # mirroring what CI does.
   - repo: local
     hooks:
       - id: readme-drift
@@ -82,3 +89,10 @@ repos:
         language: system
         pass_filenames: false
         files: \.yaml$
+      - id: readme-drift-vs-main
+        name: README drift vs origin/main merge
+        entry: tools/check-readme-drift-vs-main.sh
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [pre-push]

--- a/tools/check-readme-drift-vs-main.sh
+++ b/tools/check-readme-drift-vs-main.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Pre-push drift check: simulate merge with origin/main, run drift linter
+# on the merged tree.
+#
+# Catches the gap left by the commit-time readme-drift hook: a branch
+# can be self-consistent at commit time and still fail CI's drift check
+# if main has moved past it (e.g., another PR added an app and bumped
+# the badges in the meantime). CI runs the linter against the merge
+# tree; this hook does the same locally so the failure surfaces before
+# push instead of after.
+#
+# Wired via .pre-commit-config.yaml stages: [pre-push].
+set -euo pipefail
+
+LINTER="tools/lint-readme-drift.py"
+REMOTE="${REMOTE:-origin}"
+BASE_BRANCH="${BASE_BRANCH:-main}"
+
+if [ ! -x "$LINTER" ]; then
+    echo "drift-check: $LINTER not executable; skipping" >&2
+    exit 0
+fi
+
+# Fetch latest base. Degrade to no-op if offline — CI will still catch
+# anything we miss, and a hard fail here would block legitimate pushes
+# when the network is down.
+if ! git fetch -q "$REMOTE" "$BASE_BRANCH" 2>/dev/null; then
+    echo "drift-check: could not fetch $REMOTE/$BASE_BRANCH; skipping" >&2
+    exit 0
+fi
+
+BASE_REF="refs/remotes/$REMOTE/$BASE_BRANCH"
+HEAD_SHA=$(git rev-parse HEAD)
+BASE_SHA=$(git rev-parse "$BASE_REF")
+
+# If HEAD already contains BASE_SHA (no behind-ness), the local linter
+# is sufficient — no merge to simulate.
+if git merge-base --is-ancestor "$BASE_SHA" "$HEAD_SHA"; then
+    exec "$LINTER"
+fi
+
+# Compute the merge tree. --write-tree refuses on conflicts (non-zero
+# exit), which is itself a signal worth blocking on.
+if ! MERGE_TREE=$(git merge-tree --write-tree "$HEAD_SHA" "$BASE_SHA" 2>/dev/null); then
+    echo "drift-check: merging $REMOTE/$BASE_BRANCH would conflict — rebase or merge first" >&2
+    exit 1
+fi
+
+# Materialize the merged tree as a detached worktree so we can run the
+# linter against it without polluting the current working tree.
+TMP_WT=$(mktemp -d)
+trap 'git worktree remove --force "$TMP_WT" >/dev/null 2>&1 || true; rm -rf "$TMP_WT"' EXIT
+
+MERGE_COMMIT=$(git commit-tree "$MERGE_TREE" -p "$HEAD_SHA" -p "$BASE_SHA" -m "drift-check tmp")
+git worktree add --detach -q "$TMP_WT" "$MERGE_COMMIT"
+
+(cd "$TMP_WT" && python3 "$LINTER")


### PR DESCRIPTION
## Summary

- New `tools/check-readme-drift-vs-main.sh` that fetches `origin/main`, simulates the merge via `git merge-tree --write-tree`, materializes the result as a detached worktree, and runs `tools/lint-readme-drift.py` against it — mirroring exactly what CI does.
- Wired into `.pre-commit-config.yaml` as a `stages: [pre-push]` hook so `pre-commit install --hook-type pre-push` gates pushes locally.
- `.agents/skills/pre-submit.md` updated to call out the push-stage hook alongside the existing commit-stage one.

## Why

The commit-time `readme-drift` hook (#11871) sees only the local tree, so it can't catch "main moved past my branch" drift — another PR added an app + bumped badges while this branch sat. CI catches it via the PR merge ref, but only after push, blaming the wrong PR.

This was the failure mode on #11875: the PR diff was memory-only, fully self-consistent at commit time, but the CI merge tree picked up an extra app from main and the badges didn't match.

## Test plan

- [x] Local: HEAD = origin/main, script delegates to local linter, passes (179/189).
- [x] Local: synthetic stale-README branch + commit, script detects drift on merge tree.
- [x] Local: from an old self-consistent commit (3592c20db7) the script merges with current main and reports the merged tree clean.
- [ ] Once installed: `pre-commit install --hook-type pre-push` and try pushing a branch that's behind on README badges; expect refusal.