### PR TITLE
docs(tei-spark): mdBook stub + SUMMARY entry (PR-5 of Stream 2)

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -11,6 +11,7 @@
 - [Power Outage Recovery](power-outage.md)
 - [Coral](coral.md)
 - [nVidia Tesla P40](p40.md)
+- [TEI on Spark — reranker for RAG](tei_spark.md)
 - [Cluster Rebuild Actions](cluster_rebuild.md)
 - [Cluster Upgrade Runbook](cluster_upgrade.md)
 - [Promote Worker to Control Plane](promote_worker_to_control_plane.md)

--- a/docs/src/tei_spark.md
+++ b/docs/src/tei_spark.md
@@ -1,0 +1,5 @@
+# TEI on Spark — reranker for RAG
+
+Moved to the vault: `~/vaults/claude/runbooks/home-ops/tei_spark.md`
+
+See HOMELAB-SPEC Layer 2 #5: the vault is canonical for runbooks.


### PR DESCRIPTION
## Summary

Final PR in Stream 2. Adds a `tei-spark` chapter to mdBook as a stub pointing at the vault runbook, mirroring the established pattern (`p40.md`, `memory_mcp.md`, `mcp_observability.md`, etc.) per HOMELAB-SPEC Layer 2 #5.

## Vault runbook covers

- **Architecture** — TEI on Spark → bge-reranker-v2-m3 → cross-encoder for Open WebUI RAG.
- **Why this model** — family-matched to `bge-m3` embedder; BAAI's own MIRACL/BEIR/CMTEB benchmarks show v2-m3 reranking bge-m3 top-100 beats `bge-reranker-large` in every multilingual setting.
- **Why it works despite the docs gap** — TEI's `router/src/lib.rs::get_backend_model_type` dispatches XLM-RoBERTa Sequence Classification generically; [Issue #713](https://github.com/huggingface/text-embeddings-inference/issues/713) confirms live operation on TEI 1.8.
- **Three known quirks** — main-branch image pin (no release tag carries #840 yet), `/metrics` on HTTP port not `--prometheus-port`, DCGM utilization counters broken on GB10.
- **Cold-start timing** — ~65 s on first start (dominated by HF Hub model download), ~55 s on subsequent restarts (PVC cache warm).
- **Verification recipes**, **cutover PR history** (#11886, #11893, #11898, #11906; PR-3 pending Tue 2026-05-26 02:00 ET), **failure modes**.

## Note — adjacent doc may want a small follow-up

`docs/src/ai_architecture.md:141` (added in #11907 yesterday) says:
> **Reranker**: BGE reranker-v2-m3 in-process, sentence-transformers on CPU (line 66). Adds ~2.5 GiB to the pod's resident set.

This is accurate **today** but goes stale on Tue 2026-05-26 when PR-3 cuts over to external TEI. Suggest adding a one-line forward pointer to `tei_spark.md` and updating after PR-3 lands. Out of scope for this PR — flagging for awareness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)