### PR TITLE
feat(ai/langgraph-agents): bump 0.2.26 → 0.2.28 + wire queue substrate

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/cnp-allow.yaml
@@ -102,6 +102,32 @@ spec:
         - ports:
             - port: "6379"
               protocol: TCP
+    # OpenTelemetry collector (observability ns) — Phase 3.K trace
+    # propagation. agents.observability.init_otel() ships spans via
+    # the OTLP gRPC exporter to :4317. The collector's CNP already
+    # allows `fromEntities: cluster` so no change needed there.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: observability
+            app.kubernetes.io/name: opentelemetry-collector
+      toPorts:
+        - ports:
+            - port: "4317"
+              protocol: TCP
+    # Windmill (home ns) — Phase 4.M2 follow-on (langgraph-agents
+    # PR #58 / #59). When the queue worker detects a paused-for-
+    # approval interrupt, it POSTs the ApprovalRequest to
+    # `f/lovenet/langgraph-approval-post` via
+    # `/api/w/lovenet/jobs/run/p/...` on windmill-app:8000. Windmill's
+    # CNP already allows ingress from langgraph-agents.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: home
+            app.kubernetes.io/name: windmill-app
+      toPorts:
+        - ports:
+            - port: "8000"
+              protocol: TCP
     # External APIs: api.pushover.net for Tier-1 alert escalations,
     # api.anthropic.com for the Claude API gated on ENABLE_CLAUDE_API.
     #

--- a/kubernetes/apps/ai/langgraph-agents/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/externalsecret.yaml
@@ -44,6 +44,16 @@ spec:
         ZULIP_HOST: chat.${SECRET_DOMAIN}
         ZULIP_TRIAGER_EMAIL: "{{ .ZULIP_TRIAGER_EMAIL }}"
         ZULIP_TRIAGER_API_KEY: "{{ .ZULIP_TRIAGER_API_KEY }}"
+
+        # Approval-post webhook (Phase 4.M2 follow-on / langgraph-agents
+        # 0.2.28). The queue worker POSTs ApprovalRequest payloads
+        # when graph.ainvoke pauses at interrupt(). Same Windmill
+        # webhook token alertmanager uses for the HolmesGPT route
+        # (1P `windmill.alertmanager_webhook_token`) — single-token
+        # rotation surface for everything that hits the run/p/
+        # endpoint.
+        APPROVAL_POST_WEBHOOK_URL: http://windmill-app.home.svc.cluster.local:8000/api/w/lovenet/jobs/run/p/f/lovenet/langgraph-approval-post
+        APPROVAL_POST_WEBHOOK_TOKEN: "{{ .alertmanager_webhook_token }}"
   dataFrom:
     - extract:
         key: langgraph-agents
@@ -51,3 +61,7 @@ spec:
     # reply-back path on source=zulip).
     - extract:
         key: zulip-bots-langgraph
+    # Windmill webhook token for the approval-post call (reused
+    # from the same token alertmanager uses to invoke HolmesGPT).
+    - extract:
+        key: windmill

--- a/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/langgraph-agents
-              tag: 0.2.26@sha256:768a08dbef7f2b30220f12ea18f15cf6b8c4e6c46962011a7607b9a89486fef8
+              tag: 0.2.28@sha256:514593a48a98b9ecbde9371240abf7e4b4b35f94ddedcbe38189e3057399ad54
 
             env:
               # --- vault ---
@@ -49,6 +49,15 @@ spec:
 
               # --- MCP gateway ---
               MCP_GATEWAY_URL: http://mcp-gateway-istio.mcp-system.svc.cluster.local:8080
+
+              # --- OpenTelemetry (Phase 3.K) ---
+              # Spans land on opentelemetry-collector in observability ns.
+              # CNP egress for :4317 is in cnp-allow.yaml. The default
+              # in agents/observability.py matches this URL; setting
+              # explicitly makes the dependency greppable from
+              # home-ops.
+              OTEL_EXPORTER_OTLP_ENDPOINT: http://opentelemetry-collector.observability.svc.cluster.local:4317
+              OTEL_SERVICE_NAME: langgraph-agents
 
               # --- cost caps (per security review cat 7) ---
               COST_CAP_PER_TASK_USD: "5.0"


### PR DESCRIPTION
## Summary

Bumps langgraph-agents to v0.2.28 — the first tagged release after PRs #50–#59 in `rwlove/langgraph-agents` shipped the queue substrate. Currently the cluster runs v0.2.26, which still calls `await graph.ainvoke(...)` inline in `/inbox` — long Zulip DMs / large reporter tasks hang the HTTP caller 300–900s.

