### PR TITLE
fix(khoj-oauth2-proxy): bump upstream-timeout 30s → 300s

### DIFF
--- a/kubernetes/apps/ai/khoj-oauth2-proxy/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/khoj-oauth2-proxy/app/helmrelease.yaml
@@ -57,6 +57,11 @@ spec:
               # while the web UI stays gated. Same pattern as immich's
               # mobile-app exception.
               - --skip-auth-route=^/api/
+              # LLM-backed: chat handler can block khoj's single uvicorn
+              # event loop long enough for sibling REST requests to exceed
+              # oauth2-proxy's default 30s upstream timeout. 300s matches
+              # khoj's own ws_ping_timeout. Multi-worker fix is in PR B.
+              - --upstream-timeout=300s
             envFrom:
               - secretRef:
                   name: khoj-oauth2-proxy-secret


### PR DESCRIPTION
## Summary

khoj runs as a single uvicorn worker by design (upstream's `main.py` calls `uvicorn.run(app, …)` with no `workers` kwarg; gunicorn is the supported multiproc path — see follow-up PR for that). The chat handler can block the event loop long enough that sibling REST calls (page navigation, background polling) exceed oauth2-proxy's default 30s `--upstream-timeout` and 502 — even though the chat itself is healthy and streaming over its websocket.

Observed today: user asked a question, chat ran for 62s over the websocket, but `/agents` page nav and `/api/chat/sessions` background polls returned 502 after ~25–30s.

## Fix

Add `--upstream-timeout=300s` to khoj-oauth2-proxy args. 300s matches khoj's own `ws_ping_timeout` and `timeout_keep_alive`, giving slow legitimate requests room to complete while still capping genuinely-stuck paths.

This is a symptom mask. The architectural fix (multi-worker via gunicorn) lands in a follow-up PR so we can ship one variable at a time.

## Test plan

- [ ] Flux reconciles HelmRelease; oauth2-proxy rolls
- [ ] Trigger a chat (~30s+ generation) and concurrently navigate within the khoj SPA
- [ ] Page navigation / background polls no longer 502 mid-chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)