### PR TITLE
docs(ai-architecture): queue substrate is live, langgraph-agents 0.2.28 → 0.2.30

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Worker nodes attach to **iot** and **sec** VLANs via Multus for direct camera an
 | **Ollama Spark** | LLM serving on Spark/GB10 (qwen2.5:32b for the agent fleet + HolmesGPT + Open WebUI, bge-m3 embeddings) |
 | **ComfyUI** | Image generation workflows |
 | **Khoj** + **khoj-oauth2-proxy** | Personal AI assistant over notes + docs (Authelia-gated) |
-| **LangGraph Agents** | Custom multi-agent runtime (`rwlove/langgraph-agents`, image `0.2.28`); Postgres-checkpointed; MCP-gateway client. See **AI architecture** section below. |
+| **LangGraph Agents** | Custom multi-agent runtime (`rwlove/langgraph-agents`, image `0.2.30`); Postgres-checkpointed with live `task_queue` + `task_dlq` substrate; MCP-gateway client. See **AI architecture** section below. |
 | **Langfuse** | LLM observability — OTLP trace sink for the langgraph-agents fleet (CNPG-backed; ClickHouse/Valkey/MinIO bundled) |
 | **claude-runner** (namespace `automation/`) | Cron-driven Claude Code workflows — daily Renovate PR triage + Claude-spend projection cards to Zulip |
 | **Paperless-AI** | Auto-tagging for paperless-ngx |
@@ -391,7 +391,7 @@ in 1Password.
 - **Open WebUI** (`collab/`) — primary chat UI. Defaults to qwen2.5:32b on Ollama-Spark; users can switch to any langgraph agent via the OpenAI-compatible API. RAG runs over Qdrant with bge-m3 embeds + BGE reranker-v2-m3 in-process. Tool servers wired in: HolmesGPT + the MCP gateway.
 - **Khoj** (`ai/`) — parallel personal-AI surface for notes + docs. Self-contained: own embedding pipeline (default gte-small, optionally ollama nomic-embed-text), chat via Ollama-P40. Does **not** consume MCP gateway or langgraph-agents.
 - **HolmesGPT** (`observability/`) — the only agent live in production. AlertManager firings reach it via Windmill's `alertmanager-holmesgpt-notify.ts`; it reasons over Prometheus + Loki + cluster state and posts a root-cause hypothesis to Zulip / ntfy. Open WebUI also surfaces it as a tool server.
-- **langgraph-agents** (`ai/`) — the FastAPI multi-agent runtime (`rwlove/langgraph-agents`, image `0.2.28`). Plumbed end-to-end (Postgres checkpoints + memory, vault PVCs, Windmill approval loop, cost caps in env) but cold: `ENABLE_CLAUDE_API: false` and no public route except `/approval`. Goes hot when the Claude key lands in 1Password.
+- **langgraph-agents** (`ai/`) — the FastAPI multi-agent runtime (`rwlove/langgraph-agents`, image `0.2.30`). Plumbed end-to-end (Postgres checkpoints + memory, live task-queue substrate in `postgres-langgraph-checkpoints`, vault PVCs, Windmill approval loop, cost caps in env) but cold: `ENABLE_CLAUDE_API: false` and no public route except `/approval`. Goes hot when the Claude key lands in 1Password.
 - **claude-runner** (`automation/`) — separate escalation lane. Two daily CronJobs (`pr-triage` 13:00 UTC, `cost-cap-commentary` 22:00 UTC) launch the Claude Code CLI with a `gh` MCP allowlist, post Zulip cards, then exit. Stateless; never consumes langgraph-agents.
 - **Windmill** (`home/`) — 12 checked-in TypeScript flows under `kubernetes/apps/home/windmill/workflows/` are the bridges that knit the surfaces above together. Every alert webhook, Zulip-triggered DM, approval round-trip, daily digest, DLQ retry, cost-cap pause, and Paperless RAG ingest is a `.ts` file there. n8n was retired during the ntfy migration.
 - **Langfuse** (`ai/`) — OTLP trace sink for langgraph-agents. Chart deploys ClickHouse + Valkey + MinIO bundled; Postgres comes from CNPG `postgres-langfuse`.

