### PR TITLE
fix(mcp-system/windmill-mcp): escape $${WINDMILL_TOKEN} from Flux postBuild

### DIFF
--- a/kubernetes/apps/mcp-system/windmill-mcp/app/resources/default.conf.template
+++ b/kubernetes/apps/mcp-system/windmill-mcp/app/resources/default.conf.template
@@ -28,7 +28,10 @@ server {
         proxy_http_version 1.1;
         proxy_set_header Host windmill-app.home.svc.cluster.local;
         proxy_set_header Connection "";
-        proxy_set_header Authorization "Bearer ${WINDMILL_TOKEN}";
+        # `$${WINDMILL_TOKEN}` (double-$) escapes Flux postBuild substitution
+        # — Flux renders it back to `${WINDMILL_TOKEN}`, which nginx's
+        # envsubst then expands from the WINDMILL_TOKEN env var at startup.
+        proxy_set_header Authorization "Bearer $${WINDMILL_TOKEN}";
 
         # SSE / streamable-HTTP friendliness — Windmill MCP streams.
         proxy_buffering off;


### PR DESCRIPTION
## Summary

PR #11874 shipped the nginx-proxy template with `${WINDMILL_TOKEN}` as
the Bearer header. Flux's `postBuild` variable substitution interpolates
any `${VAR}` it sees across the rendered manifest — including ConfigMap
data — and replaces unbound variables with the empty string. So the
ConfigMap landed in the cluster with `Authorization: "Bearer "`
(literally empty), and every broker → windmill-mcp request got
`401 Unauthorized` from Windmill.

The token plumbing past that point is correct: the WINDMILL_TOKEN env
var arrives in the container (sourced from `windmill-mcp-secret`,
itself produced by the `windmill-mcp` ExternalSecret reading `mcp_token`
from the 1P `Kubernetes/windmill` item). The only missing step was
escaping `${VAR}` so Flux passes it through unchanged.

The fix is a one-line escape: `$${WINDMILL_TOKEN}`. Flux renders that
back to a literal `${WINDMILL_TOKEN}` in the ConfigMap, and
nginx-unprivileged's envsubst expands it from the env var at container
startup.

## Discovery context

Found while investigating `CiliumPolicyDropsSustained{destination_namespace="mcp-system"}`
(separate from the ICMP root cause — windmill-mcp wedged in
`CreateContainerConfigError` for ~40m, fixed by adding the missing
`mcp_token` field to 1P). Once the pod came up, drops stopped — but
nginx logs showed `POST /mcp HTTP/1.1" 401` from mcp-broker, so the MCP
tools weren't actually reachable yet. Tracing the chain:

1. ExternalSecret → `windmill-mcp-secret` populated with the token ✓
2. Pod env `WINDMILL_TOKEN` populated from secret ✓
3. nginx ConfigMap data: `Authorization "Bearer "` (empty) ✗
4. nginx-unprivileged envsubst pass: nothing to expand — value is already
   empty in the template at container start

The empty value in step 3 is the postBuild-substitution swallow.

## Test plan

- [ ] Flux reconciles the ConfigMap update; `kubectl -n mcp-system get cm
      windmill-mcp-nginx-config -o yaml | grep Authorization` shows the
      literal `${WINDMILL_TOKEN}`, not `Bearer ` (empty)
- [ ] Pod restarts and renders `Authorization "Bearer <token>"` at
      `/etc/nginx/conf.d/default.conf`
- [ ] `kubectl -n mcp-system logs deployment/windmill-mcp --tail=20`
      shows `POST /mcp HTTP/1.1" 200` (not 401) from `mcp-broker`
- [ ] mcp-broker auto-discovery surfaces windmill tools in
      `claude mcp list` within ~10m

🤖 Generated with [Claude Code](https://claude.com/claude-code)