### PR TITLE
docs: add Material for MkDocs preview build alongside mdBook

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -11,6 +11,11 @@ on:
       - README.md
       - .github/workflows/docs.yaml
       - kubernetes/**
+  pull_request:
+    paths:
+      - docs/**
+      - README.md
+      - .github/workflows/docs.yaml
 
 permissions:
   actions: write
@@ -20,6 +25,7 @@ permissions:
 
 jobs:
   publish:
+    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
@@ -49,3 +55,35 @@ jobs:
           publish_dir: ./docs/book/html
           user_name: "rosey-the-renovator-bot[bot]"
           user_email: "rosey-the-renovator-bot <98764075+rosey-the-renovator-bot[bot]@users.noreply.github.com>"
+
+  material-preview:
+    # Preview-only build for the Material for MkDocs migration. Uploads
+    # the rendered site as a CI artifact so Rob can inspect the new
+    # look-and-feel before PR #2 swaps the live deploy. No deploy here.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: 3.14.x
+
+      - name: Install mkdocs-material
+        shell: bash
+        working-directory: docs
+        run: pip install -r requirements.txt
+
+      - name: Build with mkdocs
+        shell: bash
+        working-directory: docs
+        run: mkdocs build
+
+      - name: Upload preview artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: material-preview
+          path: docs/site/
+          retention-days: 7
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ Thumbs.db
 # Sops
 .decrypted~*.yaml
 /docs/book/
+/docs/site/
+/docs/.venv/
+**/__pycache__/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+---
 # yaml-language-server: $schema=https://json.schemastore.org/pre-commit-config.json
 
 # Pre-commit hooks for home-ops.
@@ -16,7 +17,9 @@ repos:
     hooks:
       - id: check-yaml
         args: [--allow-multiple-documents]
-        exclude: ^(.*\.sops\..*|.*/resources/.*)$
+        # mkdocs.yml uses PyYAML !!python/name: tags for Material's
+        # emoji extension config — safe-load rejects them.
+        exclude: ^(.*\.sops\..*|.*/resources/.*|docs/mkdocs\.yml)$
       - id: check-json
       - id: check-merge-conflict
       - id: check-symlinks

--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -1,0 +1,20 @@
+"""MkDocs hooks for home-ops docs.
+
+Ports the single entry in the legacy mdBook ``replace-patterns.json``:
+drop the ``### 📖 Docs`` section from the repo README before it lands
+in ``introduction.md`` via ``--8<-- "README.md"`` (the pymdownx.snippets
+include). The repo README points readers at the docs site; when the
+README is itself embedded in the docs site, the pointer is a loop.
+"""
+
+from __future__ import annotations
+
+import re
+
+_DOCS_SECTION_RE = re.compile(r"\n### 📖 Docs[\s\S]*?---\n")
+
+
+def on_page_markdown(markdown: str, *, page, config, files) -> str:
+    if page.file.src_uri == "introduction.md":
+        return _DOCS_SECTION_RE.sub("", markdown)
+    return markdown

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,0 +1,125 @@
+---
+# yaml-language-server: $schema=https://squidfunk.github.io/mkdocs-material/schema.json
+site_name: Home Operations
+site_url: https://rwlove.github.io/home-ops/
+site_description: GitOps-managed home Kubernetes cluster — runbooks, design docs, audits.
+site_author: Bubba
+repo_url: https://github.com/rwlove/home-ops
+repo_name: rwlove/home-ops
+edit_uri: edit/main/docs/src/
+docs_dir: src
+site_dir: site
+
+theme:
+  name: material
+  language: en
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.sections
+    - navigation.top
+    - navigation.indexes
+    - navigation.footer
+    - search.highlight
+    - search.share
+    - search.suggest
+    - content.code.copy
+    - content.code.annotate
+    - content.action.edit
+    - toc.follow
+  icon:
+    repo: fontawesome/brands/github
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - md_in_html
+  - tables
+  - footnotes
+  - def_list
+  - pymdownx.details
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets:
+      base_path: [".", "..", "src"]
+      check_paths: true
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - toc:
+      permalink: true
+
+hooks:
+  - hooks.py
+
+nav:
+  - Welcome:
+      - introduction.md
+      - index.md
+  - AI & Workflow:
+      - ai_architecture.md
+      - workflow_automation.md
+      - memory_mcp.md
+      - mcp_observability.md
+      - tei_spark.md
+      - coral.md
+      - p40.md
+  - Cluster Lifecycle:
+      - cluster_rebuild.md
+      - cluster_upgrade.md
+      - promote_worker_to_control_plane.md
+      - init_teardown.md
+      - master1_etcd_disk_swap.md
+      - power-outage.md
+  - DR & Restore:
+      - rook_ceph_dr.md
+      - cnpg_restore.md
+      - longhorn_restore.md
+      - garage_restore.md
+      - frigate_dr.md
+      - immich_cnpg.md
+      - offsite_recovery.md
+  - Network & Security:
+      - per-route-cert-migration.md
+      - apiserver_audit_logging.md
+      - networkpolicy_rollout_plan.md
+      - egress_restriction_design.md
+      - mtls_rollout_design.md
+      - pod_security_audit.md
+      - rbac_audit.md
+  - Substrate & Orchestration:
+      - orchestration_substrate.md
+      - task_queue_substrate_design.md
+      - github_webhook.md
+      - limits.md
+  - Audits:
+      - audit/post-spark-tool-call-leakage-2026-05-18.md
+  - Reference:
+      - debugging.md

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+mkdocs-material==9.7.6
+pymdown-extensions==10.21.3
+mkdocs-material-extensions==1.3.1


