### PR TITLE
fix(ai/cnp): allow holmesgpt ingress to ollama + ollama-spark on 11434

### DIFF
--- a/kubernetes/apps/ai/ollama-spark/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/ollama-spark/app/cnp-allow.yaml
@@ -48,6 +48,13 @@ spec:
         - matchLabels:
             io.kubernetes.pod.namespace: observability
             app.kubernetes.io/name: prometheus-blackbox-exporter
+        # HolmesGPT chat-mode investigation LLM calls. MODEL is
+        # `ollama/qwen2.5:32b` served here per the Spark-Unblocks-RAG
+        # cutover (PR #11752); the holmesgpt egress side allows :11434
+        # to the cluster.
+        - matchLabels:
+            io.kubernetes.pod.namespace: observability
+            app.kubernetes.io/name: holmesgpt
       toPorts:
         - ports:
             - port: "11434"

--- a/kubernetes/apps/ai/ollama/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/ollama/app/cnp-allow.yaml
@@ -54,6 +54,13 @@ spec:
         - matchLabels:
             io.kubernetes.pod.namespace: observability
             app.kubernetes.io/name: prometheus-blackbox-exporter
+        # HolmesGPT rollback path. Active MODEL is on ollama-spark
+        # post-Spark cutover (PR #11752), but a one-env-flip back to
+        # this P40 endpoint is the documented rollback — keep ingress
+        # open so the rollback doesn't silently fail at this CNP.
+        - matchLabels:
+            io.kubernetes.pod.namespace: observability
+            app.kubernetes.io/name: holmesgpt
       toPorts:
         - ports:
             - port: "11434"


### PR DESCRIPTION
## Summary

Sibling of #11884 (blackbox-exporter ingress) and #11885 (Holmes egress). On top of #11885, Holmes' egress to ollama-spark now resolves, but every SYN is still dropped at the destination — ollama-spark's ingress CNP is an explicit allowlist and `observability/holmesgpt` was never in it.

The diagnosis I wrote in #11885 ("Cilium 1.19 toEndpoints+toPorts realization bug") was wrong. Memory-mcp works because `mcp-system/*` matches the destination's wildcard allow; Holmes failed because `observability/holmesgpt` matched neither the wildcard nor any specific entry. Once this lands, Stream 1d.A's verification probe should actually complete.

This PR adds the missing allowlist entries on both ollama-spark (active backend) and ollama (P40, the documented rollback target).

## Test plan

- [x] Confirmed via Hubble post-#11885 that drops are at destination side (SYN ALLOWED + FORWARDED out of Holmes, then dropped before reaching ollama-spark).
- [x] Confirmed memory-mcp connects fine via the `mcp-system/*` wildcard match on the same destination CNP.
- [ ] After Flux reconcile: re-run the Stream 1d.A probe (POST /api/chat from a windmill-app pod). Expect end-to-end HTTP 200 with a coherent investigation, no `litellm.exceptions.APIConnectionError`, no `Policy denied DROPPED` in Hubble for Holmes → ollama-spark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)