### PR TITLE
feat(ai/langgraph-agents): bump 0.2.28 → 0.2.30

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/langgraph-agents
-              tag: 0.2.28@sha256:514593a48a98b9ecbde9371240abf7e4b4b35f94ddedcbe38189e3057399ad54
+              tag: 0.2.30@sha256:d4f3b43782d22088cde79b9df0f393bb9c30e49b5c0923971b5a1685ef5a1ae3
 
             env:
               # --- vault ---


### PR DESCRIPTION
## Summary

Pulls in two upstream fixes:

- **#60 (in v0.2.29)** \`fix(queue/migrate): split multi-statement SQL files before execute\` — the checkpointer pool's \`prepare_threshold=0\` setting (added to mitigate asyncio lock contention) broke psycopg's extended-query protocol path for multi-statement migrations.
- **#61 (headline)** \`fix(api/admin): dedicated checkpointer instance for read endpoints\` — \`/admin/tasks\` (used by Windmill's \`f/lovenet/langgraph-awaiting-user-sweep\` every 5 min) was blocked by the shared \`AsyncPostgresSaver.lock\`. PR adds a second compiled graph with its own pool + lock for read-only admin endpoints. See rwlove/langgraph-agents#61.

## Expected cluster impact

- \`f/lovenet/langgraph-awaiting-user-sweep\` Windmill schedule turns green within 5 min of reconcile (was timing out at 30s every fire).
- No change to dispatch-path behavior.
- ~1-2 extra idle Postgres connections (the dedicated admin pool's steady-state cost).

## Diff

\`\`\`
tag: 0.2.28@sha256:51459... → 0.2.30@sha256:d4f3b...
\`\`\`

## Test plan

- [ ] CI passes
- [ ] After merge, Flux reconciles the new image; \`kubectl get deploy -n ai langgraph-agents\` rolls over to the new pod
- [ ] \`kubectl logs -n ai deploy/langgraph-agents -f\` shows two checkpointer pools opening at startup (main + admin)
- [ ] \`curl http://langgraph-agents.ai.svc.cluster.local:8765/admin/tasks\` returns quickly (no 30s hangs)
- [ ] Next 5-min fire of \`langgraph-awaiting-user-sweep\` in Windmill is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)