### PR TITLE
docs(ai-architecture): new chapter + README rewrite + drift-check extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ Local-first by default — chat, agents, retrieval, alert triage, doc
 ops — with explicit, separately-gated escape hatches to Claude API
 and Claude Code when a task genuinely needs cloud capacity.
 
-> 📖 **Full chapter**: see [`docs/src/ai_architecture.md`](docs/src/ai_architecture.md)
+> 📖 **Full chapter**: see [`docs/src/ai_architecture.md`](https://github.com/rwlove/home-ops/blob/main/docs/src/ai_architecture.md)
 > for per-app integration paths, RAG pipelines, escalation matrix, and the file:line
 > references behind every claim here.
 

--- a/README.md
+++ b/README.md
@@ -177,19 +177,20 @@ Worker nodes attach to **iot** and **sec** VLANs via Multus for direct camera an
 </details>
 
 <details>
-<summary>🤖 <b>AI & ML</b> — Local inference, agents, image generation</summary>
+<summary>🤖 <b>AI & ML</b> — Local inference, agents, image generation (namespace <code>ai/</code>, plus <code>automation/</code> for claude-runner)</summary>
 
 | App | Purpose |
 |-----|---------|
 | **Ollama** (P40) | Local LLM serving on the Pascal P40 (≤8b-class models, embeddings) |
 | **Ollama Spark** | LLM serving on Spark/GB10 (qwen2.5:32b for the agent fleet + HolmesGPT + Open WebUI, bge-m3 embeddings) |
 | **ComfyUI** | Image generation workflows |
-| **Khoj** | Personal AI assistant over notes + docs |
-| **LangGraph Agents** | Custom multi-agent runtime (`rwlove/langgraph-agents`); Postgres-checkpointed; MCP-gateway client. See **AI agent pipeline** section below. |
-| **Langfuse** | LLM observability — traces, evals, prompt versioning for the agent fleet |
-| **MCP Inspector** | Model Context Protocol debugger UI |
+| **Khoj** + **khoj-oauth2-proxy** | Personal AI assistant over notes + docs (Authelia-gated) |
+| **LangGraph Agents** | Custom multi-agent runtime (`rwlove/langgraph-agents`, image `0.2.28`); Postgres-checkpointed; MCP-gateway client. See **AI architecture** section below. |
+| **Langfuse** | LLM observability — OTLP trace sink for the langgraph-agents fleet (CNPG-backed; ClickHouse/Valkey/MinIO bundled) |
+| **claude-runner** (namespace `automation/`) | Cron-driven Claude Code workflows — daily Renovate PR triage + Claude-spend projection cards to Zulip |
 | **Paperless-AI** | Auto-tagging for paperless-ngx |
 | **sync-receiver** | Cross-host AI state sync endpoint |
+| **tei-spark** | Text-embedding-inference reranker (unsuspended 2026-05-21) |
 
 </details>
 
@@ -261,11 +262,11 @@ Worker nodes attach to **iot** and **sec** VLANs via Multus for direct camera an
 | **Paperless-ngx** | Document scanning, OCR, tagging (CNPG-backed, offsite-backed) |
 | **Obsidian** + **obsidian-couchdb** | Notes sync (CouchDB w/ Cloudflare rate-limiting) |
 | **Zulip** | Self-hosted team chat (also wired into agent pipeline approvals) |
-| **Windmill** | Workflow automation (AlertManager → HolmesGPT, daily digests, DLQ watcher) |
+| **Windmill** | Workflow automation; 12 checked-in TypeScript flows under `kubernetes/apps/home/windmill/workflows/` cover AlertManager → HolmesGPT, langgraph inbox/approval/digest/DLQ/cost-cap/awaiting-user, paperless RAG ingest+tombstone, Zulip triager webhook, and the workaround upstream-watcher |
 | **ntfy** | Self-hosted push notifications (operator approvals via Android tap actions) |
 | **BentoPDF** | Self-hosted PDF toolkit |
 | **Kitchenowl** | Shopping lists + recipe / meal management |
-| **Open WebUI** | Self-hosted LLM frontend (Ollama + MCP servers as tool servers) |
+| **Open WebUI** | Self-hosted LLM frontend; routes chat to Ollama-Spark (default) / Ollama-P40, surfaces langgraph agents as selectable models, and pulls in HolmesGPT + the MCP gateway as tool servers. RAG via bge-m3 + bge-reranker-v2-m3 over Qdrant |
 | **SearXNG** | Privacy-respecting metasearch engine |
 | **Glance** | Personal dashboard / start page |
 | **Atuin** | Encrypted shell-history sync across machines |
@@ -277,7 +278,7 @@ Worker nodes attach to **iot** and **sec** VLANs via Multus for direct camera an
 </details>
 
 <details>
-<summary>🔌 <b>MCP Servers</b> — 14 Model Context Protocol servers behind an Authelia-gated gateway</summary>
+<summary>🔌 <b>MCP Servers</b> — 16 Model Context Protocol servers behind an Authelia-gated gateway</summary>
 
 | Server | Exposes |
 |--------|---------|
@@ -295,120 +296,144 @@ Worker nodes attach to **iot** and **sec** VLANs via Multus for direct camera an
 | **arr-mcp** | Library-search interface to media-pull apps |
 | **time-mcp** | Time / timezone utilities (`rwlove/time-mcp` native-SHTTP build) |
 | **chrome-mcp** | Playwright-driven Chromium browser automation for agents |
-| **memory-mcp** | Cross-agent knowledge graph backed by Postgres + pgvector |
+| **memory-mcp** | Cross-agent knowledge graph backed by Postgres + pgvector (bge-m3 1024-dim) |
+| **cilium-mcp** | Read-only Cilium / Hubble introspection (kubectl-mcp-style, Cilium-scoped) |
+| **windmill-mcp** | Aggregated Windmill workspace tools (script run, flow trigger) |
 
 </details>
 
 ---
 
-## 🧠 AI agent pipeline
+## 🧠 AI architecture (overview)
 
-How local AI agents run, get work, ask for human approval, and produce reports — all without putting data in someone else's cloud unless a task genuinely needs it.
+Local-first by default — chat, agents, retrieval, alert triage, doc
+ops — with explicit, separately-gated escape hatches to Claude API
+and Claude Code when a task genuinely needs cloud capacity.
 
-> 📖 **Operator's guide**: see [`docs/src/workflow_automation.md`](https://github.com/rwlove/home-ops/blob/main/docs/src/workflow_automation.md) for the
-> end-to-end view — how to trigger jobs from Android, the approval lifecycle, and where results land.
+> 📖 **Full chapter**: see [`docs/src/ai_architecture.md`](docs/src/ai_architecture.md)
+> for per-app integration paths, RAG pipelines, escalation matrix, and the file:line
+> references behind every claim here.
 
 ```mermaid
 flowchart TB
-    subgraph Inputs[Inputs]
-        AM[AlertManager alerts]
-        Op[Operator chat / voice]
-        Cron[Windmill cron + webhooks]
+    subgraph Surfaces[Surfaces]
+        OWUI[Open WebUI<br/>chat + RAG]
+        Khoj[Khoj<br/>personal AI]
+        Voice[HA voice 'inbox …']
+        ZulipDM[Zulip DM<br/>Triager bot]
+        AM[AlertManager]
     end
 
-    subgraph Frontends[Frontends]
-        OWUI[Open WebUI]
-        HA[Home Assistant<br/>voice + conversation]
-        WM[Windmill workflows]
+    subgraph Bridges[Windmill bridges<br/>12 TS workflows]
+        WInbox[langgraph-inbox.ts]
+        WAlert[alertmanager-holmesgpt-notify.ts]
+        WApprove[langgraph-approval-post/receive.ts]
+        WPaperless[paperless-rag-ingest.ts]
+        WOther[…digest/DLQ/cost-cap/<br/>awaiting-user/workaround]
     end
 
-    subgraph Orchestration[Orchestration]
-        Holmes[HolmesGPT<br/>alert RCA]
-        LG[LangGraph Agents<br/>agent fleet]
+    subgraph Agents[Agents]
+        Holmes[HolmesGPT<br/>✅ live · qwen2.5:32b]
+        LG[langgraph-agents<br/>🟡 plumbed, cold]
+        CR[claude-runner<br/>✅ live · cron-only]
     end
 
     subgraph Inference[Inference]
-        OllamaP40[Ollama on P40<br/>≤8b + embeddings]
-        OllamaSpark[Ollama on Spark/GB10<br/>qwen2.5:32b + bge-m3]
-        Claude[Claude API<br/>escalation only]
+        OllamaP40[(ollama / P40<br/>qwen2.5:7b · embeddings)]
+        OllamaSpark[(ollama-spark / GB10<br/>qwen2.5:32b · bge-m3)]
+        Claude[(Claude API)]
+        CC[(Claude Code CLI)]
     end
 
-    subgraph Tools[Tools]
-        Gw[MCP Gateway<br/>Authelia-gated JWT]
-        Servers[14× MCP servers<br/>HA · Immich · k8s · Grafana · …]
+    subgraph Tools[Tools + retrieval]
+        Gw[MCP Gateway<br/>16 servers]
+        Q[(Qdrant<br/>vector DB)]
+        Mem[(memory-mcp<br/>pgvector KG)]
     end
 
-    subgraph Outputs[Outputs]
-        Z[Zulip<br/>approvals + chat]
-        N[ntfy<br/>Android tap-to-approve]
-        V[(langgraph-vault<br/>drafts + reports)]
-        DB[(Postgres CNPG<br/>checkpoints + memory)]
+    subgraph Outputs[Outputs + observability]
+        Zulip[Zulip threads]
+        Ntfy[ntfy push]
+        Vault[(langgraph-vault)]
+        LF[Langfuse traces]
     end
 
-    AM --> Holmes
-    Op --> OWUI
-    Op --> HA
-    Cron --> WM
-
-    OWUI --> OllamaSpark
-    HA --> OllamaP40
-    WM --> LG
-
+    Voice --> WInbox --> LG
+    ZulipDM --> WInbox
+    OWUI -->|chat| OllamaSpark
+    OWUI -->|agent-as-model| LG
+    OWUI --> Gw
+    OWUI --> Holmes
+    OWUI --> Q
+    Khoj --> OllamaP40
+    AM --> WAlert --> Holmes
     Holmes --> OllamaSpark
     LG --> OllamaSpark
     LG --> OllamaP40
-    LG -.-> Claude
-
-    Holmes --> WM
-    LG --> Gw
-    OWUI --> Gw
-    Gw --> Servers
-
-    WM --> Z
-    WM --> N
-    LG --> V
-    LG --> DB
+    LG -.->|gated| Claude
+    LG --> Gw --> Mem
+    LG -.->|OTLP| LF
+    WPaperless --> Q
+    CR --> CC
+    CR -->|gh MCP| Gw
+    LG --> WApprove --> Zulip & Ntfy
+    LG --> Vault
+    Holmes --> Zulip
+    CR --> Zulip
 ```
 
-### Agent fleet (LangGraph)
+Dashed lines mark cold paths: `ENABLE_CLAUDE_API: false` today on
+langgraph-agents; OTLP exporter fires only once Langfuse keys land
+in 1Password.
 
-A single `rwlove/langgraph-agents` FastAPI service runs the fleet. Each agent is a LangGraph graph with its own persona, tool set, and cost cap. Postgres-checkpointed state lets long-running plans survive restarts.
+### Surfaces, agents, and bridges
 
-| Agent                  | Role                                                       |
-|------------------------|------------------------------------------------------------|
-| `supervisor`           | Routes work to specialist agents; opens approvals         |
-| `researcher`           | Web + repo + vault research                                |
-| `coder`                | Code reading, drafting, PR descriptions                    |
-| `reviewer`             | Reviews drafts before they reach the operator              |
-| `triager`              | Classifies inbound items, assigns owner agent              |
-| `reporter`             | Daily digests, summaries, status rollups                   |
-| `note-maker`           | Captures decisions + facts back into the vault             |
-| `homelab-engineer`     | Cluster ops, HelmRelease drafting, PR-shaped output        |
-| `smart-home-engineer`  | Home Assistant entities, automations, ESPHome configs      |
-| `ml-tuner`             | Frigate, Immich CLIP, model tuning                         |
-| `errand-runner`        | One-shot real-world tasks (purchases, lookups, scheduling) |
-| `property-coordinator` | 3532 Foxhall workstreams (contractors, deck, pool)         |
-| `health-tracker`       | Local-only — never escalated to Claude API                 |
-| `doc-writer` (Scribner) | Sweeps repos for stale docs; drafts README + `docs/` patches as diffs when commits land |
+- **Open WebUI** (`collab/`) — primary chat UI. Defaults to qwen2.5:32b on Ollama-Spark; users can switch to any langgraph agent via the OpenAI-compatible API. RAG runs over Qdrant with bge-m3 embeds + BGE reranker-v2-m3 in-process. Tool servers wired in: HolmesGPT + the MCP gateway.
+- **Khoj** (`ai/`) — parallel personal-AI surface for notes + docs. Self-contained: own embedding pipeline (default gte-small, optionally ollama nomic-embed-text), chat via Ollama-P40. Does **not** consume MCP gateway or langgraph-agents.
+- **HolmesGPT** (`observability/`) — the only agent live in production. AlertManager firings reach it via Windmill's `alertmanager-holmesgpt-notify.ts`; it reasons over Prometheus + Loki + cluster state and posts a root-cause hypothesis to Zulip / ntfy. Open WebUI also surfaces it as a tool server.
+- **langgraph-agents** (`ai/`) — the FastAPI multi-agent runtime (`rwlove/langgraph-agents`, image `0.2.28`). Plumbed end-to-end (Postgres checkpoints + memory, vault PVCs, Windmill approval loop, cost caps in env) but cold: `ENABLE_CLAUDE_API: false` and no public route except `/approval`. Goes hot when the Claude key lands in 1Password.
+- **claude-runner** (`automation/`) — separate escalation lane. Two daily CronJobs (`pr-triage` 13:00 UTC, `cost-cap-commentary` 22:00 UTC) launch the Claude Code CLI with a `gh` MCP allowlist, post Zulip cards, then exit. Stateless; never consumes langgraph-agents.
+- **Windmill** (`home/`) — 12 checked-in TypeScript flows under `kubernetes/apps/home/windmill/workflows/` are the bridges that knit the surfaces above together. Every alert webhook, Zulip-triggered DM, approval round-trip, daily digest, DLQ retry, cost-cap pause, and Paperless RAG ingest is a `.ts` file there. n8n was retired during the ntfy migration.
+- **Langfuse** (`ai/`) — OTLP trace sink for langgraph-agents. Chart deploys ClickHouse + Valkey + MinIO bundled; Postgres comes from CNPG `postgres-langfuse`.
+- **memory-mcp** (`mcp-system/`) — cross-agent knowledge graph on `postgres-langgraph-memory` with pgvector(1024). bge-m3 embeds via Ollama-Spark. Same surface for langgraph agents and claude-runner.
 
-### Pipeline stages
+### Agent fleet — activation status
 
-1. **Inbox** — `langgraph-inbox.json` workflow ingests requests from chat, AlertManager, or scheduled triggers.
-2. **Triage** — `triager` classifies and assigns to a specialist agent.
-3. **Plan** — agent drafts an action plan (goals, steps, tool calls, expected cost) into Postgres state.
-4. **Approval (HITL)** — for anything non-trivial, `langgraph-approval-post` sends a signed Zulip message + Pushover ping with the plan summary; `langgraph-approval-receive` waits on the reply; `langgraph-awaiting-user-sweep` chases stuck tasks.
-5. **Execute** — agent runs tool calls through the MCP gateway. Cost caps enforced by `langgraph-cost-cap-watcher` ($5/task, $10/agent/day, $30/global/day).
-6. **Report** — output written to `langgraph-vault` (drafts / finals), summarized into the `reporter` agent's daily Zulip digest (`langgraph-daily-digest`).
+| Agent                  | Role                                                       | Status |
+|------------------------|------------------------------------------------------------|--------|
+| `HolmesGPT`            | AlertManager-driven root-cause investigation               | ✅ live |
+| `claude-runner pr-triage` | Daily Renovate-PR summarization to Zulip               | ✅ live |
+| `claude-runner cost-cap-commentary` | Daily LangGraph + Claude spend projection      | ✅ live |
+| `supervisor`           | Routes work to specialist agents; opens approvals          | 🟡 cold |
+| `researcher`           | Web + repo + vault research                                | 🟡 cold |
+| `coder`                | Code reading, drafting, PR descriptions                    | 🟡 cold |
+| `reviewer`             | Reviews drafts before they reach the operator              | 🟡 cold |
+| `triager`              | Classifies inbound items, assigns owner agent              | 🟡 cold |
+| `reporter`             | Daily digests, summaries, status rollups                   | 🟡 cold |
+| `note-maker`           | Captures decisions + facts back into the vault             | 🟡 cold |
+| `homelab-engineer`     | Cluster ops, HelmRelease drafting, PR-shaped output        | 🟡 cold |
+| `smart-home-engineer`  | Home Assistant entities, automations, ESPHome configs      | 🟡 cold |
+| `ml-tuner`             | Frigate, Immich CLIP, model tuning                         | 🟡 cold |
+| `errand-runner`        | One-shot real-world tasks                                  | 🟡 cold · local-only |
+| `property-coordinator` | 3532 Foxhall workstreams (contractors, deck, pool)         | 🟡 cold |
+| `health-tracker`       | Personal health tracking                                   | 🟡 cold · local-only |
+| `doc-writer` (Scribner) | Sweeps repos for stale docs; drafts README + `docs/` patches as diffs when commits land | 🟥 aspirational |
 
-### Local-first by design
+✅ live · 🟡 plumbed but cold (`ENABLE_CLAUDE_API: false`, no production triggers) · 🟥 not built
 
-| Tier | Backend                       | When used                                                  |
-|------|-------------------------------|------------------------------------------------------------|
-| 1    | `qwen2.5:7b` on Ollama (P40)  | Fast / simple agents (`triager`, `note-maker` drafts)      |
-| 2    | `qwen2.5:14b` on Ollama (P40) | Default for everything else                                |
-| 3    | Claude API (escalation)       | Only on explicit uncertainty markers, repeated local-retry failure, novel/long-context work, or `requires_cloud` tag |
+`health-tracker` and `errand-runner` are pinned local-only at the
+routing layer — they never escalate to Claude API regardless of agent
+uncertainty, because the data class isn't suitable for off-site
+inference.
 
-`health-tracker` and `errand-runner` are pinned local-only — they never escalate, even if quality suffers, because the data class isn't suitable for off-site inference.
+### Local-first routing tiers
+
+| Tier | Backend                              | When used                                                  |
+|------|--------------------------------------|------------------------------------------------------------|
+| 1    | `qwen2.5:7b` on Ollama (P40)         | Fast / simple agents (`triager`, `note-maker` drafts)      |
+| 2    | `qwen2.5:32b` on Ollama-Spark (GB10) | Default chat + agent inference + HolmesGPT                 |
+| 3    | Claude API (langgraph escalation)    | Explicit uncertainty markers, repeated local-retry failure, novel/long-context, or `requires_cloud` tag. Cost caps `$5/task` · `$10/agent/day` · `$30/global/day` enforced inside the cluster |
+| 4    | Claude Code (claude-runner CronJobs) | Cron-scheduled PR-triage + cost-cap-commentary only; not invoked by any agent path |
 
 ### Voice-to-action: power button → HA Assist → agents → Obsidian
 
@@ -422,13 +447,13 @@ flowchart LR
     Whisper --> Sentence[Sentence trigger:<br/>'inbox &#123;content&#125;']
     Sentence --> Ollama[conversation.ollama_voice<br/>qwen3:8b]
     Ollama --> Rest[HA rest_command<br/>POST + Authelia JWT]
-    Rest --> Hook[n8n: langgraph-inbox]
+    Rest --> Hook[Windmill:<br/>langgraph-inbox.ts]
     Hook --> LG[langgraph-agents /inbox]
     LG --> Triage[triager classifies]
     Triage -->|capture only| Note[note-maker]
     Triage -->|plan + act| Spec[specialist agent<br/>drafts plan]
-    Spec -->|needs input| Zulip[💬 Zulip approval<br/>+ Pushover ping]
-    Zulip -->|reply| Receive[approval-receive]
+    Spec -->|needs input| Zulip[💬 Zulip approval<br/>+ ntfy push]
+    Zulip -->|reply / tap| Receive[approval-receive]
     Receive --> Spec
     Spec --> Done[outcome to vault]
     Note --> Inbox[/vault/inbox/YYYY-MM-DD-…md/]
@@ -445,27 +470,28 @@ flowchart LR
 3. **STT in cluster.** The Assist pipeline routes the audio to **Whisper** (`wyoming-services`, GPU-accelerated on the P40).
 4. **Intent + LLM.** A sentence trigger matches `inbox {content}` and hands `{content}` to `conversation.ollama_voice` (qwen3:8b on Ollama, tool-calling enabled). The conversation agent's only job here is to confirm the intent and call the rest_command — it does not interpret the content.
 5. **Auth'd POST.** An HA `rest_command` POSTs to `https://langgraph-inbox.${SECRET_DOMAIN}/webhook` with `{ source:"voice", user:"rob", content:"<transcript>" }`. The request carries an **Authelia client_credentials JWT** issued to a dedicated `ha-voice-inbox` OIDC client — same daily-rotated signing-key machinery the MCP gateway already uses. Envoy's `SecurityPolicy` validates the JWT against Authelia's JWKS at the gateway.
-6. **n8n langgraph-inbox.** Normalizes the payload and POSTs to `/inbox` on `langgraph-agents`.
+6. **Windmill `langgraph-inbox.ts`.** Normalizes the payload and POSTs to `/inbox` on `langgraph-agents`.
 7. **Triager classifies.** Research question, household errand, homelab change, property task, or note-to-self — and picks the specialist agent.
 8. **Capture path → note-maker writes the file** to `/vault/inbox/YYYY-MM-DD-HHMM-<slug>.md` on the `langgraph-vault-rw` PVC. Single writer, no race with the phone.
 9. **Plan-and-act path → specialist drafts a plan** into Postgres + a draft under `/vault/outputs/drafts/`. HITL approval via the existing Zulip + Pushover loop when needed (see triggers above).
 10. **Round-trip to the phone.** `obsidian-couchdb` watches the vault PVC and replicates new files through Self-hosted LiveSync — the note from step 8, plus any drafts/finals from step 9, appear in the Obsidian app on the phone within a sync cycle. Same surface the dictation started on.
 
-The loop closes locally and on one surface: power-button → speak → outcome appears in the vault. Whisper, Ollama, n8n, and the agents all run in the cluster; the only off-site dependency is `claude.com` if the local fleet escalates a task.
+The loop closes locally and on one surface: power-button → speak → outcome appears in the vault. Whisper, Ollama, Windmill, and the agents all run in the cluster; the only off-site dependency is `claude.com` if the local fleet escalates a task.
 
 ### Alert triage (production today)
 
 HolmesGPT is the one agent already running in production:
 
-- **AlertManager → HolmesGPT** webhook (via `alertmanager-holmesgpt-pushover.json`) on every firing alert
+- **AlertManager → Windmill `alertmanager-holmesgpt-notify.ts` → HolmesGPT** on every firing alert
 - HolmesGPT queries Prometheus, Loki, and the cluster directly to build a root-cause hypothesis
-- Result posted back as a Pushover message + Zulip thread; n8n sanitizes raw tool-call descriptors out of the agent text before delivery
+- Result posted back as a Pushover message + Zulip thread; the Windmill workflow sanitizes raw tool-call descriptors out of the agent text before delivery
 
-### Current state (2026-05-16)
+### Current state (2026-05-21)
 
-- **HolmesGPT** — live, handling cluster alerts daily.
-- **LangGraph fleet** — plumbed but cold (`ENABLE_CLAUDE_API: false`, no production triggers). Gated on NVIDIA Spark / Ascent GX10 arrival (~2026-05-20), which becomes the primary Ollama backend before the fleet goes hot.
-- **KubeClaw** — running in parallel during the LangGraph transition; scheduled for retirement once LangGraph is validated.
+- **HolmesGPT** — live, handling cluster alerts daily on Ollama-Spark / qwen2.5:32b.
+- **claude-runner** — live (PR triage 13:00 UTC + cost-cap commentary 22:00 UTC). Watching useful-card rate; kill criteria documented in the app's in-tree README.
+- **LangGraph fleet** — plumbed but cold (`ENABLE_CLAUDE_API: false`, no public route except `/approval`). Gated on the Claude API key + a cluster-confidence sign-off; the Spark migration that was the prior gate completed 2026-05-20.
+- **KubeClaw** — retired (memo `project_open_issues_cleanup_2026_05_20`).
 
 ---
 
@@ -527,6 +553,7 @@ The full operator handbook lives in the mdBook site: **<https://rwlove.github.io
 
 Frequently referenced pages:
 
+- [AI architecture](https://rwlove.github.io/home-ops/ai_architecture.html)
 - [Cluster rebuild](https://rwlove.github.io/home-ops/cluster_rebuild.html)
 - [Initialization & teardown](https://rwlove.github.io/home-ops/init_teardown.html)
 - [Cluster upgrade](https://rwlove.github.io/home-ops/cluster_upgrade.html)

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -4,6 +4,7 @@
 
 - [👋 Introduction](introduction.md)
 
+- [AI Architecture](ai_architecture.md)
 - [Workflow Automation: Agents, Approvals, and Push](workflow_automation.md)
 - [Memory MCP — Cross-Agent Knowledge Graph](memory_mcp.md)
 - [MCP Fleet Observability](mcp_observability.md)

--- a/docs/src/ai_architecture.md
+++ b/docs/src/ai_architecture.md
@@ -1,0 +1,343 @@
+# AI Architecture
+
+How AI work flows through the cluster — from the surface that takes
+the request to the model that answers it, with every routing,
+approval, and escalation hop named.
+
+This chapter is **architectural**. Operational procedures
+(how to trigger a job, where to look when a workflow stalls) live in
+the vault runbook at `~/vaults/claude/runbooks/home-ops/workflow_automation.md`
+per HOMELAB-SPEC Layer 2 #5.
+
+## Big picture
+
+```mermaid
+flowchart TB
+    subgraph Surfaces[Surfaces — how work enters]
+        Voice[HA voice<br/>'inbox …']
+        Zulip[Zulip DM<br/>Triager bot]
+        OWUI[Open WebUI<br/>chat]
+        Khoj[Khoj UI<br/>personal AI]
+        AM[AlertManager<br/>firing alert]
+        Cron[Cron schedules]
+    end
+
+    subgraph Bridges[Bridges — Windmill TS workflows]
+        WInbox[langgraph-inbox.ts]
+        WZulip[zulip-triager-webhook.ts]
+        WAlert[alertmanager-holmesgpt-notify.ts]
+        WDigest[langgraph-daily-digest.ts]
+        WCost[langgraph-cost-cap-watcher.ts]
+        WSweep[langgraph-awaiting-user-sweep.ts]
+        WDLQ[langgraph-dlq-watcher.ts]
+        WApprovePost[langgraph-approval-post.ts]
+        WApproveRecv[langgraph-approval-receive.ts]
+        WPaperless[paperless-rag-ingest.ts<br/>paperless-rag-tombstone.ts]
+        WWork[workaround-watcher.ts]
+    end
+
+    subgraph Agents[Agents]
+        Holmes[HolmesGPT<br/>✅ live]
+        LG[langgraph-agents<br/>🟡 plumbed, cold]
+        CR[claude-runner<br/>✅ live<br/>cron-only]
+    end
+
+    subgraph Inference[Inference]
+        OllamaP40[(ollama / P40<br/>qwen2.5:7b · gte-small)]
+        OllamaSpark[(ollama-spark / GB10<br/>qwen2.5:32b · bge-m3)]
+        Claude[(Claude API<br/>via langgraph-agents)]
+        ClaudeCode[(Claude Code<br/>via claude-runner CronJobs)]
+    end
+
+    subgraph Tools[Tool surfaces]
+        Gw[MCP Gateway<br/>16 MCP servers behind Istio]
+        Q[(Qdrant<br/>vector DB)]
+        PG[(Postgres CNPG<br/>checkpoints + memory + langfuse)]
+    end
+
+    subgraph Outputs[Outputs]
+        Vault[(Obsidian vault<br/>via langgraph-vault PVC)]
+        ZulipO[Zulip threads]
+        Ntfy[ntfy push<br/>tap-to-approve]
+        LF[Langfuse traces]
+    end
+
+    Voice --> WInbox
+    Zulip --> WZulip --> WInbox
+    OWUI -->|chat| OllamaSpark
+    OWUI -->|agent-as-model| LG
+    OWUI -->|tool calls| Gw
+    OWUI -->|tool calls| Holmes
+    Khoj --> OllamaP40
+    AM --> WAlert --> Holmes
+    Cron --> WDigest & WCost & WSweep & WDLQ & WWork & WPaperless
+
+    WInbox --> LG
+    Holmes --> OllamaSpark
+    LG --> OllamaSpark
+    LG --> OllamaP40
+    LG -.-> Claude
+    LG --> Gw
+    LG --> PG
+    LG -.->|OTLP| LF
+
+    CR --> ClaudeCode
+    CR -->|gh MCP| Gw
+
+    LG --> WApprovePost --> ZulipO & Ntfy
+    Ntfy --> WApproveRecv --> LG
+    LG --> Vault
+    Holmes --> ZulipO
+    CR --> ZulipO
+    WPaperless --> Q
+    OWUI --> Q
+```
+
+Dashed lines mark cold paths (Claude API is gated; OTLP exporter
+only fires once Langfuse keys are populated in 1Password).
+
+## Ingress surfaces — what enters the cluster as work
+
+| Surface | Transport | Lands at |
+|---|---|---|
+| HA voice ("inbox …") | Whisper STT → ollama_voice conversation → HA `rest_command` → Authelia-JWT POST | Windmill `langgraph-inbox.ts` (`kubernetes/apps/home/windmill/workflows/langgraph-inbox.ts:42`) |
+| Zulip DM to Triager bot | Outgoing-webhook (bot_type=3) | Windmill `zulip-triager-webhook.ts` → forwards to `langgraph-inbox.ts` |
+| Open WebUI chat | Browser → Authelia OIDC → Open WebUI backend | Routes to ollama-spark (default) or to a langgraph agent via OpenAI-compat API (`kubernetes/apps/collab/open-webui/app/helmrelease.yaml:41-46`) |
+| Khoj UI | Browser → khoj-oauth2-proxy → khoj | Khoj's own embedding pipeline; chat via ollama P40 |
+| AlertManager firing alert | Webhook receiver | Windmill `alertmanager-holmesgpt-notify.ts` → HolmesGPT `/investigate` |
+| Operator tap on ntfy | Action button → HMAC-signed URL | `langgraph-agents` `/approval` endpoint (`kubernetes/apps/ai/langgraph-agents/app/route-approval.yaml`) |
+| Cron — daily digest / DLQ / cost-cap / awaiting-user / workaround | Windmill scheduled trigger | Each `.ts` workflow under `kubernetes/apps/home/windmill/workflows/` |
+| Cron — Renovate PR triage / cost commentary | Kubernetes CronJob | `claude-runner` (`kubernetes/apps/automation/claude-runner/app/cronjob-*.yaml`) |
+
+There are **12 Windmill TypeScript workflows** in the repo today;
+they're all under `kubernetes/apps/home/windmill/workflows/`. There is
+**no n8n** — its flows were ported during the ntfy/Zulip approval
+migration.
+
+## Inference backends
+
+| Backend | Hardware | Service URL | Models | Notes |
+|---|---|---|---|---|
+| `ollama` | P40 (Pascal, 24 GB) on worker8 | `http://ollama.ai.svc.cluster.local:11434` | qwen2.5:7b, qwen3:8b (voice), bge-m3 (memory rebuild), gte-small/nomic-embed-text (khoj) | The pre-Spark generation. ≤8b chat, embeddings, voice STT/TTS pipeline support. |
+| `ollama-spark` | GB10 (Grace-Blackwell, 128 GB unified) | `http://ollama-spark.ai.svc.cluster.local:11434` | qwen2.5:32b (chat default), bge-m3 (1024-dim embeds) | The post-Spark workhorse. Open WebUI default; HolmesGPT model; langgraph-agents default for memory embeds. |
+| Claude API | Anthropic-hosted | langgraph-agents only, gated | per-task | Off by default — `ENABLE_CLAUDE_API: "false"` (`kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml:36`). Cost caps `$5/task`, `$10/agent/day`, `$30/global/day` (lines 54-56) enforced in code, not Anthropic's billing. |
+| Claude Code | Anthropic-hosted, CLI | `claude-runner` only | per-task | `claude` CLI baked into `ghcr.io/rwlove/claude-runner:0.1.1`; called from CronJobs with `--max-turns 20`. |
+
+Routing decisions belong in `langgraph-agents/.agents/instructions/hardware-routing.md`
+(canonical) and `.agents/instructions/gpu-routing.md` in this repo
+(local pointer + cluster-specific facts).
+
+## RAG paths
+
+Three distinct retrieval pipelines exist today. They share the Spark
+embedder (bge-m3) but otherwise don't overlap.
+
+### Open WebUI RAG
+
+User-facing chat with retrieval over Open WebUI's own collections,
+plus web search.
+
+- **Embedder**: bge-m3 via ollama-spark (`kubernetes/apps/collab/open-webui/app/helmrelease.yaml:58`).
+- **Reranker**: BGE reranker-v2-m3 in-process, sentence-transformers on CPU (line 66). Adds ~2.5 GiB to the pod's resident set.
+- **Vector DB**: Qdrant at `http://qdrant.databases.svc.cluster.local:6333` (line 69).
+- **Web search**: SearXNG (`collab.svc.cluster.local:8080`) via `RAG_WEB_SEARCH_ENGINE=searxng` (line 68).
+- **Tool servers** also wired in: HolmesGPT (`observability.svc.cluster.local:8080/openapi.json`) and MCP gateway (`mcp-system.svc.cluster.local:8080/mcp`) — both visible to chat as callable tools (lines 88-112).
+
+Phase A bge-m3 cutover (2026-05-20, PR #11792) showed bge-m3 (1024-dim)
+beat nomic-embed-text (768-dim) by +23 MRR@10 pts on a 50-doc Paperless
+eval. The cluster moved to bge-m3 for new embedding work.
+
+### Khoj — personal AI assistant
+
+A parallel RAG surface aimed at notes + the operator's documents, not
+the agent fleet.
+
+- **Embedder**: configured post-bootstrap in `/server/admin` →
+  `SearchModelConfig`. Default is `thenlper/gte-small` (~130 MB) pulled
+  from HuggingFace into the `khoj-models` PVC. Can be flipped to ollama
+  nomic-embed-text via the admin UI by setting `api_type=OPENAI`.
+- **Chat**: `qwen2.5:7b` on P40 ollama (`kubernetes/apps/ai/khoj/app/helmrelease.yaml:71-72`).
+- **Web search**: SearXNG (`kubernetes/apps/ai/khoj/app/helmrelease.yaml:64`).
+- **Storage**: two RWO PVCs — `khoj-config` (config + Django state) and `khoj-models` (HF embedding model cache).
+
+Khoj does **not** consume the MCP gateway or langgraph-agents. It is a
+self-contained personal-AI app.
+
+### Paperless RAG ingest
+
+Document-store-to-vector-store pipeline run by Windmill, not by any
+agent.
+
+- **Source**: paperless-ngx via API token (`PAPERLESS_TOKEN` whitelisted
+  for Windmill workers at `kubernetes/apps/home/windmill/app/helmrelease.yaml:77`).
+- **Ingest**: `paperless-rag-ingest.ts` pulls new/changed docs, embeds
+  via ollama-spark bge-m3, writes to Qdrant.
+- **Tombstone**: `paperless-rag-tombstone.ts` removes vectors for
+  deleted docs.
+- **Vector DB**: Qdrant — same instance Open WebUI uses, with separate
+  collections.
+
+There is currently a known gap: Open WebUI's Knowledge UI manages its
+own collection namespacing and does not directly read the
+Windmill-ingested `paperless` collection. Operator-side access is via
+`paperless-mcp` (the MCP server), not Open WebUI's KB UI.
+
+### memory-mcp knowledge graph
+
+Cross-agent shared memory, not user-facing.
+
+- **Backend**: CNPG cluster `postgres-langgraph-memory` with pgvector
+  (1024-dim column).
+- **Embedder**: bge-m3 via ollama-spark
+  (`kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml:47-48`).
+- **Surface**: `memory-mcp` MCP server (`kubernetes/apps/mcp-system/memory-mcp/`),
+  exposed through the gateway.
+- **Writers**: langgraph-agents writes observations via direct SQL;
+  Claude Code consumes the same KG via the MCP gateway (search +
+  graph-walk tools).
+
+## Agent fleet — status today
+
+| Agent | Surface | Status | Notes |
+|---|---|---|---|
+| HolmesGPT | `holmesgpt.observability` | ✅ live | qwen2.5:32b on ollama-spark; AlertManager-driven RCA; also a tool server for Open WebUI |
+| supervisor / researcher / coder / reviewer / triager / reporter / note-maker / homelab-engineer / smart-home-engineer / ml-tuner / errand-runner / property-coordinator / health-tracker | langgraph-agents fleet | 🟡 plumbed, cold | `ENABLE_CLAUDE_API: false`, no public route except `/approval`. Image `ghcr.io/rwlove/langgraph-agents:0.2.28` (post queue-substrate cutover, PR #11891). Vault PVCs mounted; checkpoint + memory Postgres ready. Gated on Claude key + cluster confidence. |
+| doc-writer (Scribner) | langgraph-agents (planned) | 🟥 aspirational | Not built. Goal: drafts README + `docs/` patches as diffs when commits land. |
+| claude-runner pr-triage | `automation/claude-runner` CronJob | ✅ live | Daily 13:00 UTC. Reads open PRs via gh MCP, posts one Zulip card per PR. |
+| claude-runner cost-cap-commentary | `automation/claude-runner` CronJob | ✅ live | Daily 22:00 UTC. Projects monthly Claude spend, flags if trending past `$30/mo`. |
+
+`health-tracker` and `errand-runner` are pinned local-only at the
+routing layer — they never escalate to Claude API regardless of agent
+uncertainty, because the data class is unsuitable for off-site
+inference.
+
+## Approval and escalation flow
+
+```mermaid
+flowchart LR
+    subgraph LG[langgraph-agents]
+        Spec[specialist agent]
+        Pause[(checkpoint:<br/>paused, awaiting_approval)]
+    end
+
+    subgraph Bridges[Windmill]
+        APost[langgraph-approval-post.ts]
+        ARecv[langgraph-approval-receive.ts]
+        Sweep[awaiting-user-sweep.ts<br/>chases stale items]
+        Cost[cost-cap-watcher.ts<br/>per-task/agent/day caps]
+        DLQ[dlq-watcher.ts]
+    end
+
+    subgraph Operator[Operator]
+        Z[Zulip thread<br/>full plan summary]
+        N[📱 ntfy<br/>tap-to-approve]
+    end
+
+    Spec --> Pause
+    Pause --> APost
+    APost -->|HMAC-signed token| Z
+    APost -->|HMAC-signed action URL| N
+    N -->|tap| ARecv
+    ARecv -->|resume task| Spec
+    Sweep -.->|TTL expired| Z
+    Cost -.->|cap exceeded| Pause
+    DLQ -.->|crash + redeliver| Pause
+```
+
+The approval token is signed with `LANGGRAPH_APPROVAL_SIGNING_KEY`
+(stored in 1Password, whitelisted into the Windmill worker env at
+`kubernetes/apps/home/windmill/app/helmrelease.yaml:77-82`). Pre-signing
+moved from approval-receive to approval-post during the ntfy migration
+so the Android tap path doesn't have to wait for langgraph to come
+back with a fresh token.
+
+Cost caps fire **before** Claude API egress. The cap-watcher polls
+`/admin/costs/today` on langgraph-agents and pauses additional
+escalations once the daily threshold is breached — the spend ceiling
+is enforced inside the cluster, not at the Anthropic billing layer.
+
+## Claude API vs Claude Code — separate escalation lanes
+
+| | Claude API (via langgraph) | Claude Code (via claude-runner) |
+|---|---|---|
+| Trigger | An agent step escalates because the local model failed, hit an uncertainty marker, or is tagged `requires_cloud` | Kubernetes CronJob fires at the scheduled hour |
+| Caller | `langgraph-agents` agent step | `claude` CLI in `ghcr.io/rwlove/claude-runner` |
+| Tool surface | MCP gateway via the agent's tool list | `claude-runner` image's baked-in MCP allowlist (`gh` + the gateway via cluster network) |
+| Cost control | In-cluster cost-cap watchers (`$5/task`, `$10/agent/day`, `$30/global/day`) | Daily `cost-cap-commentary` CronJob projects monthly spend and surfaces an upgrade signal if trending past `$30/mo` |
+| Activation gate | `ENABLE_CLAUDE_API` env flag | `ks.yaml` suspend gate + presence of `anthropic_api_key` in 1Password |
+| State | Postgres-checkpointed in `postgres-langgraph-checkpoints` | Stateless per-run; workspace is `emptyDir` tmpfs |
+| Output | Vault file + Zulip thread + Langfuse trace | One Zulip card per PR (pr-triage) or one summary card (cost-commentary) |
+
+The two lanes do not consume each other. `claude-runner` does not call
+langgraph-agents; it's a parallel reasoning surface that reads the
+cluster directly via `gh` MCP and uses langgraph's `/admin/costs/today`
+endpoint only as a data source.
+
+Kill criteria for any `claude-runner` workflow (per
+`kubernetes/apps/automation/claude-runner/README.md:40-47`):
+
+- useful-card rate < 30% after 2 weeks
+- zero acted-upon cards in 14 days
+- > 5 unintended noise reactions in any 7-day window
+
+Document the kill in the plan's changelog and remove the CronJob.
+
+## Observability of the AI fleet
+
+| Subject | Sink | Wired by |
+|---|---|---|
+| langgraph-agents traces | Langfuse (OTLP) | `LANGFUSE_INIT_PROJECT_PUBLIC_KEY` / `_SECRET_KEY` provisioned at first boot (`kubernetes/apps/ai/langfuse/app/helmrelease.yaml:146-157`); SDK in `langgraph-agents` reads them from 1Password |
+| langgraph-agents metrics | Prometheus | `kubernetes/apps/ai/langgraph-agents/app/servicemonitor.yaml` + `prometheusrule.yaml` |
+| HolmesGPT investigations | Pushover + Zulip | `alertmanager-holmesgpt-notify.ts` sanitizes the agent text before delivery |
+| Ollama (both) | Prometheus | scraped via standard ollama exporter Service in the `ai` namespace |
+| GPU utilization | Prometheus via DCGM | GB10's DCGM counters are mostly broken — use `POWER_USAGE` as the proxy (see `.agents/instructions/gpu-routing.md`) |
+| Windmill workflows | Windmill's own UI + Loki | Workflow logs ship via Vector → Loki under the windmill namespace |
+| claude-runner | Zulip stream `ops/pr-triage`, `ops/cost-cap-commentary` + CronJob events | No persistent state; useful-card rate is operator-observed |
+
+### Langfuse storage substrate
+
+Langfuse v3 needs four backends. The chart deploys three in-namespace
+and uses the cluster's CNPG for Postgres:
+
+- **Postgres** — CNPG `postgres-langfuse` (the chart's bundled bitnami
+  postgresql is disabled; `helmrelease.yaml:30-36`). DSN consumed via
+  the `uri` key in `postgres-langfuse-app`.
+- **ClickHouse** — chart-bundled, default `ceph-block` storage.
+- **Valkey (Redis)** — chart-bundled.
+- **MinIO (S3)** — chart-bundled.
+
+Subchart auth secrets all share `langfuse-secret`. The CNPG-generated
+secret is mirrored into the `ai` namespace by emberstack reflector
+(see `databases/cloudnative-pg/config/langfuse/cluster.yaml`).
+
+## File reference (quick index)
+
+- **Khoj** — `kubernetes/apps/ai/khoj/app/helmrelease.yaml`
+- **khoj-oauth2-proxy** — `kubernetes/apps/ai/khoj-oauth2-proxy/`
+- **langfuse** — `kubernetes/apps/ai/langfuse/app/helmrelease.yaml`
+- **langgraph-agents** — `kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml`
+- **ollama** (P40) — `kubernetes/apps/ai/ollama/app/`
+- **ollama-spark** (GB10) — `kubernetes/apps/ai/ollama-spark/app/`
+- **paperless-ai** — `kubernetes/apps/ai/paperless-ai/app/helmrelease.yaml`
+- **sync-receiver** — `kubernetes/apps/ai/sync-receiver/`
+- **tei-spark** — `kubernetes/apps/ai/tei-spark/` (unsuspended 2026-05-21, PR #11893)
+- **open-webui** — `kubernetes/apps/collab/open-webui/app/helmrelease.yaml`
+- **holmesgpt** — `kubernetes/apps/observability/holmesgpt/app/helmrelease.yaml`
+- **windmill** — `kubernetes/apps/home/windmill/app/helmrelease.yaml`
+- **windmill workflows** — `kubernetes/apps/home/windmill/workflows/*.ts` (12 today)
+- **claude-runner** — `kubernetes/apps/automation/claude-runner/`
+- **MCP gateway** — `kubernetes/apps/mcp-system/mcp-gateway/`
+- **MCP servers** — 16 sibling directories under `kubernetes/apps/mcp-system/`
+
+## See also
+
+- [MCP Fleet Observability](mcp_observability.md) — gateway internals,
+  per-server health
+- [Memory MCP — Cross-Agent Knowledge Graph](memory_mcp.md) — KG schema
+  and ingest path
+- [Workflow Automation: Agents, Approvals, and Push](workflow_automation.md)
+  — operator runbook (lives in the vault)
+- [Orchestration Substrate](orchestration_substrate.md) — why a real
+  task queue is still the missing piece
+- [Task Queue Substrate — design proposal](task_queue_substrate_design.md)
+  — the candidates being weighed

--- a/tools/lint-readme-drift.py
+++ b/tools/lint-readme-drift.py
@@ -6,7 +6,7 @@ and docs/ are updated in the same PR as the change they describe. Stale
 docs are bugs." This check makes that enforceable for the README's
 mechanically-countable claims.
 
-What it asserts:
+What it asserts (badge-style, auto-fixable):
 
   apps badge          == number of dirs at kubernetes/apps/<group>/<app>/
   HelmReleases badge  == number of files declaring `kind: HelmRelease` under kubernetes/
@@ -17,16 +17,28 @@ What it asserts:
 The node count is self-consistency only (CI can't reach the cluster) —
 it ensures a new hardware row is paired with a badge bump.
 
+What it also asserts (narrative drift, manual-fix only):
+
+  MCP servers count   — the "🔌 MCP Servers — N …" summary line must match
+                        the MCPServerRegistration count in kubernetes/
+  Windmill workflows  — "(\\d+) TypeScript flows" claims in the README must
+                        match the *.ts file count under
+                        kubernetes/apps/home/windmill/workflows/
+  Namespace paths     — every `kubernetes/apps/<group>/<app>/` path
+                        mentioned in the README must exist on disk
+  Mermaid hygiene     — blocks must not mention `n8n` (retired during the
+                        ntfy migration); blocks with an `Inference`
+                        subgraph must mention `ollama-spark`
+
 Usage:
     tools/lint-readme-drift.py [README_PATH]
     tools/lint-readme-drift.py --fix [README_PATH]
 
-Exits 0 if all badges match, 1 if any drift.
+Exits 0 if everything passes, 1 if any drift.
 
-With `--fix`, drift is corrected in-place and the script exits 0
-(or 2 if the only drift is the `k8s_nodes` badge — that one is
-operator-edited alongside the Hardware table, not auto-derivable from
-code, so we refuse to auto-rewrite it).
+With `--fix`, badge drift is corrected in-place. Narrative drift is
+never auto-fixable (it requires operator judgment about which prose to
+update) — if any narrative check fails the script still exits 2.
 """
 from __future__ import annotations
 
@@ -37,10 +49,24 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 APPS_DIR = REPO_ROOT / "kubernetes" / "apps"
 KUBERNETES_DIR = REPO_ROOT / "kubernetes"
+WINDMILL_WORKFLOWS_DIR = (
+    REPO_ROOT / "kubernetes" / "apps" / "home" / "windmill" / "workflows"
+)
 
 BADGE_RE = re.compile(
     r"!\[(?P<name>[^\]]+)\]\(https://img\.shields\.io/badge/"
     r"(?P<label>[^-]+)-(?P<value>[^-]+)-",
+)
+MERMAID_BLOCK_RE = re.compile(r"```mermaid\n(.*?)```", re.DOTALL)
+NAMESPACE_PATH_RE = re.compile(
+    r"kubernetes/apps/([a-z0-9][a-z0-9-]*)/([a-z0-9][a-z0-9-]*)(?:/|\b)"
+)
+MCP_SUMMARY_RE = re.compile(
+    r"<b>MCP Servers</b>\s*[—\-]\s*(\d+)\s+Model Context Protocol"
+)
+WINDMILL_COUNT_RE = re.compile(
+    r"(\d+)\s+(?:checked-in\s+)?(?:TypeScript|TS)\s+(?:flows?|workflows?)",
+    re.IGNORECASE,
 )
 
 
@@ -114,6 +140,111 @@ def parse_badges(readme_text: str) -> dict[str, str]:
     return out
 
 
+def check_mcp_count(readme_text: str) -> list[str]:
+    """The README's MCP-section summary line must agree with the
+    MCPServerRegistration count in kubernetes/.
+
+    Returns a list of drift messages (empty list = no drift).
+    """
+    actual = count_kind("MCPServerRegistration", KUBERNETES_DIR)
+    m = MCP_SUMMARY_RE.search(readme_text)
+    if not m:
+        return [
+            f"MCP-servers summary line not found in README "
+            f"(expected `🔌 MCP Servers — {actual} Model Context Protocol …`)"
+        ]
+    claimed = int(m.group(1))
+    if claimed != actual:
+        return [
+            f"README claims {claimed} MCP servers; repo has {actual} "
+            f"MCPServerRegistration kinds under kubernetes/"
+        ]
+    return []
+
+
+def check_windmill_workflow_count(readme_text: str) -> list[str]:
+    """Every `(\\d+) TypeScript flows` claim in the README must match the
+    `*.ts` file count under kubernetes/apps/home/windmill/workflows/.
+
+    Quiet (no drift) if the workflows directory doesn't exist yet or the
+    README makes no count claim — this check is only for keeping an
+    explicit number honest, not for forcing one to be written.
+    """
+    if not WINDMILL_WORKFLOWS_DIR.is_dir():
+        return []
+    actual = len(list(WINDMILL_WORKFLOWS_DIR.glob("*.ts")))
+    matches = WINDMILL_COUNT_RE.findall(readme_text)
+    if not matches:
+        return []
+    drifts: list[str] = []
+    for claimed_str in matches:
+        if int(claimed_str) != actual:
+            drifts.append(
+                f"README claims {claimed_str} Windmill TS workflows; "
+                f"repo has {actual} .ts files under "
+                f"kubernetes/apps/home/windmill/workflows/"
+            )
+    return drifts
+
+
+def check_namespace_paths(readme_text: str) -> list[str]:
+    """Every `kubernetes/apps/<group>/<app>/` path mentioned in README
+    must exist on disk. Catches stale references like
+    `kubernetes/apps/default/khoj/` after an app moves namespaces.
+    """
+    drifts: list[str] = []
+    seen: set[tuple[str, str]] = set()
+    for m in NAMESPACE_PATH_RE.finditer(readme_text):
+        group, app = m.group(1), m.group(2)
+        if (group, app) in seen:
+            continue
+        seen.add((group, app))
+        if not (APPS_DIR / group / app).is_dir():
+            drifts.append(
+                f"README references kubernetes/apps/{group}/{app}/ "
+                f"which doesn't exist on disk"
+            )
+    return drifts
+
+
+def check_mermaid_sanity(readme_text: str) -> list[str]:
+    """Lightweight textual lints on each ```mermaid``` block:
+
+    - Block the literal `n8n` (retired during the ntfy migration; any
+      remaining mention is stale).
+    - Any block containing an `Inference` subgraph header must also
+      mention `ollama-spark` (the post-Spark backend is the cluster's
+      current workhorse).
+
+    Not a full graph parser — just regex-grade sanity.
+    """
+    drifts: list[str] = []
+    for i, block_match in enumerate(MERMAID_BLOCK_RE.finditer(readme_text), start=1):
+        block = block_match.group(1)
+        if re.search(r"\bn8n\b", block):
+            drifts.append(
+                f"mermaid block #{i} mentions `n8n` — retired during "
+                f"the ntfy migration; update to Windmill"
+            )
+        if "Inference" in block and "ollama-spark" not in block.lower() \
+                and "OllamaSpark" not in block:
+            drifts.append(
+                f"mermaid block #{i} has an Inference subgraph but "
+                f"doesn't mention ollama-spark (post-Spark default)"
+            )
+    return drifts
+
+
+def run_narrative_checks(readme_text: str) -> list[str]:
+    """Run every non-badge check; return the flat list of drift lines."""
+    drifts: list[str] = []
+    drifts.extend(check_mcp_count(readme_text))
+    drifts.extend(check_windmill_workflow_count(readme_text))
+    drifts.extend(check_namespace_paths(readme_text))
+    drifts.extend(check_mermaid_sanity(readme_text))
+    return drifts
+
+
 def rewrite_badge(text: str, label: str, new_value: str) -> str:
     """Replace the value in a shields.io badge for `label` with `new_value`.
 
@@ -155,16 +286,22 @@ def main(argv: list[str]) -> int:
         elif actual != expected:
             drift.append((label, actual, expected))
 
-    if not drift:
+    narrative_drift = run_narrative_checks(text)
+
+    if not drift and not narrative_drift:
         print("✅ README badges match repo reality:")
         for label, value in expectations.items():
             print(f"   {label}: {value}")
+        print("✅ README narrative checks passed:")
+        print("   MCP-server count, Windmill workflow count, "
+              "namespace paths, mermaid hygiene")
         return 0
 
     if fix:
-        # Auto-fix all drift except `k8s_nodes` — that one is sourced
-        # from the README's own Hardware table, so fixing the badge
-        # would just paper over a stale table. Surface it instead.
+        # Auto-fix all badge drift except `k8s_nodes` — that one is
+        # sourced from the README's own Hardware table, so fixing the
+        # badge would just paper over a stale table. Surface it
+        # instead. Narrative drift is never auto-fixable.
         unfixed: list[tuple[str, str, str]] = []
         new_text = text
         fixed = []
@@ -184,22 +321,32 @@ def main(argv: list[str]) -> int:
             for label, actual, expected in fixed:
                 print(f"   {label}: {actual} → {expected}")
         if unfixed:
-            print("⚠️  Drift NOT auto-fixed (requires manual edit):")
+            print("⚠️  Badge drift NOT auto-fixed (requires manual edit):")
             for label, actual, expected in unfixed:
                 print(f"   {label}: {actual} → {expected} (Hardware table or missing badge)")
-            return 2
-        return 0
+        if narrative_drift:
+            print("⚠️  Narrative drift NOT auto-fixed (requires operator edit):")
+            for line in narrative_drift:
+                print(f"   - {line}")
+        return 2 if (unfixed or narrative_drift) else 0
 
-    print("❌ README.md is drifting from repo reality:")
-    for label, actual, expected in drift:
-        print(f"  - badge `{label}` says `{actual}`; repo reality is `{expected}`")
-    print()
-    print("Update the badges + any matching body text in the same PR")
-    print("that changed the underlying counts, per CLAUDE.md:")
+    if drift:
+        print("❌ README.md badges are drifting from repo reality:")
+        for label, actual, expected in drift:
+            print(f"  - badge `{label}` says `{actual}`; repo reality is `{expected}`")
+        print()
+    if narrative_drift:
+        print("❌ README.md narrative is drifting from repo reality:")
+        for line in narrative_drift:
+            print(f"  - {line}")
+        print()
+    print("Update the README + any matching body text in the same PR")
+    print("that changed the underlying state, per CLAUDE.md:")
     print('  "Repo README.md and docs/ are updated in the same PR as')
     print('   the change they describe. Stale docs are bugs."')
     print()
-    print("Or run `tools/lint-readme-drift.py --fix` to auto-correct.")
+    if drift:
+        print("For badge drift only: run `tools/lint-readme-drift.py --fix`.")
     return 1
 
 


### PR DESCRIPTION
## Summary

- New mdBook chapter at `docs/src/ai_architecture.md` (~340 lines) covering the full AI stack — Khoj, Open WebUI, Langfuse, HolmesGPT, langgraph-agents, claude-runner, the 12 Windmill TS bridges, three distinct RAG paths, agent activation status, and the Claude API vs Claude Code escalation matrix.
- README's "AI agent pipeline" section rewritten as a tighter "AI architecture (overview)" that links to the chapter, marks each agent ✅ live / 🟡 cold / 🟥 aspirational, and fixes accumulated drift (default/ → ai/ namespace, n8n → Windmill, MCP count 14 → 16, qwen2.5:14b → 32b on Spark, adds claude-runner).
- `tools/lint-readme-drift.py` gains four mechanical narrative checks (MCP count, Windmill workflow count, namespace-path existence, mermaid hygiene). All four self-tested via deliberate-drift injection.

## Dependency

This depends on PR #11896 (docs-build CI + the `docs/src/` regex preprocessor) for the new chapter to render at `rwlove.github.io/home-ops/ai_architecture.html`. The chapter's own internal links use bare filenames so they'd pass linkcheck regardless, but the README's Documentation list links to the GH Pages URL which only resolves once the chapter is in the published book.

Order-independent: this PR is safe to merge before or after #11896.

## Test plan

- [x] `python3 tools/lint-readme-drift.py` passes on the updated README (5 badges + 4 narrative checks).
- [x] Self-tested each of the four new lint checks via deliberate-drift injection on temp copies of the README — all four fire with the expected message.
- [ ] CI lint workflow green.
- [ ] Visual scan of the rendered chapter once #11896 + this PR are both on main (or `mdbook build` locally with the replace-patterns fix applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)