### PR TITLE
fix(ai/langgraph-agents): bump 0.2.32 → 0.2.33 (Zulip Host header fix)

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/langgraph-agents
-              tag: 0.2.32@sha256:046dc4e5555f18d8f007d62e1ca54638f39a7bfa35a997791d17959541deb7b1
+              tag: 0.2.33@sha256:beea1750f62fbf1fd7c064a0cc4841656ee485b8678d1c39b87abb80ca8a27da
 
             env:
               # --- vault ---


### PR DESCRIPTION
Companion bump for [langgraph-agents PR #64](https://github.com/rwlove/langgraph-agents/pull/64).

## Why

v0.2.31's \`ZULIP_BASE_URL\` fix solved TCP routing to the cluster-internal Zulip Service. The DM reply-back still failed with Django's bare 400 page (\`<h1>Bad Request (400)</h1>\`) because:

\`\`\`
httpx-sent Host: zulip.collab.svc.cluster.local
Zulip ALLOWED_HOSTS includes:  chat.${SECRET_DOMAIN}
                       result: DisallowedHost → 400
\`\`\`

PR #64 sets \`Host: {zulip_host}\` explicitly when \`zulip_base_url\` is set. Verified in-pod with both \`type=direct\` and \`type=private\` returning 200 OK.

## Changes

Only the image tag bump. The existing \`ZULIP_BASE_URL\` env var (added in PR #11910) stays — that's what triggers the new Host override.

## Test plan

- [ ] DM "what is the time?" to Triager 📥 → reply lands in same DM thread within ~60s
- [ ] \`kubectl -n ai logs deploy/langgraph-agents | grep zulip-reply\` shows \`status=200 msg_id=...\` (not 400)

🤖 Generated with [Claude Code](https://claude.com/claude-code)