### PR TITLE
ci(lint): run mdbook build on docs PRs

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -147,6 +147,29 @@ jobs:
       shell: bash
       run: tools/lint-readme-drift.py
 
+  docs-build:
+    name: docs-build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+
+    - name: Get changed files
+      id: changed-files
+      uses: bjw-s-labs/action-changed-files@a9a36fb08ce06db9b02fbd8026cc2c0945eb9841 # v0.6.0
+      with:
+        patterns: |-
+          docs/**
+          .github/workflows/lint.yaml
+
+    - name: Build docs
+      if: steps.changed-files.outputs.changed_files != '[]'
+      uses: docker://ghcr.io/bjw-s-labs/mdbook:0.4.49@sha256:ee4b71f559c7286dfd110a962f0b7660e82bf3e5bbe659a8eef0ba975789f9c9
+      with:
+        args: bash -c "cd docs && mdbook build"
+
   lint_success:
     needs:
     - actionlint
@@ -154,6 +177,7 @@ jobs:
     - markdownlint
     - cnp-empty-rules
     - readme-drift
+    - docs-build
     if: ${{ !cancelled() }}
     name: Lint successful
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ Worker nodes attach to **iot** and **sec** VLANs via Multus for direct camera an
 
 How local AI agents run, get work, ask for human approval, and produce reports — all without putting data in someone else's cloud unless a task genuinely needs it.
 
-> 📖 **Operator's guide**: see [`docs/src/workflow_automation.md`](docs/src/workflow_automation.md) for the
+> 📖 **Operator's guide**: see [`docs/src/workflow_automation.md`](https://github.com/rwlove/home-ops/blob/main/docs/src/workflow_automation.md) for the
 > end-to-end view — how to trigger jobs from Android, the approval lifecycle, and where results land.
 
 ```mermaid


### PR DESCRIPTION
## Summary

- `docs.yaml` runs `mdbook build` only on push to main, so the `[output.linkcheck]` backend (configured in `docs/book.toml:38`) catches broken intra-doc links **after** they land. Recent example: run 26225196696 — the publish job on main has been failing since PR #11815 left a pointer stub at `docs/src/workflow_automation.md` while the README's reference to it broke when expanded via the include preprocessor.
- Add a `docs-build` job to `.github/workflows/lint.yaml` that runs the same `mdbook build` (no deploy) on PRs touching `docs/**`. Wired into `lint_success`'s `needs:` so it gates the existing "Lint successful" check already required by the main-branch ruleset — no ruleset change needed.
- Also fix the pre-existing broken link in `README.md:308`. Root cause: `docs/src/introduction.md` includes `../../README.md`; the relative link `(docs/src/workflow_automation.md)` resolves to `docs/src/docs/src/workflow_automation.md` post-include and fails linkcheck. `mdbook-regex` is a tempting fix but returns `unsupported` for the linkcheck renderer (`mdbook-regex supports linkcheck` → exit 1), so its rewrites never reach linkcheck. Simplest cross-context-correct fix: full GitHub URL — mdbook-linkcheck doesn't validate external URLs by default, and GitHub renders the README identically.
- Runs on `ubuntu-latest` to match `docs.yaml`. The `docker://ghcr.io/bjw-s-labs/mdbook` action needs Docker on the runner; the ARC runners don't ship docker-in-docker.

## Verification

- Reproduced the failure locally with `podman run … mdbook build` against the bjw-s-labs/mdbook image — 1 broken link.
- After the README change, same local run reports "No broken links found".

## Test plan

- [ ] CI: `Lint successful` green (new `docs-build` job runs `mdbook build` end-to-end and reports 0 broken links)
- [ ] Post-merge: the `docs.yaml` publish job on push to main also passes (was broken before this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)