### PR TITLE
fix(ai/langgraph-agents): bump 0.2.31 → 0.2.32 — fixes /admin/tasks self-deadlock

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/langgraph-agents
-              tag: 0.2.31@sha256:f8bb7330b51ab3f81151ad6b9a269be9edeb1018d9355fd45251e4c97cb5edfa
+              tag: 0.2.32@sha256:046dc4e5555f18d8f007d62e1ca54638f39a7bfa35a997791d17959541deb7b1
 
             env:
               # --- vault ---


### PR DESCRIPTION
## Summary

#11910 just shipped 0.2.31 (lg-agents PR #62 — `pg_notify` + `zulip_base_url`). But `/admin/tasks` still hangs on a quiet cluster — verified live on the just-rolled 0.2.31 pod with a \`curl -m 15\` that times out at exactly 15s.

This PR bumps to 0.2.32 which adds lg-agents PR #63 — the two-phase \`list_tasks\` fix.

## Root cause (re-discovered post-#61)

PR #61 added a dedicated admin checkpointer so /admin reads can't be blocked by the dispatch path's lock. That isolation is correct and necessary — but \`list_tasks\` self-deadlocks on the admin saver's **own** lock:

\`AsyncPostgresSaver._cursor\` does \`async with self.lock, get_connection(...)\` and holds that lock across \`alist\`'s yield points. Calling \`aget_state\` inside the loop body re-acquires the same non-reentrant \`asyncio.Lock\` that the task already holds — and waits forever. Verified in prod with py-spy: handler stuck in \`aget_tuple __aenter__\`.

PR #63 splits the loop into two phases — drain \`alist\` first to collect thread_ids (lock released when iterator exits), then \`aget_state\` per thread.

## Impact

Unblocks \`f/lovenet/langgraph-awaiting-user-sweep\` Windmill cron which has been hitting its 30s timeout on every fire since v0.2.26.

## Test plan

- [ ] CI green
- [ ] Post-merge: pod rolls to \`0.2.32@sha256:046dc4e5555f…\`
- [ ] Post-merge: \`curl -m 30 http://langgraph-agents.ai.svc.cluster.local:8765/admin/tasks\` returns JSON in <1s
- [ ] Post-merge: next 5-min fire of \`langgraph-awaiting-user-sweep\` cron is green
- [ ] Post-merge: \`/admin/dlq\` still returns 200 (regression check on PR #62/#63 cohabitation)

## Drift note

\`langgraph-agents/pyproject.toml\` still says \`0.2.31\` in the v0.2.32 tag — matches the prior v0.2.30 tag-leads-pyproject precedent during quick-turn hotfix sequences. To re-sync at the next coordinated release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)