### PR TITLE
feat(ai/langgraph-agents): bump 0.2.26 → 0.2.27 + wire approval-post webhook

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/externalsecret.yaml
@@ -44,6 +44,29 @@ spec:
         ZULIP_HOST: chat.${SECRET_DOMAIN}
         ZULIP_TRIAGER_EMAIL: "{{ .ZULIP_TRIAGER_EMAIL }}"
         ZULIP_TRIAGER_API_KEY: "{{ .ZULIP_TRIAGER_API_KEY }}"
+
+        # Phase 4.M2 worker-side approval webhook. When a specialist
+        # node calls `interrupt()` with an ApprovalRequest, the queue
+        # worker POSTs `{task_id, approval_request}` to this URL so
+        # the ntfy + Zulip approval-post path fires immediately.
+        # Without it, the first user-visible signal is the 30-min
+        # escalation tier from `langgraph-awaiting-user-sweep.ts`.
+        #
+        # URL embeds a Windmill API token via query param because the
+        # worker's httpx call sends no Authorization header. Token is
+        # a dedicated webhook-scoped token in the same `windmill` 1P
+        # item that holds `alertmanager_webhook_token` and `mcp_token`.
+        APPROVAL_POST_WEBHOOK_URL: "http://windmill-app.home.svc.cluster.local:8000/api/w/lovenet/jobs/run/p/f/lovenet/langgraph-approval-post?token={{ .WINDMILL_APPROVAL_POST_TOKEN }}"
+  data:
+    # Dedicated Windmill webhook token. Required 1P field:
+    # `windmill.approval_post_webhook_token` — create via
+    # `op item edit windmill approval_post_webhook_token=<token>`
+    # with a Windmill API token scoped to run
+    # `f/lovenet/langgraph-approval-post`.
+    - secretKey: WINDMILL_APPROVAL_POST_TOKEN
+      remoteRef:
+        key: windmill
+        property: approval_post_webhook_token
   dataFrom:
     - extract:
         key: langgraph-agents

--- a/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/langgraph-agents
-              tag: 0.2.26@sha256:768a08dbef7f2b30220f12ea18f15cf6b8c4e6c46962011a7607b9a89486fef8
+              tag: 0.2.27@sha256:c1a5548ce43a0beff77f78f07a8ed241a7247eb85f5de63df55136b6190e5558
 
             env:
               # --- vault ---

--- a/kubernetes/apps/home/windmill/workflows/langgraph-approval-post.ts
+++ b/kubernetes/apps/home/windmill/workflows/langgraph-approval-post.ts
@@ -23,9 +23,11 @@ type ApprovalRequest = {
     cost_estimate_usd?: number;
 };
 
-// Body keys from langgraph-agents: task_id + paused_for.
-export async function main(task_id: string, paused_for: { approval_request: ApprovalRequest }) {
-    const r = paused_for.approval_request;
+// Body keys from langgraph-agents' queue worker on interrupt:
+// `{task_id, approval_request}` (see v0.2.27 worker.py
+// `_post_approval_for_interrupts`).
+export async function main(task_id: string, approval_request: ApprovalRequest) {
+    const r = approval_request;
     const topic = `${task_id} — Class ${r.action_class}: ${r.target}`;
 
     // Pre-sign three tokens (one per verdict). The /approval endpoint


### PR DESCRIPTION
## Summary

- Bumps `langgraph-agents` to v0.2.27, landing the Phase 4.M1–M3 queue cutover (lg-agents PRs #50–#58). `/inbox` becomes 202-async + worker-driven; the postgres-checkpointer `asyncio.Lock` contention is no longer user-visible at the request boundary.
- Wires `APPROVAL_POST_WEBHOOK_URL` so the worker fires the ntfy/Zulip approval card on `interrupt()` immediately — without it, approvals would only surface at the 30-min `langgraph-awaiting-user-sweep.ts` escalation tier (regression vs v0.2.26 where the synchronous `/inbox` response triggered `langgraph-inbox.ts:postApproval` directly).
- Fixes `langgraph-approval-post.ts` argument signature to match the worker's POST body (`{task_id, approval_request}`, not `{task_id, paused_for: {...}}`). Without this the script would crash on `paused_for.approval_request` even with the URL wired.

## Why this is three changes in one PR

Tag bump alone introduces a known approval-latency regression because `langgraph-inbox.ts:50-53`'s synchronous `lg.status === "paused"` branch becomes dead code (response status is now `"accepted"`, never `"paused"`). Wiring the worker-side webhook restores immediate approval surfaces. The signature fix is required for the webhook to actually work.

## Pre-merge operator action — **REQUIRED**

Populate the new 1P field before merge or the env var interpolates to literal `?token=` and Windmill returns 401:

```
op item edit windmill approval_post_webhook_token=<token>
```

where `<token>` is a Windmill API token scoped to run `f/lovenet/langgraph-approval-post` in the `lovenet` workspace. Same 1P item that already holds `alertmanager_webhook_token` + `mcp_token`.

## Test plan

- [ ] 1P `windmill.approval_post_webhook_token` field populated
- [ ] Renovate has not already opened a competing bump PR for 0.2.27 (close one if so)
- [ ] Merge during routine maintenance window (any night 02:00–05:00 ET)
- [ ] Post-merge: `kubectl -n ai get externalsecret langgraph-agents` shows `SYNCED=true`
- [ ] Post-merge: `kubectl -n ai get secret langgraph-agents-secret -o jsonpath='{.data.APPROVAL_POST_WEBHOOK_URL}' | base64 -d` includes a non-empty token query param
- [ ] Post-merge: rolled pod image is `0.2.27@sha256:c1a5548c…`
- [ ] Post-merge: `curl -X POST http://localhost:8765/inbox …` returns HTTP 202 with `{task_id, status:"accepted"}`
- [ ] Post-merge: `curl http://localhost:8765/admin/dlq` reachable
- [ ] Post-merge: trigger a known-pausing intent (or wait for organic one); verify ntfy push lands within ~10s of the worker invocation, not 30 min later
- [ ] Post-merge: daily-digest cron at 22:00 ET completes successfully (uses `/admin/tasks/<id>` polling per langgraph-daily-digest.ts:90-118)
- [ ] Post-merge: triager-bot DM via Zulip enqueues and returns ack within Zulip's 10s outgoing-webhook timeout

## Out of scope / follow-ups

- `langgraph-inbox.ts:50-53` synchronous `postApproval` branch is dead under 202-async. Harmless (never fires) but worth cleaning up in a subsequent PR.
- Per-repo memory note `project_langgraph_reporter_post_node_hang.md` needs updating once this lands — the long-standing "fix sitting on main untagged" entry should flip to "deployed".

🤖 Generated with [Claude Code](https://claude.com/claude-code)