### PR TITLE
fix(ai/tei-spark): /metrics is on the HTTP port, not --prometheus-port

### DIFF
--- a/kubernetes/apps/ai/tei-spark/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/tei-spark/app/cnp-allow.yaml
@@ -12,25 +12,21 @@ spec:
     egress: false
     ingress: false
   ingress:
-    # Open WebUI reranker traffic (Stream 2d cutover lands the
-    # corresponding egress rule on the open-webui CNP).
+    # API + metrics share port 3000 — TEI's HTTP variant serves
+    # /metrics on the main HTTP port; --prometheus-port does NOT open
+    # a separate listener (verified live against 121-sha-5bc4d88).
+    # Stream 2d cutover lands the corresponding egress rule on the
+    # open-webui CNP for the rerank path.
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: collab
             app.kubernetes.io/name: open-webui
-      toPorts:
-        - ports:
-            - port: "3000"
-              protocol: TCP
-    # Prometheus scrape on the dedicated metrics port (TEI exposes
-    # /metrics on --prometheus-port, separate from the HTTP API).
-    - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: observability
             app.kubernetes.io/name: prometheus
       toPorts:
         - ports:
-            - port: "9000"
+            - port: "3000"
               protocol: TCP
   egress:
     # HuggingFace Hub model download — bge-reranker-v2-m3 weights pulled

--- a/kubernetes/apps/ai/tei-spark/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/tei-spark/app/helmrelease.yaml
@@ -62,8 +62,13 @@ spec:
             env:
               MODEL_ID: BAAI/bge-reranker-v2-m3
               HOSTNAME: 0.0.0.0
+              # TEI's HTTP variant serves /metrics on the main API port;
+              # --prometheus-port / PROMETHEUS_PORT does NOT open a
+              # separate listener (verified live against 121-sha-5bc4d88
+              # — port 9000 connect-refused while /metrics on 3000 works).
+              # Single port keeps the Service + CNP + ServiceMonitor
+              # surface coherent.
               PORT: &httpPort 3000
-              PROMETHEUS_PORT: &metricsPort 9000
               HUGGINGFACE_HUB_CACHE: &cachePath /data
               # FP16 — bge-reranker-v2-m3 is XLM-RoBERTa (568M params);
               # FP16 halves VRAM use and is the default for CUDA backends.
@@ -136,8 +141,6 @@ spec:
         ports:
           http:
             port: *httpPort
-          metrics:
-            port: *metricsPort
 
     persistence:
       cache:

--- a/kubernetes/apps/ai/tei-spark/app/servicemonitor.yaml
+++ b/kubernetes/apps/ai/tei-spark/app/servicemonitor.yaml
@@ -13,7 +13,7 @@ spec:
   endpoints:
     - interval: 30s
       path: /metrics
-      port: metrics
+      port: http
       scheme: http
       scrapeTimeout: 10s
   namespaceSelector:


### PR DESCRIPTION
## Summary

Followup to PR #11893 (tei-spark unsuspend). PR-2 verified the rerank path against `bge-reranker-v2-m3` works end-to-end — correct doc ranked top-1, FlashBert engaged on `Cuda(CudaDevice(DeviceId(1)))`, cold start 65s. What did **not** work: Prometheus scrape.

```
prom target: http://10.42.11.123:9000/metrics  | down | dial tcp 10.42.11.123:9000: connect: connection refused
```

Pod is listening only on 3000. TEI's HTTP variant serves `/metrics` on the main API port; `--prometheus-port` doesn't open a separate listener (it likely applies only to the gRPC build).

Verified live:

```
$ curl tei-spark.ai.svc.cluster.local:3000/metrics | head
te_request_count{method="batch"} 1
te_predict_count 3
te_request_success{method="batch"} 1
te_queue_size 0
te_request_input_length_bucket{...
```

## Diff

- `helmrelease.yaml` — drop `PROMETHEUS_PORT` env, drop `&metricsPort` anchor, drop `service.app.ports.metrics`.
- `servicemonitor.yaml` — `port: metrics` → `port: http`.
- `cnp-allow.yaml` — collapse the prom-on-9000 rule into the open-webui-on-3000 rule (both clients hit 3000 now).

No rerank-path behavior change; restores observability.

## Test plan

- [x] `kubectl kustomize kubernetes/apps/ai/tei-spark/app` clean
- [ ] After merge: prom target flips to `up`, `te_request_*` / `te_predict_*` series visible in Prometheus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)