### PR TITLE
fix(observability/holmesgpt): use toEntities: cluster for ollama egress

### DIFF
--- a/kubernetes/apps/observability/holmesgpt/app/cnp-allow.yaml
+++ b/kubernetes/apps/observability/holmesgpt/app/cnp-allow.yaml
@@ -31,21 +31,23 @@ spec:
             - port: "8080"
               protocol: TCP
   egress:
-    # LLM backend — ollama (P40) + ollama-spark (Blackwell) in ai ns
-    # (Pattern E). Both endpoints selected for parallel-routing readiness;
-    # current MODEL/OLLAMA_API_BASE target ollama-spark, but the rollback
-    # path is a one-env-flip back to ollama — keep both reachable.
-    - toEndpoints:
-        - matchLabels:
-            io.kubernetes.pod.namespace: ai
-            app.kubernetes.io/name: ollama
-        - matchLabels:
-            io.kubernetes.pod.namespace: ai
-            app.kubernetes.io/name: ollama-spark
+    # LLM backend — ollama (P40) + ollama-spark (Blackwell) in ai ns.
+    # Reaches both for parallel-routing readiness; current
+    # MODEL/OLLAMA_API_BASE target ollama-spark, with the P40 ollama
+    # endpoint kept reachable as a one-env-flip rollback.
+    #
+    # NB: a targeted `toEndpoints + toPorts: 11434` rule for ai/ollama
+    # + ai/ollama-spark was the original shape but Cilium 1.19 silently
+    # dropped Holmes → ollama-spark SYNs (Hubble verdict:
+    # `policy-verdict:none ... DENIED`) despite the selector → identity
+    # resolution succeeding. Same realization issue PR #11870 hit on
+    # blackbox-exporter against the same destinations. Using
+    # `toEntities: cluster` (the prometheus-allow pattern) sidesteps it.
+    # Tradeoff: any cluster pod on :11434 — in practice nothing else
+    # listens on 11434, so the effective destination set is unchanged.
+    - toEntities:
+        - cluster
       toPorts:
         - ports:
             - port: "11434"
               protocol: TCP
-    # HolmesGPT investigates k8s resources at runtime — needs to query
-    # prometheus + alertmanager + loki (intra-ns; baseline covers) and
-    # the apiserver (baseline covers). No external egress required.


### PR DESCRIPTION
## Summary

HolmesGPT has been non-functional end-to-end since the Spark cutover. Hubble verdict on every Holmes → ollama-spark:11434 SYN is `policy-verdict:none ... DENIED` despite a syntactically-correct `toEndpoints + toPorts: 11434` allow rule. Same Cilium 1.19 realization issue PR #11870 hit on blackbox-exporter against the same backends.

Fix mirrors PR #11870's pattern: replace the targeted `toEndpoints + toPorts` rule with `toEntities: cluster + toPorts: 11434`. The port restriction is preserved; only ollama instances listen on 11434 cluster-wide.

This was uncovered by a Stream 1d.A verification probe — see commit body for the full diagnostic. Stream 1d.A (LITELLM_TIMEOUT 900s → 600s revert) was waiting on a soak gate that could never be evidenced because every alert hitting the windmill-investigate AM receiver was being filtered by Windmill before reaching Holmes, leaving Holmes silent and the breakage invisible.

## Test plan

- [x] Hubble drop verdict confirms the policy denial on the original `toEndpoints + toPorts` shape (in commit body).
- [x] memory-mcp on the same node uses the same shape and works — confirms host networking is healthy and the issue is per-endpoint policy realization.
- [ ] After Flux reconcile: re-run a `POST /api/chat` probe from a windmill-app pod targeting Holmes; expect HTTP 200 instead of HTTP 500.
- [ ] Confirm Holmes pod-level Hubble flows show `policy-verdict:allow EGRESS` on the SYN to ollama-spark-0:11434.
- [ ] If working, capture end-to-end probe latency to inform the Stream 1d.A LITELLM_TIMEOUT decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)