### PR TITLE
feat(ai/tei-spark): scaffold reranker HelmRelease (suspended)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ _Production-grade Kubernetes for a household._
 
 <br/>
 
-![apps](https://img.shields.io/badge/apps-179-blue?style=for-the-badge)
-![helmreleases](https://img.shields.io/badge/HelmReleases-189-326CE5?style=for-the-badge&logo=helm&logoColor=white)
+![apps](https://img.shields.io/badge/apps-180-blue?style=for-the-badge)
+![helmreleases](https://img.shields.io/badge/HelmReleases-190-326CE5?style=for-the-badge&logo=helm&logoColor=white)
 ![nodes](https://img.shields.io/badge/k8s_nodes-11-326CE5?style=for-the-badge&logo=kubernetes&logoColor=white)
 ![cnpg](https://img.shields.io/badge/Postgres_clusters-25-336791?style=for-the-badge&logo=postgresql&logoColor=white)
 ![secrets](https://img.shields.io/badge/secrets-113-0572EC?style=for-the-badge&logo=1password&logoColor=white)

--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -21,5 +21,6 @@ resources:
   - ./ollama-spark/ks.yaml
   - ./paperless-ai/ks.yaml
   - ./sync-receiver/ks.yaml
+  - ./tei-spark/ks.yaml
   - ./khoj/ks.yaml
   - ./khoj-oauth2-proxy/ks.yaml

--- a/kubernetes/apps/ai/tei-spark/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/tei-spark/app/cnp-allow.yaml
@@ -1,0 +1,44 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: tei-spark-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: tei-spark
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # Open WebUI reranker traffic (Stream 2d cutover lands the
+    # corresponding egress rule on the open-webui CNP).
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: collab
+            app.kubernetes.io/name: open-webui
+      toPorts:
+        - ports:
+            - port: "3000"
+              protocol: TCP
+    # Prometheus scrape on the dedicated metrics port (TEI exposes
+    # /metrics on --prometheus-port, separate from the HTTP API).
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: observability
+            app.kubernetes.io/name: prometheus
+      toPorts:
+        - ports:
+            - port: "9000"
+              protocol: TCP
+  egress:
+    # HuggingFace Hub model download — bge-reranker-v2-m3 weights pulled
+    # to the model cache PVC on first start. Reuses the same world:443
+    # pattern as ollama-spark for the same reason (HF / CDN IPs are not
+    # FQDN-stable enough for toFQDNs).
+    - toEntities: [world]
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/ai/tei-spark/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/tei-spark/app/helmrelease.yaml
@@ -1,0 +1,164 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: tei-spark
+spec:
+  # Suspended on initial scaffold. PR-2 of the Stream 2 cutover removes
+  # this flag (and only this flag) once the surrounding manifests have
+  # been reviewed in isolation. See spark-unblocks-rag-cutover-done memo
+  # and the Stream 2 plan for the full sequence.
+  suspend: true
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 30m
+  install:
+    disableWait: true
+  upgrade:
+    disableWait: true
+  values:
+    controllers:
+      tei:
+        pod:
+          nodeSelector:
+            node-role.kubernetes.io/gpu: blackwell
+
+          # Spark taints: arm64 (keeps amd64-only workloads off — kubelet
+          # only catches arch mismatch at pull time, too late) and the
+          # nvidia.com/gpu reservation. Mirrors ollama-spark.
+          tolerations:
+            - key: kubernetes.io/arch
+              operator: Equal
+              value: arm64
+              effect: NoSchedule
+            - key: nvidia.com/gpu
+              operator: Equal
+              value: "true"
+              effect: NoSchedule
+
+          priorityClassName: ai-gpu-critical
+
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            fsGroupChangePolicy: OnRootMismatch
+            seccompProfile:
+              type: RuntimeDefault
+
+        type: deployment
+
+        containers:
+          app:
+            image:
+              # workaround: https://github.com/huggingface/text-embeddings-inference/issues/870
+              #   — remove when TEI cuts a release tag containing PRs
+              #   #840 (sm_121 arm64) + #852 (12.1 arm64-restricted),
+              #   currently only on main post-v1.9.3.
+              # Pinned to the multi-arch index digest; arm64 is the only
+              # platform inside this index (TEI #852 restricted 12.1
+              # builds to linux/arm64).
+              repository: ghcr.io/huggingface/text-embeddings-inference
+              tag: 121-sha-5bc4d88@sha256:f5c419e98b9178184e83bf96856f60e70d515f663493b235f61edf1c5f2de8dc
+
+            env:
+              MODEL_ID: BAAI/bge-reranker-v2-m3
+              HOSTNAME: 0.0.0.0
+              PORT: &httpPort 3000
+              PROMETHEUS_PORT: &metricsPort 9000
+              HUGGINGFACE_HUB_CACHE: &cachePath /data
+              # FP16 — bge-reranker-v2-m3 is XLM-RoBERTa (568M params);
+              # FP16 halves VRAM use and is the default for CUDA backends.
+              DTYPE: float16
+              # Truncate over-long inputs rather than 413 the client.
+              # Default-true upstream; pinned here for clarity.
+              AUTO_TRUNCATE: "true"
+              JSON_OUTPUT: "true"
+
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: *httpPort
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: *httpPort
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              # Generous startup budget: bge-reranker-v2-m3 cold start
+              # is HF Hub download (~570 MB) + safetensors load to GPU.
+              # 60 * 5s = 5 min, refined in PR-2 once we have wall-clock
+              # numbers from Spark.
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: *httpPort
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                  timeoutSeconds: 5
+                  failureThreshold: 60
+
+            resources:
+              requests:
+                cpu: 500m
+                memory: 4Gi
+                nvidia.com/gpu: 1
+              limits:
+                memory: 12Gi
+                nvidia.com/gpu: 1
+
+            securityContext:
+              runAsNonRoot: true
+              runAsUser: 1000
+              runAsGroup: 1000
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop: ["ALL"]
+
+    service:
+      app:
+        controller: tei
+        ports:
+          http:
+            port: *httpPort
+          metrics:
+            port: *metricsPort
+
+    persistence:
+      cache:
+        existingClaim: tei-spark-cache-pvc
+        advancedMounts:
+          tei:
+            app:
+              - path: *cachePath
+
+      # TEI extracts safetensors / tokenizers and uses /tmp for the
+      # internal gRPC UDS socket. Read-only rootfs requires a writable
+      # /tmp; emptyDir is the established pattern (langgraph-agents,
+      # see helmrelease.security.md).
+      tmp:
+        type: emptyDir
+        advancedMounts:
+          tei:
+            app:
+              - path: /tmp

--- a/kubernetes/apps/ai/tei-spark/app/kustomization.yaml
+++ b/kubernetes/apps/ai/tei-spark/app/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../components/repos/app-template
+
+resources:
+  - ./cnp-allow.yaml
+  - ./helmrelease.yaml
+  - ./pvc.yaml
+  - ./servicemonitor.yaml

--- a/kubernetes/apps/ai/tei-spark/app/pvc.yaml
+++ b/kubernetes/apps/ai/tei-spark/app/pvc.yaml
@@ -1,0 +1,13 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: tei-spark-cache-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: ceph-block
+  resources:
+    requests:
+      storage: 5Gi

--- a/kubernetes/apps/ai/tei-spark/app/servicemonitor.yaml
+++ b/kubernetes/apps/ai/tei-spark/app/servicemonitor.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/servicemonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: tei-spark
+  labels:
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/instance: tei-spark
+    app.kubernetes.io/name: tei-spark
+    prometheus: kube-prometheus
+spec:
+  endpoints:
+    - interval: 30s
+      path: /metrics
+      port: metrics
+      scheme: http
+      scrapeTimeout: 10s
+  namespaceSelector:
+    matchNames:
+      - ai
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tei-spark

--- a/kubernetes/apps/ai/tei-spark/ks.yaml
+++ b/kubernetes/apps/ai/tei-spark/ks.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app tei-spark
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: ai
+  path: "./kubernetes/apps/ai/tei-spark/app"
+  interval: 30m
+  timeout: 5m
+  prune: true
+  wait: true
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: onepassword-connect
+      namespace: external-secrets
+    - name: gpu-operator
+      namespace: kube-system
+    - name: rook-ceph-cluster
+      namespace: rook-ceph


### PR DESCRIPTION
## Summary

PR-1 of 5 for **Stream 2** — moving Open WebUI's reranker off in-process into a dedicated `text-embeddings-inference` (TEI) service on Spark. Lands the scaffold **suspended**; PR-2 unsuspends after this lands clean.

- Mirrors `kubernetes/apps/ai/ollama-spark/` shape: blackwell nodeSelector, arm64 + nvidia.com/gpu tolerations, `ai-gpu-critical` priority class.
- 5 Gi `ceph-block` PVC for the HF Hub model cache (bge-reranker-v2-m3 ≈570 MB; regenerable → ceph-block per `.agents/instructions/storage-class.instructions.md` rule 2).
- Security defaults per `.agents/instructions/helmrelease.security.md`: non-root 1000:1000, read-only rootfs + tmpfs `/tmp`, drop-ALL caps, RuntimeDefault seccomp.
- CNP ingress: open-webui:3000 (rerank), prometheus:9000 (metrics). Egress: world:443 (HF Hub).
- ServiceMonitor scrapes TEI's dedicated `--prometheus-port` 9000.

## Why now / why this shape

This is **architectural prep**, not a memory-pain fix. `kubectl top pod -n collab open-webui-0` shows 685 Mi resident — the in-process reranker isn't even loaded today (Open WebUI's KB doesn't read the external `paperless` Qdrant collection, so nothing's invoking rerank). Stream 2 sets up the right place for rerank to live before that gap closes.

Model is `BAAI/bge-reranker-v2-m3` — the family-matched pair to the cluster's `bge-m3` embedder, and per BAAI's own MIRACL/BEIR/CMTEB benchmarks, beats `bge-reranker-large` in every multilingual setting when reranking bge-m3 top-100 retrievals.

## Image pin + workaround

Upstream's `121-` (sm_121 arm64 Blackwell) variant only exists on `main` post-v1.9.3 — PRs [#840](https://github.com/huggingface/text-embeddings-inference/pull/840) (multi-arch CUDA Dockerfile, sm_121) and [#852](https://github.com/huggingface/text-embeddings-inference/pull/852) (restrict 12.1 to linux/arm64) merged 2026-03-31 but no release has been cut since. Pinned to the immutable `121-sha-5bc4d88@sha256:f5c419e9…` tag under a `# workaround:` annotation per `.agents/instructions/workarounds.md`. Removes when TEI cuts a tag containing #840.

## Why `bge-reranker-v2-m3` works on TEI despite not being on the docs list

TEI's `router/src/lib.rs::get_backend_model_type` matches `arch.ends_with("Classification")` generically — no allowlist. `XLMRobertaForSequenceClassification` (what v2-m3 is) falls through to the Candle CUDA backend cleanly. [Issue #713](https://github.com/huggingface/text-embeddings-inference/issues/713) confirms it serving live on TEI 1.8.

## Test plan

- [x] `kubectl kustomize kubernetes/apps/ai/tei-spark/app` renders 5 resources
- [x] `kubectl kustomize kubernetes/apps/ai` includes the new ks.yaml without breaking siblings
- [x] flux-local schema validation (CI)
- [ ] PR-2 (unsuspend) — soak verification: `/health` returns 200, smoke-test rerank against bge-reranker-v2-m3, prom scrape captures `te_request_*` series. Falls back to **Infinity** (same model, Blackwell-aware) if TEI's sm_121 image misbehaves with v2-m3, not to a different reranker.
- [ ] PR-3 (window-gated to **Tue 2026-05-26 02:00 ET**) — Open WebUI switch to `RAG_RERANKING_ENGINE: external`, memory limit 6Gi → 2Gi.

## Rollback

Single revert. Suspended HR has no runtime impact; revert just removes the scaffold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)