### PR TITLE
fix(ai/langgraph-agents): bump 0.2.30 → 0.2.31 + ZULIP_BASE_URL

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/externalsecret.yaml
@@ -42,6 +42,14 @@ spec:
         # `zulip-bots-langgraph` 1P item (single source — same place
         # the bot identities pull from).
         ZULIP_HOST: chat.${SECRET_DOMAIN}
+        # ZULIP_BASE_URL overrides the implicit `https://{ZULIP_HOST}`
+        # constructed in agents.tools.zulip.send_dm. Set to the
+        # cluster-internal Service URL because chat.${SECRET_DOMAIN}
+        # resolves via split-horizon DNS to an external LB IP that
+        # pods can't reach (Cilium kube-proxy-replacement quirk —
+        # same pattern as windmill-workflows-secret ZULIP_API_URL).
+        # Available in langgraph-agents 0.2.31+ (PR #62).
+        ZULIP_BASE_URL: http://zulip.collab.svc.cluster.local
         ZULIP_TRIAGER_EMAIL: "{{ .ZULIP_TRIAGER_EMAIL }}"
         ZULIP_TRIAGER_API_KEY: "{{ .ZULIP_TRIAGER_API_KEY }}"
 

--- a/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/langgraph-agents
-              tag: 0.2.30@sha256:d4f3b43782d22088cde79b9df0f393bb9c30e49b5c0923971b5a1685ef5a1ae3
+              tag: 0.2.31@sha256:f8bb7330b51ab3f81151ad6b9a269be9edeb1018d9355fd45251e4c97cb5edfa
 
             env:
               # --- vault ---


### PR DESCRIPTION
## Summary

Companion bump for [langgraph-agents PR #62](https://github.com/rwlove/langgraph-agents/pull/62), which fixes two post-cutover bugs found while smoking the deployed v0.2.30.

### 1. /inbox returns HTTP 500 — NOTIFY can't carry bind params

\`queue/store.py:enqueue\` ran \`NOTIFY {channel}, %s\` to wake LISTEN workers. \`NOTIFY\` is a SQL command — bind parameters aren't permitted in its payload slot. Postgres rejects:

\`\`\`
psycopg.errors.SyntaxError: syntax error at or near "$1"
LINE 1: NOTIFY task_queue_new, $1
\`\`\`

The poll-based dequeue path kept working in parallel — worker still picked up tasks on its visibility-timeout cadence. That masked the enqueue bug from the queue substrate's smoke (PR #11905 verified the **dequeue** half but not /inbox itself).

Fix in PR #62: route through \`pg_notify(text, text)\` — an ordinary function call that accepts bind parameters.

### 2. Worker DM reply-back fails silently — split-horizon LB

\`agents.tools.zulip.send_dm\` constructed the URL as \`https://{zulip_host}\`. \`chat.\${SECRET_DOMAIN}\` resolves via split-horizon DNS to an external LB IP pods can't reach (same Cilium kube-proxy-replacement quirk that drove \`windmill-workflows-secret.ZULIP_API_URL\` to use the cluster-internal Service URL months ago).

Fix in PR #62: optional \`zulip_base_url\` setting overrides the implicit URL. Set here to \`http://zulip.collab.svc.cluster.local\` (same canonical target Windmill workflows use).

## Changes

- \`helmrelease.yaml\` — tag 0.2.30 → 0.2.31 (\`@sha256:f8bb7330b5…\`)
- \`externalsecret.yaml\` — \`ZULIP_BASE_URL: http://zulip.collab.svc.cluster.local\`

## Test plan

After merge + reconcile:

- [ ] \`POST /inbox\` returns 202 + task_id (not 500)
- [ ] Worker logs \`task_enqueued\` immediately followed by \`task_dequeued\` (LISTEN wakeup latency, not the 2s poll cadence)
- [ ] DM "what is the time?" to Triager 📥 → ack lands in <5s, agent's reply lands in same DM thread within ~30s
- [ ] \`/admin/dlq\` stays empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)