### PR TITLE
feat(ai/langgraph-agents): bump 0.2.26 → 0.2.30 — queue cutover (fixed migration)

### DIFF
--- a/.github/renovate/packageRules.json5
+++ b/.github/renovate/packageRules.json5
@@ -8,17 +8,6 @@
       "automerge": false
     },
     {
-      // workaround: https://github.com/rwlove/langgraph-agents/issues/TBD — remove when 0.2.29+ ships
-      // 0.2.28 ships a broken queue migration (multi-statement DDL via
-      // psycopg 3 prepared-statement protocol). Disabling Renovate
-      // here so it doesn't auto-bump us back to a broken tag —
-      // ghcr.io/rwlove/* is in autoMerge.json5's allowlist.
-      "description": "TEMP: pin langgraph-agents until 0.2.29 fixes queue migration",
-      "matchDatasources": ["docker"],
-      "matchPackageNames": ["ghcr.io/rwlove/langgraph-agents"],
-      "enabled": false
-    },
-    {
       "matchDatasources": ["docker", "github-tags"],
       "matchPackageNames": ["ghcr.io/fluxcd/flux-manifests", "fluxcd/flux2"],
       "groupName": "fluxcd/flux2"

--- a/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
@@ -20,18 +20,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/langgraph-agents
-              # workaround: https://github.com/rwlove/langgraph-agents/issues/TBD — remove when 0.2.29+ ships
-              # Pin to last known-good. 0.2.28 ships the Phase 4.M queue
-              # cutover, but `agents.queue.migrate.ensure_schema` calls
-              # `await conn.execute(sql)` on multi-statement DDL — psycopg
-              # 3 routes single-arg execute through the extended-query
-              # (prepared-statement) protocol, which rejects multi-command
-              # input. The pod crashes at FastAPI lifespan, no Ready
-              # endpoints, every Windmill workflow hitting langgraph-agents
-              # times out. The cnp-allow + externalsecret + OTEL env
-              # additions from PR #11891 are left in place — 0.2.26
-              # ignores them so they're inert until the fixed tag re-bumps.
-              tag: 0.2.26@sha256:768a08dbef7f2b30220f12ea18f15cf6b8c4e6c46962011a7607b9a89486fef8
+              tag: 0.2.30@sha256:d4f3b43782d22088cde79b9df0f393bb9c30e49b5c0923971b5a1685ef5a1ae3
 
             env:
               # --- vault ---


### PR DESCRIPTION
## Summary

Re-applies the Phase 4.M queue cutover that #11891 attempted, this time on a tag that actually starts up. Removes the two temporary workarounds from #11901.

## What ships in 0.2.30

Two follow-on fixes published since v0.2.28:

- **v0.2.29** (lg-agents PR #60): `agents.queue.migrate.ensure_schema` now splits multi-statement SQL files before dispatch, instead of passing them whole to `conn.execute()`. The checkpointer pool runs with `prepare_threshold=0`, so every statement was being prepared — and the extended-query protocol cannot carry multi-command input, raising `SyntaxError: cannot insert multiple commands into a prepared statement` and aborting FastAPI lifespan. (Verified this exact failure mode when v0.2.28 deployed; Helm auto-rolled back to v41 and the pod has been on 0.2.26 since.)

- **v0.2.30** (lg-agents PR #61): /admin reads use a dedicated checkpointer instance with its own connection pool + asyncio.Lock, so a paused-for-user write on the dispatch path no longer blocks `/admin/tasks/<id>` polling. Fixes the 30s timeouts on the awaiting-user-sweep cron observed on v0.2.26.

The 0.2.28 cnp-allow + externalsecret + OTEL env additions from #11891 are unchanged — they were inert on 0.2.26 and become active again on 0.2.30 (queue worker fires `APPROVAL_POST_WEBHOOK_URL` on interrupt; OTLP traces go to opentelemetry-collector).

## Cleanup

- `helmrelease.yaml`: removes the multi-line workaround comment from #11901 explaining the 0.2.26 pin.
- `packageRules.json5`: removes the \`enabled: false\` rule that paused Renovate for \`ghcr.io/rwlove/langgraph-agents\`. Future bumps flow through Renovate normally again.

## Pre-merge state confirmed clean

The \`langgraph_checkpoints\` DB was queried directly before pushing tags — no \`task_queue\` / \`task_dlq\` tables existed, confirming the 0.2.28 migration crashed client-side at the psycopg Parse step without committing any schema. The 0.2.30 migration applies to a clean DB.

## Test plan

- [ ] CI green
- [ ] Post-merge: \`kubectl -n ai rollout status deployment/langgraph-agents\` reaches Ready
- [ ] Post-merge: logs show \`applying migration: 001_task_queue.sql\`, \`applying migration: 002_task_result.sql\`, \`task-queue schema ready\`
- [ ] Post-merge: \`task_queue\` + \`task_dlq\` tables exist in \`langgraph_checkpoints\` DB
- [ ] Post-merge: next Windmill \`langgraph-dlq-watcher\` cron tick returns 200, not TimeoutError
- [ ] Post-merge: \`langgraph-awaiting-user-sweep\` cron no longer hits the 30s timeout on /admin/tasks (PR #61 effect)
- [ ] Post-merge: pod image is \`0.2.30@sha256:d4f3b43782d2…\`

Closes the chain opened by #11891 (queue cutover attempt) and #11901 (emergency revert).

🤖 Generated with [Claude Code](https://claude.com/claude-code)