--- a/docs/src/ai_architecture.md
+++ b/docs/src/ai_architecture.md
@@ -201,7 +201,7 @@ Cross-agent shared memory, not user-facing.
 | Agent | Surface | Status | Notes |
 |---|---|---|---|
 | HolmesGPT | `holmesgpt.observability` | ✅ live | qwen2.5:32b on ollama-spark; AlertManager-driven RCA; also a tool server for Open WebUI |
-| supervisor / researcher / coder / reviewer / triager / reporter / note-maker / homelab-engineer / smart-home-engineer / ml-tuner / errand-runner / property-coordinator / health-tracker | langgraph-agents fleet | 🟡 plumbed, cold | `ENABLE_CLAUDE_API: false`, no public route except `/approval`. Image `ghcr.io/rwlove/langgraph-agents:0.2.28` (post queue-substrate cutover, PR #11891). Vault PVCs mounted; checkpoint + memory Postgres ready. Gated on Claude key + cluster confidence. |
+| supervisor / researcher / coder / reviewer / triager / reporter / note-maker / homelab-engineer / smart-home-engineer / ml-tuner / errand-runner / property-coordinator / health-tracker | langgraph-agents fleet | 🟡 plumbed, cold | `ENABLE_CLAUDE_API: false`, no public route except `/approval`. Image `ghcr.io/rwlove/langgraph-agents:0.2.30` (post queue-substrate cutover, PR #11905 — #11891 was the initial attempt that #11901 reverted). Vault PVCs mounted; checkpoint + memory Postgres ready; queue substrate (`task_queue` + `task_dlq` tables) live in `postgres-langgraph-checkpoints` and the migration ran cleanly on 2026-05-21. Gated on Claude key + cluster confidence. |
 | doc-writer (Scribner) | langgraph-agents (planned) | 🟥 aspirational | Not built. Goal: drafts README + `docs/` patches as diffs when commits land. |
 | claude-runner pr-triage | `automation/claude-runner` CronJob | ✅ live | Daily 13:00 UTC. Reads open PRs via gh MCP, posts one Zulip card per PR. |
 | claude-runner cost-cap-commentary | `automation/claude-runner` CronJob | ✅ live | Daily 22:00 UTC. Projects monthly Claude spend, flags if trending past `$30/mo`. |
@@ -320,7 +320,7 @@ secret is mirrored into the `ai` namespace by emberstack reflector
 - **ollama-spark** (GB10) — `kubernetes/apps/ai/ollama-spark/app/`
 - **paperless-ai** — `kubernetes/apps/ai/paperless-ai/app/helmrelease.yaml`
 - **sync-receiver** — `kubernetes/apps/ai/sync-receiver/`
-- **tei-spark** — `kubernetes/apps/ai/tei-spark/` (unsuspended 2026-05-21, PR #11893)
+- **tei-spark** — `kubernetes/apps/ai/tei-spark/` (unsuspended 2026-05-21, PR #11893; PrometheusRule added in PR #11906)
 - **open-webui** — `kubernetes/apps/collab/open-webui/app/helmrelease.yaml`
 - **holmesgpt** — `kubernetes/apps/observability/holmesgpt/app/helmrelease.yaml`
 - **windmill** — `kubernetes/apps/home/windmill/app/helmrelease.yaml`


### PR DESCRIPTION
## Summary

Re-sync the AI architecture docs against what's on main after PRs #11905 (queue cutover, fixed migration) and #11906 (tei-spark PrometheusRule) merged. Docs-only.

- README + chapter: image cite `0.2.28` → `0.2.30`, name the live `task_queue` + `task_dlq` tables in `postgres-langgraph-checkpoints`.
- Chapter agent-fleet table: correct the cutover PR reference from #11891 (the original attempt that #11901 reverted) to #11905 (the retry that actually shipped). Note migration ran cleanly 2026-05-21.
- Chapter file index: note PR #11906 added a PrometheusRule for tei-spark.

Agent fleet status stays 🟡 plumbed, cold — the queue substrate going live doesn't flip `ENABLE_CLAUDE_API` on its own.

## Test plan

- [x] `python3 tools/lint-readme-drift.py` passes (5 badges + 4 narrative checks).
- [ ] CI lint workflow green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)