### PR TITLE
docs: restore runbook content from vault to docs/src/

### DIFF
--- a/docs/src/apiserver_audit_logging.md
+++ b/docs/src/apiserver_audit_logging.md
@@ -1,5 +1,190 @@
-# Apiserver Audit Logging Runbook
+# Apiserver Audit Logging — Phase 5.P operator runbook
 
-Moved to the vault: `~/vaults/claude/runbooks/home-ops/apiserver_audit_logging.md`
+**Operator-side.** Per Inv 9, control-plane static-pod manifests are
+not modified by agents. Agents prep the policy file + Vector pipeline;
+the kubeadm patch + apiserver restart per node is yours.
 
-See HOMELAB-SPEC Layer 2 #5: the vault is canonical for runbooks.
+## What this gives us
+
+Per PSA labels shipped in PR #11615 plus the analysis in
+`docs/src/pod_security_audit.md`, the cluster currently has
+Pod-Security-Admission targeting per-namespace BUT no apiserver
+`--audit-log-path` configured. Violations are computed and discarded;
+the labels are inert.
+
+After this runbook:
+
+- PSA `audit-violations` and `enforce-policy` annotations appear in
+  the audit log on every pod admission decision
+- RBAC changes are recorded at RequestResponse level
+- Namespace lifecycle events pair with the Kyverno 5.O3 enforce policy
+  for blast-radius traceability
+- Vector ships `/var/log/kubernetes/audit.log` to Loki for query
+
+## Prerequisites
+
+1. Audit policy committed at `kubernetes/control-plane-config/audit-policy.yaml`
+   (already in the repo as of Phase 5.P prep PR)
+2. Vector pipeline already shipping `/var/log/kubernetes/audit.log` to
+   Loki (also in the Phase 5.P prep PR — gets it on each node via the
+   agent DaemonSet that already mounts `/var/log` host path)
+
+## Per-node procedure
+
+**Run on ONE control-plane node at a time. Never two on the same day.**
+
+### Step 1 — Copy the audit policy to the node
+
+```sh
+scp kubernetes/control-plane-config/audit-policy.yaml \
+    root@masterN.${SECRET_DOMAIN}:/etc/kubernetes/audit-policy.yaml
+```
+
+Verify:
+
+```sh
+ssh root@masterN.${SECRET_DOMAIN} 'ls -la /etc/kubernetes/audit-policy.yaml'
+```
+
+### Step 2 — Create the audit log directory
+
+```sh
+ssh root@masterN.${SECRET_DOMAIN} 'mkdir -p /var/log/kubernetes && touch /var/log/kubernetes/audit.log'
+```
+
+### Step 3 — Patch the kube-apiserver static manifest
+
+Open an SSH session, leave it open the whole time. If apiserver fails
+to restart cleanly, this session is your rollback path.
+
+```sh
+ssh root@masterN.${SECRET_DOMAIN}
+```
+
+Then on the node:
+
+```sh
+cp /etc/kubernetes/manifests/kube-apiserver.yaml \
+   /root/kube-apiserver.yaml.pre-audit
+```
+
+Edit `/etc/kubernetes/manifests/kube-apiserver.yaml` and add to the
+`spec.containers[0].command` array (insert anywhere after `kube-apiserver`):
+
+```yaml
+- --audit-policy-file=/etc/kubernetes/audit-policy.yaml
+- --audit-log-path=/var/log/kubernetes/audit.log
+- --audit-log-maxage=14
+- --audit-log-maxbackup=3
+- --audit-log-maxsize=200
+```
+
+Add these volume + mount entries to the same Pod spec:
+
+```yaml
+# Under spec.volumes:
+- name: audit-policy
+  hostPath:
+    path: /etc/kubernetes/audit-policy.yaml
+    type: File
+- name: audit-log
+  hostPath:
+    path: /var/log/kubernetes
+    type: DirectoryOrCreate
+
+# Under spec.containers[0].volumeMounts:
+- name: audit-policy
+  mountPath: /etc/kubernetes/audit-policy.yaml
+  readOnly: true
+- name: audit-log
+  mountPath: /var/log/kubernetes
+```
+
+### Step 4 — Wait for kubelet to restart the apiserver
+
+Kubelet watches the manifest file and restarts the apiserver pod
+automatically when the file changes (mtime-based).
+
+```sh
+# Watch the apiserver pod restart
+crictl ps --name kube-apiserver --all
+# OR via journalctl
+journalctl -u kubelet -f
+```
+
+Expected: `kube-apiserver` pod enters `Stopped` → new pod
+`Running`. Total downtime ~30-60s on this one apiserver. The other 2
+control-plane apiservers keep serving during this window.
+
+### Step 5 — Verify the audit log is being written
+
+```sh
+ssh root@masterN.${SECRET_DOMAIN} 'tail -n 5 /var/log/kubernetes/audit.log'
+```
+
+You should see JSON audit events. If empty after 30s, something is
+wrong — see Recovery below.
+
+### Step 6 — Confirm Loki is receiving
+
+From any host with kubectl access:
+
+```sh
+# Vector should be shipping; logs land with label app=kube-apiserver-audit
+# or similar. Query Loki:
+logcli query '{filename="/var/log/kubernetes/audit.log"}' --limit 5 --tail
+```
+
+### Step 7 — Wait at least 24 hours before doing the next node
+
+This gives the audit log time to accumulate; if anything's off,
+you'll see it before instrumenting the next master.
+
+## Recovery — apiserver won't restart
+
+If kubelet logs show the new apiserver crashlooping:
+
+```sh
+# Restore the pre-audit manifest:
+cp /root/kube-apiserver.yaml.pre-audit /etc/kubernetes/manifests/kube-apiserver.yaml
+
+# Kubelet picks up the change within ~10s. Apiserver returns to its
+# pre-audit config.
+```
+
+Then debug from the logs. Common gotchas:
+
+- **Audit policy YAML invalid** — apiserver rejects the policy file at
+  startup; kubelet shows the apiserver pod stuck in CrashLoopBackOff
+  with an error message about audit policy parse failure.
+- **Audit log directory not writable** — apiserver fails to open the
+  log file. Check ownership on `/var/log/kubernetes/`.
+- **Volume mount missing** — apiserver can't read the policy file.
+  Check the `volumes` + `volumeMounts` entries in the manifest.
+
+## Schedule
+
+| Step | Node | Earliest |
+|---|---|---|
+| 5.P1 | master1 | Any low-traffic evening |
+| 5.P2 | master2 | ≥1 day after 5.P1 lands cleanly |
+| 5.P3 | master3 | ≥1 day after 5.P2 lands cleanly |
+
+Skip the next step if any prior step was anything other than
+uneventful.
+
+## Disk pressure
+
+Audit log defaults: 200MB max per file, 3 backups, 14d retention.
+That's up to 800MB per master = ~2.4GB across 3 masters. Tune via
+the `maxage`/`maxbackup`/`maxsize` flags if disk pressure shows up.
+
+## See also
+
+- `kubernetes/control-plane-config/audit-policy.yaml` — the policy
+- `docs/src/pod_security_audit.md` — what PSA already labels
+- `~/vaults/claude/runbooks/home-ops/cluster_rebuild.md` — adjacent
+  control-plane procedure
+- `~/vaults/claude/runbooks/home-ops/master1_etcd_disk_swap.md` —
+  prior precedent for master1-first instrumentation
+- Memory: `project_psa_audit_privileged_is_noop` — the gap this closes

--- a/docs/src/cluster_rebuild.md
+++ b/docs/src/cluster_rebuild.md
@@ -1,5 +1,315 @@
 # Cluster Rebuild Runbook
 
-Moved to the vault: `~/vaults/claude/runbooks/home-ops/cluster_rebuild.md`
+End-to-end recovery procedure for losing the cluster and rebuilding it
+from Git + 1Password + Garage. Read this before you need it.
 
-See HOMELAB-SPEC Layer 2 #5: the vault is canonical for runbooks.
+## What survives a rebuild
+
+| Survives | Lives on | Notes |
+|---|---|---|
+| Git repo | GitHub | Source of truth for everything below `kubernetes/` |
+| 1Password vault | Cloud | Holds every `op://` reference in `bootstrap/resources.yaml.j2` and every `ExternalSecret` |
+| Garage S3 buckets (`postgres-*-backup/`) | NFS via `${NFS_HOST_0}:/mnt/kubernetes/garage/data` | This is what CNPG recovery depends on. Verify NFS host is healthy *before* destroying anything. |
+| NFS-backed app data | `${NFS_HOST_0}` / `${NFS_HOST_2}` | Media libraries, garage data + meta, anything mounted via NFS PVs |
+
+## What does NOT survive
+
+- **Ceph OSDs** — `init/destroy-cluster.sh` wipes `/dev/ceph-*` on every
+  node. Anything on `ceph-block` (every CNPG `PGData`, app config
+  PVCs) is gone.
+- **Longhorn replicas** — `/var/lib/longhorn/*` is wiped on every
+  worker. Re-replicated data is lost; non-replicated data on a single
+  node may survive but treat it as gone.
+- **etcd** — `/var/lib/etcd/` wiped on every control-plane node.
+- **kube-vip lease, certificates, kubeconfigs** — regenerated.
+
+The only PG durability layer that survives is the Barman base
+backups + WAL stored in Garage. Verify `${NFS_HOST_0}` is up and the
+`/mnt/kubernetes/garage/{data,meta}` exports are intact before you
+run `destroy-cluster.sh`.
+
+## Preflight (do before destroying anything)
+
+1. **Confirm NFS host health** for both `${NFS_HOST_0}` (Garage +
+   media) and `${NFS_HOST_2}`. `showmount -e <host>` should list the
+   exports.
+2. **Confirm a recent CNPG backup exists** for every cluster you care
+   about. Either inspect `s3://postgres-*-backup/<serverName>/base/`
+   in the Garage WebUI, or run an immediate backup first:
+
+   ```bash
+   ./tools/onetime-cnpg-backup.sh        # uses postgres cluster name
+   ```
+
+   For per-app, edit `kubernetes/apps/databases/cloudnative-pg/config/onetimebackup.yaml`
+   to target the cluster (e.g. `postgres-immich`) and apply.
+3. **Confirm 1Password Connect creds are current** — the `kubernetes`
+   vault must contain `1password/OP_CREDENTIALS_JSON`,
+   `1password/OP_CONNECT_TOKEN`, and the `homelab` item with
+   `SECRET_DOMAIN`, `EMAIL`, `NFS_HOST_*`.
+4. **Note any suspended Flux resources** — `flux get all -A | grep -i
+   suspend`. Suspended state is *not* in Git; you'll lose the
+   suspension on rebuild and Flux will reconcile those apps. Decide
+   per app whether that's OK.
+5. **Check for in-flight `disable-<app>` commits** on `main` (see
+   `CLAUDE.md` → "Flux suspend / disable workflow"). Don't rebuild
+   while one of those is pending.
+
+## Tear down
+
+Only needed if reusing the same hardware. Skip on a fresh fleet.
+
+```bash
+./init/destroy-cluster.sh    # from your laptop, NOT a control plane
+```
+
+This drains every node, runs `kubeadm reset`, wipes Ceph devices via
+`/root/ceph-cleanup.sh` on each node, and clears
+`/var/lib/{etcd,kubelet,longhorn,rook}`.
+
+## Bootstrap
+
+1. **Create the cluster** (run on `master1`):
+
+   ```bash
+   ./init/create-cluster.sh
+   ```
+
+   Sets up kube-vip, runs `kubeadm init`, joins masters 2/3 and all
+   workers, labels Longhorn-eligible nodes, makes `master1`
+   schedulable.
+
+2. **Initialize the cluster** (run on your laptop):
+
+   ```bash
+   ./init/initialize-cluster.sh
+   ```
+
+   Pulls the kubeconfig from `master1`, creates the bootstrap
+   namespaces, runs `just -f bootstrap/mod.just resources` (renders
+   1Password-backed secrets), applies CRDs from
+   `bootstrap/helmfile.d/00-crds.yaml`, then `helmfile sync` for
+   `01-apps.yaml` (Cilium, CoreDNS, cert-manager, external-secrets,
+   1Password Connect, Flux operator + instance).
+
+3. **Remove the static kube-vip manifest** (run on your laptop):
+
+   ```bash
+   ssh root@master1 rm /etc/kubernetes/manifests/kube-vip.yaml
+   ```
+
+   Once Flux brings up the in-cluster kube-vip, the static pod is
+   redundant and will fight for the VIP.
+
+## Verify GitOps
+
+Flux should now be reconciling everything under `kubernetes/`. Watch
+for the bootstrap chain:
+
+```bash
+flux get sources git -A
+flux get ks -A          # kustomizations should turn Ready=True
+flux get hr -A
+kubectl get events -A --sort-by=.lastTimestamp | tail -50
+```
+
+Order to expect things to come up:
+
+1. `flux-system` → cilium, coredns, cert-manager, external-secrets, 1Password Connect
+2. `rook-ceph` → operator, then `rook-ceph-cluster` (slow; wait for OSDs to form)
+3. `databases/cloudnative-pg` (operator + barman-cloud plugin)
+4. `storage/garage` (NFS-backed; should come up quickly once
+   external-secrets is alive)
+5. The per-cluster CNPG `Cluster` resources, which trigger recovery
+   (next section)
+6. App workloads
+
+## CNPG recovery from Garage
+
+This is the load-bearing part of the rebuild. **Do not skip the
+verification steps.**
+
+### How it works
+
+Each CNPG cluster under
+`kubernetes/apps/databases/cloudnative-pg/config/<app>/` has three
+files that together drive recovery:
+
+- `objectstore.yaml` — `barmancloud.cnpg.io/v1 ObjectStore` pointing
+  at `http://garage.storage.svc.cluster.local:3900` with bucket
+  `s3://postgres-<app>-backup/`. Credentials come from the per-app
+  `*-secret` (synced from 1Password by the app's
+  `externalsecret.yaml`).
+- `cluster.yaml` — the `postgresql.cnpg.io/v1 Cluster`. Two relevant
+  blocks:
+  - `spec.bootstrap.recovery.source: source` — tells CNPG to
+    initialize a brand-new cluster by restoring from `externalClusters[0]`.
+  - `spec.externalClusters[].plugin.parameters` — references the
+    `ObjectStore` by `barmanObjectName` and `serverName`.
+- `scheduledbackup.yaml` — the recurring backup that produced what
+  you're now restoring.
+
+`bootstrap.recovery` **only fires on first cluster creation**. If a
+PVC already exists for the cluster, CNPG will resume from local data,
+not from Garage. That's why teardown wipes Ceph — it forces a true
+first-creation on the way back up.
+
+### State of the bootstrap blocks
+
+CNPG clusters fall into three groups today. Verify with:
+
+```sh
+for f in kubernetes/apps/databases/cloudnative-pg/config/*/cluster.yaml; do
+  name=$(basename "$(dirname "$f")")
+  if   grep -qE '^[^#]*recovery:' "$f"; then echo "PRE-ARMED:  $name"
+  elif grep -qE '^\s*#\s*recovery:' "$f"; then echo "COMMENTED:  $name"
+  else                                       echo "NO_RECOVERY:$name"
+  fi
+done
+```
+
+**Pre-armed** — `bootstrap.recovery` is un-commented. No-op while the cluster exists; ready to recover on next bootstrap:
+
+- `atuin`, `home-assistant`, `immich`, `lldap`, `paperless`
+
+**Commented** — block exists in the file but is commented out. Uncomment before the relevant Flux Kustomization runs on rebuild:
+
+- `cutvideo`, `lidarr`, `medikeep`, `netbox`, `prowlarr`, `pump`, `radarr`, `romm`, `sonarr`, `sparkyfitness`
+
+**No recovery block at all** — these clusters have never been wired for Barman recovery. **Add a `bootstrap.recovery` block (and confirm an `ObjectStore` + `ScheduledBackup` exist) before any rebuild that needs them to survive:**
+
+- `authelia`, `av1corrector`, `khoj`, `langgraph-checkpoints`, `langgraph-memory`, `n8n`, `nametag`, `videodupfinder`, `zulip`
+
+For commented and no-recovery sets, edit `cluster.yaml` to include:
+
+```yaml
+bootstrap:
+  recovery:
+    source: source
+```
+
+Commit and push so Flux sees it. (For a planned rebuild you can do
+this in advance on a branch and merge right before destroy.)
+
+### Per-cluster recovery (no manual steps required if pre-armed)
+
+1. Wait for `cnpg` operator + `plugin-barman-cloud` HelmReleases to
+   be ready, and the `garage` Kustomization to be Ready.
+2. The per-app Flux Kustomization (e.g. `cnpg-immich`) creates the
+   `ObjectStore` + `Cluster` + `ScheduledBackup`.
+3. CNPG sees no PGData PVC, runs the bootstrap recovery job, which
+   pulls the most recent base backup from `s3://postgres-<app>-backup/`
+   and replays WAL up to the latest archived segment.
+4. Cluster transitions through `Setting up primary` → `Cluster in
+   healthy state`. Replicas are then created normally on `ceph-block`.
+
+Watch one cluster at a time:
+
+```bash
+kubectl -n databases get cluster -w
+kubectl -n databases describe cluster postgres-immich | tail -50
+kubectl cnpg -n databases status postgres-immich
+kubectl -n databases logs -l cnpg.io/jobRole=full-recovery -f
+```
+
+### Point-in-time recovery (PITR)
+
+To recover to a specific moment instead of "latest WAL", add a
+`recoveryTarget` block — see the commented template in
+`config/nextcloud/cluster.yaml`:
+
+```yaml
+  bootstrap:
+    recovery:
+      source: source
+      recoveryTarget:
+        targetTime: "2025-12-01 00:00:00.00000+00"
+```
+
+Apply, wait for recovery to complete, then **remove the
+`recoveryTarget`** in a follow-up commit so future bootstrap attempts
+default to "restore latest".
+
+### Verifying a recovery
+
+```bash
+kubectl cnpg -n databases status <cluster-name>
+kubectl cnpg -n databases psql <cluster-name> -- -c '\l'
+kubectl cnpg -n databases psql <cluster-name> -- -c 'SELECT pg_is_in_recovery(), now();'
+```
+
+Confirm row counts on a critical table per app (e.g. `assets` for
+immich, `documents_document` for paperless). Compare against your
+last known production count if you have one.
+
+### Recovery failure modes
+
+- **`ObjectStore` not Ready** → check the per-app secret synced
+  (`kubectl -n databases get externalsecret`), and the Garage
+  endpoint resolves (`kubectl -n databases run -it --rm curl
+  --image=curlimages/curl -- curl -v http://garage.storage.svc.cluster.local:3900`).
+- **Recovery job pulls nothing** → bucket is empty or `serverName`
+  doesn't match. Check the Garage WebUI for
+  `s3://postgres-<app>-backup/<serverName>/base/`.
+- **Recovery job hangs on WAL replay** → likely a single corrupt WAL
+  or a base backup older than the oldest WAL retained. Switch to
+  PITR with `targetTime` set just past the base backup timestamp.
+- **Cluster goes healthy but app reports missing rows** → you
+  recovered to the latest WAL archive, which may lag behind the last
+  in-flight transactions. Expected. WAL is archived on
+  `archive_command`, not synchronously.
+- **Cluster keeps recreating with no bootstrap** → the PVC from a
+  previous attempt is still around. Delete the `Cluster`, then the
+  PVCs (`kubectl -n databases delete pvc -l cnpg.io/cluster=<name>`),
+  then let Flux re-create.
+
+## Restoring app-level data that bypasses CNPG
+
+The Immich photo library, Jellyfin media, etc. live on Longhorn or
+NFS, *not* in CNPG. Recovery for those:
+
+- **NFS-backed** (most media, Garage data) → no action; data was
+  never on the cluster.
+- **Longhorn `numberOfReplicas: 1`** → gone. Restore from whatever
+  external backup you have for that PV (none, for media that's
+  re-acquirable).
+- **Longhorn `numberOfReplicas: 2+`** → also gone after a full
+  destroy; the wipe runs on every node. Restore from external backup.
+
+**Offsite-backed apps** (Immich photo library and Paperless documents) ship encrypted to AWS S3 Glacier Deep Archive via per-app rclone CronJobs — files **and** Garage-stored Postgres backups. Recovery procedure is in [`offsite_recovery.md`](offsite_recovery.md). For everything else (media, Jellyfin libraries, etc.) there is no offsite layer today — that data is rebuildable from upstream or lost in a full-site loss.
+
+## Post-rebuild tasks
+
+1. **Update `KUBECONFIG` GitHub Actions secret**:
+   GitHub → repo Settings → Secrets and Variables → Actions → edit
+   `KUBECONFIG`:
+
+   ```bash
+   cat ~/.kube/config | base64 -w0
+   ```
+
+2. **Re-comment any `bootstrap.recovery` blocks you uncommented**
+   for the rebuild, in a follow-up commit. They're no-ops once the
+   cluster exists, but leaving an explicit recovery source in Git
+   confuses future readers about whether the cluster is currently
+   recovering.
+3. **Re-suspend any Flux resources** that were suspended pre-rebuild
+   (suspension state is not in Git).
+4. **Verify the Ceph dashboard password**:
+
+   ```bash
+   ./tools/get-ceph-password.sh
+   ```
+
+5. **Watch one full backup cycle complete** for each CNPG cluster
+   before considering the rebuild done. `kubectl -n databases get
+   backup` should show a new entry per cluster.
+
+## Related runbooks
+
+- [Power Outage Recovery](power-outage.md) — kube-vip won't start;
+  set the VIP manually on master1.
+- [Initialization and Teardown](init_teardown.md) — prereqs and the
+  bare command list.
+- [Immich restore to new CNPG database](immich_cnpg.md) — only
+  needed if recovering from a `pg_dump` instead of Barman.

--- a/docs/src/cluster_rebuild.md
+++ b/docs/src/cluster_rebuild.md
@@ -174,7 +174,7 @@ done
 
 **Commented** — block exists in the file but is commented out. Uncomment before the relevant Flux Kustomization runs on rebuild:
 
-- `cutvideo`, `lidarr`, `medikeep`, `netbox`, `prowlarr`, `pump`, `radarr`, `romm`, `sonarr`, `sparkyfitness`
+- `cutvideo`, `medikeep`, `netbox`, `pump`, `romm`, `sparkyfitness`, the media-pull-stack apps
 
 **No recovery block at all** — these clusters have never been wired for Barman recovery. **Add a `bootstrap.recovery` block (and confirm an `ObjectStore` + `ScheduledBackup` exist) before any rebuild that needs them to survive:**
 

--- a/docs/src/cluster_upgrade.md
+++ b/docs/src/cluster_upgrade.md
@@ -1,5 +1,511 @@
 # Cluster Upgrade Runbook
 
-Moved to the vault: `~/vaults/claude/runbooks/home-ops/cluster_upgrade.md`
+> **This is a retrospective.** The 1.34 → 1.34.7 patch + 1.34 → 1.35 minor
+> upgrades were executed 2026-05-02 / 2026-05-03 and the cluster is now on
+> v1.35.4 across all nodes. Phase 3 (per-node procedure) is the reusable
+> part — apply it verbatim for future minor bumps. The "Phase 0 preflight"
+> checklist and "Failure modes" table are the load-bearing references.
 
