### PR TITLE
docs: cross-link tei_spark.md and ai_architecture.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ Thumbs.db
 .task/
 # Sops
 .decrypted~*.yaml
+/docs/book/

--- a/docs/src/ai_architecture.md
+++ b/docs/src/ai_architecture.md
@@ -341,3 +341,5 @@ secret is mirrored into the `ai` namespace by emberstack reflector
   task queue is still the missing piece
 - [Task Queue Substrate — design proposal](task_queue_substrate_design.md)
   — the candidates being weighed
+- [TEI on Spark — reranker for RAG](tei_spark.md) — text-embedding-
+  inference deployment (vault-canonical runbook)

--- a/docs/src/tei_spark.md
+++ b/docs/src/tei_spark.md
@@ -3,3 +3,6 @@
 Moved to the vault: `~/vaults/claude/runbooks/home-ops/tei_spark.md`
 
 See HOMELAB-SPEC Layer 2 #5: the vault is canonical for runbooks.
+
+For cluster-level role of TEI in the RAG architecture, see the
+[AI Architecture](ai_architecture.md) chapter.


### PR DESCRIPTION
## Summary

Two chapters landed within hours: the AI architecture chapter (#11907) covers TEI on Spark as part of the broader RAG-and-reranker picture; the tei-spark vault-redirect stub (#11908) is the operator-runbook landing. Wire them together — see-also pointers in both directions.

## Test plan

- [x] `python3 tools/lint-readme-drift.py` passes.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)