### PR TITLE
fix(ai/langgraph-agents): revert to 0.2.26 — 0.2.28 queue migration crashes startup

### DIFF
--- a/.github/renovate/packageRules.json5
+++ b/.github/renovate/packageRules.json5
@@ -8,6 +8,17 @@
       "automerge": false
     },
     {
+      // workaround: https://github.com/rwlove/langgraph-agents/issues/TBD — remove when 0.2.29+ ships
+      // 0.2.28 ships a broken queue migration (multi-statement DDL via
+      // psycopg 3 prepared-statement protocol). Disabling Renovate
+      // here so it doesn't auto-bump us back to a broken tag —
+      // ghcr.io/rwlove/* is in autoMerge.json5's allowlist.
+      "description": "TEMP: pin langgraph-agents until 0.2.29 fixes queue migration",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["ghcr.io/rwlove/langgraph-agents"],
+      "enabled": false
+    },
+    {
       "matchDatasources": ["docker", "github-tags"],
       "matchPackageNames": ["ghcr.io/fluxcd/flux-manifests", "fluxcd/flux2"],
       "groupName": "fluxcd/flux2"

--- a/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
@@ -20,7 +20,18 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/langgraph-agents
-              tag: 0.2.28@sha256:514593a48a98b9ecbde9371240abf7e4b4b35f94ddedcbe38189e3057399ad54
+              # workaround: https://github.com/rwlove/langgraph-agents/issues/TBD — remove when 0.2.29+ ships
+              # Pin to last known-good. 0.2.28 ships the Phase 4.M queue
+              # cutover, but `agents.queue.migrate.ensure_schema` calls
+              # `await conn.execute(sql)` on multi-statement DDL — psycopg
+              # 3 routes single-arg execute through the extended-query
+              # (prepared-statement) protocol, which rejects multi-command
+              # input. The pod crashes at FastAPI lifespan, no Ready
+              # endpoints, every Windmill workflow hitting langgraph-agents
+              # times out. The cnp-allow + externalsecret + OTEL env
+              # additions from PR #11891 are left in place — 0.2.26
+              # ignores them so they're inert until the fixed tag re-bumps.
+              tag: 0.2.26@sha256:768a08dbef7f2b30220f12ea18f15cf6b8c4e6c46962011a7607b9a89486fef8
 
             env:
               # --- vault ---


### PR DESCRIPTION
## Summary

- Reverts `langgraph-agents` image tag from `0.2.28` back to `0.2.26@sha256:768a08db…` (last known-good).
- Adds a temporary `packageRules` entry disabling Renovate for `ghcr.io/rwlove/langgraph-agents` so it doesn't auto-bump back (that image is on the `ghcr.io/rwlove/*` auto-merge allowlist).

## Why

0.2.28 ships the Phase 4.M queue cutover (lg-agents PRs #50–#59). On first startup against the real CNPG checkpointer DB, the migration step crashes the FastAPI lifespan:

```
File \"/app/src/agents/queue/migrate.py\", line 32, in ensure_schema
    await conn.execute(sql)
psycopg.errors.SyntaxError: cannot insert multiple commands into a prepared statement
ERROR:    Application startup failed. Exiting.
```

Root cause: `agents.queue.migrate.ensure_schema` does `await conn.execute(sql)` on `001_task_queue.sql` / `002_task_result.sql`, which are multi-statement DDL files. psycopg 3 routes paramless `Connection.execute()` through the extended-query (prepared-statement) protocol, which rejects multi-command input — only the simple-query protocol supports multi-statement.

Consequence: pod stuck in CrashLoopBackOff, Service has no Ready endpoints, every Windmill workflow hitting `langgraph-agents.ai.svc.cluster.local:8765` times out. First caught by `langgraph-dlq-watcher` cron (15.223s timeout matching its `AbortSignal.timeout(15_000)`).

## Why tag-only (not full PR revert)

PR #11891 also added cnp-allow egress, externalsecret keys (`APPROVAL_POST_WEBHOOK_*`), and OTEL env vars. Per #11891's own body: *"Rolling back to 0.2.26 leaves the task_queue / task_dlq tables in place but harmless (v0.2.26 doesn't read them)."* — same applies to those config additions. 0.2.26 ignores the unknown env vars and unused secret keys; the cnp-allow rules are additive. Leaving them in place keeps the re-bump to 0.2.29 a clean tag-only change.

## Test plan

- [ ] Post-merge: `kubectl -n ai rollout status deployment/langgraph-agents` reaches Ready
- [ ] Post-merge: `kubectl -n ai logs deployment/langgraph-agents` shows no `psycopg.errors.SyntaxError`
- [ ] Post-merge: Windmill `langgraph-dlq-watcher` cron's next run returns 200, not `TimeoutError`
- [ ] Post-merge: `kubectl -n ai exec deploy/langgraph-agents -- curl -sS http://localhost:8765/inbox -X POST -H 'Content-Type: application/json' -d '{\"...\"}'` returns whatever 0.2.26's synchronous shape was (regression to pre-cutover behavior is acceptable — that's the point)

## Follow-up

Companion fix PR in `langgraph-agents`: switch `migrate.py:32` to `await conn.execute(sql, prepare=False)` so psycopg uses the simple-query protocol. Tag 0.2.29. Then re-bump home-ops + remove both workarounds in this file (the helmrelease tag comment and the renovate.json5 pin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)