-See HOMELAB-SPEC Layer 2 #5: the vault is canonical for runbooks.
+This runbook covers an in-place rolling upgrade of the cluster, planned
+in May 2026 to bring all nodes to a single k8s 1.34 patch + cri-o 1.34,
+then to k8s 1.35.
+
+The cluster runs kubeadm with stacked etcd and kube-vip (DaemonSet) for
+the control-plane VIP at `192.168.6.1`.
+
+## State at the start of the upgrade
+
+| Aspect | Reality |
+|--------|---------|
+| Control plane | 3 nodes (master1/2/3), HA via kube-vip DaemonSet |
+| Workers | 7 nodes (worker2-8), each runs a Ceph OSD |
+| Special hardware | worker8 = NVIDIA GPU; worker4 = Frigate Coral USB + Intel GPU + vlan-security |
+| k8s | All nodes on 1.34.x, drift across `.2`/`.6`/`.7` |
+| cri-o | master1 on 1.34.2 (modern); all others on 1.28.4 (legacy `el8` build, outside skew) |
+| OS | master1 on CentOS Stream 10; all others on CentOS Stream 9 |
+| etcd | 3.6.5 across all masters, healthy |
+| Storage | Rook/Ceph (`ceph-block`), Longhorn (per-app named SCs), Garage (S3) |
+| GitOps | Flux pulls from `home-ops-kubernetes` GitRepository |
+
+## Phase 0 — Pre-flight (✅ done)
+
+- ✅ Master1 stale kube-vip static pod removed
+  (`/root/kube-vip.yaml.removed-20260502` is the rollback breadcrumb)
+- ✅ etcd snapshot saved off-cluster
+  (`~/cluster-backups/etcd-20260502/snapshot-prephase0-20260502.db`)
+- ✅ `isv_cri-o_stable_v1.34.repo` pre-staged on all nodes via dnf —
+  master1 already had it from its earlier rebuild
+- ✅ `descheduler` HelmRelease suspended via the `disable-descheduler`
+  commit pattern. Resume in Phase 5.
+- ✅ Cilium 1.19.3 confirmed compatible with k8s 1.35 (Rook 1.19.5,
+  CNPG 1.29.0, Istio 1.29.2 also confirmed)
+- ✅ kube-vip DaemonSet already on v1.1.2; Renovate is tracking it
+- ✅ API deprecation grep clean — no core k8s alpha/beta apiVersions
+  used outside of vendor CRDs
+
+## Per-node procedure (used in Phases 1–3)
+
+The cri-o package swap, kubeadm upgrade, and kubelet bump all happen
+inside the same drain window per node, so we drain once per node.
+
+### Order
+
+Standard "clean RPM" workers first, then the special cases, then masters.
+
+1. `worker7` ✅ migrated 2026-05-02 — k8s 1.34.7 + cri-o 1.34.7
+2. `worker3` — Intel GPU label but no pinned pods; **mon-f is pinned
+   here, drain only when worker3 is the active mon target** (see
+   "mon nodeSelector trap" below)
+3. `worker2`
+4. `worker4` — Frigate node. **Pre-suspend frigate, zigbee2mqtt,
+   zwave-js-ui** via the `disable-<app>` GitOps pattern; expect brief
+   recording / automation gap.
+5. `worker8` — NVIDIA. **Pre-suspend ollama, comfyui.** Carefully
+   port the NVIDIA runtime stanza to a drop-in. Smoke-test with a
+   `runtimeClassName: nvidia` pod before un-suspending.
+6. `worker6` — **manual-install kubelet/cri-o**, requires the
+   alternate procedure below (no `rm crio.conf`, use `dnf install`).
+7. `worker5` — same alternate procedure as worker6.
+8. `master3`
+9. `master2` (kubelet already 1.34.7; cri-o still 1.28.4)
+10. `master1` (last — already on 1.34.2 + cri-o 1.34.2; just kubelet
+    patch bump). The VIP risk is bounded by master2/master3 kube-vip
+    DaemonSet pods.
+
+Never drain two masters concurrently. After each master, verify etcd
+quorum:
+
+```sh
+kubectl exec -n kube-system etcd-master1.${SECRET_DOMAIN} -- etcdctl \
+  --endpoints=https://127.0.0.1:2379 \
+  --cacert=/etc/kubernetes/pki/etcd/ca.crt \
+  --cert=/etc/kubernetes/pki/etcd/server.crt \
+  --key=/etc/kubernetes/pki/etcd/server.key \
+  endpoint status --cluster -w table
+```
+
+### Pre-flight before every node (lessons from 2026-05-02)
+
+These checks **must** happen before draining any node. Skipping any of
+them caused real damage on the first attempt at this phase.
+
+1. **Drain Longhorn replicas off the target node FIRST, before
+   `kubectl drain`.** Otherwise: when the node's longhorn-manager
+   blips during the cri-o restart, every replica still on that node
+   becomes inaccessible, and pods on OTHER nodes whose replicas are
+   here go into CrashLoopBackOff. That cascades into CNPG PDBs
+   blocking subsequent drains. Two ways to do this:
+
+   **Via Longhorn UI** (preferred — visual confirmation):
+   - Open the Longhorn UI (port-forward `longhorn-frontend` in
+     `longhorn-system` if you don't have ingress wired up).
+   - Node tab → click target node → "Edit Node" → set "Node
+     Scheduling" to **Disable** AND "Eviction Requested" to **True**.
+   - Watch the Volume tab — every volume with a replica on this node
+     should show its replica count restoring on other nodes.
+   - When the target node's "Replicas" count reaches 0, proceed.
+   - **Re-enable scheduling and clear eviction after the node is back
+     and you've uncordoned it**, otherwise replicas won't return.
+
+   **Via kubectl** (equivalent):
+
+   ```sh
+   kubectl patch -n longhorn-system nodes.longhorn.io <node> \
+     --type=merge -p '{"spec":{"allowScheduling":false,"evictionRequested":true}}'
+
+   # Wait until no replicas remain on the node
+   until [ "$(kubectl get replicas.longhorn.io -n longhorn-system -o json |
+     jq -r --arg n "<node>" '.items[] | select(.spec.nodeID==$n) | .metadata.name' |
+     wc -l)" = "0" ]; do sleep 10; done
+
+   # … do the drain + upgrade + uncordon …
+
+   # After uncordon and node Ready, restore Longhorn scheduling:
+   kubectl patch -n longhorn-system nodes.longhorn.io <node> \
+     --type=merge -p '{"spec":{"allowScheduling":true,"evictionRequested":false}}'
+   ```
+
+2. **Wait for `ceph -s` HEALTH_OK** before draining the next node.
+   Not just "the previous node's OSD pod is Ready" — Rook creates
+   dynamic per-host OSD PDBs (`rook-ceph-osd-host-<host>`) when an
+   OSD is unavailable, with `MAX UNAVAILABLE: 1, ALLOWED DISRUPTIONS:
+   0`. While ANY OSD-host PDB exists for ANY host, the next drain
+   will hang indefinitely on its own host's PDB. This cost ~20
+   minutes of stuck drain on worker3 because worker6 was still
+   degraded in the background.
+
+3. **Check mon nodeSelectors and don't drain a mon's pinned host
+   while another mon is also down.** Rook pins each mon to a
+   specific node and recreates them under new letters as nodes drop
+   in/out:
+
+   ```sh
+   kubectl get pod -n rook-ceph -l app=rook-ceph-mon -o jsonpath='{range .items[*]}{.metadata.labels.mon}{"\t"}{.spec.nodeSelector.kubernetes\.io/hostname}{"\n"}{end}'
+   ```
+
+   Re-check before every node — the mon names shift (we saw c,e,f →
+   c,e,g → c,e,h over a single afternoon as nodes drained). Draining
+   a node hosting a pinned mon strands that mon — it cannot
+   reschedule until the pin is satisfied again. **If two mons are
+   pinned to drained nodes, ceph quorum is lost.** Drain pinned-mon
+   nodes one at a time and let the mon come back before touching the
+   next.
+
+4. **Check the package install style on the target node.** Some
+   nodes have `kubelet/kubeadm/kubectl/cri-o` installed via dnf
+   (RPM-tracked). Others have manually-installed binaries (no RPM
+   entries):
+
+   ```sh
+   ssh root@<node> 'rpm -qa | grep -cE "^(kubeadm|kubelet|kubectl|cri-o)-"'
+   ```
+
+   Returns 4 → standard procedure. Returns 0 → **alternate
+   procedure** (don't `rm crio.conf`; use `dnf install` not `dnf
+   upgrade`). Nodes known to be manual-install: worker5, worker6.
+
+5. **CNPG primary failover**:
+
+   ```sh
+   for c in $(kubectl get pod -n databases -l 'cnpg.io/instanceRole=primary' \
+       --field-selector spec.nodeName=<node>.${SECRET_DOMAIN} \
+       -o jsonpath='{range .items[*]}{.metadata.labels.cnpg\.io/cluster}{"\n"}{end}'); do
+     replica=$(kubectl get pod -n databases -l "cnpg.io/cluster=$c,cnpg.io/instanceRole=replica" \
+       -o jsonpath='{range .items[?(@.spec.nodeName!="<node>.${SECRET_DOMAIN}")]}{.metadata.name}{"\n"}{end}' | head -1)
+     kubectl cnpg promote -n databases "$c" "$replica"
+   done
+   ```
+
+   Then poll `kubectl get pod -n databases -l 'cnpg.io/instanceRole=primary' --field-selector spec.nodeName=<node>...`
+   until empty.
+
+6. **Hardware-pinned pod suspension** (worker4: frigate +
+   zigbee2mqtt + zwave-js-ui; worker8: ollama + comfyui). Use the
+   `disable-<app>` GitOps commit pattern, not `kubectl scale` —
+   Flux will revert imperative scales. Wait for Flux reconciliation
+   to actually take the pods down before draining.
+
+### Standard per-worker procedure (RPM-tracked nodes)
+
+For workers with RPM entries (rpm-qa returns 4 packages):
+
+1. Pre-flight checks above.
+2. **Drain**:
+
+   ```sh
+   kubectl drain <worker>.${SECRET_DOMAIN} \
+     --ignore-daemonsets --delete-emptydir-data
+   ```
+
+3. **Package upgrade and kubelet config refresh**:
+
+   ```sh
+   ssh root@<worker>.${SECRET_DOMAIN} '
+     # Drop the legacy crio.conf / .rpmnew. Order matters: only do
+     # this RIGHT BEFORE the upgrade succeeds — leaving cri-o
+     # without a config will trigger the "unsafe procfs detected"
+     # runc error and break ALL pods on the node.
+     rm -f /etc/crio/crio.conf /etc/crio/crio.conf.rpmnew /etc/crio/crio.conf.working
+
+     # Single transaction: cri-o upgrade picks up the new isv repo
+     # automatically since 1.34.7 > 1.28.4.
+     dnf upgrade -y cri-o kubelet-1.34.7 kubeadm-1.34.7 kubectl-1.34.7
+
+     kubeadm upgrade node
+     systemctl daemon-reload
+     systemctl restart crio
+     systemctl restart kubelet
+   '
+   ```
+
+4. **Smoke-test before uncordon**:
+
+   ```sh
+   ssh root@<worker>.${SECRET_DOMAIN} '
+     systemctl is-active crio kubelet
+     crictl info | grep -E "CgroupManagerName|DefaultRuntime"
+     ls /etc/crio/crio.conf.d/   # should exist; legacy crio.conf should be gone
+   '
+   kubectl get node <worker>.${SECRET_DOMAIN} -o wide   # version + cri-o version match expected
+   ```
+
+5. **Uncordon**:
+
+   ```sh
+   kubectl uncordon <worker>.${SECRET_DOMAIN}
+   ```
+
+   Rook auto-clears any host noout flag on its own a few seconds
+   after uncordon — don't manually unset it.
+6. **Wait for `ceph -s` HEALTH_OK** (no OSDs down, no degraded PGs)
+   before the next node. Do not skip this. Typically ~1–3 minutes.
+
+### Alternate procedure for manual-install nodes (worker5, worker6)
+
+These nodes have kubelet/cri-o binaries in `/usr/bin/` not tracked by
+RPM. `dnf upgrade` cannot upgrade what it cannot see, and `rm
+crio.conf` will break the node since the dnf step provides no
+replacement.
+
+1. Pre-flight checks (same as above).
+2. **Drain** (same as above).
+3. **Fresh-install via dnf** (overwrites the un-tracked binaries):
+
+   ```sh
+   ssh root@<worker>.${SECRET_DOMAIN} '
+     # Stop services so we can replace running binaries cleanly
+     systemctl stop kubelet
+     systemctl stop crio
+
+     # Move the manual binaries aside (rollback if dnf install fails)
+     mv /usr/bin/kubelet  /usr/bin/kubelet.manual
+     mv /usr/bin/kubeadm  /usr/bin/kubeadm.manual
+     mv /usr/bin/kubectl  /usr/bin/kubectl.manual
+     mv /usr/bin/crio     /usr/bin/crio.manual
+
+     # Install the RPMs fresh (now they will be tracked)
+     dnf install -y cri-o kubelet-1.34.7 kubeadm-1.34.7 kubectl-1.34.7
+
+     # Now we can safely remove crio.conf — package provides drop-in
+     rm -f /etc/crio/crio.conf /etc/crio/crio.conf.rpmnew /etc/crio/crio.conf.working
+
+     kubeadm upgrade node
+     systemctl daemon-reload
+
+     # Multi-minor cri-o jumps (1.28 → 1.34) leave stale container
+     # refs that hang internal_wipe forever. Skip the regular start;
+     # do the kill+wipe+start dance up front.
+     systemctl kill --signal=SIGKILL crio || true
+     crio wipe -f
+     systemctl start crio
+     systemctl start kubelet
+
+     # Verify and clean up rollback files only after success
+     rpm -q cri-o kubelet kubeadm kubectl
+     systemctl is-active crio kubelet
+     # rm /usr/bin/*.manual-pre-1.34.7    # only after smoke-test confirms success
+   '
+   ```
+
+4. Smoke-test, uncordon, wait for `HEALTH_OK` — same as above.
+
+### Worker8 (NVIDIA) extra steps
+
+After the standard procedure:
+
+```sh
+ssh root@worker8.${SECRET_DOMAIN} 'cat > /etc/crio/crio.conf.d/20-nvidia.conf <<EOF
+[crio.runtime.runtimes.nvidia]
+runtime_path = "/usr/bin/nvidia-container-runtime"
+runtime_root = "/run/nvidia"
+runtime_type = "oci"
+EOF
+systemctl restart crio'
+```
+
+Smoke-test before resuming ollama / comfyui:
+
+```sh
+kubectl run nvidia-smoke --rm -i --restart=Never \
+  --overrides='{"spec":{"runtimeClassName":"nvidia","nodeName":"worker8.${SECRET_DOMAIN}"}}' \
+  --image=nvidia/cuda:12.0-base-ubuntu22.04 -- nvidia-smi
+```
+
+### Failure modes seen during the 1.34.2 → 1.34.7 (2026-05-02) and 1.34.7 → 1.35.4 (2026-05-03) upgrades
+
+| Symptom | Root cause | Fix |
+|---------|-----------|-----|
+| Drain hangs ~indefinitely on `rook-ceph-osd-host-*` PDB | A previous node's OSD is still degraded; Rook's per-host PDB blocks all OSD evictions cluster-wide. On this homelab, ceph "Global Recovery Event" can run for an HOUR at default ~683 KB/s — far longer than the 30-min drain timeout suggests. | Two options: (1) wait for `ceph -s` HEALTH_OK and zero remapped/misplaced pgs; or (2) `kubectl delete pod -n rook-ceph rook-ceph-osd-N-...` directly — drain bypasses the eviction API once the pod is already terminating. Safe with 8 OSDs + 3-way replication for the ~10-min window. |
+| New pods on a node fail with `runc create failed: unsafe procfs detected` | `/etc/crio/crio.conf` was removed but the new cri-o package didn't install | Restore `crio.conf` from a peer node's identical version (`scp root@<peer>:/etc/crio/crio.conf root@<broken>:/etc/crio/`), `systemctl restart crio` |
+| `mon-X` stays Pending after drain | Mon is pinned via `nodeSelector` to the cordoned node | Uncordon the pinned node, mon comes back. Don't drain another mon's host until quorum is restored. (Note: Rook recreates mons under new letters as nodes drop in/out — re-check assignments before each drain.) |
+| `dnf upgrade` reports `kubelet-1.34.7: No match for argument` | Node has manually-installed kubelet (no RPM entry) | Use the alternate procedure (`dnf install` after moving binaries aside). Affects worker5 and worker6. |
+| `longhorn-manager-X` stuck CrashLoopBackOff with `bind: address already in use` on port 9502 | Old longhorn-manager process orphaned by a previous container; cri-o lost track of it but the binary is still bound | `ssh root@<node> 'pgrep -af "longhorn-manager -d daemon"'` → `kill -9 <pid>`; then `kubectl delete pod -n longhorn-system longhorn-manager-X` |
+| Multiple CNPG replica pods stuck Init:CrashLoopBackOff on a recently-broken node | Their Longhorn volumes failed to attach during the node's outage; pods are now in 5-minute kubelet backoff | Once Longhorn recovers, `kubectl delete pod` each one to force immediate retry. Volume attaches succeed. |
+| Replicas-cascading-CNPG-PDB-blocks-drain | One replica unhealthy in cluster X means PDB has 0 disruptions; subsequent drain anywhere blocks on cluster X's PDB | Heal the unhealthy replica before draining its peer's host. The Longhorn pre-drain step (above) prevents this. |
+| cri-o stuck in `activating (start)` indefinitely after package upgrade; logs flood with `Killing container <id> failed: container does not exist` | cri-o's `internal_wipe = true` tries to kill phantom containers left in `/var/lib/containers/storage/` by the previous version, but their runc state in `/run/crun` is gone. Worse across multi-minor jumps (1.28 → 1.34). | `systemctl kill --signal=SIGKILL crio` → `crio wipe -f` (clears container refs, keeps images) → `systemctl start crio` → `systemctl start kubelet`. Hit on worker6 during the manual-install upgrade. |
+| Suspended app stays at `replicas: 0` after the suspend HR is reverted | Manually scaling a StatefulSet/Deployment to 0 before drain (the post-suspend step that actually stops pods) sticks. Helm/Flux applying the un-suspended HR doesn't reset the imperative scale. | After reverting `disable-<app>`, `kubectl scale -n <ns> statefulset <app> --replicas=1` (or whatever the desired count is). Bit us repeatedly with frigate, ollama, comfyui. |
+| Reboot scheduled with `(sleep 5 && systemctl reboot) &` never fires | The backgrounded subshell gets SIGHUPed when the SSH session ends, killing the sleep before it triggers reboot | Use `systemd-run --on-active=5s --unit=upgrade-reboot systemctl reboot` instead — runs as a transient systemd unit independent of the SSH session |
+| Node boots into a kernel with no initramfs ("Kernel panic - VFS: Unable to mount root") | `dnf upgrade -y` installed a new kernel package but the dracut hook that generates `/boot/initramfs-<KVER>.img` failed silently | At grub, select an older kernel to boot. Once back, regenerate: `dracut -f /boot/initramfs-<KVER>.img <KVER>`. Then reboot. **Prevent it**: add an initramfs check before the reboot step (see procedure). |
+| Initramfs check via `rpm -q kernel-core` fails on manual-install nodes | Worker5/6 don't have kernel-core in the RPM database; query returns "package kernel-core is not installed" and the check loop iterates over the wrong tokens | Use `ls -1 /boot/vmlinuz-* \| grep -v rescue \| sort -V \| tail -1 \| sed 's\|/boot/vmlinuz-\|\|'` instead — works on any node regardless of RPM tracking |
+| crio + kubelet inactive after reboot (services disabled in systemd) | New cri-o/kubelet RPM install on top of an existing manual-install node resets the systemd unit enable state to disabled | Always `systemctl enable crio kubelet` *before* the reboot step, or after the reboot if you forgot |
+| Longhorn instance-manager won't evict even though node has 0 replicas | Longhorn keeps the per-node instance-manager PDB at `disruptionsAllowed: 0` until `spec.evictionRequested: true` is set on the Longhorn node CR | Before drain: `kubectl patch -n longhorn-system nodes.longhorn.io <node> --type=merge -p '{"spec":{"allowScheduling":false,"evictionRequested":true}}'`. The Longhorn UI does this for you when you set "Disable Scheduling + Eviction Requested". After uncordon, restore: `'{"spec":{"allowScheduling":true,"evictionRequested":false}}'` |
+| HelmRelease `spec.suspend: true` revert pushed to git, but cluster HR still shows `suspend: true` after Flux reconciles | Flux's helm-controller can get stuck on a transient state; observedGeneration matches but the spec doesn't reflect the new file | Direct patch: `kubectl patch hr -n <ns> <name> --type=merge -p '{"spec":{"suspend":null}}'`. Bit us with descheduler at the end of Phase 3. |
+| Static pod manifests (apiserver, controller-manager, scheduler, etcd) stay at the old patch version after `kubeadm upgrade node` on patch bumps | `kubeadm upgrade node` only refreshes the kubelet config + kubeconfig on patches; static pod images are only bumped via `kubeadm upgrade apply` (one master) or by the minor bump. So `apiserver: v1.34.2` can persist for months while kubelets are at 1.34.7. | Acceptable while inside the same minor. The next minor bump (`kubeadm upgrade apply v1.35.x`) refreshes them. |
+
+### Master procedure
+
+Same as worker, with two differences:
+
+- **Master1 is special** (already on cri-o 1.34.x). Skip the cri-o swap;
+  just do the k8s patch / minor bump. Master1 is also the last in the
+  order for patch upgrades so the kube-vip VIP can fail over to
+  master2/master3 during master1's drain.
+- **First control plane in a minor bump** uses
+  `kubeadm upgrade apply v1.X.Y`; the others use `kubeadm upgrade
+  node`. The first one *must* be done before any others. Order in
+  Phase 3 was: master1 (apply) → master2 (node) → master3 (node) →
+  workers.
+
+## Phase 3 — k8s minor bump (1.34 → 1.35), per-node procedure
+
+The per-node procedure that actually worked across all 10 nodes for
+the 2026-05-03 minor bump. Use this verbatim for future minor bumps —
+it's substantially more robust than what's in the per-worker section
+above (which was for the 1.34 patch upgrade).
+
+### Phase 3 prep (once, before any node)
+
+```sh
+# Stage v1.35 repos on every node
+ssh root@<every-node> 'cat > /etc/yum.repos.d/Kubernetes-1.35.repo <<EOF
+[Kubernetes-1.35]
+name=Kubernetes 1.35 Repo
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.35/rpm/
+enabled=1
+gpgcheck=1
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.35/rpm/repodata/repomd.xml.key
+EOF
+cat > /etc/yum.repos.d/isv_cri-o_stable_v1.35.repo <<EOF
+[isv_cri-o_stable_v1.35]
+name=CRI-O v1.35 (Stable) (rpm)
+baseurl=https://download.opensuse.org/repositories/isv:/cri-o:/stable:/v1.35/rpm/
+gpgcheck=1
+gpgkey=https://download.opensuse.org/repositories/isv:/cri-o:/stable:/v1.35/rpm/repodata/repomd.xml.key
+enabled=1
+EOF'
+
+# etcd snapshot (off-cluster)
+kubectl exec -n kube-system etcd-master1.${SECRET_DOMAIN} -- etcdctl ... snapshot save /var/lib/etcd/snapshot-prephase3-$(date +%Y%m%d).db
+scp root@master1:/var/lib/etcd/snapshot-prephase3-*.db ~/cluster-backups/etcd-prephase3/
+
+# Suspend descheduler (commit `new: disable-descheduler` + scale to 0)
+
+# kubeadm upgrade plan (from the master that will receive `apply`)
+ssh root@master1 'dnf install -y kubeadm-1.35.4 && kubeadm upgrade plan v1.35.4'
+```
+
+### First control plane (master1): `kubeadm upgrade apply`
+
+```sh
+# Pre-flight: CNPG primaries failover, set Longhorn evictionRequested=true
+# (see standard worker procedure)
+
+kubectl drain master1.${SECRET_DOMAIN} --ignore-daemonsets --delete-emptydir-data
+
+ssh root@master1.${SECRET_DOMAIN} '
+  set -eu
+  kubeadm upgrade apply v1.35.4 --yes
+  dnf install -y kubelet-1.35.4 kubectl-1.35.4
+  dnf upgrade -y                       # full system, picks up new kernel + cri-o 1.35.x
+  systemctl enable crio kubelet        # RPM upgrade can reset enable state
+  systemd-run --on-active=5s --unit=upgrade-reboot systemctl reboot
+'
+
+# Wait for reboot + Ready, then uncordon. cri-o post-reboot recovery
+# can take 60-120s of "activating" before settling.
+```
+
+### Other control planes (master2, master3): `kubeadm upgrade node`
+
+Same as master1 but replace `kubeadm upgrade apply v1.35.4 --yes` with
+`kubeadm upgrade node`. Wait for `ceph -s HEALTH_OK` between each.
+
+### Workers (with hardware-pinned variants)
+
+The robust per-worker block is:
+
+```sh
+# Pre-flight (do all of these IN ORDER):
+# 1. Confirm Longhorn replicas on the node are 0 via UI eviction
+#    (or `kubectl patch -n longhorn-system nodes.longhorn.io <node>
+#    --type=merge -p '{"spec":{"allowScheduling":false,
+#    "evictionRequested":true}}'` and wait for replicas to migrate).
+# 2. Verify ceph HEALTH_OK and zero remapped/misplaced pgs.
+# 3. Verify mons not pinned to this node — or accept 2/3 quorum.
+# 4. CNPG primary failover for any primary on this node.
+# 5. Hardware-pinned pod suspend (frigate / ollama / comfyui / zigbee /
+#    zwave) via the `disable-<app>` GitOps commit pattern, plus
+#    `kubectl scale ... --replicas=0` once Flux applies the suspend.
+
+# Drain — with auto OSD-pod-delete after 60s if drain stalls on the
+# Rook OSD-host PDB:
+kubectl drain <node> --ignore-daemonsets --delete-emptydir-data \
+  --timeout=600s &
+DRAIN_PID=$!
+sleep 60
+if kill -0 $DRAIN_PID 2>/dev/null; then
+  REMAINING=$(kubectl get pods -A --field-selector spec.nodeName=<node> \
+    -o wide 2>&1 | grep -vE \
+    'cilium-|node-tuning|node-feature|node-problem|engine-image|longhorn-csi-plugin|longhorn-manager|multus|node-exporter|smartctl|vector-agent|nodeplugin|intel-gpu|NAME' \
+    | wc -l)
+  if [ "$REMAINING" -ge "1" ]; then
+    OSD=$(kubectl get pod -n rook-ceph -l 'app=rook-ceph-osd' \
+      --field-selector spec.nodeName=<node> \
+      -o jsonpath='{.items[0].metadata.name}')
+    [ -n "$OSD" ] && kubectl delete pod -n rook-ceph "$OSD" --grace-period=30
+  fi
+fi
+wait $DRAIN_PID
+
+# Upgrade + full system update + initramfs check + reboot:
+ssh root@<node> 'set -eu
+  dnf install -y kubeadm-1.35.4 kubelet-1.35.4 kubectl-1.35.4
+  kubeadm upgrade node
+  dnf upgrade -y                           # full system; may bump kernel + cri-o
+
+  # Initramfs check via /boot (works on RPM and manual-install nodes)
+  LATEST_K=$(ls -1 /boot/vmlinuz-* | grep -v rescue | sort -V | tail -1 \
+    | sed "s|/boot/vmlinuz-||")
+  if [ ! -f /boot/initramfs-${LATEST_K}.img ]; then
+    dracut -f /boot/initramfs-${LATEST_K}.img $LATEST_K
+  fi
+
+  systemctl enable crio kubelet            # RPM upgrade can reset state
+  systemd-run --on-active=5s --unit=upgrade-reboot systemctl reboot
+'
+
+# Wait for SSH back, services active, Ready, kubelet at v1.35.4.
+# Then uncordon, restore Longhorn (allowScheduling=true,
+# evictionRequested=false), revert the disable-<app> commit, scale
+# the StatefulSet/Deployment back to 1.
+```
+
+### Phase 3 worker order (used 2026-05-03)
+
+`worker7 → worker3 → worker2 → worker6 → worker5 → worker4 → worker8`.
+
+The hardware-pinned ones go last so we don't suspend their workloads
+longer than necessary.
+
+## Phase 5 — verify and clean up
+
+- All nodes show same kubelet + cri-o version: `kubectl get nodes -o wide`
+- Flux reconciled: `flux get all -A | grep -v True`
+- `ceph -s` is `HEALTH_OK`
+- Run `tools/etcd-defrag.sh` (etcd grew during the upgrade)
+- **Resume descheduler**: `git revert <disable-descheduler sha>` and
+  push. Same for any hardware-pinned `disable-<app>` commits made
+  along the way.
+- Update this runbook with anything new that bit you, before memory
+  fades.
+
+## Rollback
+
+In-place RPM downgrade is messy, especially for kubelet across a minor
+boundary. Realistic rollback paths:
+
+- Per-node, *before* `kubeadm upgrade apply` on the first master: roll
+  back is just `dnf downgrade kubeadm kubelet kubectl` to 1.34 + put
+  the old `crio.conf` back (it's saved as `crio.conf.rpmsave` after the
+  package swap).
+- Per-node, *after* `kubeadm upgrade apply`: bring forward the rest of
+  the cluster. Don't try to roll back the apiserver minor.
+- Catastrophic (etcd corruption, control plane unrecoverable): restore
+  from `~/cluster-backups/etcd-20260502/snapshot-prephase0-20260502.db`
+  via [the kubeadm etcd recovery procedure][1]. **This is a last
+  resort and has not been tested in this homelab.** It assumes you
+  have at least one master with the original PKI intact and can
+  `etcdctl snapshot restore` to a fresh data dir, then restart etcd
+  static pods.
+
+[1]: https://kubernetes.io/docs/tasks/administer-cluster/configure-upgrade-etcd/#restoring-an-etcd-cluster

--- a/docs/src/cnpg_restore.md
+++ b/docs/src/cnpg_restore.md
@@ -126,8 +126,7 @@ shipped offsite. App reconstruction depends on the app:
 - `atuin` — terminal history; gone, restart fresh
 - `home-assistant` — see `home-assistant-config/` for what's
   in-Git and what's runtime-only
-- `radarr/sonarr/lidarr/prowlarr/recyclarr/suggestarr/soularr` —
-  media-pull-stack apps; full data loss is non-recoverable beyond
+- media-pull-stack apps — full data loss is non-recoverable beyond
   re-scraping from external sources
 - `medikeep` — full loss; manual reentry
 - `pump`, `sparkyfitness`, `videodupfinder`, `cutvideo` —

--- a/docs/src/cnpg_restore.md
+++ b/docs/src/cnpg_restore.md
@@ -1,5 +1,196 @@
 # CNPG Cluster Restore Template
 
-Moved to the vault: `~/vaults/claude/runbooks/home-ops/cnpg_restore.md`
+Per-cluster restore procedure for any of the ~25 CloudNativePG
+`Cluster` resources under
+`kubernetes/apps/databases/cloudnative-pg/config/<app>/`. Paper
+runbook — verify against the actual app's `cluster.yaml` +
+`objectstore.yaml` before executing.
 
-See HOMELAB-SPEC Layer 2 #5: the vault is canonical for runbooks.
+## When to use this
+
+The PGData volume is gone (ceph-block PVC lost, ceph cluster wipe,
+namespace deleted, etc.) but the Barman ObjectStore in Garage is
+intact. **Most "the database is broken" cases are NOT this** — see
+the gotchas section at the bottom first.
+
+## What survives in Garage
+
+Every CNPG cluster in this repo writes to a paired Barman
+ObjectStore (`barmancloud.cnpg.io/ObjectStore`). The bucket layout
+in Garage:
+
+- `<cluster-name>/base/<backup-id>/` — full base backups (daily
+  cadence on most clusters, scheduled by `ScheduledBackup`)
+- `<cluster-name>/wals/` — WAL archive (continuous)
+
+Lose Garage and you lose the recovery target. See
+`garage_restore.md` for Garage substrate recovery.
+
+## Recovery scenarios
+
+### Scenario A — point-in-time recovery (PITR)
+
+The PGData is intact but the database state is wrong (bad
+migration, accidental `DELETE`, corrupted row). Restore to a
+specific timestamp without losing the cluster.
+
+1. Identify the recovery target:
+
+   ```sh
+   kubectl -n databases get cluster <app> -o yaml | yq '.spec.backup'
+   # confirm the ObjectStore path
+   kubectl -n databases logs <app>-1 -c postgres | grep -i 'archived'
+   # find the latest WAL timestamp before the bad event
+   ```
+
+2. Edit `kubernetes/apps/databases/cloudnative-pg/config/<app>/cluster.yaml`
+   to add `spec.bootstrap.recovery`:
+
+   ```yaml
+   spec:
+     bootstrap:
+       recovery:
+         source: <app>
+         recoveryTarget:
+           targetTime: "2026-05-20 14:30:00.00+00"
+     externalClusters:
+       - name: <app>
+         plugin:
+           name: barman-cloud.cloudnative-pg.io
+           parameters:
+             barmanObjectName: <app>
+             serverName: <app>
+   ```
+
+3. **Delete the existing cluster** (destructive):
+
+   ```sh
+   kubectl -n databases delete cluster <app>
+   # Wait for full teardown; CNPG operator drops the PVCs too.
+   ```
+
+4. Reconcile Flux:
+
+   ```sh
+   flux reconcile kustomization databases-cloudnative-pg-<app>
+   ```
+
+5. Watch the recovery:
+
+   ```sh
+   kubectl -n databases logs -l cnpg.io/cluster=<app>,role=primary -c postgres -f
+   ```
+
+   Recovery applies the base backup + WALs up to `targetTime`.
+
+6. Verify and remove the `bootstrap.recovery` block (or leave it
+   commented out for next time) in a follow-up PR.
+
+### Scenario B — total cluster loss
+
+PGData PVCs gone (ceph-block wipe, namespace nuked, etc.). Restore
+the cluster from scratch from the latest base backup + WALs to
+"now".
+
+Same as Scenario A but with `recoveryTarget` set to `latest`
+(omitting `targetTime`), or simply leave the cluster's normal spec
+in place and CNPG will bootstrap from the ObjectStore on its own —
+the `barmancloud.cnpg.io/ObjectStore` is the bootstrap source by
+convention in this repo.
+
+Concretely:
+
+1. Verify the ObjectStore is intact:
+
+   ```sh
+   kubectl -n databases get objectstore <app>
+   # Check Garage bucket directly:
+   AWS_ENDPOINT_URL_S3=https://s3.${SECRET_DOMAIN} \
+     aws s3 ls s3://cnpg-<app>/base/
+   ```
+
+2. Reconcile Flux to re-create the cluster CR. CNPG sees no
+   PGData PVC and falls back to bootstrap-from-ObjectStore
+   automatically (this is the default behavior with our setup).
+
+3. Watch logs as above. Recovery completes when the cluster
+   pod reports `database system is ready to accept connections`.
+
+### Scenario C — Garage substrate gone
+
+Both the database AND the Barman ObjectStore in Garage are lost.
+
+**For most clusters**: full data loss — these apps' state isn't
+shipped offsite. App reconstruction depends on the app:
+
+- `atuin` — terminal history; gone, restart fresh
+- `home-assistant` — see `home-assistant-config/` for what's
+  in-Git and what's runtime-only
+- `radarr/sonarr/lidarr/prowlarr/recyclarr/suggestarr/soularr` —
+  media-pull-stack apps; full data loss is non-recoverable beyond
+  re-scraping from external sources
+- `medikeep` — full loss; manual reentry
+- `pump`, `sparkyfitness`, `videodupfinder`, `cutvideo` —
+  application-specific; mostly recoverable from source data
+- `nametag`, `medialyze`, `windmill` — workflow / metadata; full
+  loss
+
+**For Immich and Paperless**: see `offsite_recovery.md` — these
+two have a separate offsite-backup pipeline to AWS Glacier Deep
+Archive, restored independently.
+
+## Per-cluster cheatsheet
+
+| Cluster | Garage bucket | Special considerations |
+|---|---|---|
+| `atuin` | `cnpg-atuin` | None — terminal history is ephemeral |
+| `home-assistant` | `cnpg-home-assistant` | Pair with HA backup (`.tar` in vault) for full restore |
+| `immich` | `cnpg-immich` | Also covered by offsite Glacier — see `offsite_recovery.md` |
+| `paperless` | `cnpg-paperless` | Also covered by offsite Glacier — see `offsite_recovery.md` |
+| `langgraph-checkpoints` | `cnpg-langgraph-checkpoints` | Ephemeral graph state — accept full loss |
+| `langgraph-memory` | `cnpg-langgraph-memory` | KG state — 35+ entities; rebuildable but expensive |
+| `langfuse` | `cnpg-langfuse` | Trace history — accept loss, traces regenerate |
+| `windmill` | `cnpg-windmill` | Workflow definitions in Git; secrets in 1P — runtime state can be re-bootstrapped |
+| `zulip` | `cnpg-zulip` | Message history — important; verify backups before any ceph-block work |
+| Others (25 total) | `cnpg-<app>` | Follow the template above |
+
+## Gotchas
+
+- **CNPG `Cluster` `bootstrap.recovery` is honored only on initial
+  bootstrap.** Once a cluster has PGData, editing the recovery
+  block does nothing. Must delete the cluster first to force
+  re-bootstrap.
+- **CNPG operator must be running** before you delete a Cluster
+  CR, or the finalizer hangs. Check
+  `kubectl -n cnpg-system get pods` first.
+- **Barman version compatibility** — the ObjectStore CR version
+  must match the CNPG operator. Bumping CNPG without bumping
+  Barman (or vice versa) can render backups unreadable.
+- **PostgreSQL major version** in the ObjectStore must match the
+  Cluster's `imageName`. PG16 base backup cannot bootstrap a PG17
+  cluster.
+- **Recovery is slow on large clusters.** Immich and Paperless can
+  take 30+ minutes on the base-backup restore alone, before WAL
+  replay starts.
+
+## Verification checklist
+
+After any restore:
+
+- [ ] Cluster pod logs report `database system is ready`
+- [ ] Application pod successfully connects (check app logs for
+  ORM connection success)
+- [ ] Smoke a representative query: `kubectl -n databases exec -it
+  <app>-1 -- psql -c "SELECT count(*) FROM <known-table>"`
+- [ ] App-level health endpoint returns 200
+- [ ] Next `ScheduledBackup` runs successfully (catches the
+  ObjectStore re-write path)
+
+## See also
+
+- `rook_ceph_dr.md` — restore underlying ceph-block first
+- `garage_restore.md` — restore the Barman backup target
+- `offsite_recovery.md` — Immich + Paperless Glacier-based restore
+- `docs/src/immich_cnpg.md` — Immich-specific CNPG migration history
+- Memory: `project_phase_a_embedder_bge_m3` — langgraph-memory KG
+  re-embedding context

--- a/docs/src/coral.md
+++ b/docs/src/coral.md
@@ -1,5 +1,44 @@
 # Coral Edge TPU
 
-Moved to the vault: `~/vaults/claude/runbooks/home-ops/coral.md`
+Frigate offloads object detection to a Coral USB Edge TPU attached to `worker4`. The Coral lets Frigate run real-time inference on multiple camera streams at sub-watt power without leaning on the P40 (which is reserved for heavier ML — see [`p40.md`](p40.md)).
 
-See HOMELAB-SPEC Layer 2 #5: the vault is canonical for runbooks.
+## Coral USB (active)
+
+The Coral USB on `worker4` is the live unit. Node selection is label-driven:
+
+```sh
+kubectl get nodes -L google.feature.node.kubernetes.io/coral-usb
+```
+
+`worker4` carries `google.feature.node.kubernetes.io/coral-usb=true`; Frigate's `nodeSelector` pins it there.
+
+### What I didn't need to do
+
+Unlike the Mini PCIe variant, I didn't need to install udev rules or build/load the apex driver to pass the USB Coral through to Frigate. The current mount strategy in `kubernetes/apps/home/frigate/app/helmrelease.yaml` handles everything via the standard `securityContext` + device mount path.
+
+### USB-reset bug + the hack
+
+Anytime the Frigate container stopped, the Coral USB went through this in `dmesg`:
+
+```text
+usb 2-5: reset SuperSpeed USB device number 22 using xhci_hcd
+usb 2-5: LPM exit latency is zeroed, disabling LPM.
+```
+
+After the reset, Node Feature Discovery could no longer see the device. The Coral USB label disappeared from the node, Frigate stayed `Pending`, and the only manual fix was unplugging and re-plugging the device. Bad anytime Frigate cycled.
+
+The workaround came from the Frigate community: <https://github.com/blakeblackshear/frigate/issues/2607#issuecomment-2092965042>. The fix bypasses the USB reset by holding the device handle open through restarts. Confirm it's still in the Frigate manifests before assuming the Coral will survive a pod restart.
+
+## Coral Mini PCIe (not in use)
+
+The Mini PCIe Coral does not enumerate in `lspci` on the Dell R730xd. Suspected causes:
+
+- PCIe lane allocation conflict with another slotted card
+- M.2-to-PCIe adapter incompatibility
+- Insufficient power on the slot
+
+Not pursued further since the USB variant on a worker node is the simpler topology. Revisit if the cluster ever wants per-camera dedicated TPUs.
+
+## Related
+
+- [`p40.md`](p40.md) — NVIDIA Tesla P40 (the heavier GPU path; not used for Frigate detection)

--- a/docs/src/debugging.md
+++ b/docs/src/debugging.md
@@ -1,5 +1,267 @@
 # Debugging
 
-Moved to the vault: `~/vaults/claude/runbooks/home-ops/debugging.md`
+Operator-first reference for triaging issues in this cluster. Roughly ordered from most-used to least.
 
-See HOMELAB-SPEC Layer 2 #5: the vault is canonical for runbooks.
+## First moves
+
+When something is broken, work outside-in: events, then logs, then state.
+
+```sh
+# Recent cluster-wide events (the most underrated diagnostic in k8s)
+kubectl get events -A --sort-by=.lastTimestamp | tail -50
+
+# Pod state across the cluster — anything not Running/Completed
+kubectl get pods -A | grep -v -E 'Running|Completed'
+
+# Flux reconciliation state (anything False is a current failure)
+flux get all -A | grep -v True
+```
+
+## Pods
+
+```sh
+# Describe a pod (events, conditions, container state)
+kubectl -n <ns> describe pod <pod>
+
+# Current logs
+kubectl -n <ns> logs <pod> -c <container>          # one container
+kubectl -n <ns> logs <pod> --all-containers --tail=200
+
+# Previous-incarnation logs (after a crash)
+kubectl -n <ns> logs <pod> -c <container> --previous
+
+# Per-pod events only
+kubectl -n <ns> get events --field-selector involvedObject.name=<pod>
+
+# Exec into a running container
+kubectl -n <ns> exec -it <pod> -c <container> -- sh
+
+# Run an ad-hoc debug pod on the same node
+kubectl debug -n <ns> <pod> --image=nicolaka/netshoot --target=<container>
+```
+
+`nicolaka/netshoot` ships `dig`, `curl`, `tcpdump`, `iperf3`, `nmap`, `mtr` — keep it as the default network-debug image.
+
+## Flux
+
+```sh
+# What's reconciling, what's failed, what's suspended
+flux get sources git -A
+flux get ks -A
+flux get hr -A
+flux get all -A | grep -v True
+
+# Force reconciliation
+flux reconcile source git flux-system
+flux reconcile ks cluster-apps -n flux-system
+flux reconcile hr <name> -n <ns>
+
+# Why is this HelmRelease unhappy?
+kubectl -n <ns> describe hr <name>
+kubectl logs -n flux-system deploy/helm-controller --tail=200 | grep -A5 <name>
+
+# Why is this Kustomization unhappy?
+kubectl -n <ns> describe ks <name>
+kubectl logs -n flux-system deploy/kustomize-controller --tail=200 | grep -A5 <name>
+```
+
+A Kustomization with `Suspended: True` is almost always deliberate — see CLAUDE.md "Flux suspend / disable workflow" and `git log --oneline | grep -E 'disable-|Revert.*disable-'` before touching it.
+
+## Ceph
+
+```sh
+# Cluster health from inside the cluster
+kubectl -n rook-ceph exec -it deploy/rook-ceph-tools -- ceph -s
+kubectl -n rook-ceph exec -it deploy/rook-ceph-tools -- ceph osd tree
+kubectl -n rook-ceph exec -it deploy/rook-ceph-tools -- ceph osd status
+kubectl -n rook-ceph exec -it deploy/rook-ceph-tools -- ceph health detail
+
+# OSD pods + per-node mapping
+kubectl -n rook-ceph get pods -l app=rook-ceph-osd -o wide
+
+# Watch a recovery in progress
+kubectl -n rook-ceph exec -it deploy/rook-ceph-tools -- watch ceph -s
+
+# Per-host PDB state (these block drains during recovery)
+kubectl get pdb -n rook-ceph | grep rook-ceph-osd-host
+```
+
+Ceph dashboard password is fetched via [`tools/get-ceph-password.sh`](https://github.com/rwlove/home-ops/blob/main/tools/get-ceph-password.sh).
+
+## Longhorn
+
+```sh
+# Per-node replica state (load-bearing during drains)
+kubectl get replicas.longhorn.io -n longhorn-system -o wide
+
+# Per-node Longhorn node state
+kubectl get nodes.longhorn.io -n longhorn-system
+
+# Watch evictions evacuate a node
+kubectl patch -n longhorn-system nodes.longhorn.io <node> \
+  --type=merge -p '{"spec":{"allowScheduling":false,"evictionRequested":true}}'
+# (wait for the node's replica count to reach 0)
+
+# Re-enable after the node is back
+kubectl patch -n longhorn-system nodes.longhorn.io <node> \
+  --type=merge -p '{"spec":{"allowScheduling":true,"evictionRequested":false}}'
+
+# Volume detail
+kubectl -n longhorn-system get volumes.longhorn.io <pvc-uuid>
+```
+
+If `longhorn-manager-X` is in CrashLoopBackOff with `bind: address already in use`, an old daemon process is orphaned on the host:
+
+```sh
+ssh root@<node> 'pgrep -af "longhorn-manager -d daemon" | xargs -r kill -9'
+kubectl -n longhorn-system delete pod longhorn-manager-X
+```
+
+## CNPG (Postgres)
+
+```sh
+# Cluster status (use the cnpg plugin)
+kubectl cnpg -n databases status <cluster-name>
+
+# Quick SQL
+kubectl cnpg -n databases psql <cluster-name> -- -c '\l'
+kubectl cnpg -n databases psql <cluster-name> -- -c 'SELECT pg_is_in_recovery(), now();'
+
+# Force a primary failover before draining a node
+kubectl cnpg promote -n databases <cluster-name> <replica-pod-name>
+
+# Backups
+kubectl -n databases get backups.postgresql.cnpg.io
+kubectl -n databases get scheduledbackups.postgresql.cnpg.io
+```
+
+For recovery, see [`cluster_rebuild.md`](cluster_rebuild.md) → "CNPG recovery from Garage".
+
+## Networking
+
+```sh
+# DNS from inside the cluster
+kubectl run -it --rm dns --image=nicolaka/netshoot --restart=Never -- \
+  dig +short <service>.<ns>.svc.cluster.local
+
+# External DNS resolution from a pod
+kubectl run -it --rm dns --image=nicolaka/netshoot --restart=Never -- \
+  dig +short google.com
+
+# Reach a service from another pod
+kubectl run -it --rm curl --image=curlimages/curl --restart=Never -- \
+  curl -v http://<service>.<ns>.svc.cluster.local
+
+# HTTPRoutes + gateway status
+kubectl get httproutes -A
+kubectl get gateways -A
+kubectl describe gateway -n network external
+
+# Cilium quick checks
+kubectl -n kube-system exec -it ds/cilium -- cilium status --brief
+kubectl -n kube-system exec -it ds/cilium -- cilium bgp peers
+kubectl get ciliumloadbalancerippool
+```
+
+DNS troubleshooting reference: <https://kubernetes.io/docs/tasks/administer-cluster/dns-debugging-resolution/>.
+
+External resolver sanity check (from the laptop): <https://dnschecker.org>.
+
+## Etcd
+
+```sh
+# Quorum + per-member latency (run on any control plane)
+kubectl exec -n kube-system etcd-master1.${SECRET_DOMAIN} -- etcdctl \
+  --endpoints=https://127.0.0.1:2379 \
+  --cacert=/etc/kubernetes/pki/etcd/ca.crt \
+  --cert=/etc/kubernetes/pki/etcd/server.crt \
+  --key=/etc/kubernetes/pki/etcd/server.key \
+  endpoint status --cluster -w table
+
+# Off-cluster snapshot before risky operations
+kubectl exec -n kube-system etcd-master1.${SECRET_DOMAIN} -- etcdctl \
+  --endpoints=https://127.0.0.1:2379 \
+  --cacert=/etc/kubernetes/pki/etcd/ca.crt \
+  --cert=/etc/kubernetes/pki/etcd/server.crt \
+  --key=/etc/kubernetes/pki/etcd/server.key \
+  snapshot save /var/lib/etcd/snapshot-$(date +%Y%m%d).db
+scp root@master1:/var/lib/etcd/snapshot-*.db ~/cluster-backups/etcd/
+
+# Defrag (run via the operator-installed CronJob, or one-off)
+./tools/etcd-defrag.sh
+```
+
+If one voter shows `slow_apply_total` 10× higher than its peers, the underlying disk is the suspect — see [`master1_etcd_disk_swap.md`](master1_etcd_disk_swap.md).
+
+## Resource pressure
+
+```sh
+# Per-node CPU/memory utilization
+kubectl top nodes
+kubectl top pods -A --sort-by=memory | head
+kubectl top pods -A --sort-by=cpu | head
+
+# Find OOMKilled pods in the cluster
+kubectl get pods -A -o json | \
+  jq -r '.items[] | select(.status.containerStatuses // [] | any(.lastState.terminated.reason == "OOMKilled")) | "\(.metadata.namespace)/\(.metadata.name)"'
+
+# Per-pod resource requests vs limits
+kubectl describe pod -n <ns> <pod> | grep -A2 -E 'Limits|Requests'
+```
+
+Resource philosophy: [`limits.md`](limits.md) — request CPU, don't limit CPU; memory limit = memory request.
+
+## Image / registry
+
+```sh
+# Why is this image failing to pull?
+kubectl -n <ns> describe pod <pod> | grep -E 'Failed|ErrImagePull|ImagePullBackOff' -A2
+
+# Verify a specific image is reachable from a node
+ssh root@<node> 'crictl pull <image>'
+
+# Renovate / dependency state
+gh pr list --label renovate --limit 20
+```
+
+## NFS
+
+```sh
+# From any node — verify the export
+showmount -e ${NFS_HOST_0}
+showmount -e ${NFS_HOST_2}
+
+# Inside a pod that mounts NFS — verify the mount works
+kubectl -n <ns> exec <pod> -- stat /mnt/...
+
+# Slow NFS? Check on the server, not in k8s
+ssh root@${NFS_HOST_0} 'nfsstat -s'
+ssh root@${NFS_HOST_0} 'nfsiostat 1 5'
+```
+
+Background reading: <https://www.redhat.com/sysadmin/using-nfsstat-nfsiostat>.
+
+## External access (out-of-band)
+
+If the cluster is fully borked and you need to reach a node from outside the LAN:
+
+```sh
+# OOB SSH path via brain (the home router)
+ssh -p 3231 root@173.69.136.210
+```
+
+That's the only path that doesn't depend on wg-easy being healthy (which depends on the cluster).
+
+## When to escalate
+
+If a problem isn't yielding to direct inspection:
+
+- **AlertManager + HolmesGPT** are wired to do automated root-cause analysis on every firing alert — check the most recent Pushover ping or Zulip alert thread for HolmesGPT's investigation report before going deeper.
+- **mdBook docs** elsewhere in `docs/src/` — `cluster_upgrade.md` has a deep failure-modes table from the 1.34 → 1.35 upgrade that captures most cri-o / kubelet / Longhorn / Rook failure shapes.
+
+## External references
+
+- Kubernetes DNS debugging: <https://kubernetes.io/docs/tasks/administer-cluster/dns-debugging-resolution/>
+- Port-forward troubleshooting: <https://kubernetes.io/docs/tasks/access-application-cluster/port-forward-access-application-cluster/>
+- netshoot toolbox: <https://github.com/nicolaka/netshoot>
+- NFS stats: <https://www.redhat.com/sysadmin/using-nfsstat-nfsiostat>

--- a/docs/src/frigate_dr.md
+++ b/docs/src/frigate_dr.md
@@ -1,5 +1,189 @@
 # Frigate + direct-NFS DR Runbook
 
-Moved to the vault: `~/vaults/claude/runbooks/home-ops/frigate_dr.md`
+Recovery procedure for Frigate (cameras, models, retention) and
+adjacent direct-NFS workloads (jellyfin, immich originals,
+unprocessed media). Paper runbook — verify before executing.
 
-See HOMELAB-SPEC Layer 2 #5: the vault is canonical for runbooks.
+## Frigate baseline
+
+- Deployment: `kubernetes/apps/home/frigate/`
+- 7+ cameras integrated; XFS project quotas on the recordings
+  volume for per-camera retention enforcement
+- Camera storage: dedicated NFS export
+  (`security-storage`-hosted), XFS with `prjquota` mount flag
+- Frigate+ model: custom-trained, retraining cadence iterative
+- Snapshot config (`frigate-snapshot` CronJob in `home/frigate/`)
+  syncs `/config/config.yml` to git as documentation; the live
+  config is in the PVC
+- Memory references:
+  - `[[project_frigate_snapshot_cronjob_broken]]` — alpine apk-add
+    fails under egress restrictions
+  - `[[reference_frigate_zone_semantics]]` — zone overlap +
+    snapshot config direction
+
+## What survives losses
+
+| Loss scenario | What's gone | What survives |
+|---|---|---|
+| Frigate pod restart | nothing | clips/recordings on NFS, config in PVC |
+| Frigate PVC loss | `/config/config.yml` (live edits), Frigate's local sqlite | clips/recordings on NFS, model on PVC if separate, config in git via snapshot CronJob (best-effort) |
+| Frigate NFS export loss | all clips + recordings | the model file (if separate), config |
+| Model file loss | model | config + clips on NFS |
+| Whole-cluster wipe | Frigate sqlite (event index), live config | clips + recordings on NFS, model + config from git snapshot |
+
+## Recovery scenarios
+
+### Scenario A — Frigate pod won't start
+
+Common after a Frigate version bump or a model file mismatch.
+
+1. Diagnose:
+
+   ```sh
+   kubectl -n home logs frigate-0 -c app --previous
+   kubectl -n home describe pod frigate-0
+   ```
+
+2. Common causes:
+   - Model path in `config.yml` points at a missing file
+   - GPU device-plugin not ready (Coral / VRAM allocation)
+   - NFS mount unavailable
+   - Config-file schema change between Frigate versions
+
+3. Rollback the image to the prior known-good version (edit the
+   HelmRelease, push, Flux reconciles). Frigate respects an
+   in-place rollback if the on-disk database schema is compatible.
+
+### Scenario B — Frigate config corruption
+
+`/config/config.yml` in the PVC is wrong; the snapshot CronJob's
+last git commit is the recovery source.
+
+1. Verify the snapshot CronJob is current — check the last commit
+   to `kubernetes/apps/home/frigate/snapshots/config.yml` (git
+   log). The CronJob ran daily until it broke; recent state may
+   be stale per memory note.
+2. Re-apply the config:
+
+   ```sh
+   # From a host with kubectl access
+   kubectl -n home cp snapshots/config.yml frigate-0:/config/config.yml -c app
+   # Restart Frigate
+   kubectl -n home delete pod frigate-0
+   ```
+
+3. Frigate restarts with the restored config.
+
+If the snapshot CronJob has been broken (see project memory),
+hand-recovery from the prior pod's logs or the user's memory is
+the fallback.
+
+### Scenario C — Camera NFS export lost
+
+All clips + recordings are gone. The cameras themselves are
+unaffected; new recordings start as soon as Frigate reconnects.
+
+1. Rebuild the NFS export on `security-storage`:
+
+   ```sh
+   ssh security-storage 'ls /mnt/<frigate-export>'
+   # Recreate the XFS filesystem if needed:
+   # mkfs.xfs -f -m crc=1,bigtime=1 /dev/<device>
+   # Mount with prjquota:
+   # mount -o prjquota /dev/<device> /mnt/<frigate-export>
+   ```
+
+2. Re-apply XFS project quotas per camera (Frigate uses these for
+   per-camera retention). The quota config is in Frigate's
+   `config.yml` under each camera's `record.retain.days`; the
+   actual filesystem-level project IDs are bootstrapped on first
+   write by Frigate.
+3. Restart Frigate: `kubectl -n home delete pod frigate-0`.
+4. Verify each camera reconnects and starts writing.
+5. **Historic clips are lost.** Frigate's event database
+   (sqlite in the PVC) still references them; the references
+   become 404s. Acceptable — Frigate self-prunes orphaned events
+   on next compaction.
+
+### Scenario D — Frigate+ model lost
+
+The custom Frigate+ model in the model file is gone (PVC wipe,
+file deletion).
+
+1. Re-pull the model from Frigate+ — log into the Frigate+ portal,
+   download the latest model.
+2. Place it in Frigate's model path (per `config.yml`).
+3. Restart Frigate.
+4. Validation: Frigate logs report `loaded model from /path`. New
+   detections start producing labels matching the model's classes.
+5. **If Frigate+ subscription has lapsed**, the model file you
+   already downloaded keeps working — Frigate+ models don't phone
+   home. But re-training requires an active subscription.
+
+### Scenario E — whole-cluster rebuild
+
+Cluster destroyed and rebuilt from Git.
+
+1. Frigate HelmRelease reconciled, pod starts; config is empty
+   (or reverted to whatever's in the snapshot file).
+2. NFS export on `security-storage` is independent of the
+   cluster — still intact, clips + recordings preserved.
+3. Frigate scans the existing recordings directory on first start
+   and reconstructs its event index over hours (it walks every
+   file). The pod is slow during this period.
+4. Apply the most-recent good config from git snapshot per
+   Scenario B.
+5. Verify each camera reconnects.
+
+## Adjacent direct-NFS workloads
+
+These also need restoration thought:
+
+- **Jellyfin media** — on `beast:/mnt/mass_storage/Movies` (and
+  related). RAID6 protects against disk loss; cluster rebuild
+  doesn't affect the data. Restore = Jellyfin scans the existing
+  library, indexes media. Watch state is in the Jellyfin CNPG
+  cluster (see `cnpg_restore.md`).
+- **Immich originals** — under `media/immich`, also direct-NFS
+  for the originals bucket. Offsite-covered for Immich
+  specifically (see `offsite_recovery.md`).
+- **Music libraries** (MP3s on beast) — direct-NFS, RAID6
+  protected. No specific Frigate-shape DR; treat as Jellyfin.
+
+## Gotchas
+
+- **XFS `prjquota` mount option** is required for per-camera
+  retention. If a remount drops it (e.g., re-export without the
+  flag), Frigate's quota enforcement silently does nothing.
+- **Frigate's sqlite event index** is in the PVC, not on NFS. PVC
+  loss → event index loss → events not searchable in UI until
+  Frigate re-indexes from recordings.
+- **`frigate-snapshot` CronJob is broken since 2026-05-08** — `apk
+  add git openssh` fails under egress restrictions. Workaround:
+  read live config directly with `kubectl exec frigate-0 -c app
+  -- cat /config/config.yml`. Pre-baked image is the real fix.
+- **HA integration** — the Frigate↔HA integration requires MQTT
+  - the HA add-on; both need to be healthy. If HA's broker is
+  down, Frigate fires detections but HA doesn't see them.
+
+## Verification checklist
+
+After any recovery:
+
+- [ ] All 7+ cameras connected (UI → Camera Status)
+- [ ] Recent clips being written (`ls -la <NFS>/<camera>/...`)
+- [ ] Model loaded (Frigate logs report load + class count)
+- [ ] HA → Frigate integration shows recent events
+- [ ] No Frigate-related alerts firing
+- [ ] XFS prjquota enforcement working (`xfs_quota -x -c "report"
+  /mnt/<export>` reports per-camera usage)
+
+## See also
+
+- `cnpg_restore.md` — Jellyfin watch-state DB restore
+- `offsite_recovery.md` — Immich (related direct-NFS app)
+- `storage-class.instructions.md` — direct-NFS tier rationale
+- Memory: `[[project_frigate_snapshot_cronjob_broken]]` — snapshot
+  CronJob recovery
+- Memory: `[[reference_frigate_zone_semantics]]` — zone-related
+  detection gotchas

--- a/docs/src/garage_restore.md
+++ b/docs/src/garage_restore.md
@@ -1,5 +1,172 @@
 # Garage Substrate Restore Runbook
 
-Moved to the vault: `~/vaults/claude/runbooks/home-ops/garage_restore.md`
+Recovery procedure for the Garage S3-compatible object store
+deployed in this cluster. Paper runbook — verify commands against
+the running deployment before executing destructive steps.
 
-See HOMELAB-SPEC Layer 2 #5: the vault is canonical for runbooks.
+## Cluster baseline
+
+- Deployment: `kubernetes/apps/storage/garage/`
+- API endpoint: `s3.${SECRET_DOMAIN}`
+- Substrate: NFS-backed PVCs on `brain`
+  - `/mnt/kubernetes/garage/data/` — object data
+  - `/mnt/kubernetes/garage/meta/` — Garage internal metadata
+- Both directories are on `brain`'s `/mnt/mass_storage` RAID6
+  (tolerates 2-disk loss)
+- Storage tier (per `storage-class.instructions.md`):
+  S3-compatible, used for CNPG Barman backups + app-level S3
+  workloads + offsite-backup destinations.
+
+## Buckets in use
+
+- `cnpg-<app>` (one per CNPG cluster) — Barman base + WAL
+- App-level workloads using S3 API (e.g. Loki object store if
+  configured, Velero if deployed, etc.)
+- Offsite-backup CronJobs (`immich-offsite-backup`,
+  `paperless-offsite-backup`) — staging or direct write
+
+## When to use this
+
+- Garage pod won't start (metadata corruption)
+- One or both substrate PVCs lost/corrupted
+- Whole-cluster rebuild — Garage redeployed fresh, needs the NFS
+  substrate re-mounted
+
+## Recovery scenarios
+
+### Scenario A — Garage pod crash, substrate intact
+
+Pod is in CrashLoopBackOff but the NFS-backed PVCs are healthy.
+
+1. Diagnose:
+
+   ```sh
+   kubectl -n storage logs sts/garage --previous
+   kubectl -n storage describe pod garage-0
+   ```
+
+2. Common causes:
+   - Metadata DB corruption — Garage writes to `meta/` and a hard
+     crash can leave the LMDB-style metadata wedged. Logs show
+     `lmdb error: MDB_CORRUPTED`.
+   - Disk full — `meta/` or `data/` directory at 100%.
+   - Network partition — Garage couldn't reach its peers (in a
+     multi-replica setup; this cluster runs single-replica, so
+     this is rare).
+
+3. For metadata corruption: Garage has a `garage repair` subcommand:
+
+   ```sh
+   kubectl -n storage exec sts/garage -- garage repair --yes scrub
+   ```
+
+4. For disk-full: free space on the NFS mount on brain or expand
+   the underlying filesystem.
+5. Pod auto-recovers once root cause is fixed.
+
+### Scenario B — NFS substrate PVCs lost
+
+The brain NFS mounts are gone (filesystem wipe, RAID failure, etc.).
+This is rare given the RAID6 substrate but possible.
+
+**What this means in practice:**
+
+- All buckets are gone — CNPG Barman backups for all clusters are
+  lost. CNPG clusters revert to "only PGData survives" recovery.
+- Offsite-backup staging is gone — but the offsite target (AWS
+  Glacier for Immich + Paperless) is independent.
+- Apps that rely on Garage for S3 storage have lost their data.
+
+**Recovery:**
+
+1. Rebuild the NFS substrate on brain — see brain's host-side
+   recovery (not in this repo; see
+   `lovenet-network-configuration/` for brain's role).
+2. Recreate the NFS exports:
+
+   ```sh
+   ssh brain 'exportfs -ra && exportfs'
+   # Verify /mnt/kubernetes/garage/{data,meta} are exported
+   ```
+
+3. The `nfs-pvc.yaml` resources in
+   `kubernetes/apps/storage/garage/app/` reference these by NFS
+   server + path. Once the exports return, the PVCs bind on next
+   pod restart.
+4. Garage starts with an empty `meta/` and `data/` — it's a fresh
+   cluster from Garage's perspective.
+5. Recreate buckets by reconciling Flux (the
+   `objectbucketclaim.objectbucket.io/v1alpha1` resources in each
+   app's manifests will re-request their buckets).
+6. CNPG clusters: next `ScheduledBackup` populates the new
+   `cnpg-<app>` buckets. **Existing data is not recovered** — only
+   future backups. To recover historic data, you needed offsite.
+7. Verify the `s3.${SECRET_DOMAIN}` route returns 200 from outside
+   the cluster.
+
+### Scenario C — whole-cluster rebuild (Garage redeployed fresh)
+
+The cluster was destroyed and rebuilt. Garage HelmRelease
+reconciled, but the NFS substrate on brain may or may not still
+have data.
+
+1. Check brain:
+
+   ```sh
+   ssh brain 'ls -la /mnt/kubernetes/garage/data/ /mnt/kubernetes/garage/meta/'
+   ```
+
+2. **If substrate is intact:** Garage sees the existing data + meta
+   on first start, reconstitutes its bucket list automatically.
+   All previous buckets and objects appear. No further action
+   needed.
+
+3. **If substrate is empty/missing:** treat as Scenario B.
+
+The substrate is on `brain` and persists across cluster
+destruction by design — that's the whole point of NFS-backed
+Garage. So Scenario C is almost always "intact" in practice.
+
+## Gotchas
+
+- **Garage repair scrub takes hours** on a populated cluster.
+  Schedule during low-IO window.
+- **The Garage admin secret** is in 1Password
+  (`Kubernetes/garage`); without it, you can't `garage` CLI into
+  the running pod for repair. Verify access before you need it.
+- **`s3.${SECRET_DOMAIN}` DNS** must resolve from the cluster
+  internally — per memory
+  `[[feedback_cilium_world_egress_split_horizon]]`, internal
+  resolves go to the LB IP via bind9 split-horizon. CNPs that use
+  `toEntities: world` for Garage egress silently drop. Use
+  cluster-internal Service URLs (`garage.storage.svc.cluster.local`)
+  in pod configs.
+- **OBC (ObjectBucketClaim) hangs after a Garage rebuild** — the
+  `objectbucket.io` controller cached the old bucket UUID. Delete
+  the OBC + its backing secret, let Flux re-create.
+
+## Verification checklist
+
+After any restore:
+
+- [ ] `kubectl -n storage get pods` shows `garage-0` Running
+- [ ] `garage status` from inside the pod reports the expected
+  node count + capacity
+- [ ] `s3.${SECRET_DOMAIN}` route returns HTTP 200 (or expected
+  S3 XML error for unauthed)
+- [ ] A test `aws s3 ls --endpoint-url
+  https://s3.${SECRET_DOMAIN}` succeeds with valid credentials
+- [ ] CNPG clusters can write to their ObjectStores — `kubectl
+  -n databases get backups` shows recent `Completed` entries
+
+## See also
+
+- `rook_ceph_dr.md` — independent storage tier
+- `cnpg_restore.md` — Garage's primary consumer
+- `offsite_recovery.md` — offsite is independent of Garage
+- `storage-class.instructions.md` — when to use Garage vs other
+  tiers
+- Memory: `[[feedback_cilium_world_egress_split_horizon]]` — Cilium
+  - split-horizon DNS gotcha when egressing to Garage
+- Memory: `[[reference_glacier_verify_script_pitfalls]]` —
+  adjacent gotcha for offsite verification

--- a/docs/src/github_webhook.md
+++ b/docs/src/github_webhook.md
@@ -1,5 +1,41 @@
 # GitHub Webhook → Flux
 
-Moved to the vault: `~/vaults/claude/runbooks/home-ops/github_webhook.md`
+Configures GitHub to ping Flux on every push so reconciliation happens immediately instead of waiting for the next polling interval.
 
-See HOMELAB-SPEC Layer 2 #5: the vault is canonical for runbooks.
+## Setup
+
+1. Get the webhook URL from the Flux `Receiver`:
+
+   ```sh
+   kubectl -n flux-system get receivers.notification.toolkit.fluxcd.io
+   ```
+
+   The `URL` column contains the public path (e.g. `/hook/<token>`); concatenate it with the public ingress (`https://flux-webhook.${SECRET_DOMAIN}`).
+
+2. Get the shared secret:
+
+   ```sh
+   kubectl -n flux-system describe secret github-webhook-token
+   ```
+
+3. In GitHub → repo Settings → Webhooks → Add webhook:
+   - **Payload URL**: `https://flux-webhook.${SECRET_DOMAIN}/hook/<token>`
+   - **Content type**: `application/json`
+   - **Secret**: paste the value from step 2
+   - **SSL verification**: Enable
+   - **Which events**: Just the push event
+   - **Active**: checked
+
+## Verifying
+
+After pushing a commit, the webhook delivery should show a `200 OK` in GitHub → Webhooks → Recent Deliveries. On the cluster side:
+
+```sh
+kubectl -n flux-system logs deploy/notification-controller --tail=50 | grep -i webhook
+```
+
+Successful trigger looks like `handling event ...source.toolkit.fluxcd.io/v1`. Failed deliveries usually mean the secret doesn't match or the public URL is wrong.
+
+## Related
+
+- [Cluster Rebuild](cluster_rebuild.md) — among the post-rebuild tasks, the `KUBECONFIG` Actions secret also needs refreshing.

--- a/docs/src/immich_cnpg.md
+++ b/docs/src/immich_cnpg.md
@@ -1,5 +1,40 @@
 # Importing an Immich DB backup into a new CNPG database
 
-Moved to the vault: `~/vaults/claude/runbooks/home-ops/immich_cnpg.md`
+This is the **alternate** Immich DB restore path — for when you have an Immich-format SQL dump (from Immich's built-in backup) rather than a Barman-cloud backup. For the standard Barman recovery path used after a cluster rebuild, see [Cluster Rebuild](cluster_rebuild.md#cnpg-recovery-from-garage); for the offsite-S3 path, see [Offsite Recovery](offsite_recovery.md).
 
-See HOMELAB-SPEC Layer 2 #5: the vault is canonical for runbooks.
+## Procedure
+
+1. **Create the target database**:
+
+   ```sh
+   kubectl cnpg -n databases psql <cluster-name> -- -c 'CREATE DATABASE immich;'
+   ```
+
+2. **Confirm you're against the primary** (writes go to the primary; replicas are read-only):
+
+   ```sh
+   kubectl cnpg -n databases status <cluster-name> | grep 'Primary instance:'
+   ```
+
+3. **Stream the dump in** via the [Immich restore command](https://immich.app/docs/administration/backup-and-restore). The `sed` rewrite is required because Immich uses extensions whose `search_path` needs to be set explicitly during restore:
+
+   ```sh
+   gunzip < "immich-db-backup-1735455600013.sql.gz" \
+     | sed "s/SELECT pg_catalog.set_config('search_path', '', false);/SELECT pg_catalog.set_config('search_path', 'public, pg_catalog', true);/g" \
+     | kubectl cnpg -n databases psql <cluster-name> --
+   ```
+
+4. **Verify** the row counts after restore (replace `<dump-row-count>` with what you'd expect from the source):
+
+   ```sh
+   kubectl cnpg -n databases psql <cluster-name> -- -d immich -c 'SELECT COUNT(*) FROM assets;'
+   ```
+
+## When to use this vs the Barman path
+
+| Situation | Use |
+|---|---|
+| Cluster rebuild, Barman backups in Garage | [Cluster Rebuild → CNPG recovery from Garage](cluster_rebuild.md#cnpg-recovery-from-garage) |
+| Total loss, only S3 offsite backup survives | [Offsite Recovery → Step 4: Restore the database via Barman](offsite_recovery.md) |
+| Have a `pg_dump` from inside Immich (admin → "Job Status" → backup) | **This doc.** |
+| Migrating Immich data between environments | This doc. |

--- a/docs/src/init_teardown.md
+++ b/docs/src/init_teardown.md
@@ -1,5 +1,54 @@
 # Initialization & Teardown
 
-Moved to the vault: `~/vaults/claude/runbooks/home-ops/init_teardown.md`
+The bare-command set to bring the cluster up from nothing, or tear it down to nothing. See [Cluster Rebuild](cluster_rebuild.md) for the full preflight and verification procedure that wraps these commands.
 
-See HOMELAB-SPEC Layer 2 #5: the vault is canonical for runbooks.
+## Prerequisites (laptop)
+
+- `op` (1Password CLI) — for rendering `bootstrap/resources.yaml.j2`
+- `minijinja-cli` — template renderer used by the bootstrap step
+- `yq` — YAML processing
+- `go-task` (alias `task`) — runs the `bootstrap/mod.just` recipes
+
+Install via `dnf` / `brew` / your package manager of choice. The bootstrap scripts will exit early if any of these are missing.
+
+## Initialization
+
+In order:
+
+1. **On `master1`** (control-plane bootstrap):
+
+   ```sh
+   ./init/create-cluster.sh
+   ```
+
+   Sets up kube-vip, runs `kubeadm init`, joins masters 2/3 and all workers, labels Longhorn-eligible nodes, makes `master1` schedulable.
+
+2. **On the laptop** (in-cluster app bootstrap):
+
+   ```sh
+   ./init/initialize-cluster.sh
+   ```
+
+   Pulls the kubeconfig from `master1`, creates bootstrap namespaces, renders 1Password-backed secrets, applies CRDs from `bootstrap/helmfile.d/00-crds.yaml`, then runs `helmfile sync` for `01-apps.yaml` (Cilium, CoreDNS, cert-manager, external-secrets, 1Password Connect, Flux operator + instance).
+
+3. **On the laptop** (remove redundant static manifest):
+
+   ```sh
+   ssh root@master1 rm /etc/kubernetes/manifests/kube-vip.yaml
+   ```
+
+   Once Flux brings up the in-cluster kube-vip, the static pod is redundant and will fight for the VIP. Remove it after step 2 settles.
+
+## Teardown
+
+Wipes the cluster, destroys Ceph OSDs, clears `/var/lib/{etcd,kubelet,longhorn,rook}`. Only run when reusing the same hardware — fresh hardware doesn't need this.
+
+```sh
+./init/destroy-cluster.sh
+```
+
+**This is destructive.** See [Cluster Rebuild](cluster_rebuild.md) → "Preflight" for the survival audit you should run *before* destroying anything. The Garage S3 buckets (CNPG backups) and any NFS-backed data are the only things that survive teardown — verify the NFS host is healthy first.
+
+## Related
+
+- [Cluster Rebuild](cluster_rebuild.md) — full end-to-end recovery including post-bootstrap verification and CNPG recovery from Garage.

--- a/docs/src/longhorn_restore.md
+++ b/docs/src/longhorn_restore.md
@@ -1,5 +1,181 @@
 # Longhorn Restore Runbook
 
-Moved to the vault: `~/vaults/claude/runbooks/home-ops/longhorn_restore.md`
+Restore procedure for any Longhorn-backed PVC after backup-target
+loss, cluster wipe, or accidental volume deletion. Paper runbook —
+verify against `kubectl -n longhorn-system ...` before executing.
 
-See HOMELAB-SPEC Layer 2 #5: the vault is canonical for runbooks.
+## Cluster baseline
+
+- Deployment: `kubernetes/apps/longhorn-system/longhorn/`
+- Backup target (set in HelmRelease):
+  `nfs://beast:/mnt/mass_storage/longhorn-backups`
+- Recurring jobs
+  (`kubernetes/apps/longhorn-system/longhorn/config/recurring-jobs.yaml`):
+  - `daily-snapshots` — every day at 00:00, retain 7
+  - `weekly-backups` — Saturdays at 00:00, retain 4
+  - `monthly-backups` — 1st of month at 00:00, retain 6
+  - `weekly-filesystem-trim` — Sundays at 03:00
+- Storage tier (per `storage-class.instructions.md`):
+  cluster-loss-survivable. Used for irreplaceable state only.
+
+## When to use this
+
+- A Longhorn-backed PVC's data is corrupt or wrong, and you have a
+  recent snapshot or backup.
+- A Longhorn-backed PVC was accidentally deleted.
+- Cluster rebuild restored from Git; Longhorn was redeployed
+  fresh and needs to ingest the backup target.
+
+## Backup target inventory
+
+Backups land on `beast:/mnt/mass_storage/longhorn-backups` (RAID6,
+tolerates 2-disk loss). The path is mounted into the
+longhorn-instance-manager pods.
+
+Listing what's available:
+
+```sh
+kubectl -n longhorn-system exec -it deploy/longhorn-ui -- sh
+# Or via UI: longhorn.${SECRET_DOMAIN} → Backup
+```
+
+Or directly from beast:
+
+```sh
+ssh beast 'ls /mnt/mass_storage/longhorn-backups/backupstore/volumes/'
+```
+
+Each volume has its own subdirectory; backup chains are stored as
+.cfg + diff files. Don't hand-edit.
+
+## Scenario A — restore from a recent snapshot
+
+A volume's data is wrong but the Longhorn volume itself is
+healthy. Restore from a daily/weekly snapshot.
+
+1. Identify the volume: `kubectl -n longhorn-system get volumes`
+   or via the UI.
+2. List snapshots: UI → Volume → Snapshots tab. Look for the most
+   recent good snapshot (timestamp before the bad event).
+3. **Detach the volume from its workload first** (scale the
+   consumer pod to 0). Longhorn does not snapshot-revert while
+   attached.
+4. UI → Volume → Snapshots → select snapshot → Revert.
+5. Re-attach: scale the consumer back to 1.
+6. Verify app starts cleanly.
+
+## Scenario B — restore from a Longhorn backup
+
+The volume is unavailable or the cluster was rebuilt. Restore from
+the `nfs://beast` backup target.
+
+1. Verify the backup target is accessible:
+
+   ```sh
+   kubectl -n longhorn-system get backuptarget default
+   # Should be Available=True
+   ```
+
+2. List backups (UI → Backup), find the volume + backup version
+   you want.
+3. **Restore creates a new volume.** Old volume (if any) stays —
+   delete it separately.
+4. UI → Backup → backup-name → Restore. Set new volume name
+   (typically reuse the old PVC name to make swap simpler).
+5. After restore completes (can be slow for large volumes — Immich
+   thumbs PVC takes 30+ minutes), edit the PV/PVC binding to point
+   at the new volume.
+
+   Easier path: name the restore volume something new, then update
+   the consumer's PVC `volumeName` to bind.
+
+6. Scale the consumer pod up.
+7. Verify app starts cleanly.
+
+## Scenario C — full Longhorn rebuild (cluster recreated)
+
+The cluster was destroyed and rebuilt from Git. Longhorn is
+deployed fresh with no volumes. The backup target NFS is intact.
+
+1. Confirm the HelmRelease's `backupTarget` points at
+   `nfs://beast:/mnt/mass_storage/longhorn-backups`. Default in
+   the values; verify:
+
+   ```sh
+   flux get helmrelease -n longhorn-system longhorn -o yaml | yq '.spec.values.backupTarget'
+   ```
+
+2. Wait for `kubectl -n longhorn-system get backuptarget default
+   -o yaml` to show `Available=True`. May take 1-2 minutes.
+3. The UI's Backup tab now lists all previously-stored backups.
+4. For each app that needs restore: follow Scenario B per volume.
+   This is sequential per app; expect 1+ hours for full cluster
+   data restore.
+
+Apps that should be restored from Longhorn (per
+`storage-class.instructions.md` rule 3 — irreplaceable state):
+
+- `media/jellyfin` — watch state, user library, playlists
+- `home/home-assistant` — device registry, automations state (the
+  CNPG cluster covers DB; Longhorn covers HA's local store)
+- `media/<media-library-app>` — library metadata
+- Others — check the repo for `longhorn-pvc.yaml` files
+
+```sh
+find kubernetes/apps -name "longhorn-pvc.yaml" | sort
+```
+
+## Per-volume backup label requirements
+
+Per the existing convention in this repo, every Longhorn volume
+needs:
+
+- Labels matching `recurring-jobs.yaml` group selector (default
+  `recurring-job.longhorn.io/source: enabled` and
+  `recurring-job-group.longhorn.io/default: enabled`)
+- `unmapMarkSnapChainRemoved=enabled` set per-Volume to prevent
+  snapshot-pinned slack
+- `chmod 755` on `lost+found` if the app runs non-root (see
+  memory `feedback_use_worktree_for_commit_bound_work` adjacent
+  references)
+
+If a restored volume doesn't show up in the recurring backups,
+verify the labels.
+
+## Gotchas
+
+- **`backupTarget` NFS unreachable** → all backup operations stall;
+  the UI shows "Backup target inaccessible". Check `ssh beast 'ls
+  /mnt/mass_storage/longhorn-backups/'` from a worker node.
+- **Restore fills the cluster's Longhorn disks faster than expected**
+  — Longhorn replicas need ~3× the PVC size during restore (live
+  copy + new replica + scratch). Verify disk space on
+  worker nodes before kicking off a large restore.
+- **Old volume still attached** — restore fails if the same
+  volume name is in use. Detach (scale consumer to 0) or restore
+  to a new name.
+- **PV reclaim policy** — most Longhorn PVs in this repo are
+  `Retain`. Manually deleting a PVC does not free the PV; you must
+  delete the PV separately. This is intentional protection but
+  surprising during a restore.
+
+## Verification checklist
+
+After any restore:
+
+- [ ] Volume reports `state: attached` and `robustness: healthy`
+- [ ] Consumer pod running and reads/writes successfully
+- [ ] Recurring backup job picks up the restored volume on next
+  cron (verify in UI's Backup tab after 24h)
+- [ ] No Longhorn alerts firing
+
+## See also
+
+- `rook_ceph_dr.md` — Longhorn's storage is independent of Ceph
+- `cluster_rebuild.md` — full cluster recovery context
+- `storage-class.instructions.md` — when to put data on Longhorn
+  vs ceph-block vs Garage vs NFS
+- Memory: `[[reference_longhorn_xfs_repair]]` — repair recipe for
+  corrupted XFS Longhorn volumes
+- Memory: `[[reference_rook_ceph_csi_plugin_tolerations_combined]]`
+  — adjacent cross-CSI gotcha

--- a/docs/src/master1_etcd_disk_swap.md
+++ b/docs/src/master1_etcd_disk_swap.md
@@ -1,5 +1,135 @@
 # master1 etcd-Disk Swap Plan
 
-Moved to the vault: `~/vaults/claude/runbooks/home-ops/master1_etcd_disk_swap.md`
+Active plan to fix master1's degraded etcd performance by replacing
+the NVMe under `/`. Captured 2026-05-05 from a diagnostic session.
 
-See HOMELAB-SPEC Layer 2 #5: the vault is canonical for runbooks.
+## Why
+
+master1's etcd is the slow voter and the cause of intermittent
+apiserver timeouts on this cluster. Confirmed via Prometheus:
+
+| 10m p99 | master1 (192.168.1.9) | master2 (192.168.4.9) | master3 (192.168.4.10) |
+|---|---|---|---|
+| `etcd_disk_wal_fsync` | **31 ms** | 17 ms | 16 ms |
+| `etcd_disk_backend_commit` | **103 ms** | 29 ms | 27 ms |
+| `etcd_server_slow_apply_total` (cumulative) | **67,523** | 21,459 | 5,738 |
+
+Read latency on the same NVMe is sub-millisecond. The slowness is on
+the **sync-write path** (page cache doesn't help `fdatasync`). The
+suspected drive is `nvme1n1` — a budget HS1TBNVME M2 1TB at 41% wear,
+hosting the LVM root that contains `/var/lib/etcd`.
+
+Cluster has a leader, zero leader changes/hr, no failed proposals —
+etcd is stable but degraded. Apiserver-master1 takes the brunt
+because it always reads from local etcd.
+
+Unrelated note: `/dev/sdb` on master1 is in `XfsShutdown` state — a
+secondary SATA disk that fell off the bus. **Does not affect etcd**
+(verified: nothing on sdb is mounted; etcd lives on `/`, OSD-1 lives
+on `nvme0n1p1`, Longhorn lives on `nvme0n1p2`). Investigate on its
+own schedule.
+
+## Drive recommendation
+
+**Micron 7450 PRO 480 GB M.2 2280** (MTFDKBA480TFR-1BC1ZABYYR), ~$200 USD.
+
+Why this one:
+
+- M.2 2280 fits the most common slot (verify before ordering).
+- 480 GB is plenty for `/` + etcd (etcd DB is ~340 MB).
+- 1 DWPD, 800 TBW endurance — etcd will not wear it out.
+- Hardware power-loss-protection capacitors — the whole point.
+- Gen4×4, negotiates down to Gen3.
+
+Alternatives if master1 has an M.2 22110 slot (longer 110 mm form factor):
+
+- Samsung PM9A3 960 GB M.2 22110 (~$230–280)
+- Micron 7450 PRO 960 GB M.2 22110 (~$270–370)
+
+See conversation history for retailer links; pricing as of 2026-05-04.
+
+## Preflight (before ordering)
+
+1. **Confirm M.2 slot length on master1**: SSH and run `lspci -vv`,
+   or look at the board. 2280 vs 22110 changes the buy.
+2. **Confirm where `cs_master1-root` LVM actually sits**:
+
+   ```sh
+   pvs && vgs && lvs && lsblk
+   ```
+
+   This is to verify the hypothesis that `/var/lib/etcd` is on
+   `nvme1n1`. If it turns out to be on `nvme0n1` (the WD Blue), the
+   diagnosis changes — the issue would be NVMe contention with
+   Longhorn/Ceph rather than a slow drive. The fix would then be
+   different (move workloads, not the drive).
+3. **Identify what was on `/dev/sdb`**:
+
+   ```sh
+   cat /etc/fstab | grep sdb
+   blkid /dev/sdb              # may return nothing if device gone
+   dmesg -T | grep -E 'sd[ab]|ata|sata'
+   ```
+
+   This is independent of the etcd fix but should be cleaned up
+   eventually.
+
+## Replacement options
+
+Two paths once the drive arrives:
+
+### Option A — Reinstall fresh (recommended)
+
+Treat master1 as a control-plane replacement: drain, remove from
+cluster, reinstall the OS on the new NVMe, rejoin via `kubeadm join
+--control-plane`. Symmetrical to
+[Promote Worker to Control Plane](promote_worker_to_control_plane.md)
+— the same Phase 2/3/4 apply, just with master1 instead of worker2.
+
+Pros: clean state, drops accumulated cruft, validates the
+documented procedure.
+
+Cons: more downtime, more steps.
+
+### Option B — Clone LVM offline
+
+Boot master1 into rescue/live media, `dd` or `pvmove` the existing
+root LVM from `nvme1n1` to the new drive, update bootloader, reboot.
+
+Pros: faster, preserves config exactly.
+
+Cons: carries forward whatever cruft is on `/`; bootloader fiddling;
+no validation that the cluster's join procedure works.
+
+## Sequencing constraints
+
+Before doing either replacement option, confirm:
+
+1. **Cluster is otherwise healthy.** Same gating conditions as the
+   [Promote Worker to Control Plane](promote_worker_to_control_plane.md)
+   preconditions — etcd voter health, Ceph HEALTH_OK, no in-flight
+   long storage operations.
+2. **Etcd snapshot saved off-host.** See the Etcd snapshot section of
+   the same runbook.
+3. **Immich offsite seed finished 2026-05-05** (5-file sample
+   round-trip verified the same day). Paperless seed also finished
+   2026-05-05 (778 MiB across docs + DB). This gating constraint is
+   resolved — the drive swap no longer needs to coordinate around the
+   initial seed. See [`offsite_recovery.md`](offsite_recovery.md).
+
+## After master1 is fixed
+
+In order:
+
+1. **Verify the fix landed.** master1's etcd `slow_apply_total`
+   should grow at the same rate as the other voters over a 10-minute
+   window. If yes, the disk swap solved the etcd problem.
+2. **Investigate `BLUESTORE_SLOW_OP_ALERT` on OSD-1.** Separate
+   issue, on `nvme0n1`. Likely Longhorn ↔ Ceph contention on the same
+   drive. Quantify with `iostat` and Ceph perf counters before
+   deciding what to do.
+3. **Then promote worker2 as a control plane** per
+   [Promote Worker to Control Plane](promote_worker_to_control_plane.md),
+   retiring the VM master2.
+4. **Then repeat for master3** with another bare-metal worker, so all
+   three control planes live in independent failure domains.

--- a/docs/src/mcp_observability.md
+++ b/docs/src/mcp_observability.md
@@ -1,5 +1,242 @@
 # MCP Fleet Observability
 
-Moved to the vault: `~/vaults/claude/runbooks/home-ops/mcp_observability.md`
+The MCP fleet under `mcp-system` ships per-tool Prometheus metrics for the
+Class A backends we own (`memory-mcp`, `time-mcp`, `netbox-mcp`) plus
+Istio-sidecar RED metrics for everything else. Alerts and a Grafana
+dashboard sit on top.
 
-See HOMELAB-SPEC Layer 2 #5: the vault is canonical for runbooks.
+| | |
+|---|---|
+| **Dashboard** | `mcp-system` (Grafana folder `mcp`) |
+| **Recording rules + alerts** | `kubernetes/apps/mcp-system/observability/app/prometheusrule.yaml` |
+| **Per-backend ServiceMonitors** | `kubernetes/apps/mcp-system/<backend>/app/servicemonitor.yaml` |
+| **Dashboard JSON** | `kubernetes/apps/observability/grafana/dashboards/mcp-system.json` |
+| **Plan archive** | `~/.claude-personal/plans/on-a-plan-to-adaptive-ripple.md` (v5, 4-pass adversarial audit) |
+
+## What's instrumented today
+
+| Class | Backends | Layer |
+|---|---|---|
+| A — per-tool metrics | `memory-mcp`, `time-mcp`, `netbox-mcp` | App-level `prometheus-client` + `@track_tool` decorator + ServiceMonitor |
+| D — istio only | `chrome-mcp`, `arr-mcp`, `github-mcp`, `grafana-mcp`, `ha-mcp`, `immich-mcp`, `kubectl-mcp`, `omada-mcp`, `paperless-mcp`, `prometheus-mcp`, `searxng-mcp` | Envoy sidecar emits `istio_requests_total` per pod; no app-level work |
+
+Class B/C never materialized: a 2026-05-19 sweep found that none of the
+upstream third-party backends expose `/metrics` today
+(see `project_mcp_phase3_metrics_sweep.md`).
+
+## How to read the dashboard
+
+Two rows:
+
+**Row 1 — Fleet (istio sidecar)** covers all 14 backends. Inbound +
+outbound rate panels + 5xx panels by `destination_workload` and
+`source_workload`. Especially useful for `chrome-mcp` / `searxng-mcp`
+where the meaningful metric is whether the outbound HTTPS calls
+succeeded.
+
+**Row 2 — Per-backend (`@track_tool`)** is the deep view, gated by
+the `$backend` template variable. Panels query the normalized
+`mcp:tool_calls:rate5m{backend, ...}` / `mcp:tool_call_duration:p99_5m`
+recording rules, so adding a 4th Class A backend doesn't require panel
+edits — the variable enumerates from the recording rules.
+
+## Alerts
+
+Six alerts, six labels:
+
+| Alert | Tier | Routing | Fires when |
+|---|---|---|---|
+| `MCPBackendScrapeFailed{backend=memory}` | warning | Pushover | `absent(up{...memory-mcp} == 1) for: 15m` |
+| `MCPBackendScrapeFailed{backend=time}` | warning | Pushover | same, time-mcp |
+| `MCPBackendScrapeFailed{backend=netbox}` | warning | Pushover | same, netbox-mcp |
+| `MCPBackendHighErrorRate` | warning | Pushover | error/total > 10% for 10m AND volume > 0.05 calls/sec |
+| `MCPBackendHighLatency` | warning | Pushover | `max by (backend) (mcp:tool_call_duration:p99_5m) > 5s for: 10m` |
+| `MCPGatewayDown` | **critical** | `windmill-investigate` (HolmesGPT) → Pushover | `absent(up{...mcp-gateway-istio} == 1) for: 5m` |
+
+The error-rate volume gate (`> 0.05 calls/sec`) prevents a single
+errored tool call on a quiet backend from triggering a 100%-error
+page. The latency `for: 10m` rides through transient downstream
+spikes (Ollama warm-up, Postgres vacuum).
+
+## Adding a new MCP backend with metrics
+
+Three places to touch:
+
+**1. Upstream code (the backend's source repo).** Mirror the
+memory-mcp v0.1.4 template:
+
+```python
+# src/<backend>/metrics.py
+from prometheus_client import Counter, Histogram
+
+TOOL_CALLS_TOTAL = Counter(
+    "<backend>_mcp_tool_calls_total",
+    "Total tool calls into <backend>-mcp.",
+    labelnames=("tool", "status"),
+)
+TOOL_CALL_DURATION_SECONDS = Histogram(
+    "<backend>_mcp_tool_call_duration_seconds",
+    "Tool call latency in seconds.",
+    labelnames=("tool",),
+    buckets=(...),  # tune to expected latency
+)
+
+def track_tool(name): ...  # see memory_mcp/metrics.py
+```
+
+For backends with **many tools**, do not edit every `@mcp.tool()`
+manually. Add an `install_tracking(mcp)` helper that monkey-patches
+`mcp.tool` to wrap every subsequent registration (`netbox-mcp` does
+this — `rwlove/containers#20`).
+
+Register `/metrics` on the same FastMCP HTTP server via
+`mcp.custom_route("/metrics", methods=["GET"])`.
+
+Add `prometheus-client>=0.20.0,<1` to the project's dependencies.
+
+**Local test before pushing:**
+
+```sh
+python -c "import urllib.request; print(urllib.request.urlopen('http://localhost:<port>/metrics').read().decode()[:1000])"
+```
+
+Verify `# HELP <backend>_mcp_tool_calls_total ...` and `# TYPE`
+directives appear. Invoke each tool at least once; counters increment.
+
+**2. Cluster manifests.** Add to
+`kubernetes/apps/mcp-system/<backend>/app/`:
+
+```yaml
+# servicemonitor.yaml — clone time-mcp's verbatim, change name + selector
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: <backend>-mcp
+  labels:
+    app.kubernetes.io/name: <backend>-mcp
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: <backend>-mcp
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+  namespaceSelector:
+    matchNames:
+      - mcp-system
+```
+
+Add `./servicemonitor.yaml` to the app's `kustomization.yaml`
+resources list.
+
+**3. Recording rule group.** Append to
+`kubernetes/apps/mcp-system/observability/app/prometheusrule.yaml`:
+
+```yaml
+    - name: mcp.recording.<backend>.rules
+      interval: 1m
+      rules:
+        - record: mcp:tool_calls:rate5m
+          expr: sum by (tool, status) (rate(<backend>_mcp_tool_calls_total[5m]))
+          labels:
+            backend: <backend>
+        - record: mcp:tool_call_duration:p99_5m
+          expr: |
+            histogram_quantile(
+              0.99,
+              sum by (le, tool) (rate(<backend>_mcp_tool_call_duration_seconds_bucket[5m]))
+            )
+          labels:
+            backend: <backend>
+```
+
+After this lands, `MCPBackendHighErrorRate` and `MCPBackendHighLatency`
+automatically fan out to cover the new backend. **You must also add a
+new `MCPBackendScrapeFailed` alert** because each `absent()` clause
+needs its own selector (the per-backend split is the documented
+exception in the plan).
+
+**4. Optional: dashboard.** The `$backend` template variable
+auto-enumerates from `label_values(mcp:tool_calls:rate5m, backend)`, so
+the dashboard surfaces the new backend without JSON edits.
+
+## Silencing alerts during planned maintenance
+
+`silence-operator` (in the `observability` ns) translates declarative
+`Silence` CRs into AlertManager silences. For a planned maintenance
+window:
+
+```yaml
+apiVersion: observability.giantswarm.io/v1alpha2
+kind: Silence
+metadata:
+  name: mcp-maintenance-<short-description>
+  namespace: observability
+spec:
+  matchers:
+    - name: alertname
+      value: MCPBackendScrapeFailed
+      isRegex: false
+    - name: backend
+      value: netbox        # or omit for all backends
+      isRegex: false
+  comment: "Planned maintenance: <link / context>"
+  duration: 2h
+```
+
+Apply, do the work, delete the Silence (or let it expire).
+
+For the broader fleet you can match `namespace=mcp-system` instead of
+`alertname` — that catches `MCPGatewayDown` too.
+
+## Cardinality budget
+
+Per Class A backend (assuming ~10 tools, 11 latency buckets):
+
+- `_tool_calls_total{tool, status}`: 10 × 2 = **20 series**
+- `_tool_call_duration_seconds_*{tool, le}`: 10 × (12 buckets + sum + count) = **140 series**
+- Embedder (memory-mcp only, `_embed_*`): **17 series**
+- Total: **~177 series per backend**
+
+3 backends × 177 ≈ **530 series**. Plus istio sidecar's
+`istio_requests_total` + latency histograms — already scraped by
+the Istio control-plane SM, not new growth.
+
+Cluster Prometheus runs at several million series — adequate headroom
+for the next ~50 backends. **Do not** add high-cardinality labels
+(`user`, `session`, `request_id`, error messages, tool arguments).
+Those belong in log lines, not metric labels.
+
+## Why not Class C / fork upstream?
+
+The 2026-05-19 sweep checked `/metrics` on every third-party backend.
+All 9 returned 404. Three upstream repos (`jmtvms/tplink-omada-mcp`,
+`isokoliuk/mcp-searxng`, and an aplaceforallmystuff redirect) are gone
+from GitHub — only the published images remain on registries.
+
+For the remaining live upstream repos (`grafana/mcp-grafana`,
+`pab1it0/prometheus-mcp-server`, `rohitg00/kubectl-mcp-server`,
+`github/github-mcp-server`, `homeassistant-ai/ha-mcp`,
+`baruchiro/paperless-mcp`, `joeru/claw2immich`,
+`microsoft/playwright-mcp`), filing upstream issues is the
+documented next step **only if a specific operational pain triggers
+it** — not a checklist. The plan capped per-backend effort at 1
+upstream issue + 1 PR + 2-week wait, demote to Class D otherwise.
+
+For now: Istio sidecar's `istio_requests_total{destination_workload,
+response_code}` answers "is this backend serving traffic?" and "is it
+returning errors?" — the RED metrics. Per-tool granularity is the
+upgrade we'd buy by forking; not worth the ownership cost yet.
+
+## References
+
+- Source code (per-tool decorator + `/metrics` template):
+  - `/home/rwlove/workspace/memory-mcp/src/memory_mcp/metrics.py` (canonical async version)
+  - `/home/rwlove/workspace/containers/time-mcp/server.py` (sync variant)
+  - `/home/rwlove/workspace/containers/netbox-mcp/src/netbox_mcp_server/metrics.py` (auto-install variant)
+- AlertManager routing: `kubernetes/apps/observability/kube-prometheus-stack/app/alertmanagerconfig.yaml`
+- Cluster scrape-failure convention (origin of the `absent(up{} == 1)` pattern):
+  `kubernetes/apps/observability/exporters/snmp-exporter/app/apc-ups/prometheusrule.yaml`
+- Rollout PRs: home-ops #11741 (substrate), #11749 (Phase 1+2 cluster bumps), #11789 (Phase 5 alerts); rwlove/containers #19 (time-mcp v0.1.1), #20 (netbox-mcp v1.1.0)

--- a/docs/src/memory_mcp.md
+++ b/docs/src/memory_mcp.md
@@ -1,5 +1,141 @@
 # Memory MCP
 
-Moved to the vault: `~/vaults/claude/runbooks/home-ops/memory_mcp.md`
+`memory-mcp` is a knowledge-graph MCP server backed by Postgres + pgvector (vchord HNSW). It exposes entity / observation / relation tools to every MCP client in the cluster, so LangGraph agents, Claude Code sessions, Open WebUI tool callers, and HolmesGPT triage runs all share the same long-term memory substrate.
 
-See HOMELAB-SPEC Layer 2 #5: the vault is canonical for runbooks.
+| | |
+|---|---|
+| **Source repo** | <https://github.com/rwlove/memory-mcp> |
+| **Image** | `ghcr.io/rwlove/memory-mcp` (digest-pinned in the HelmRelease) |
+| **Manifests** | `kubernetes/apps/mcp-system/memory-mcp/` |
+| **Backend** | `postgres-langgraph-memory` CNPG cluster, schema `kg` |
+| **Tool prefix at the gateway** | `memory_` |
+
+## Architecture
+
+```text
+              ┌─ Claude Code (laptop) ──┐
+              │  + markdown auto-memory │  (per-project, parallel)
+              │  + memory_* MCP tools   │
+              └──────────┬──────────────┘
+                         │
+LangGraph agents ────────┤ ←  MCPMemoryStore(BaseStore) writes
+                         │     directly to kg.* via psycopg3
+Open WebUI / HolmesGPT ──┤
+                         │
+                         ▼
+            ┌──────────────────────────────┐
+            │  mcp-gateway (Envoy + Istio) │
+            └──────────────┬───────────────┘
+                           │ memory_* (toolPrefix)
+                           ▼
+            ┌──────────────────────────────┐
+            │  memory-mcp  (FastMCP)       │
+            │  streamable-http :8070       │
+            └──────────────┬───────────────┘
+                           │ psycopg / asyncpg
+                           ▼
+            ┌──────────────────────────────┐
+            │ postgres-langgraph-memory    │
+            │ pgvector + vchordrq HNSW     │
+            │ database: langgraph_memory   │
+            │ schema:   kg                 │
+            └──────────────────────────────┘
+```
+
+LangGraph agents bypass the MCP transport — they speak direct SQL to the same `kg.*` schema via `MCPMemoryStore(BaseStore)`. The two write paths converge on identical rows.
+
+## Schema
+
+Three tables under the `kg` schema:
+
+```sql
+kg.entities      (id, name UNIQUE, type, namespace, source JSONB,
+                  created_at, updated_at)
+kg.observations  (id, entity_id, content, embedding vector(768),
+                  source JSONB, created_at, deleted_at)
+kg.relations     (id, from_entity, to_entity, type, source JSONB,
+                  created_at, UNIQUE (from_entity, to_entity, type))
+```
+
+Indexes: `kg_obs_embedding_hnsw` using `vchordrq (embedding vector_cosine_ops)` for semantic search; per-column indexes on entity type + namespace.
+
+Embedding model is `nomic-embed-text` (768 dimensions). The model must be resident on Ollama — see [Ollama /api/embed reference](./offsite_recovery.md) for the pull procedure (`POST /api/pull` with `{"model": "nomic-embed-text", "stream": false}`).
+
+**Soft delete only.** `memory_delete_observation` sets `deleted_at = now()`, never DROPs. The principle is "don't silently delete memories across namespaces" — observation history stays inspectable even after a logical delete.
+
+## Tool surface (12 tools, prefix `memory_`)
+
+| Tool | Purpose |
+|------|---------|
+| `create_entity` | Create node + initial observations |
+| `add_observation` | Append observation to existing entity |
+| `get_entity` | Fetch by name + (optionally) one-hop relations |
+| `list_entities` | Enumerate, filterable by type / namespace |
+| `update_entity` | Rename / retype / re-namespace; relations survive via id-based join |
+| `update_observation` | Replace content + re-embed in place |
+| `delete_observation` | Soft delete (`deleted_at`) |
+| `create_relation` | Typed directed edge between two entities |
+| `link` | Sugar for `create_relation` (default type `related_to`) |
+| `search` | Hybrid (semantic via vchord cosine, keyword via ILIKE) |
+| `graph_walk` | BFS to depth N (cap 4) from a start entity |
+| `recent` | Most-recent observations, filterable by agent / since / entity |
+| `create_entities` | Transactional bulk-create |
+| `add_observations` | Transactional bulk-append |
+
+## Namespace conventions
+
+Two distinct namespacings live in this schema:
+
+1. **`entities.namespace`** — caller-supplied free-form grouping (e.g. `infra`, `cluster`, `software`, `people`). Filter via `memory_list_entities(namespace_filter=...)` or `memory_search(namespace_filter=...)`.
+2. **`langgraph/*` prefix** — entities created by `MCPMemoryStore` (the LangGraph BaseStore adapter) all live under `langgraph/{ns0}/{ns1}/...`, where the LangGraph `namespace: tuple[str, ...]` becomes the path. Their `type` is always `langgraph-store-item`. This keeps fleet writes visually separated from human-seeded entries (host/cnpg/service/etc.) when other agents query the graph.
+
+## Provenance
+
+Every write carries a `source` JSONB. Server stamps `at: ISO8601` if the caller didn't. Conventions:
+
+| Caller | Minimum source |
+|--------|----------------|
+| Claude Code | `{"agent": "claude-code", "claude_namespace": "<encoded-cwd>"}` |
+| LangGraph fleet (via MCPMemoryStore) | `{"agent": "langgraph", "store": "MCPMemoryStore"}` (set automatically) |
+| Open WebUI tool calls | `{"agent": "open-webui"}` |
+| HolmesGPT | `{"agent": "holmesgpt"}` |
+
+A `memory_recent(agent_filter="claude-code")` query shows just one agent's recent contributions.
+
+## Observability
+
+`/metrics` exposes Prometheus scrape data:
+
+- **Process / GC collectors** (CPU, RSS, fd count, GC pauses) — `prometheus_client` defaults.
+- **`memory_mcp_tool_calls_total{tool, status}`** — counter per tool, status ∈ {success, error}. Tool-level negative responses (entity not found etc.) count as success.
+- **`memory_mcp_tool_call_duration_seconds{tool}`** — histogram, buckets `0.01..30s`.
+- **`memory_mcp_embed_calls_total{status}`** — embedding requests, status ∈ {success, empty, error}.
+- **`memory_mcp_embed_call_duration_seconds`** — embed latency histogram.
+
+A `ServiceMonitor` in `mcp-system` scrapes `/metrics` every 30s. This is currently the only instrumented MCP backend in the cluster — see [`project_todo_mcp_layer_observability_gap`](https://github.com/rwlove/home-ops) for fleet-wide rollout context.
+
+Probes:
+
+- **`/healthz`** — process up + Postgres `SELECT 1`. Used by liveness + startup probes.
+- **`/readyz`** — `/healthz` plus Ollama `/api/tags` reachable. Used by readiness probe; returns 503 if Ollama is degraded, dropping the pod from the Service rotation until embeddings work again.
+
+## Schema migrations
+
+The server **does not** apply schema. A one-shot `Job` (`memory-mcp-schema-init`) under the same Kustomization runs `psql -f /sql/schema.sql` on every Flux reconcile. All DDL is idempotent (`CREATE IF NOT EXISTS`), so re-runs are no-ops.
+
+**Job gotcha:** Kubernetes `Job.spec.template` is immutable. Editing the `command` field (e.g. the diagnostic echo) without bumping the schema-init annotation or deleting the existing Job will deadlock Flux with `field is immutable`. Recovery: `kubectl delete job memory-mcp-schema-init -n mcp-system` and let Flux recreate.
+
+## Troubleshooting
+
+| Symptom | First check |
+|---------|-------------|
+| Semantic search returns nothing | `kubectl exec memory-mcp-... -- curl http://ollama.ai.svc:11434/api/embed -d '{"model":"nomic-embed-text","input":"x"}'` — 404 = model not pulled |
+| Pod `CrashLoopBackOff` on startup | Pod logs for `kg.<table> missing` — schema-init Job hasn't completed yet (or failed) |
+| Flux Kustomization stuck on `field is immutable` | Job-template change without delete; see Schema migrations above |
+| Embed counter `error` spiking | Ollama unreachable or model unloaded; `/readyz` will already be 503 |
+| Search returns 0 for a query that obviously matches | Run with `mode=keyword` to isolate. If keyword finds it but hybrid doesn't, semantic is broken (Ollama). |
+
+## See also
+
+- [Offsite Recovery (Postgres restore)](./offsite_recovery.md) — for `postgres-langgraph-memory` backup recovery (Barman → Garage).
+- The [project_memory_mcp_phase0_done memory entry](https://github.com/rwlove/home-ops) records the rollout history (Phases 0-3) including v0.1.x bumps + Phase 1 seed.

--- a/docs/src/offsite_recovery.md
+++ b/docs/src/offsite_recovery.md
@@ -1,5 +1,225 @@
 # Offsite Recovery — Immich and Paperless
 
-Moved to the vault: `~/vaults/claude/runbooks/home-ops/offsite_recovery.md`
+Restoring Immich or Paperless from the offsite Glacier Deep Archive backups.
+Both apps follow the same shape: documents/photos in `crypt:media` (or
+`crypt:data` + `crypt:external` for Immich), CNPG/Barman database backups in
+`crypt:db`. The crypt overlay encrypts everything before it lands in S3 — the
+crypt passphrase from 1Password is the only thing that makes the backup
+recoverable. **Lose both 1Password and the cluster, and the backup is opaque
+ciphertext.**
 
-See HOMELAB-SPEC Layer 2 #5: the vault is canonical for runbooks.
+The buckets:
+
+| App | S3 bucket | 1Password item |
+|---|---|---|
+| Immich | `lovenet-immich-offsite-backup` | `immich-offsite-backup` |
+| Paperless | `lovenet-paperless-offsite-backup` | `paperless-offsite-backup` |
+
+## Prerequisites for any restore
+
+- AWS credentials with read access to the bucket (the same keys stored in the
+  1Password item, or any IAM principal that can `s3:GetObject` /
+  `s3:RestoreObject`).
+- The crypt passphrases (`RCLONE_CRYPT_PASSWORD` + `RCLONE_CRYPT_PASSWORD2`) from
+  1Password.
+- A working `rclone` somewhere — laptop, recovery box, or in-cluster pod.
+- For database restore: a CNPG cluster on the destination (existing or fresh).
+
+## Choosing a recovery scenario
+
+| Scenario | What survived | What to do |
+|---|---|---|
+| A — Cluster destroyed, NFS + Longhorn intact | All PVCs and Garage backups | Rebuild cluster, reattach PVs, restart apps. **Skip offsite restore entirely.** |
+| B — NFS/Longhorn destroyed, cluster intact | Postgres-in-Garage may also be destroyed if Garage was on the failed storage | Thaw S3, restore files to new PVCs, restore DB via Barman from S3 |
+| C — Total loss (cluster + storage) | Only S3 | Bootstrap new cluster per `cluster_rebuild.md`, then follow Scenario B |
+
+Most "disaster" cases are actually Scenario A in disguise. Don't reach for the
+offsite copy unless the local data is genuinely gone.
+
+## Scenario B and C — restoring from S3
+
+### Step 1: Thaw the Glacier Deep Archive objects
+
+Lifecycle moves objects to Deep Archive after 1 day. Anything older than that is
+cold-stored and takes 12+ hours (Standard tier) or ~48 hours (Bulk) to thaw.
+
+Bulk-restore everything in the bucket:
+
+```sh
+# Immich
+aws s3api list-objects-v2 --bucket lovenet-immich-offsite-backup \
+    --query 'Contents[?StorageClass==`DEEP_ARCHIVE`].Key' \
+    --output text \
+  | tr '\t' '\n' \
+  | while read -r KEY; do
+      aws s3api restore-object \
+        --bucket lovenet-immich-offsite-backup \
+        --key "$KEY" \
+        --restore-request '{"Days":7,"GlacierJobParameters":{"Tier":"Standard"}}'
+    done
+
+# Paperless — same pattern, swap the bucket name
+```
+
+Tier choice: **Standard** for a real recovery (12h, ~$0.01/GB). **Bulk** if the
+event isn't urgent (48h, ~$0.0025/GB). For a 2.5 TB Immich library Bulk saves
+~$20.
+
+Wait until `aws s3api head-object --bucket … --key … --query Restore` returns
+`ongoing-request="false"`.
+
+### Step 2: Stand up a temporary rclone with the right config
+
+In-cluster pod is easiest because the existing offsite-backup secret already has
+the rclone.conf. If the cluster is gone, recreate the rclone.conf locally from
+the 1Password item — same format as in
+`kubernetes/apps/{media,collab}/{immich,paperless}/app/externalsecret-offsite-backup.yaml`.
+
+```sh
+# Local recovery — reconstruct rclone.conf
+cat > /tmp/rclone.conf <<'EOF'
+[s3]
+type = s3
+provider = AWS
+access_key_id = <AWS_ACCESS_KEY_ID from 1Password>
+secret_access_key = <AWS_SECRET_ACCESS_KEY from 1Password>
+region = us-east-1
+
+[crypt]
+type = crypt
+remote = s3:lovenet-immich-offsite-backup
+filename_encryption = standard
+directory_name_encryption = true
+password = <RCLONE_CRYPT_PASSWORD from 1Password>
+password2 = <RCLONE_CRYPT_PASSWORD2 from 1Password>
+EOF
+chmod 0600 /tmp/rclone.conf
+export RCLONE_CONFIG=/tmp/rclone.conf
+
+# Sanity: list the encrypted root — should show "data", "external", "db" for Immich
+rclone lsd crypt:
+```
+
+### Step 3: Restore the files
+
+Immich (NFS-backed in normal operation; choose any RWX target on recovery):
+
+```sh
+rclone copy crypt:data    /restore/immich/data    --transfers=8 --progress
+rclone copy crypt:external /restore/immich/external --transfers=8 --progress
+```
+
+Paperless (Longhorn-backed in normal operation; restore into a fresh
+`paperless-library-pvc`):
+
+```sh
+rclone copy crypt:media /restore/paperless/library/media/documents --transfers=8 --progress
+```
+
+The thumbnails were excluded from backup. Paperless will regenerate them
+automatically once the app starts and reindexes; nothing to do.
+
+### Step 4: Restore the database via Barman
+
+The `crypt:db` tree mirrors what CNPG/barman-cloud writes to Garage. Push it
+back into a new Garage bucket (or any S3-compatible target) and point a new
+CNPG cluster at it.
+
+#### 4a. Sync the encrypted DB backup back to a recoverable S3 location
+
+```sh
+# In the recovered cluster, after Garage is back up:
+rclone copy crypt:db garage-recovered:postgres-immich-backup
+```
+
+If the cluster is fresh, you can also use AWS S3 directly as the Barman source
+during restore by adding a temporary `[s3-recovery]` remote in rclone.conf and
+syncing decrypted contents to a regular bucket. Garage is preferred because
+that's where the existing CNPG `ObjectStore` resources point.
+
+#### 4b. Bootstrap a new CNPG cluster from the backup
+
+Edit the CNPG `Cluster` manifest (e.g.
+`kubernetes/apps/databases/cloudnative-pg/config/immich/cluster.yaml`) to add a
+`bootstrap.recovery` section pointing at the Barman ObjectStore:
+
+```yaml
+spec:
+  bootstrap:
+    recovery:
+      source: postgres-immich-backup
+  externalClusters:
+    - name: postgres-immich-backup
+      plugin:
+        name: barman-cloud.cloudnative-pg.io
+        parameters:
+          serverName: postgres-immich
+          barmanObjectName: garage-immich
+```
+
+Or, for a clean new cluster name (recommended — avoids any race with a
+half-existing cluster of the same name):
+
+```yaml
+metadata:
+  name: postgres-immich-restored
+spec:
+  bootstrap:
+    recovery:
+      source: postgres-immich-backup
+      # Optional: target a specific point in time
+      # recoveryTarget:
+      #   targetTime: "2026-05-04 18:00:00+00"
+```
+
+Apply, wait for the cluster to come up, verify with `kubectl cnpg status -n
+databases postgres-immich-restored`. Then point the immich helmrelease at the
+new cluster name and reconcile.
+
+For paperless: same procedure, swapping `immich` for `paperless` everywhere.
+
+### Step 5: Bring the app up against restored data
+
+Immich:
+
+1. Update `kubernetes/apps/media/immich/app/nfs-pvc.yaml` if the NFS path
+   changed (the PV's `nfs.path` and `nfs.server`).
+2. Make sure `immich-secret` still has valid `DB_*` env vars matching the new
+   CNPG cluster.
+3. Reconcile the immich kustomization. Immich will reindex thumbnails / ML
+   embeddings on first run — expect significant CPU load for hours.
+
+Paperless:
+
+1. PVC bound to fresh Longhorn volume containing the restored
+   `library/media/documents/`.
+2. CNPG cluster restored, paperless-secret pointing at it.
+3. Reconcile. Paperless regenerates thumbnails on first display; OCR /
+   classifier indexes are restored from the DB.
+
+### Step 6: Verify
+
+- Immich: log in, browse a known album. Spot-check that EXIF dates, faces, and
+  user edits survived (those are DB-backed).
+- Paperless: search for a known document. Confirm tags, correspondents, custom
+  fields, and OCR text are present.
+- Both: trigger a fresh offsite-backup CronJob run manually
+  (`kubectl create job --from=cronjob/<name> ...`) to confirm the next
+  scheduled cycle will work cleanly.
+
+## What to do *before* you need this
+
+- Run the offsite backup at least once weekly per app — both CronJobs are
+  scheduled `@weekly` already.
+- Periodically (~quarterly) thaw a single small object via
+  `aws s3api restore-object` and verify rclone+crypt can decode it. Both the
+  Immich data path (2.5 TB, 5-file sample round-trip) and the Paperless data
+  path (778 MiB across docs + DB) were validated 2026-05-05.
+- Keep the 1Password vault backed up independently. If 1Password is also
+  destroyed, the encrypted S3 contents are unrecoverable.
+
+## Related
+
+- `cluster_rebuild.md` — bootstrapping a fresh cluster from this repo
+- `immich_cnpg.md` — Immich's *built-in* DB export format restore (different
+  format than Barman; only applies when an export was taken from inside Immich)

--- a/docs/src/p40.md
+++ b/docs/src/p40.md
@@ -1,5 +1,171 @@
 # NVIDIA Tesla P40
 
-Moved to the vault: `~/vaults/claude/runbooks/home-ops/p40.md`
+24 GiB Pascal (sm_61) accelerator passed through to one Kubernetes node, time-sliced across multiple AI workloads.
 
-See HOMELAB-SPEC Layer 2 #5: the vault is canonical for runbooks.
+## Overview
+
+A single Tesla P40 lives in slot 6 of [`beast`][beast] (a Dell R730 hypervisor, not itself a k8s node), passed through via VFIO to the `worker8` VM. `worker8` joins the cluster as a normal worker node; the P40 is exposed to pods as `nvidia.com/gpu` resources, time-sliced 8 ways by the NVIDIA GPU Operator.
+
+[beast]: https://github.com/rwlove/home-ops/blob/main/README.md#-hardware
+
+## Hardware
+
+| Field | Value |
+| --- | --- |
+| Card | NVIDIA Tesla P40 |
+| Architecture | Pascal (`sm_61`) |
+| VRAM | 24,576 MiB |
+| Host | `beast` (Dell R730, slot 6, PCIe 3.0 x16) |
+| Consumer VM | `worker8` (CentOS Stream 9) |
+| PCI passthrough | VFIO via `vfio-pci.ids=10de:1b38` |
+| Cluster resource | `nvidia.com/gpu` (8× time-sliced replicas) |
+
+## Host (beast) — PCI passthrough
+
+1. Append to `GRUB_CMDLINE_LINUX` in `/etc/default/grub`:
+
+   ```text
+   intel_iommu=on pci-stub.ids=10de:1b38
+   ```
+
+2. Register the VFIO driver for the device:
+
+   ```sh
+   grubby --add-kernel "$(grubby --default-kernel)" \
+     --copy-default \
+     --args=vfio_pci.ids=10de:1b38 \
+     --title "Default kernel with vfio_pci" \
+     --make-default
+   ```
+
+3. Reboot.
+
+4. In `virt-manager` for the `worker8` VM: **Add Hardware → PCI Host Device** → select the P40.
+
+Reference: [IBM PCI passthrough docs](https://www.ibm.com/docs/en/linux-on-systems?topic=through-pci).
+
+## VM (worker8) — driver installation
+
+Driver install on `worker8` is **manual** today, not operator-managed. The NVIDIA GPU Operator does not ship precompiled driver containers for CentOS Stream 9, and source-build mode needs entitled `kernel-devel` packages. Driver installation will flip to operator-managed when `worker8` is rebuilt onto a supported OS (deferred until a second GPU node arrives).
+
+### Blacklist `nouveau`
+
+```sh
+echo "blacklist nouveau" > /etc/modprobe.d/blacklist-nouveau.conf
+```
+
+Comment out the `nvidia` `OutputClass` section in `/etc/X11/xorg.conf.d/10-nvidia.conf`, then reboot.
+
+### Install the proprietary driver
+
+The P40 is Pascal — it **requires the proprietary closed driver**. Open kernel modules don't support sm_61.
+
+```sh
+dnf config-manager --add-repo \
+  "http://developer.download.nvidia.com/compute/cuda/repos/rhel9/$(uname -i)/cuda-rhel9.repo"
+
+dnf module install nvidia-driver:580-dkms
+```
+
+(`580` is the current branch; bump as newer LTS branches land.)
+
+Verify with `nvidia-smi`. The GPU should report 24 GiB and `sm_61`.
+
+## Cluster integration — NVIDIA GPU Operator
+
+Everything above the kernel driver is managed declaratively by the GPU Operator HelmRelease at [`kubernetes/apps/kube-system/gpu-operator/app/helmrelease.yaml`](https://github.com/rwlove/home-ops/blob/main/kubernetes/apps/kube-system/gpu-operator/app/helmrelease.yaml).
+
+| Component | State | Notes |
+| --- | --- | --- |
+| `driver.enabled` | **false** | Manual driver retained on worker8 until OS rebuild |
+| `toolkit.enabled` | true | Operator installs `nvidia-container-toolkit` into `/usr/local/nvidia` |
+| `devicePlugin.enabled` | true | Operator manages the device plugin (replaces the standalone HelmRelease that previously lived here) |
+| `dcgmExporter.enabled` | true | Prometheus scrape via `ServiceMonitor` |
+| `gfd.enabled` | true | GPU Feature Discovery labels worker8 with `nvidia.com/gpu.*` |
+| `nodeStatusExporter` | true | Surfaces operator state |
+| `mig.strategy` | `none` | MIG is a Hopper/Ampere feature; not applicable to Pascal |
+| `migManager.enabled` | false | Same |
+
+### Time-slicing
+
+The single P40 is exposed to the scheduler as **8 replicas** of `nvidia.com/gpu` via the `gpu-operator-time-slicing-config` ConfigMap at [`timeslicing-config.yaml`](https://github.com/rwlove/home-ops/blob/main/kubernetes/apps/kube-system/gpu-operator/app/timeslicing-config.yaml):
+
+```yaml
+sharing:
+  timeSlicing:
+    renameByDefault: false
+    failRequestsGreaterThanOne: false
+    resources:
+      - name: nvidia.com/gpu
+        replicas: 8
+```
+
+Time-slicing multiplexes **compute**, not memory. The 24 GiB VRAM is one shared pool — pods don't get a memory partition. Sizing your VRAM budget across resident workloads matters more than the replica count.
+
+### Workload-side request
+
+Workloads request a GPU via the standard resource pattern:
+
+```yaml
+resources:
+  limits:
+    nvidia.com/gpu: 1
+```
+
+`failRequestsGreaterThanOne: false` means asking for more than 1 is allowed but the time-slicing config caps the effective concurrency at 8.
+
+## Pascal (sm_61) constraints
+
+The P40 is on the wrong side of two recent NVIDIA upstream breaks:
+
+1. **PyTorch ≥ 2.7 + cu128 dropped sm_61.** Anything pinned to a torch 2.7+ wheel won't run on the P40. immich-pet-tagger is the canonical example: the cluster pulls the [`rwlove/immich-pet-tagger:v1.2.0-p40` fork](https://github.com/rwlove/immich-pet-tagger) which is pinned to torch 2.6.0+cu124. Drop this fork the day a non-Pascal GPU joins the cluster.
+2. **Open kernel modules are Volta-or-newer.** `useOpenKernelModules: true` will silently fail on Pascal. Keep the proprietary driver.
+
+When `worker8` is rebuilt onto Ubuntu 24.04 LTS (DGX-aligned), `driver.enabled` flips to `true` for that node only — Spark (Blackwell) and any future cards can use the open module variant via `nodeSelector`-scoped operator config.
+
+## Workloads currently using the P40
+
+Steady-state VRAM ~14.5 GiB used out of 24 GiB. Most consumers are resident; ComfyUI and AV1 transcodes spike on demand.
+
+| Workload | Behavior | Approx VRAM |
+| --- | --- | --- |
+| Ollama (Qwen 2.5 7B/14B, embeddings) | Resident; idles down on keep-alive timeout | 5–9 GiB |
+| Immich machine-learning (CLIP + face recognition) | Resident | ~4 GiB |
+| Whisper STT (`wyoming-services`, `large-v3-turbo` preloaded) | Resident | ~1.6 GiB |
+| ComfyUI (SD checkpoints / Flux fp8) | On-demand | 2–16 GiB |
+| Frigate GenAI captions (`gemma3:4b` via Ollama) | On-demand | ~3 GiB |
+| `immich-pet-tagger` (Pascal fork) | On-demand | varies |
+| `pump-cv` (yolov8m-pose, cuda:0) | Resident | ~1.5 GiB |
+| `av1corrector` (NVENC) | On-demand during transcode | ~0.2 GiB |
+
+## Monitoring
+
+DCGM-exporter ships GPU metrics into Prometheus. The standard NVIDIA GPU dashboards (DCGM `0_0_1`) work in Grafana once the data source is wired up. Watch:
+
+- `DCGM_FI_DEV_GPU_UTIL` — compute utilization
+- `DCGM_FI_DEV_FB_USED` — VRAM in use (the steady-state ceiling matters more than utilization)
+- `DCGM_FI_DEV_GPU_TEMP` — important for fan control discussion below
+
+Alerts are defined in [`monitoring/alerts.yaml`](https://github.com/rwlove/home-ops/blob/main/kubernetes/apps/kube-system/gpu-operator/app/monitoring/alerts.yaml).
+
+## Tools
+
+- [`nvidia-htop`](https://github.com/peci1/nvidia-htop) — improved `nvidia-smi` with per-process detail.
+- `nvidia-smi --query-gpu=memory.used --format=csv -l 5` — quick VRAM watch.
+- `dcgmi diag -r 1` — quick self-test via DCGM (requires running on the host with the driver).
+
+## Fan control
+
+The R730xd doesn't natively recognize the P40, so its default fan curve is incorrect under sustained GPU load. Below are workarounds — **none of them implemented in this cluster yet**:
+
+- [IPMI Fan Control (DrSpeedy)](https://github.com/DrSpeedy/ipmi_fancontrol-ng)
+- [Fan control script (fragtion)](https://gist.github.com/fragtion/92ab3b33cfbaccb8e70037fb4f1b6c42)
+- [iDRAC7 fan control (brezlord)](https://github.com/brezlord/iDRAC7_fan_control)
+
+Today the GPU is well within thermal envelope on the cluster's typical workloads; fan control becomes interesting when sustained Flux / fine-tuning workloads are added.
+
+## Roadmap
+
+- **Second GPU node (Spark / NVIDIA Ascent GX10)** is the trigger for re-evaluating worker8's OS and driver path. See the GPU upgrade decision in memory.
+- **worker8 OS rebuild** to Ubuntu 24.04 LTS will flip `driver.enabled` to `true` for that node and let the operator manage the entire stack end-to-end. Deferred until two GPU nodes makes standardization worth the rebuild churn.
+- **Drop the `immich-pet-tagger` Pascal fork** the day a non-Pascal GPU joins the cluster.

--- a/docs/src/power-outage.md
+++ b/docs/src/power-outage.md
@@ -1,5 +1,35 @@
 # Whole-home power outage / cold-start recovery
 
-Moved to the vault: `~/vaults/claude/runbooks/home-ops/power-outage.md`
+After a full power outage where every node power-cycled at once, `kube-vip` may fail to come up cleanly — its static-pod manifest depends on the control-plane VIP (`192.168.6.1`) being reachable, but the VIP itself is owned by `kube-vip`. Chicken-and-egg.
 
-See HOMELAB-SPEC Layer 2 #5: the vault is canonical for runbooks.
+The fix: manually attach the VIP to `master1`'s physical interface so the apiserver becomes reachable. Once apiserver is up, `kube-vip` reconciles and re-takes ownership of the VIP automatically.
+
+## Recovery
+
+SSH into `master1` and add the VIP to the primary interface:
+
+```sh
+ssh root@master1.${SECRET_DOMAIN}
+ip addr add 192.168.6.1/32 dev $(ip -br -4 route show default | awk '{print $5}')
+```
+
+The interface auto-detection picks whatever holds the default route — currently `enp0s31f6` on master1, but the detection makes this resilient to NIC swaps and OS rebuilds.
+
+Confirm it stuck:
+
+```sh
+ip -br -4 addr show | grep 192.168.6.1
+curl -k https://192.168.6.1:6443/healthz   # apiserver responds
+```
+
+Within ~60 seconds, `kube-vip` pods should come up and you can delete the temporary VIP — or just leave it; `ip addr add` is non-persistent and disappears on the next reboot.
+
+## Why it happens
+
+- `kube-vip` runs as a static pod on each control-plane node, managed by kubelet, not by the apiserver.
+- It uses [BGP ECMP via Cilium](https://github.com/rwlove/home-ops/tree/main/kubernetes/apps/network/cilium) in this cluster, but during cold boot the VIP attach can race against kubelet bringing up the static pod.
+- Once the VIP is up *anywhere*, every node's kubelet can talk to the apiserver and the rest cascades.
+
+## Related
+
+- [Cluster Rebuild](cluster_rebuild.md) — for the case where the cluster genuinely needs to be reinitialized rather than just nudged.

--- a/docs/src/promote_worker_to_control_plane.md
+++ b/docs/src/promote_worker_to_control_plane.md
@@ -1,5 +1,345 @@
 # Promote a Worker to a Schedulable Control Plane
 
-Moved to the vault: `~/vaults/claude/runbooks/home-ops/promote_worker_to_control_plane.md`
+End-to-end procedure for converting a bare-metal worker into a third
+(or replacement) control-plane node, while removing an existing
+control plane (typically a VM master that needs to retire).
 
-See HOMELAB-SPEC Layer 2 #5: the vault is canonical for runbooks.
+The worked example below promotes `worker2.${SECRET_DOMAIN}` and
+retires the VM `master2.${SECRET_DOMAIN}`. Substitute names freely —
+nothing in the procedure is specific to those hosts.
+
+## Why this exists
+
+The control plane in this cluster runs three etcd voters. When two of
+those live on the same physical host (e.g. master2 + master3 as VMs on
+one box), one hardware failure costs you etcd quorum. Promoting a
+bare-metal worker into the control-plane pool fixes that without
+changing the etcd voter count.
+
+The promoted node stays **schedulable** — control-plane and worker
+roles are stacked on the same host, the same way master1 already runs
+in this cluster.
+
+## What you need to know first
+
+This cluster is **kubeadm + kube-vip + cri-o + Cilium** on CentOS
+Stream. Relevant facts:
+
+- Control-plane VIP is `192.168.6.1:6443` (kube-vip). Clients keep
+  their kubeconfigs unchanged through this whole procedure.
+- kube-vip is a static pod under `/etc/kubernetes/manifests/kube-vip.yaml`
+  on every control-plane node. New control planes need this file
+  themselves; see `init/kube-vip.sh` for the canonical generator.
+- kubelet-csr-approver is running, so node CSRs auto-approve. Manual
+  approval (`init/approve-csrs.sh`) is the fallback.
+- `kubeadm-config` ConfigMap in `kube-system` carries the list of
+  control-plane endpoints. Old members must be removed from it.
+
+## Hostname strategy
+
+"Convert worker2 to master2" can mean two things. **Default to (a)**
+unless you have a concrete reason to rename:
+
+- **(a) Promote in place.** Keep the hostname (`worker2.${SECRET_DOMAIN}`).
+  The `master`/`worker` prefix is purely cosmetic; the
+  `node-role.kubernetes.io/control-plane` label is what matters.
+- **(b) Rename to `masterN.${SECRET_DOMAIN}`.** Requires
+  regenerating client certs, a new etcd member name, a new kube-vip
+  pod identity, and DNS coordination. High risk, no functional gain.
+
+The procedure below assumes **(a)**.
+
+## Preconditions
+
+Do not start until all of these are true:
+
+1. **Surviving etcd voters are healthy as voters.** This is the load-bearing
+   check, because Phase 1 takes you to a 2/2 etcd quorum. What matters is
+   *write performance*, not just "is the node Ready":
+   - On each surviving control-plane node, the etcd container should
+     show no recent `apply request took too long` or `waiting for
+     ReadIndex response took too long` warnings:
+
+     ```sh
+     kubectl -n kube-system logs etcd-<node> --since=1h \
+       | grep -E 'took too long|ReadIndex'
+     ```
+
+     A handful per hour is normal; sustained streams mean the voter is
+     limping and you should not start the procedure.
+   - On each surviving control-plane node, check disk latency on the
+     device hosting `/var/lib/etcd` (often the OS LVM root, *not*
+     necessarily the same disk as Longhorn or Ceph): `iostat -xz 5` and
+     watch `await`/`%util`. Sustained `await` > a few ms on the etcd
+     device is a problem; etcd wants single-digit-ms fsync.
+   - A failed *secondary* disk on a control-plane node (e.g. a SATA
+     drive that dropped off the bus while etcd lives on NVMe) is not
+     an automatic blocker — but check whether the failure is causing
+     bus resets or kernel I/O retries that bleed into the etcd device.
+2. **Ceph is HEALTH_OK.** Slow-OSD alerts on a control-plane node may
+   *or may not* indicate disk failure (Ceph and Longhorn often share an
+   NVMe — contention can produce slow ops without a dying disk). Either
+   way, do not stack: an unhealthy Ceph plus a transient 2-voter window
+   plus an OSD coming out for the worker drain is too many concurrent
+   degradations.
+3. **No long-running storage operations are in flight** that touch the
+   worker being drained — e.g. an Immich offsite seed, a CNPG full
+   backup, a Longhorn rebuild.
+4. **Etcd snapshot saved off-host.** See [Etcd snapshot](#etcd-snapshot)
+   below.
+5. **Decision made on the retiring control plane.** Either remove it
+   first (briefly run on 2 voters), or defer it until after the new
+   control plane is healthy (briefly run on 4 voters). Removing first
+   is preferred — a 4-member etcd adds a write-quorum cost without
+   improving fault tolerance.
+6. **Kubelet/kubeadm version match.** Confirm the worker's kubelet
+   and kubeadm packages match what's currently on the control plane.
+   Mismatched skew causes join to fail mid-handshake.
+7. **Firewalld is disabled** on the worker (per cluster policy —
+   firewalld silently drops kubelet traffic post-reboot).
+
+## Etcd snapshot
+
+Take from a healthy member (typically the leader; identify with
+`etcdctl endpoint status --cluster`):
+
+```sh
+kubectl -n kube-system exec etcd-master1.${SECRET_DOMAIN} -- \
+  etcdctl --endpoints=https://127.0.0.1:2379 \
+  --cacert=/etc/kubernetes/pki/etcd/ca.crt \
+  --cert=/etc/kubernetes/pki/etcd/peer.crt \
+  --key=/etc/kubernetes/pki/etcd/peer.key \
+  snapshot save /var/lib/etcd-backup/pre-cp-swap-$(date +%F).db
+```
+
+Copy the snapshot off the host before continuing.
+
+## Audit what the worker is carrying
+
+Before you drain, inventory anything hardware-pinned or
+single-replica:
+
+- **USB devices** (Z-Wave dongles, etc.) attached to the worker
+  pin pods to it via NFD `usb-*` feature labels. The hardware stays
+  with the box; if you reuse the box for control plane, those pods
+  return after rejoin. If you physically move the box, plan to move
+  the dongles too.
+- **GPU resources** (`gpu.intel.com/i915`, NVIDIA, Coral) — same
+  story: stay with the box, re-published after rejoin.
+- **Custom node labels** (`node.network/vlan-*`, app-specific
+  pinning labels) — capture them now, re-apply in
+  [Phase 4](#phase-4--make-it-schedulable--restore-roles).
+- **CNPG primaries** — failover-friendly but you may want to manually
+  promote a replica off the worker first to control timing.
+- **Single-replica controllers** — istiod, MCP gateways, etc. These
+  will reschedule but cause brief disruption to mesh-injection or
+  tool calls.
+- **Ceph OSD on the worker** — needs `ceph osd out N` and rebalance
+  before drain.
+- **Ceph mon on the worker** — Rook will recreate it on a different
+  node automatically, but cluster runs at 2/3 mons in the gap.
+
+Capture the worker's labels:
+
+```sh
+kubectl get node worker2.${SECRET_DOMAIN} -o yaml > /tmp/worker2-pre-drain.yaml
+```
+
+## Phase 1 — Retire the outgoing control plane
+
+Skip this phase if you're adding a 4th control plane and removing the
+old one later.
+
+1. Drain the outgoing master:
+
+   ```sh
+   kubectl drain master2.${SECRET_DOMAIN} --ignore-daemonsets --delete-emptydir-data
+   ```
+
+2. Reset kubeadm state on the host:
+
+   ```sh
+   ssh master2 'kubeadm reset --force && systemctl stop kubelet'
+   ```
+
+   Do **not** wipe `/var/lib/etcd` yet — it's your in-place rollback
+   if the new control plane fails to join.
+3. Remove the etcd member (run from a remaining control plane):
+
+   ```sh
+   etcdctl ... member list                    # find master2's member ID
+   etcdctl ... member remove <member-id>
+   ```
+
+4. Update kubeadm bookkeeping:
+
+   ```sh
+   kubectl -n kube-system edit cm kubeadm-config   # drop master2 endpoint
+   kubectl delete node master2.${SECRET_DOMAIN}
+   ```
+
+5. Power down the VM. Keep the VM image around for 24h as rollback.
+
+You're now on 2 control planes. Etcd quorum is 2/2 — any further loss
+fails writes. Don't dawdle.
+
+## Phase 2 — Drain the worker cleanly
+
+1. Optionally suspend Flux for noisy releases that you don't want
+   re-reconciling mid-drain:
+
+   ```sh
+   flux suspend kustomization <name>
+   ```
+
+2. Cordon: `kubectl cordon worker2.${SECRET_DOMAIN}`
+3. Out the OSD and wait for Ceph to rebalance:
+
+   ```sh
+   kubectl -n rook-ceph patch deploy rook-ceph-osd-N --replicas=0 \
+     --type=merge -p '{"spec":{"replicas":0}}'
+   # from a working ceph CLI (e.g. rook-ceph-tools pod):
+   ceph osd out N
+   ceph -w   # wait for HEALTH_OK and PGs active+clean
+   ```
+
+4. Move CNPG primaries off the worker:
+
+   ```sh
+   kubectl cnpg promote <cluster> <healthy-replica-instance>
+   ```
+
+   Or accept the brief failover window during drain.
+5. Drain:
+
+   ```sh
+   kubectl drain worker2.${SECRET_DOMAIN} \
+     --ignore-daemonsets --delete-emptydir-data --force
+   ```
+
+6. Remove from the cluster:
+
+   ```sh
+   kubectl delete node worker2.${SECRET_DOMAIN}
+   ```
+
+7. On the host, reset kubeadm state but **preserve Longhorn data**:
+
+   ```sh
+   kubeadm reset --force
+   rm -rf /etc/kubernetes /var/lib/etcd /var/lib/kubelet
+   # leave /var/lib/longhorn alone — replicas re-attach after rejoin
+   ```
+
+## Phase 3 — Rejoin as a control plane
+
+1. From an existing control plane, generate fresh join material:
+
+   ```sh
+   CERT_KEY=$(kubeadm init phase upload-certs --upload-certs \
+     --config /path/to/init/clusterconfiguration.yaml | tail -1)
+   JOIN=$(kubeadm token create --print-join-command)
+   echo "$JOIN --control-plane --certificate-key $CERT_KEY"
+   ```
+
+2. On the worker (still its original hostname), preflight the kernel:
+
+   ```sh
+   modprobe br_netfilter
+   echo 1 > /proc/sys/net/ipv4/ip_forward
+   ```
+
+3. Run the printed join command. After it completes:
+
+   ```sh
+   mkdir -p /etc/kubernetes/manifests
+   ```
+
+4. **Drop a kube-vip static pod manifest** into
+   `/etc/kubernetes/manifests/kube-vip.yaml`. Mirror what
+   `init/kube-vip.sh` produces — but verify the `INTERFACE` env var
+   matches *this* host's NIC (master1 uses `enp0s31f6`; the new
+   control plane may differ). Without kube-vip on the new master, the
+   VIP just stays put on the survivors — non-fatal, but you lose the
+   new node from leader election.
+5. Approve any pending CSRs (kubelet-csr-approver should auto-approve;
+   check anyway):
+
+   ```sh
+   kubectl get csr | grep Pending
+   ./init/approve-csrs.sh   # if needed
+   ```
+
+## Phase 4 — Make it schedulable + restore roles
+
+1. Remove the control-plane NoSchedule taint:
+
+   ```sh
+   kubectl taint nodes worker2.${SECRET_DOMAIN} \
+     node-role.kubernetes.io/control-plane:NoSchedule-
+   ```
+
+2. Re-apply node labels you captured in
+   [Audit](#audit-what-the-worker-is-carrying). NFD will re-publish
+   hardware feature labels on its own; you only need to re-apply the
+   manual ones:
+
+   ```sh
+   kubectl label nodes worker2.${SECRET_DOMAIN} \
+     node.longhorn.io/create-default-disk=true \
+     node.network/vlan-iot=true \
+     node.network/vlan-security=true
+   ```
+
+3. Recreate Ceph OSD. With `useAllNodes`/`useAllDevices` enabled, Rook
+   picks the disk back up automatically. Otherwise add the host to the
+   `CephCluster` `nodes` list.
+4. Resume any Flux kustomizations you suspended in Phase 2.
+
+## Phase 5 — Verify
+
+- `kubectl get nodes -o wide` — promoted node has `control-plane`
+  role and is `Ready`.
+- `flux get all -A | grep -v True` is empty (or only known-suspended
+  entries).
+- Etcd shows three members:
+
+  ```sh
+  etcdctl ... member list
+  etcdctl ... endpoint status --cluster -w table
+  ```
+
+- Ceph: `ceph -s` HEALTH_OK, all OSDs in/up, all PGs `active+clean`.
+- VIP serving from the new node too:
+
+  ```sh
+  curl -k https://192.168.6.1:6443/healthz
+  ```
+
+- Hardware-pinned pods returned (e.g. `zwave-js-ui-0`, GPU
+  transcoders).
+
+## Rollback
+
+The cheapest rollback is **before Phase 3 step 3** (the new
+`kubeadm join`). Up to that point:
+
+- The old VM master is powered off but its `/var/lib/etcd` is intact.
+  Power it back on, restart kubelet, and it will re-join the etcd
+  cluster on its old member ID — *if* you haven't yet removed it via
+  `etcdctl member remove`. After member-remove, you have to
+  re-bootstrap that member.
+- The worker has been drained but not yet re-joined. `kubectl
+  uncordon` is enough to put it back in service as a worker — but
+  you'll need to re-add the labels you removed.
+
+After the new control plane has been healthy for ~24h, the old VM's
+etcd data dir can be wiped and the VM image deleted.
+
+## What this does NOT solve
+
+This procedure swaps one control-plane host. If two of your three
+control planes still share a single failure domain (e.g. master3
+remains a VM on the same host as the retired master2 *was*), repeat
+the procedure for master3 against another bare-metal worker. Only then
+does the control plane have three independent failure domains.

--- a/docs/src/rook_ceph_dr.md
+++ b/docs/src/rook_ceph_dr.md
@@ -1,5 +1,183 @@
 # Rook-Ceph DR Runbook
 
-Moved to the vault: `~/vaults/claude/runbooks/home-ops/rook_ceph_dr.md`
+Procedural recovery for Rook-Ceph failures in this cluster. Paper
+runbook — commands are documented but **not** rehearsed; verify
+against `kubectl rook-ceph -- ...` before running any destructive
+step.
 
-See HOMELAB-SPEC Layer 2 #5: the vault is canonical for runbooks.
+## Cluster baseline
+
+- Deployment: `kubernetes/apps/rook-ceph/rook-ceph/`
+- ~8 OSDs spread across worker nodes, 3-way replication on the
+  `ceph-block` pool (per `storage-class.instructions.md`)
+- Mons live on dedicated control-plane / mon nodes per the
+  CephCluster CR
+- Toolbox pod: `rook-ceph-tools-*` in the `rook-ceph` namespace —
+  `kubectl exec -it -n rook-ceph deploy/rook-ceph-tools -- ceph -s`
+
+## Tier 1 — Single OSD loss
+
+**Symptom:** `ceph -s` shows `HEALTH_WARN`, one OSD `down/out`,
+recovery in progress.
+
+**Diagnose:**
+
+```sh
+kubectl rook-ceph -n rook-ceph -- ceph osd tree
+kubectl rook-ceph -n rook-ceph -- ceph -s
+kubectl -n rook-ceph get pods -l app=rook-ceph-osd | grep -v Running
+```
+
+**Recover:**
+
+1. If the OSD pod is `CrashLoopBackOff` and the underlying disk is
+   intact, deleting the pod usually self-heals after Rook re-creates
+   it. Wait 5 minutes before escalating.
+2. If the disk is dead, mark the OSD `out`:
+
+   ```sh
+   kubectl rook-ceph -n rook-ceph -- ceph osd out <id>
+   ```
+
+   Wait for `ceph -s` to show `recovery_io` complete (can run hours
+   at ~683 KB/s — see `docs/src/cluster_upgrade.md` note about
+   global recovery events). Then purge:
+
+   ```sh
+   kubectl rook-ceph -n rook-ceph -- ceph osd purge <id> --yes-i-really-mean-it
+   ```
+
+3. Edit the CephCluster CR to remove the dead device, or replace
+   the disk and let Rook re-provision via auto-discovery.
+4. Verify replication health: `ceph -s` reports `HEALTH_OK` and
+   zero `misplaced` or `degraded` PGs.
+
+With 3-way replication and 8 OSDs, losing one OSD is fully
+tolerated. The recovery window is the only at-risk period; don't
+lose a second OSD during it.
+
+## Tier 2 — Mon quorum loss
+
+**Symptom:** `ceph -s` hangs or reports `mon election`; pods using
+ceph-block PVCs get IO errors.
+
+**Diagnose:**
+
+```sh
+kubectl -n rook-ceph get pods -l app=rook-ceph-mon
+kubectl -n rook-ceph logs deploy/rook-ceph-operator | tail -100
+```
+
+**Recover:**
+
+This cluster runs an odd-numbered mon set (3 mons). Quorum requires
+2 of 3 alive.
+
+1. **If 2/3 mons alive:** quorum holds. Identify the dead mon's
+   node, fix the node (reboot, replace disk), and let Rook
+   re-provision.
+2. **If 1/3 mons alive:** quorum lost. Rook's `monMaxOSDChange`
+   safeguard kicks in. Recovery path:
+   - Identify the surviving mon (`ceph mon stat`).
+   - Edit the `cephclusters.ceph.rook.io` CR to reduce mon count to
+     1 temporarily.
+   - Rook re-elects with the surviving mon as quorum-of-1.
+   - Add mons back one at a time, verifying quorum at each step.
+3. **If 0/3 mons alive:** disaster — see Tier 3.
+
+The Rook-Ceph upstream toolbox has explicit mon-recovery scripts
+(`rook-ceph-mon-quorum-recovery`). Use those before manual quorum
+edits. Reference:
+<https://rook.io/docs/rook/v1.18/Storage-Configuration/Advanced/ceph-mon-health/>
+
+## Tier 3 — Full Ceph cluster loss
+
+**Symptom:** all mons dead, OSDs dead, or the rook-ceph namespace
+itself trashed.
+
+**Recover:**
+
+ceph-block is the in-cluster durable tier, **not** the
+cluster-loss-survivable tier. Per `storage-class.instructions.md`,
+data on ceph-block does NOT survive a Ceph cluster wipe unless it
+was also being shipped offsite.
+
+What survives:
+
+- **CNPG cluster data** — yes, via Barman ObjectStore backups to
+  Garage. Every CNPG `Cluster` in this repo has a paired
+  `barmancloud.cnpg.io/ObjectStore`. Restore path: see
+  `cnpg_restore.md`.
+- **Longhorn-backed apps** — yes, via the backup target on
+  beast NFS. Restore path: see `longhorn_restore.md`.
+- **Garage substrate** — yes, via the NFS substrate (Garage's
+  storage isn't ceph-block-backed). Garage stays intact.
+- **Anything else on ceph-block** — no. Application configuration
+  on ceph-block is regenerable (per the storage-class doc), so the
+  app will reconstruct on next pod start.
+
+**Steps:**
+
+1. Confirm no path to recover — Tier 1 / Tier 2 procedures
+   exhausted.
+2. Suspend the `rook-ceph-cluster` Flux Kustomization to prevent
+   automatic re-reconciliation while you assess.
+3. Drain workloads using `ceph-block` PVCs:
+   `kubectl get pvc -A -o yaml | yq '.items[] | select(
+   .spec.storageClassName == "ceph-block") | .metadata.namespace +
+   "/" + .metadata.name'` — scale them to zero.
+4. Tear down the existing rook-ceph deployment per
+   <https://rook.io/docs/rook/v1.18/Storage-Configuration/Advanced/ceph-teardown/>
+   — `Cluster`, `OperatorConfig`, then delete the namespace.
+5. Wipe the OSD disks on each worker (Rook-Ceph teardown does NOT
+   wipe disks; you must `dd if=/dev/zero of=/dev/<osd-disk>
+   bs=1M count=100` on each before re-deploying).
+6. Re-deploy rook-ceph: unsuspend the Kustomization, let Flux
+   reconcile a fresh CephCluster.
+7. Wait for `HEALTH_OK` + zero PGs in unknown state.
+8. Restore data per the per-tier runbooks (CNPG → cnpg_restore.md;
+   Longhorn → longhorn_restore.md).
+9. Scale the drained workloads back. Apps regenerate config on
+   first start.
+
+Expect Tier 3 recovery to take 4–8 hours total: ~30 min teardown,
+~30 min fresh deploy, the rest is data restore + service smoke.
+
+## Common gotchas
+
+- **`Drain hangs ~indefinitely on rook-ceph-osd-host-*` PDB.** A
+  previous node's OSD is still degraded; Rook's per-host PDB
+  blocks all OSD evictions cluster-wide. See
+  `docs/src/cluster_upgrade.md`. Two options: wait for `ceph -s`
+  HEALTH_OK + zero remapped/misplaced PGs, OR `kubectl delete pod
+  -n rook-ceph rook-ceph-osd-N-...` directly (bypasses eviction
+  API; safe with 8 OSDs + 3-way replication for the ~10-min
+  recovery window).
+- **OSD pods stuck on `Init:0/N`.** Usually a `lvm tag`
+  mismatch on the disk after a hard power loss. Run the
+  rook-ceph-tools `ceph-volume lvm zap --osd-id <id>` to clear,
+  then let Rook re-provision.
+- **`HEALTH_WARN: mons are allowing insecure global_id reclaim`** —
+  cosmetic; clear with `ceph config set mon auth_allow_insecure_global_id_reclaim false`.
+
+## Verification checklist
+
+After any Tier 1/2/3 recovery:
+
+- [ ] `ceph -s` → `HEALTH_OK`
+- [ ] `ceph osd tree` → all expected OSDs `up/in`
+- [ ] `ceph -s` shows zero `degraded`, `misplaced`, `inactive` PGs
+- [ ] A representative ceph-block PVC mounts cleanly
+  (`kubectl run dr-verify --image=alpine -- sh -c "sleep 60"`
+  with a PVC attached)
+- [ ] No `CephClusterErrorState` PrometheusAlert firing
+
+## See also
+
+- `docs/src/cluster_upgrade.md` — node-drain interactions with OSD PDB
+- `cnpg_restore.md` — restore CNPG data after ceph-block loss
+- `longhorn_restore.md` — restore Longhorn-backed apps
+- `garage_restore.md` — restore Garage (NFS-substrate, doesn't
+  depend on ceph)
+- Memory: `[[reference_predict_linear_sparse_data_false_positives]]` —
+  PR #11755 disk-fill alerting context

--- a/docs/src/tei_spark.md
+++ b/docs/src/tei_spark.md
@@ -80,7 +80,7 @@ Subsequent pod restarts skip the HF Hub steps (PVC cache is warm) and complete i
 
 ### 5. DCGM utilization counters are broken on GB10
 
-Per [reference_dcgm_gb10_broken_counters](../../reference_dcgm_gb10_broken_counters.md): `GPU_UTIL`, `MEM_COPY_UTIL`, `GR_ENGINE_ACTIVE`, `FB_USED` are stuck at 0 or empty on Spark. Only `POWER_USAGE` and `SM_CLOCK` report. Don't write GPU-utilization-based alerts; use request-success metrics instead.
+Most DCGM utilization counters are broken on GB10: `GPU_UTIL`, `MEM_COPY_UTIL`, `GR_ENGINE_ACTIVE`, `FB_USED` are stuck at 0 or empty on Spark. Only `POWER_USAGE` and `SM_CLOCK` report. Don't write GPU-utilization-based alerts; use request-success metrics instead.
 
 ## Configuration knobs
 

--- a/docs/src/tei_spark.md
+++ b/docs/src/tei_spark.md
@@ -1,8 +1,144 @@
 # TEI on Spark — reranker for RAG
 
-Moved to the vault: `~/vaults/claude/runbooks/home-ops/tei_spark.md`
+`tei-spark` is a HuggingFace `text-embeddings-inference` deployment on the Spark node, serving `BAAI/bge-reranker-v2-m3` as an external cross-encoder for Open WebUI's RAG pipeline. It replaces Open WebUI's in-process reranker so the chat pod doesn't carry a 6 Gi GPU-less-reranker memory footprint and so reranking runs on Spark next to the bge-m3 embedder.
 
-See HOMELAB-SPEC Layer 2 #5: the vault is canonical for runbooks.
+| | |
+|---|---|
+| **Upstream image** | `ghcr.io/huggingface/text-embeddings-inference:121-sha-<sha>` (digest-pinned) |
+| **Model** | `BAAI/bge-reranker-v2-m3` |
+| **Manifests** | `kubernetes/apps/ai/tei-spark/` |
+| **Cluster service** | `tei-spark.ai.svc.cluster.local:3000` (HTTP `/rerank`, `/metrics`) |
+| **Node** | `spark.thesteamedcrab.com` (arm64, GB10, sm_121) |
+| **GPU** | `nvidia.com/gpu: 1`, `ai-gpu-critical` priority |
+| **Model cache** | 5 Gi `ceph-block` PVC (`tei-spark-cache-pvc`) at `/data` |
 
-For cluster-level role of TEI in the RAG architecture, see the
-[AI Architecture](ai_architecture.md) chapter.
+## Why this shape
+
+**Family-matched reranker.** `bge-reranker-v2-m3` is BAAI's v2 reranker designed to pair with the `bge-m3` embedder (Phase A 2026-05-20). On BAAI's published MIRACL/BEIR/CMTEB benchmarks reranking `bge-m3` top-100 retrievals, v2-m3 beats `bge-reranker-large` in every multilingual setting. Don't substitute to a v1-family reranker for "TEI tier-1 supported" reasons (see Quirks).
+
+**Spark, not P40.** The P40 is Pascal (sm_61). bge-reranker-v2-m3 wants FP16; Pascal handles FP16 poorly. Spark's Blackwell (sm_121) is the right home, and co-locating with the bge-m3 embedder eliminates a network hop.
+
+**External, not in-process.** Open WebUI's in-process reranker shipped with a 6 Gi memory limit headroom even though the model wasn't always loaded. Pulling it out cleans the architecture for the day Open WebUI's KB external-Qdrant gap closes and rerank actually becomes hot.
+
+## Architecture
+
+```text
+                  ┌────────────────────────────┐
+   Open WebUI ───▶│ tei-spark (Service:3000)   │
+                  │ - /rerank                  │
+                  │ - /health                  │
+                  │ - /metrics                 │
+                  └──────────┬─────────────────┘
+                             │ runs on
+                             ▼
+                  ┌────────────────────────────┐
+                  │ Spark node (arm64, GB10)   │
+                  │ TEI HTTP variant           │
+                  │ Candle CUDA backend        │
+                  │ FlashBert on sm_121        │
+                  │ dtype=float16              │
+                  └──────────┬─────────────────┘
+                             │ HF Hub download (first start only,
+                             │ cached on ceph-block PVC)
+                             ▼
+                  ┌────────────────────────────┐
+                  │ BAAI/bge-reranker-v2-m3    │
+                  │ XLM-RoBERTa-base (568M)    │
+                  └────────────────────────────┘
+```
+
+## Quirks
+
+### 1. The 121- image is built from `main`, not a tagged release
+
+Upstream PRs [#840](https://github.com/huggingface/text-embeddings-inference/pull/840) (multi-arch CUDA, sm_121) and [#852](https://github.com/huggingface/text-embeddings-inference/pull/852) (restrict 12.1 to linux/arm64) merged 2026-03-31 but no TEI release tag has been cut since `v1.9.3` (pre-#840). The HelmRelease pins to `121-sha-<sha>@sha256:...` under a `# workaround:` annotation. Remove the pin when TEI cuts a release containing #840.
+
+### 2. `bge-reranker-v2-m3` is not on TEI's documented supported-rerankers list
+
+TEI's `docs/source/en/supported_models.md` lists `bge-reranker-base` / `bge-reranker-large` / GTE rerankers — not v2-m3. **It still loads cleanly** because TEI's `router/src/lib.rs::get_backend_model_type` dispatches XLM-RoBERTa Sequence Classification generically via `arch.ends_with("Classification")`; the Candle CUDA backend implements the forward pass. [Issue #713](https://github.com/huggingface/text-embeddings-inference/issues/713) confirms it serving live on TEI 1.8.
+
+If TEI ever tightens the architecture allowlist, v2-m3 could break — keep an eye on release notes. Fallback options in priority order:
+
+1. **Same model, different server** — `michaelfeil/infinity` lists v2-m3 in tested models, Blackwell support landed 2025-07.
+2. **Different model, same server** — `bge-reranker-large` (TEI tier-1 listed) but it's the older v1 family and worse on multilingual.
+
+### 3. `/metrics` is on the HTTP port, not `--prometheus-port`
+
+TEI's HTTP variant serves `/metrics` on the main API port (3000 in this deploy). The `--prometheus-port` / `PROMETHEUS_PORT` setting does **not** open a separate listener — it's a no-op for the HTTP variant (likely applies only to the gRPC build). The HelmRelease originally set `PROMETHEUS_PORT: 9000` and the ServiceMonitor scraped `:9000`; the scrape silently failed with "connection refused" until corrected in PR #11898. Single port, single ServiceMonitor endpoint (`port: http`), CNP allows both Open WebUI and Prometheus on 3000.
+
+### 4. Cold start is ~65 seconds, dominated by HF Hub model download
+
+First-boot timing on Spark:
+
+- Image pull: ~30 s (the TEI 121- image is large; CUDA libs + Rust binary).
+- HF Hub artifact download (configs, tokenizer): ~1 s.
+- Model weights (safetensors, ~570 MB) → PVC: ~48 s.
+- CUDA backend load + warmup: ~14 s.
+- HTTP server up + `Ready`: total ~65 s.
+
+Subsequent pod restarts skip the HF Hub steps (PVC cache is warm) and complete in ~55 s. The `startupProbe` budget is 5 min (60 × 5 s) — comfortable margin, can be tightened to ~2 min if/when we want faster pod-failure detection.
+
+### 5. DCGM utilization counters are broken on GB10
+
+Per [reference_dcgm_gb10_broken_counters](../../reference_dcgm_gb10_broken_counters.md): `GPU_UTIL`, `MEM_COPY_UTIL`, `GR_ENGINE_ACTIVE`, `FB_USED` are stuck at 0 or empty on Spark. Only `POWER_USAGE` and `SM_CLOCK` report. Don't write GPU-utilization-based alerts; use request-success metrics instead.
+
+## Configuration knobs
+
+In `kubernetes/apps/ai/tei-spark/app/helmrelease.yaml`:
+
+| Env | Value | Notes |
+|---|---|---|
+| `MODEL_ID` | `BAAI/bge-reranker-v2-m3` | Family-matched to bge-m3 embedder |
+| `PORT` | `3000` | HTTP + metrics share this port |
+| `HUGGINGFACE_HUB_CACHE` | `/data` | ceph-block PVC mount |
+| `DTYPE` | `float16` | Halves VRAM use, sm_121 native |
+| `AUTO_TRUNCATE` | `true` | Truncate over-long inputs rather than 413 |
+| `JSON_OUTPUT` | `true` | Structured logs for Loki ingestion |
+
+## Verification recipes
+
+### Service is live and reranking
+
+```sh
+kubectl -n ai run --rm -i tei-smoke --image=curlimages/curl:8.10.1 --restart=Never \
+  -- curl -sS -X POST http://tei-spark.ai.svc.cluster.local:3000/rerank \
+  -H 'content-type: application/json' \
+  -d '{"query":"What is RAG?",
+       "texts":["RAG combines retrieval and generation.",
+                "Pizza is delicious.",
+                "Embeddings are vector representations."]}'
+```
+
+Expected: JSON array with `index 0` scored highest by an order of magnitude.
+
+### Prometheus scrape is healthy
+
+```sh
+kubectl -n observability port-forward sts/prometheus-kube-prometheus-stack 19090:9090 &
+curl -sS 'http://localhost:19090/api/v1/targets' \
+  | jq '.data.activeTargets[] | select(.scrapeUrl | contains("tei-spark"))'
+```
+
+Expected: `"health": "up"`, scrapeUrl on port 3000.
+
+### Alerts are loaded
+
+`SparkTeiRerankPodDown` (critical, 5 min) and `SparkTeiRerankErrorRate` (warning, 10 min, >5%) ship in the same kustomization. Verify via Prom `/api/v1/rules` or the Alerts UI.
+
+## Cutover history
+
+| PR | Description |
+|---|---|
+| #11886 | PR-1 — scaffold HelmRelease (suspended) |
+| #11893 | PR-2 — unsuspend; first pod up, smoke test against v2-m3 passes |
+| #11898 | PR-2.1 — fix `/metrics` port wiring (was scraping wrong port) |
+| #11906 | PR-4 — PrometheusRule (pod-down + error-rate alerts) |
+| _pending_ | PR-3 — Open WebUI cutover to `RAG_RERANKING_ENGINE: external`; window-gated to Tue 2026-05-26 02:00 ET |
+
+Before PR-3 lands, TEI is dark capacity — no consumer routes to it, alerts are inert. Soak metrics on the Spark side (POWER_USAGE baseline, pod memory) can still be observed during this window.
+
+## Common failure modes (anticipated; populate as encountered)
+
+- **HF Hub 429 during first start** — model weights download fails. Fix: delete pod, retry. Hub rate limits are per-IP and brief. Long-term mitigation: pre-stage weights into the PVC via a one-shot Job.
+- **CUDA OOM** — bge-reranker-v2-m3 at FP16 needs ~1.5 Gi VRAM with batched requests; should never OOM on GB10's 128 Gi unified memory unless something else on the GPU is leaking. Check `nvidia-smi` on the Spark node.
+- **Tokenizer panic on input** — TEI logs the offending input; not seen yet in this deploy. `AUTO_TRUNCATE: true` should prevent this for length issues.

--- a/docs/src/workflow_automation.md
+++ b/docs/src/workflow_automation.md
@@ -250,6 +250,5 @@ need attention:
   Zulip approval-receive path is unaffected; it stays as the
   reliable fallback.
 
-See the migration write-up at
-[`audit/n8n-to-windmill.md`](audit/n8n-to-windmill.md) (if present)
-or memory `project_n8n_to_windmill_migration_done` for the history.
+See memory `project_n8n_to_windmill_migration_done` for the history
+of the migration off n8n.

--- a/docs/src/workflow_automation.md
+++ b/docs/src/workflow_automation.md
@@ -1,5 +1,255 @@
 # Workflow Automation: Agents, Approvals, and Push
 
-Moved to the vault: `~/vaults/claude/runbooks/home-ops/workflow_automation.md`
+> **Authoritative maintainer**: the documentation agent owns keeping
+> this page in sync with the cluster. If you spot drift, run the doc
+> agent — don't hand-edit unless you also intend to update upstream
+> sources.
 
-See HOMELAB-SPEC Layer 2 #5: the vault is canonical for runbooks.
+This is the system that turns a voice memo, a Zulip ping, or a critical
+AlertManager event into work done by a fleet of LLM agents — with a
+human in the loop for anything risky, and a paper trail in the vault
+for anything important.
+
+## The system at a glance
+
+```mermaid
+flowchart LR
+    subgraph "Triggers (you)"
+        Voice[🎙️ Voice<br/>Wyoming → Whisper]
+        ZulipApp[📱 Zulip app<br/>#inbox / @-mentions]
+        HAApp[🏠 HA companion<br/>REST webhook]
+    end
+
+    subgraph "Workflow runtime"
+        Windmill[💨 Windmill<br/>7 TypeScript flows]
+    end
+
+    subgraph "Agent fleet (ai ns)"
+        LG[🧠 langgraph-agents<br/>FastAPI · :8765]
+        Ollama[(Local Ollama<br/>P40 + Spark)]
+        Claude[(Anthropic API<br/>opt-in per agent)]
+    end
+
+    subgraph "Surfaces (notifications)"
+        Push[📲 ntfy / Pushover<br/>action buttons]
+        ZulipStream[💬 Zulip streams<br/>#approvals · #digests]
+        Vault[📓 Obsidian vault<br/>reports/]
+    end
+
+    subgraph "Alert path"
+        AM[🚨 AlertManager<br/>severity=critical]
+        Holmes[🔍 HolmesGPT<br/>investigates]
+    end
+
+    Voice & ZulipApp & HAApp --> Windmill
+    AM --> Windmill
+    Windmill --> LG
+    Windmill --> Holmes
+    Holmes --> LG
+    LG --> Ollama
+    LG -. opt-in .-> Claude
+    Windmill --> Push
+    Windmill --> ZulipStream
+    LG --> ZulipStream
+    LG --> Vault
+```
+
+Each block in **Workflow runtime** is a single TypeScript file checked
+into `kubernetes/apps/home/windmill/workflows/`. They run in Deno
+sandboxes inside the Windmill worker pods, with secrets injected via
+the `windmill-workflows-secret` k8s Secret (sourced from 1Password).
+
+The **agent fleet** is `langgraph-agents` — a FastAPI service in the
+`ai` namespace. It exposes `/inbox` (submit a task), `/approval`
+(answer a paused task), and `/admin/*` for housekeeping. Internally it
+routes each agent to either a local Ollama backend (default) or the
+Anthropic API (opt-in per agent, gated by daily cost cap).
+
+## Triggering jobs from Android
+
+Three first-class paths. All three end up POSTing to `/inbox` on
+`langgraph-agents` — the difference is just the front door.
+
+### Option 1 — Zulip mobile app (recommended for ad-hoc)
+
+Send a direct message to the `triager-bot` in the Zulip app (the bot
+named **Triager 📥**). The Zulip mobile app is a Play-Store install,
+already logged in if you set it up before, and works over LTE without
+needing the VPN.
+
+What happens:
+
+- Triager listens on a webhook → forwards your message to `/inbox`.
+- The triager LLM classifies your task and routes to one of the
+  specialist agents (coder, errand-runner, homelab-engineer,
+  smart-home-engineer, etc.).
+- If the agent can complete autonomously, it does so and posts the
+  result to a topic in `#tasks` (Zulip stream).
+- If the agent needs your approval, it pauses and you get a push
+  notification (see [Approval flow](#approval-flow) below).
+
+When to use: anything conversational. "Schedule the dishwasher to
+run after 11pm tonight." "What's my power draw averaging this week?"
+"Draft a reply to Joakim about the deck stain colors."
+
+### Option 2 — Voice intake (Wyoming + Whisper)
+
+The `wyoming-services` namespace runs Whisper for speech-to-text. The
+Home Assistant companion app on Android has an "Assist" button that
+records audio → posts to HA → routes to Whisper → forwards transcribed
+text to Windmill's `/api/w/lovenet/jobs/run/p/f/lovenet/langgraph-inbox`
+webhook → same `/inbox` as the Zulip path.
+
+When to use: hands-free in the car, while cooking, or anytime typing
+is friction. The Assist button is configurable as a phone shortcut
+or a quick-action tile in the HA app's UI.
+
+### Option 3 — Home Assistant companion app (templated tasks)
+
+In the HA dashboard, add a button that calls the `windmill_inbox`
+script (an HA `rest_command`). The button can pre-fill the task
+content — useful for recurring asks like "give me today's energy
+report" or "run the daily backups summary."
+
+When to use: anything you do more than once a week and want as
+one-tap. Less general than voice, more reliable than tapping through
+the Zulip app.
+
+## Approval flow
+
+Some actions are dangerous enough that the agent shouldn't run them
+alone. The fleet uses a four-class taxonomy:
+
+| Class | Examples | Default behavior |
+|---|---|---|
+| **A** | Read-only queries; vault writes; status reports | Run autonomously |
+| **B** | Idempotent ops with trivial undo (toggle a HA light, set a thermostat) | Run autonomously |
+| **C** | Stateful changes with non-trivial undo (reschedule a recurring HA automation, edit Frigate zones, schedule a CronJob, push a draft message) | **Pause — needs approval** |
+| **D** | Irreversible or high-blast-radius (delete data, send a real email/SMS, ship to PR, restart a service) | **Pause — needs approval; escalate to D only if undo_path is empty** |
+
+When an agent proposes a Class C or D action, it pauses and emits an
+**approval request**. You'll see it through two channels:
+
+```mermaid
+sequenceDiagram
+    participant Agent as agent (langgraph)
+    participant Windmill
+    participant ZulipStream as #approvals
+    participant Push as ntfy / Pushover
+    participant You
+
+    Agent->>Windmill: POST /webhook/approval-post<br/>{task_id, action_class, target, ...}
+    Windmill->>ZulipStream: 🔔 New topic:<br/>"task-id — Class C: target"
+    Windmill->>Push: Tier-1 push<br/>(tap-to-approve buttons)
+    Note over You: 📲 You see push +<br/>Zulip notification
+
+    alt approve via ntfy tap
+        Push->>+Agent: POST /approval<br/>(pre-signed HMAC token)
+        Agent-->>Agent: validate token,<br/>resume task
+    else approve via Zulip @-mention
+        You->>ZulipStream: @**Approval Receiver** approve
+        ZulipStream->>Windmill: outgoing-webhook<br/>(message body + topic)
+        Windmill->>Agent: POST /approval<br/>(HMAC-signed token)
+        Agent-->>Agent: validate token,<br/>resume task
+    end
+
+    Agent->>ZulipStream: 📝 Task continues<br/>(status update in same topic)
+```
+
+### Giving / rejecting approval
+
+Two paths to the same outcome — pick whichever is in front of you:
+
+- **From the push notification** (ntfy on Android, Pushover during
+  the migration window): tap one of the action buttons:
+  - **Approve** — resume the task
+  - **Reject** — cancel the task; the agent will say so in the
+    Zulip topic and not retry
+  - **Defer 4h** — silence for 4 hours; sweep will re-notify at the
+    4h mark
+- **From Zulip** (mobile, desktop, or web): in the approval topic
+  (named `<task_id> — Class C: <target>`), post one of:
+  - `@**Approval Receiver** approve`
+  - `@**Approval Receiver** reject`
+  - `@**Approval Receiver** defer`
+
+The two paths are equivalent and idempotent — once a decision is
+recorded, follow-up attempts are no-ops.
+
+### Escalation timeline
+
+If you don't respond:
+
+| Age | What happens |
+|---|---|
+| 30 min | Second push notification (tier-1 attention sound) |
+| 4 h | Task marked "cold"; no further pushes; still resumable |
+| 7 d | Auto-cancelled with reason `"7-day timeout"` (with a handful of per-agent exceptions; health-tracker never auto-cancels) |
+
+The 30 min / 4 h / 7 d sweep is the `langgraph-awaiting-user-sweep`
+Windmill flow, running every 5 minutes.
+
+## Where results land
+
+Different surfaces for different shapes of output:
+
+- **Long-form deliverables** → the Obsidian vault, under
+  `~/vaults/claude/reports/`. Daily digests, weekly summaries,
+  research findings, draft emails — anything that's a document.
+  The reporter agent writes these and tells you the filename via
+  Zulip.
+- **Status updates + acknowledgements** → the same Zulip topic as
+  the approval request, so the conversation stays threaded.
+- **Daily roll-up** → `#digests` stream, one topic per day named
+  `daily-YYYY-MM-DD`. Auto-posted at 22:00 ET by the `daily-digest`
+  cron flow.
+- **Alert investigations** → push notification with HolmesGPT's
+  ≤500-char root-cause summary + Zulip ack of the original alert.
+- **Cost / state alerts** → push only (cost cap watcher, awaiting-
+  user escalations).
+
+If you want to dig deeper than the surface message:
+
+- **Windmill UI** at `https://windmill.${SECRET_DOMAIN}` →
+  workspace `lovenet` → Runs tab. Every execution has full args,
+  return value, stdout, and timings.
+- **langgraph-agents** at `https://agents.${SECRET_DOMAIN}` (auth-
+  gated) → `/admin/tasks` for task state, `/admin/tasks/<id>` for
+  the full state machine of a specific task.
+
+## The seven Windmill workflows
+
+| Workflow | Trigger | What it does |
+|---|---|---|
+| `alertmanager-holmesgpt-pushover` | Webhook (AlertManager `severity=critical`) | Calls HolmesGPT to investigate (≤2 tool calls, <500 chars); pushes the summary |
+| `langgraph-inbox` | Webhook (Zulip bot, voice, HA companion) | Forwards to `/inbox`; if the task pauses, fans out an approval-post |
+| `langgraph-approval-post` | Webhook (langgraph pause) | Posts approval request to Zulip `#approvals` + tier-1 push |
+| `langgraph-approval-receive` | Outgoing-webhook (Zulip `@Approval Receiver`) | Verifies actor + emoji/keyword; HMAC-signs token; POSTs `/approval` |
+| `langgraph-awaiting-user-sweep` | Cron (every 5 min) | Tier-1 push at 30m; mark cold at 4h; auto-cancel at 7d |
+| `langgraph-cost-cap-watcher` | Cron (every 4 h) | Push if today's Anthropic spend ≥ 80% (warn) or 100% (cap-hit) |
+| `langgraph-daily-digest` | Cron (22:00 ET) | Triggers the reporter agent to write today's digest + posts summary to `#digests` |
+
+Source-of-truth on disk:
+`kubernetes/apps/home/windmill/workflows/<name>.ts`. The Windmill DB
+holds the runtime copy; we sync from git when scripts change.
+
+## Operating notes
+
+The system is mostly self-tending, but a few things will eventually
+need attention:
+
+- **HolmesGPT is slow** — each alert investigation takes ~5–7 min on
+  P40-class Ollama hardware. If a burst of critical alerts fires,
+  the workflow queue backs up but every job still runs eventually.
+- **`/admin/tasks` hangs** on langgraph-agents (pre-existing,
+  unrelated to Windmill). The awaiting-user-sweep tolerates this
+  with a `{skip: true}` return; no errors, just a 5-min retry
+  cadence until langgraph fixes the endpoint.
+- **Push backend in transition** — Pushover (SaaS, paid) is being
+  replaced with **ntfy** (self-hosted, tap-to-action buttons). The
+  Zulip approval-receive path is unaffected; it stays as the
+  reliable fallback.
+
+See the migration write-up at
+[`audit/n8n-to-windmill.md`](audit/n8n-to-windmill.md) (if present)
+or memory `project_n8n_to_windmill_migration_done` for the history.


### PR DESCRIPTION
## Summary

Reverses the move-runbooks-to-vault chain ([#11815](https://github.com/rwlove/home-ops/pull/11815), [#11827](https://github.com/rwlove/home-ops/pull/11827), [#11857](https://github.com/rwlove/home-ops/pull/11857), [#11908](https://github.com/rwlove/home-ops/pull/11908)). Those interpreted HOMELAB-SPEC Layer 2 #5 (*"vault is canonical for runbooks"*) as "vault holds the content, docs are pointers." That read was over-broad — "canonical" was meant as conflict-resolution authority, not exclusive location.

The docs site is the operator-facing surface; runbook content lives there.

## What's in scope

- **22 files restored** from `~/vaults/claude/runbooks/home-ops/*.md` back to `docs/src/`. Frontmatter (`source:`, `moved:`, `spec:`) stripped during restoration.
- **Mechanical markdownlint cleanups** (MD031 / MD032 / MD004 / MD034) applied via `markdownlint-cli2 --fix`; one wrapped-URL split in `rook_ceph_dr.md` fixed by hand. The original docs had these violations pre-existing.

Restored files:

```
apiserver_audit_logging.md      longhorn_restore.md
cluster_rebuild.md              master1_etcd_disk_swap.md
cluster_upgrade.md              mcp_observability.md
cnpg_restore.md                 memory_mcp.md
coral.md                        offsite_recovery.md
debugging.md                    p40.md
frigate_dr.md                   power-outage.md
garage_restore.md               promote_worker_to_control_plane.md
github_webhook.md               rook_ceph_dr.md
immich_cnpg.md                  tei_spark.md
init_teardown.md                workflow_automation.md
```

## What's NOT in this PR (vault-side, separate from repo)

- **HOMELAB-SPEC.md update** — clarified Layer 2 #5 and Layer 3 Documentation in `~/vaults/claude/user/HOMELAB-SPEC.md` so future agent runs don't repeat the over-broad read. Vault file, not in this repo.
- **Vault runbook deletion** — `~/vaults/claude/runbooks/home-ops/*.md` will be deleted once this PR lands and we've confirmed restoration is complete. Keeping them until merge as a safety net.

## Sensitivity check

Restored content uses placeholder refs (`${NFS_HOST_0}`, `${NFS_HOST_2}`, `${SECRET_DOMAIN}`) — the same form it had on the public docs site before the move. No new data exposure.

## Relationship to PR #11913 (Material for MkDocs preview)

[PR #11913](https://github.com/rwlove/home-ops/pull/11913) added a side-by-side Material preview build. With this restore PR merged, the Material preview will show full content instead of stub pages. Independent PRs — neither blocks the other, but landing this first makes the preview more useful for the look-and-feel evaluation.

## Test plan

- [ ] CI passes (lint, mkdocs preview build from PR #11913 will pick up the restored content once both branches converge)
- [ ] Spot-check a restored page on the docs site after merge (cluster_rebuild, rook_ceph_dr, debugging) — content should match what was in the vault
- [ ] Confirm `~/vaults/claude/runbooks/home-ops/` files still match repo (drift check before deletion)
- [ ] HOMELAB-SPEC.md reads cleanly with the updated wording (manual review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)