### PR DESCRIPTION
## Summary

PR #1 of 2 for the docs site migration from mdBook to **Material for MkDocs**. This PR adds the new build path alongside the existing one; the live site stays on mdBook. PR #2 will swap the live deploy and remove mdBook.

The new `material-preview` CI job builds with `mkdocs` and uploads `docs/site/` as a CI artifact for review. To preview the new look:

```bash
gh run download <run-id> -n material-preview -D /tmp/preview
cd /tmp/preview && python -m http.server 8000
# Open http://localhost:8000
```

## What's in scope

- `docs/mkdocs.yml` — Material theme config, light/dark palette, pymdownx extensions for admonish / snippets / emoji, nav grouped from the current flat `SUMMARY.md` into seven sections
- `docs/requirements.txt` — pinned `mkdocs-material 9.7.6`, `pymdown-extensions 10.21.3`, `mkdocs-material-extensions 1.3.1` (Renovate-tracked)
- `docs/hooks.py` — ports the single `replace-patterns.json` regex (strips the README `### 📖 Docs` pointer when the README is included in `introduction.md`) as an `on_page_markdown` hook
- `.github/workflows/docs.yaml` — new `material-preview` job runs on pull_request + workflow_dispatch + push to main; uploads `docs/site/` as artifact (retention 7d). Existing `publish` job gated with `if: github.event_name != 'pull_request'` so PRs don't trigger the live mdBook build.
- `.pre-commit-config.yaml` — exclude `docs/mkdocs.yml` from `check-yaml` (it uses PyYAML `!!python/name:` tags for Material's emoji extension); also add missing `---` document-start marker that yamllint now flags
- `.gitignore` — cover `docs/site/`, `docs/.venv/`, `__pycache__/`

## What's NOT in scope (deferred to PR #2)

- Converting `docs/src/introduction.md` (1 `admonish warning` block + 1 `{{ #include }}` directive). These render as literal text in the preview — that's fine, the preview is for evaluating the look-and-feel.
- Swapping the live deploy from mdBook to mkdocs
- Removing `docs/book.toml`, `docs/theme/`, `docs/assets/`, `docs/replace-patterns.json`
- Link validation replacement for `mdbook-linkcheck`

Plan: `/home/rwlove/.claude-personal/plans/i-don-t-like-the-gleaming-clover.md`

## Test plan

- [ ] CI's `material-preview` job runs green
- [ ] Download `material-preview` artifact, serve locally, browse a few pages, evaluate the look
- [ ] Confirm nav grouping (Welcome / AI & Workflow / Cluster Lifecycle / DR & Restore / Network & Security / Substrate & Orchestration / Audits / Reference) reads well
- [ ] Light/dark toggle, search, code-block copy work
- [ ] Existing mdBook `publish` does NOT run on this PR (gated off pull_request)
- [ ] No accidental change to the live site at https://rwlove.github.io/home-ops/

🤖 Generated with [Claude Code](https://claude.com/claude-code)