### PR TITLE
feat(khoj): enable --anonymous-mode behind oauth2-proxy

### DIFF
--- a/kubernetes/apps/ai/khoj/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/khoj/app/helmrelease.yaml
@@ -51,8 +51,14 @@ spec:
             # TTY prompt that would otherwise CrashLoop the pod.
             # --host 0.0.0.0 overrides upstream default of 127.0.0.1
             # (src/khoj/utils/cli.py) so the Service can reach uvicorn.
+            # --anonymous-mode treats every request as the auto-bootstrapped
+            # "default" KhojUser (configure.py:_initialize_default_user),
+            # skipping khoj's own login UI. Safe because oauth2-proxy +
+            # Authelia + lldap gate khoj.${SECRET_DOMAIN} at the edge —
+            # only authenticated household users ever reach this pod.
             args:
               - --non-interactive
+              - --anonymous-mode
               - --host
               - 0.0.0.0
             env:


### PR DESCRIPTION
## Summary

- khoj-ai/khoj ships its own internal email/Google login UI even when the URL is already gated externally.
- `khoj.${SECRET_DOMAIN}` is gated by oauth2-proxy → Authelia → lldap, so only authenticated household users can reach this pod. The inner khoj login is redundant.
- `--anonymous-mode` (`src/khoj/utils/cli.py:30`, `configure.py:217`) maps every request to the auto-bootstrapped `default` KhojUser created by `_initialize_default_user()` on first start, suppressing the inner login.
- The household effectively shares one khoj user. Acceptable for personal-research notes inside the same trust boundary as the lldap directory.

## Test plan

- [ ] Flux reconciles; Recreate strategy rolls the pod
- [ ] New pod logs no longer warn `Start Khoj with --anonymous-mode flag or to enable authentication`
- [ ] `khoj.${SECRET_DOMAIN}` loads straight into the chat UI (no "Sign in to unlock your second brain" modal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)