### PR TITLE
fix(ai/langgraph-agents): bump 0.2.28 → 0.2.29 (migration runner fix)

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/langgraph-agents
-              tag: 0.2.28@sha256:514593a48a98b9ecbde9371240abf7e4b4b35f94ddedcbe38189e3057399ad54
+              tag: 0.2.29@sha256:49a0f6c1fd7c545a841610d18811f6a65fe52f65e87f75e0ad52a54c7ab8b5f9
 
             env:
               # --- vault ---


### PR DESCRIPTION
Companion bump for langgraph-agents PR #60.

v0.2.28 attempt earlier today (PR #11891) crashed on lifespan with \`cannot insert multiple commands into a prepared statement\` — the checkpointer pool's \`prepare_threshold=0\` blocks multi-statement SQL from \`conn.execute\`. Helm auto-rolled back to v41 (0.2.26). HelmRelease is currently suspended.

v0.2.29 splits each .sql file into individual statements before execute. See [langgraph-agents PR #60](https://github.com/rwlove/langgraph-agents/pull/60).

## Deploy plan

1. Merge this PR.
2. \`flux reconcile source git flux-system\`
3. \`flux resume helmrelease langgraph-agents -n ai\`
4. Watch rollout + verify migration tables land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)