### PR TITLE
fix(home/windmill): migrate dlq-watcher off retired deno.land/x/wmill

### DIFF
--- a/kubernetes/apps/home/windmill/workflows/langgraph-dlq-watcher.ts
+++ b/kubernetes/apps/home/windmill/workflows/langgraph-dlq-watcher.ts
@@ -8,7 +8,10 @@
 // Companion to lga 4.M3 (`/admin/dlq` endpoints + Phase 4.M2 worker
 // that writes to task_dlq on terminal failure).
 
-import * as wmill from "https://deno.land/x/wmill@v1.470.0/mod.ts";
+// `deno.land/x/wmill` was retired in favor of the npm package; the
+// deno.land/x path now returns 404, so any script using it fails at
+// module-resolution time. Pin the same version via `npm:` instead.
+import * as wmill from "npm:windmill-client@1.470.0";
 
 type DlqEntry = {
     id: string;


### PR DESCRIPTION
## Summary

\`https://deno.land/x/wmill@v1.470.0/mod.ts\` returns **404** — the path was retired in favor of the npm package \`windmill-client\`. Every 5-minute schedule of \`f/lovenet/langgraph-dlq-watcher\` has been failing at module-resolution time with:

\`\`\`
error: Module not found "https://deno.land/x/wmill@v1.470.0/mod.ts".
    at file:///tmp/windmill/wk-default-.../main.ts:11:24
\`\`\`

Switching to \`npm:windmill-client@1.470.0\` pins the same version through the canonical resolver. \`wmill.getState()\` / \`wmill.setState()\` are stable across the two surfaces.

## ⚠️ Runtime sync needed

This fixes the **in-repo source file**. The runtime script in Windmill (\`f/lovenet/langgraph-dlq-watcher\` in the \`lovenet\` workspace) ALSO needs the import updated — there's no auto-sync from \`workflows/\` to Windmill. The README in that dir references \`tools/wmill-sync.sh\` which doesn't exist.

After merge:

1. Open \`https://windmill.thesteamedcrab.com/scripts/get/f/lovenet/langgraph-dlq-watcher\` in the editor
2. Replace line 11 \`import * as wmill from "https://deno.land/x/wmill@v1.470.0/mod.ts";\` with \`import * as wmill from "npm:windmill-client@1.470.0";\`
3. Click "Save Draft" / "Deploy" — the next scheduled run picks it up

Or via the Windmill admin API:

\`\`\`
op item get windmill --vault Kubernetes --reveal --format json | jq -r '.fields[] | select(.label=="admin_password") | .value'
# then: curl -X POST https://windmill.${SECRET_DOMAIN}/api/w/lovenet/scripts/create with the new content
\`\`\`

## Other failing schedule (not in this PR)

\`f/lovenet/langgraph-awaiting-user-sweep\` is also failing every 5 minutes — but its failure is **`TimeoutError: Signal timed out.`** after 30s. That's the known langgraph \`/inbox\` hang from memory \`project_langgraph_reporter_post_node_hang.md\` — a separate, langgraph-side bug, not a Windmill script bug. Tracked already.

## Test plan

- [ ] CI passes
- [ ] After merge + manual sync to Windmill, the next 5-minute fire of \`langgraph-dlq-watcher\` succeeds (or returns \`{posted: 0, last_seen: ...}\`)
- [ ] No more red dots for this script in the Windmill Runs view

🤖 Generated with [Claude Code](https://claude.com/claude-code)