### PR TITLE
feat(ai/tei-spark): unsuspend HelmRelease (PR-2 of Stream 2)

### DIFF
--- a/kubernetes/apps/ai/tei-spark/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/tei-spark/app/helmrelease.yaml
@@ -5,11 +5,6 @@ kind: HelmRelease
 metadata:
   name: tei-spark
 spec:
-  # Suspended on initial scaffold. PR-2 of the Stream 2 cutover removes
-  # this flag (and only this flag) once the surrounding manifests have
-  # been reviewed in isolation. See spark-unblocks-rag-cutover-done memo
-  # and the Stream 2 plan for the full sequence.
-  suspend: true
   chartRef:
     kind: OCIRepository
     name: app-template


### PR DESCRIPTION
## Summary

PR-2 of 5 for Stream 2. Removes the scaffold-time `suspend: true` from PR #11886 (which merged 2026-05-21 12:07 UTC). With this in, Flux starts reconciling the HelmRelease:

1. Pull `ghcr.io/huggingface/text-embeddings-inference:121-sha-5bc4d88` to the Spark node (arm64, sm_121).
2. TEI starts, downloads `BAAI/bge-reranker-v2-m3` weights (~570 MB) from HF Hub into the `tei-spark-cache-pvc` (5 Gi, ceph-block).
3. Service answers on `:3000`; `/metrics` exposed on `:9000`.

No consumer routes to it yet — Open WebUI still reranks in-process. **PR-3** (window-gated to **Tue 2026-05-26 02:00 ET**) does the Open WebUI cutover. Until then, TEI is dark capacity, exercised only by Prometheus scrape + any manual smoke tests.

## Verification (post-merge)

```sh
# pod schedules + becomes Ready (cold-start budget is 5min via startupProbe)
kubectl -n ai get pod -l app.kubernetes.io/name=tei-spark -w

# health
kubectl -n ai exec deploy/tei-spark -- curl -sf http://localhost:3000/health

# smoke-test rerank (this is the load-bearing one — confirms v2-m3 loads
# cleanly on TEI's 121- arm64 image despite not being on the docs supported list)
kubectl -n ai run --rm -i tei-test --image=curlimages/curl:8.10.1 --restart=Never -- \
  curl -sS -X POST http://tei-spark.ai.svc.cluster.local:3000/rerank \
    -H 'content-type: application/json' \
    -d '{"query":"What is RAG?","texts":["RAG combines retrieval and generation.","Pizza is delicious.","Embeddings are vector representations."]}'

# prom scrape
curl -s 'http://prometheus-operated.observability:9090/api/v1/query?query=up{job="tei-spark"}'
```

## Rollback

Single revert. Pod terminates; PVC stays attached. Open WebUI's in-process reranker is untouched throughout, so user-visible impact is zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)