### PR TITLE
fix(home/windmill): alertmanager-holmesgpt-notify arg-shape

### DIFF
--- a/kubernetes/apps/home/windmill/workflows/alertmanager-holmesgpt-notify.ts
+++ b/kubernetes/apps/home/windmill/workflows/alertmanager-holmesgpt-notify.ts
@@ -5,15 +5,19 @@
 //
 // Replaces the n8n flow "AlertManager → HolmesGPT → Pushover".
 
-type AlertmanagerPayload = {
-    alerts: Array<{
-        labels: { alertname: string; severity?: string; namespace?: string; pod?: string };
-        annotations: { summary?: string; description?: string };
-    }>;
+type AlertmanagerAlert = {
+    labels: { alertname: string; severity?: string; namespace?: string; pod?: string };
+    annotations: { summary?: string; description?: string };
 };
 
-export async function main(body: AlertmanagerPayload) {
-    const a = body.alerts?.[0];
+// Windmill maps top-level JSON keys of the webhook body to function
+// args by name — it does NOT wrap the whole body into a single
+// parameter. Alertmanager POSTs `{"alerts": [...], "version": "4",
+// "groupKey": "...", ...}`; Windmill invokes
+// `main(alerts=[...], version="4", ...)`. Take `alerts` directly.
+// See memory `project_n8n_to_windmill_migration_done.md`.
+export async function main(alerts?: AlertmanagerAlert[]) {
+    const a = alerts?.[0];
     if (!a) {
         return { skip: true, reason: "no alerts in payload" };
     }


### PR DESCRIPTION
## Summary

Script signature didn't match how Windmill invokes webhook scripts. Every fire of \`f/lovenet/alertmanager-holmesgpt-notify\` failed at \`main.ts:16:20\` with:

\`\`\`
TypeError: Cannot read properties of undefined (reading 'alerts')
    at main (file:///.../main.ts:16:20)
\`\`\`

## Root cause

\`\`\`ts
export async function main(body: AlertmanagerPayload) {
    const a = body.alerts?.[0];      // body === undefined
\`\`\`

Windmill maps top-level JSON keys of the webhook body to function args **by name** — it does NOT wrap the whole body into a single \`body\` parameter. So when Alertmanager POSTs \`{"alerts": [...], "version": "4", "groupKey": "...", ...}\`, Windmill calls \`main(alerts=[...], version="4", ...)\`.

Same gotcha as the n8n → Windmill migration (memory \`project_n8n_to_windmill_migration_done.md\` — Zulip outgoing webhook required the same flattening).

## Fix

Take \`alerts\` as a top-level arg directly:

\`\`\`ts
export async function main(alerts?: AlertmanagerAlert[]) {
    const a = alerts?.[0];
    if (!a) return { skip: true, reason: "no alerts in payload" };
    // …rest unchanged
\`\`\`

## ⚠️ Runtime sync needed

This fixes the in-repo source file. The runtime script at \`f/lovenet/alertmanager-holmesgpt-notify\` in Windmill (\`lovenet\` workspace) also needs the signature updated — there's no auto-sync from \`workflows/\` to Windmill. See #11883 for the manual sync recipe (UI or admin API).

## Test plan

- [ ] CI passes
- [ ] After merge + runtime sync, fire a test alert (or wait for a real one) — script returns \`{alertname, holmes_chars, ntfy}\` instead of TypeError
- [ ] ntfy push lands in \`#alerts\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)