### PR TITLE
fix(khoj): bind uvicorn to 0.0.0.0 + add TCP-socket probes

### DIFF
--- a/kubernetes/apps/ai/khoj/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/khoj/app/helmrelease.yaml
@@ -47,10 +47,14 @@ spec:
               repository: ghcr.io/khoj-ai/khoj
               tag: 2.0.0-beta.28
             # First-run superuser bootstrap is automatic when KHOJ_ADMIN_EMAIL
-              # + KHOJ_ADMIN_PASSWORD are set; --non-interactive skips the
-              # TTY prompt that would otherwise CrashLoop the pod.
+            # + KHOJ_ADMIN_PASSWORD are set; --non-interactive skips the
+            # TTY prompt that would otherwise CrashLoop the pod.
+            # --host 0.0.0.0 overrides upstream default of 127.0.0.1
+            # (src/khoj/utils/cli.py) so the Service can reach uvicorn.
             args:
               - --non-interactive
+              - --host
+              - 0.0.0.0
             env:
               KHOJ_DOMAIN: khoj.${SECRET_DOMAIN}
               KHOJ_ALLOWED_DOMAIN: khoj.${SECRET_DOMAIN}
@@ -71,6 +75,40 @@ spec:
             envFrom:
               - secretRef:
                   name: khoj-secret
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: &httpPort 42110
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 3
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: *httpPort
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 3
+                  failureThreshold: 3
+              # First start downloads ~500MB of embedding models into
+              # khoj-models PVC — wide failureThreshold accommodates the
+              # cold-cache case (matches disableWait rationale above).
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: *httpPort
+                  initialDelaySeconds: 15
+                  periodSeconds: 10
+                  timeoutSeconds: 3
+                  failureThreshold: 60
             resources:
               requests:
                 cpu: 100m


### PR DESCRIPTION
## Summary

- `khoj-ai/khoj`'s CLI defaults `--host` to `127.0.0.1` (`src/khoj/utils/cli.py:19`). The HelmRelease only passed `--non-interactive`, so uvicorn was binding loopback-only — the Service had endpoints but nothing on the cluster network could reach the pod. khoj-oauth2-proxy returned 502 on every upstream dial.
- Pod was `Running` with **0 restarts for 6 days** before this was noticed — no liveness or readiness probe was defined, so a missing HTTP listener never failed the pod or removed it from the Service.

## Fix

- Add `--host 0.0.0.0` to the launcher args (verified against the live image's `src/khoj/utils/cli.py`).
- Add liveness, readiness, and startup probes against port 42110 (TCP socket) so a missing listener now fails the pod immediately. Startup `failureThreshold: 60` (10 min) preserves headroom for the first-run embedding-model download path that motivated `disableWait: true`.

## Test plan

- [ ] Flux reconciles HelmRelease; Recreate strategy rolls khoj pod
- [ ] New pod logs show `Uvicorn running on http://0.0.0.0:42110`
- [ ] `curl http://khoj.ai.svc.cluster.local:42110/api/health` from an in-cluster pod returns 200
- [ ] `khoj.${SECRET_DOMAIN}` no longer 502s through oauth2-proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)