### PR TITLE
feat(precommit): wrap credential scanner as local hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -96,3 +96,19 @@ repos:
         pass_filenames: false
         always_run: true
         stages: [pre-push]
+      - id: literal-credentials
+        # Wraps `tools/git-hooks/pre-commit` — scans for URL-embedded
+        # creds, common query-string secret patterns, plain-text YAML
+        # secret fields, and streaming-URL credential patterns. See
+        # the script itself for the exact regex set.
+        #
+        # Without this entry, `pre-commit install` would overwrite the
+        # standalone .git/hooks/pre-commit symlink and silently drop
+        # credential scanning. Surfacing it here lets `pre-commit
+        # install` be the canonical hook install, with the symlink
+        # still working for clones that haven't installed pre-commit.
+        name: No literal credentials in staged YAML
+        entry: tools/git-hooks/pre-commit
+        language: system
+        pass_filenames: false
+        files: \.ya?ml$


### PR DESCRIPTION
## Summary

The existing \`tools/git-hooks/pre-commit\` credential scanner is installed via a manual symlink (\`ln -sf ../../tools/git-hooks/pre-commit .git/hooks/pre-commit\`). Running \`pre-commit install\` overwrites that symlink with the framework's dispatcher and silently drops the credential scan.

This wraps the same script as a \`local\` hook in \`.pre-commit-config.yaml\` so \`pre-commit install\` is now a safe no-op-replacement for the symlink — both paths run the credential scanner.

## After this PR + \`pre-commit install\` once-per-clone, every \`git commit\` runs:

- File hygiene (check-yaml, check-json, trailing-whitespace, etc.)
- Gitleaks
- yamllint --strict
- markdownlint-cli2
- actionlint
- readme-drift
- cnp-empty-rules
- **literal-credentials** (this PR)

Plus \`pre-push\`: readme-drift-vs-origin/main (added in #11881).

## Verified

This PR's own commit was blocked by the credential scanner on the first try (false positive on a comment that contained the literal regex triggers). I rewrote the comment to use descriptive prose instead of the literal patterns, and the hook now passes — eats its own dogfood.

## Test plan

- [ ] CI passes (yamllint + readme-drift + cnp-empty-rules)
- [ ] Run \`pre-commit run literal-credentials --all-files\` locally — passes
- [ ] Plant a literal cred in a YAML, stage, commit — hook blocks with the expected error
- [ ] After merge, \`pre-commit install\` in a clone replaces the symlink without losing the credential check

🤖 Generated with [Claude Code](https://claude.com/claude-code)