### PR TITLE
fix(ai/cnp): allow blackbox-exporter ingress to ollama + ollama-spark on 11434

### DIFF
--- a/kubernetes/apps/ai/ollama-spark/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/ollama-spark/app/cnp-allow.yaml
@@ -41,6 +41,13 @@ spec:
             app.kubernetes.io/name: open-webui
         - matchLabels:
             io.kubernetes.pod.namespace: mcp-system
+        # OllamaWedged synthetic probe (ollama_embed blackbox module
+        # against bge-m3). Distinct from the Prometheus scrape allowed
+        # by the baseline allow-monitoring-scrape — that one matches
+        # `app.kubernetes.io/name: prometheus`.
+        - matchLabels:
+            io.kubernetes.pod.namespace: observability
+            app.kubernetes.io/name: prometheus-blackbox-exporter
       toPorts:
         - ports:
             - port: "11434"

--- a/kubernetes/apps/ai/ollama/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/ollama/app/cnp-allow.yaml
@@ -47,6 +47,13 @@ spec:
             app.kubernetes.io/name: open-webui
         - matchLabels:
             io.kubernetes.pod.namespace: mcp-system
+        # OllamaWedged synthetic probe (ollama_embed blackbox module
+        # against bge-m3). Distinct from the Prometheus scrape allowed
+        # by the baseline allow-monitoring-scrape — that one matches
+        # `app.kubernetes.io/name: prometheus`.
+        - matchLabels:
+            io.kubernetes.pod.namespace: observability
+            app.kubernetes.io/name: prometheus-blackbox-exporter
       toPorts:
         - ports:
             - port: "11434"


### PR DESCRIPTION
## Summary

- The `OllamaWedged` synthetic probes (Probes `ollama-embed` and `ollama-spark-embed`, `ollama_embed` blackbox module → bge-m3) live in `observability/` and target `ollama.ai:11434` / `ollama-spark.ai:11434`. The baseline `allow-monitoring-scrape` CNP only matches `app.kubernetes.io/name: prometheus`, so the synthetic-probe SYNs were silently denied.
- This surfaced as `CiliumPolicyDropsSustained` with `destination_namespace=ai` at ~0.11 pkt/s (verified via `hubble observe --type drop --to-namespace ai`).
- Fix adds `observability/prometheus-blackbox-exporter` as a permitted ingress source on the per-app `ollama-allow` / `ollama-spark-allow` CNPs (port 11434/TCP). Scoped to just the two apps the probes actually target — does **not** widen the cluster baseline.

## Test plan

- [ ] Flux reconciles the two `cnp-allow.yaml` files in the `ai` namespace
- [ ] `hubble observe --to-namespace ai --type drop --last 50` no longer shows the `observability/blackbox-exporter → ai/ollama-spark-0:11434 SYN` pattern
- [ ] `sum by (destination_namespace) (rate(hubble_drop_total{destination_namespace="ai",reason="POLICY_DENIED"}[5m]))` decays toward 0
- [ ] `CiliumPolicyDropsSustained{destination_namespace="ai"}` resolves after the 10m `for:` window
- [ ] The `ollama_embed` blackbox probes return `probe_success=1` for `ollama.ai` and `ollama-spark.ai`

🤖 Generated with [Claude Code](https://claude.com/claude-code)