After this PR, `/inbox` returns 202 + `task_id` in <100ms; the worker drains a CNPG LISTEN/NOTIFY queue in the background. See [`project_langgraph_reporter_post_node_hang`](memory) and the [implementation plan](/home/rwlove/.claude-personal/plans/gentle-fluttering-alpaca.md) for context.

## What lands with v0.2.28

| PR | Phase | Effect |
|---|---|---|
| #50 | 5 | task envelope (trace_id, requester, intent, priority, ttl_seconds, retry_policy, data_tier) |
| #51 | 3.G | Dragonfly idempotency dedup at /inbox |
| #52 | 3.I | Renee allowlist gate (default `{action, question}`) |
| #53 | 3.H | data_tier-driven emission redaction |
| #54 | 3.K | OTel tracing → opentelemetry-collector |
| #55 | 4.M1 | CNPG LISTEN/NOTIFY queue primitives |
| #56 | 4.M2 | /inbox hard cutover to enqueue + 202 + background worker |
| #57 | 4.M3 | /admin/dlq endpoints |
| #58 | 4.M2-fo | worker-side approval-post on interrupt |
| #59 | 4.M2-fo | nest approval payload + Bearer token |

## Companion home-ops changes (in this PR)

1. **helmrelease.yaml** — tag → `0.2.28@sha256:514593a4…`. Add explicit `OTEL_EXPORTER_OTLP_ENDPOINT` + `OTEL_SERVICE_NAME` matching `settings.py` defaults so the dependency is greppable from home-ops.
2. **cnp-allow.yaml** — add egress to opentelemetry-collector (`observability` ns :4317) and to windmill-app (`home` ns :8000). Existing dragonfly/postgres/ollama/mcp-system/zulip rules already cover the rest.
3. **externalsecret.yaml** — add `APPROVAL_POST_WEBHOOK_URL` (plain) + `APPROVAL_POST_WEBHOOK_TOKEN` (reused from 1P `windmill.alertmanager_webhook_token` — same token alertmanager uses for the HolmesGPT route, single-token rotation surface).

The companion Windmill workflow `langgraph-approval-post.ts` is already in tree from a prior PR.

## What home-ops already had pre-wired

- `kubernetes/apps/home/windmill/workflows/langgraph-daily-digest.ts` — polls `/admin/tasks/<id>` after enqueue (PR #11847)
- `kubernetes/apps/home/windmill/workflows/langgraph-dlq-watcher.ts` — polls `/admin/dlq`, posts to Zulip #operations
- `kubernetes/apps/home/windmill/workflows/langgraph-approval-post.ts` — ntfy + Zulip approval card
- `kubernetes/apps/observability/grafana/dashboards/task-queue.json` — queue dashboard
- `kubernetes/apps/home/windmill/workflows/zulip-triager-webhook.ts` — already uses fire-and-forget; 2s abort is plenty for a 202

## What we deferred

- **DLQ depth + queue backlog Prometheus alerts.** langgraph-agents doesn't expose those gauges yet — adding them is a separate follow-on. DLQ visibility is already covered by the existing `langgraph-dlq-watcher` cron posting to Zulip #operations.
- **Zulip reply-back split-horizon fix.** `agents.tools.zulip.send_dm` still POSTs `https://chat.thesteamedcrab.com/...` (split-horizon LB IP unreachable from inside cluster). Worker logs the failure but doesn't raise. Separate PR (`zulip_base_url` setting + ExternalSecret update).
- **Dead `status === "paused"` branch in `langgraph-inbox.ts`.** Never fires post-cutover. Cleanup PR.

## Test plan

- [ ] `flux-local diff` — confirm only langgraph-agents + dependent resources change
- [ ] CI: lint, image-registry-check, gitleaks, flux-local, codeql, data-classification-scrub, webhook-validate
- [ ] After merge in routine window (02:00–05:00 ET):
  - [ ] `kubectl -n ai rollout status deploy/langgraph-agents --timeout=180s`
  - [ ] Schema migrations applied: `\dt` in `langgraph_checkpoints` shows `task_queue` + `task_dlq`
  - [ ] Smoke `/inbox` → 202 with task_id; poll `/admin/tasks/<id>` → done with output
  - [ ] DM "what is the current time?" to Triager 📥 — task lands done in `/admin/tasks/<id>`; Zulip DM reply still fails (Phase 5 — expected)
  - [ ] Trigger a Class-B operator intent → ntfy push within seconds, tap-to-approve works
  - [ ] Daily-digest cron next run — Zulip #digests post lands
  - [ ] `/admin/dlq` empty 24h after deploy
  - [ ] OTel span visible in Tempo for at least one `queue.process` trace

## Rollback

Revert this PR. Flux rolls back to 0.2.26. `task_queue` / `task_dlq` tables remain in postgres-langgraph-checkpoints — inert (v0.2.26 doesn't read them); optional drop in rollback steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)