### PR TITLE
docs(homeaiops): add DoD rubric for Stage 1 stabilization

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,8 @@ with Rob as the human-in-the-loop gate.
 - Component docs: README files co-located with components
 - Agent-loaded conventions: `/.agents/instructions/` (auto-imported via this CLAUDE.md)
 - Agent skills: `/.agents/skills/` (invoked on demand)
+- AI pipeline architecture: `docs/src/ai_architecture.md` (component map)
+- AI pipeline DoD: `docs/src/homeaiops_dod.md` (verification rubric — Stage 1 stabilization)
 
 ## Adding Documentation
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -5,6 +5,7 @@
 - [👋 Introduction](introduction.md)
 
 - [AI Architecture](ai_architecture.md)
+- [HomeAIOps Definition of Done](homeaiops_dod.md)
 - [Workflow Automation: Agents, Approvals, and Push](workflow_automation.md)
 - [Memory MCP — Cross-Agent Knowledge Graph](memory_mcp.md)
 - [MCP Fleet Observability](mcp_observability.md)

--- a/docs/src/homeaiops_dod.md
+++ b/docs/src/homeaiops_dod.md
@@ -1,0 +1,333 @@
+# HomeAIOps Definition of Done
+
+The verification rubric for the local AI pipeline (the "HomeAIOps"
+stack — surfaces, bridges, agents, inference, tools, outputs).
+Paired with `ai_architecture.md` (the component map) and `goal.md`
+(the stabilization + inversion directive).
+
+This document exists because `goal.md` Stage 1 references
+"the DoD documented in `CLAUDE.md` and the repo" — that DoD did not
+yet exist as a single artifact. Per the goal's conflict-resolution
+order (repo wins; flag the drift and update `CLAUDE.md`), this file
+is the missing artifact. It is the rubric every Stage 1 verification
+PR cites for "done."
+
+## Per-component-class checklist
+
+Every HomeAIOps component sits in one of three classes. Each class
+has a minimum DoD; specific components can add component-specific
+checks on top.
+
+### Class A — live (✅)
+
+For components currently serving traffic: HolmesGPT, claude-runner,
+all live MCP servers, both ollama backends, Qdrant, all CNPG
+clusters, Langfuse, the Windmill bridges that are wired today.
+
+A live component is **done** when:
+
+1. **Pod ready.** All replicas `Running` + `Ready`, restart count
+   acceptable (< 5 in the last 24 h unless explained).
+2. **Flux reconciled.** Owning HelmRelease and Kustomization
+   `Ready=True`, no `Stalled` condition, no upgrade-failure backlog.
+3. **Endpoint healthy.** The documented health check (HTTP
+   `/healthz`, `/readyz`, `/metrics`, or component-specific probe)
+   returns 2xx. If no documented health check exists, *adding one*
+   is part of the stabilization work, not a separate followup.
+4. **Survives pod restart.** `kubectl delete pod …` → comes back
+   `Ready`, traffic resumes within the documented SLA, no human
+   intervention needed.
+5. **Survives Flux suspend/resume.** `flux suspend ks <name>` →
+   `flux resume ks <name>` → reconciles cleanly, no manual touch.
+6. **Observability.** ServiceMonitor / PodMonitor / scrape target
+   `up == 1` in Prometheus. Logs visible in Loki under the expected
+   labels. Pod-level traces or events visible where the component
+   emits them.
+7. **Top failure mode documented.** At least one entry in
+   `docs/src/` (or a runbook section) for the most likely failure
+   mode an operator will hit. "We've never seen it fail" is fine —
+   document that too.
+
+### Class B — plumbed, cold (🟡)
+
+For components whose infrastructure is deployed and reconciled but
+which are deliberately gated off behind an env flag / cron suspend /
+absent secret. Today this is **langgraph-agents** (and its 13
+specialist agents), gated on `ENABLE_CLAUDE_API: false`.
+
+A plumbed-cold component is **done** when:
+
+1. **Class A items 1, 2, 4, 5, 6 apply unchanged.** The substrate
+   itself is live even if the path through it is cold.
+2. **Gate is explicit.** The env flag / suspend / missing-secret is
+   documented in `ai_architecture.md` or the component's
+   `app/README.md`. A bystander reads the doc and knows why nothing
+   is happening.
+3. **Substrate verification.** Queue tables, checkpoint store,
+   memory KG, vault PVC mounts, and MCP gateway reachability all
+   pass even though no task is flowing. Specifically:
+   - `task_queue` + `task_dlq` exist; cardinality reads cleanly.
+   - Checkpoint store accepts a hand-written test row.
+   - Memory KG schema is up; `pgvector` operator returns sane.
+   - Vault PVCs are mounted at the expected paths.
+   - MCP gateway exposes the expected tool prefix list.
+4. **Flip-on procedure exists.** A runbook section explaining
+   exactly which env / secret / Kustomization to toggle to bring
+   the component hot, what to expect (cost, latency, blast radius),
+   and how to revert.
+
+### Class C — aspirational (🟥)
+
+For components named in `ai_architecture.md` but not yet built.
+Today this is **doc-writer / Scribner** and any other agent listed
+as 🟥.
+
+An aspirational component is **done** *for Stage 1* when:
+
+1. It is named in `ai_architecture.md` with status 🟥.
+2. The intended scope is captured in a 1–3 sentence "what this
+   would do" section in `ai_architecture.md` or its own design
+   note.
+3. **No verification required.** Stage 1 does not build new
+   components; it only stabilizes what exists. Aspirational
+   components carry a row in the table below marked `n/a`.
+
+## End-to-end smoke test
+
+Stage 1 DoD #2: "End-to-end smoke test passes: task in → result
+out." This is one round-trip, not a thorough integration test.
+
+Per `goal.md` (user choice on Stage 1 scope), the smoke test must
+exercise the **hot path including Claude API escalation**: a task
+enters via one of the live surfaces, routes through Windmill, lands
+on langgraph-agents, escalates to Claude API under the in-cluster
+cost cap, and produces a result in the vault / Zulip / ntfy.
+
+**Concrete smoke**: see the Stage 1 Gate 1 evidence PR for the
+chosen task, transcript, and Langfuse trace ID.
+
+## Flux suspend/resume cycle
+
+Stage 1 DoD #3: "Survives a `flux suspend` / `resume` cycle on the
+relevant kustomizations without manual intervention."
+
+Scope is **every Kustomization that contributes to the AI pipeline**.
+That's at minimum:
+
+- `kubernetes/apps/ai/` — langgraph-agents, langfuse, ollama,
+  ollama-spark, khoj, tei-spark, paperless-ai, comfyui (where
+  HomeAIOps-relevant)
+- `kubernetes/apps/mcp-system/` — gateway + every MCP server
+- `kubernetes/apps/observability/` — Prometheus, AlertManager,
+  Loki, Grafana, HolmesGPT
+- `kubernetes/apps/automation/claude-runner/` — pr-triage,
+  cost-cap-commentary
+- `kubernetes/apps/home/windmill/` — server, worker, workflows
+- `kubernetes/apps/databases/cloudnative-pg/` — checkpoints,
+  memory, langfuse clusters
+- `kubernetes/apps/storage/qdrant/` — vector DB
+
+Procedure per Kustomization: `flux suspend ks <name>`, wait 30 s,
+`flux resume ks <name>`, verify `Ready=True` within 5 min, verify
+no transient drift in dependent resources.
+
+## Pod-level restart per component
+
+Stage 1 DoD #4: "Survives a pod-level restart of each component."
+
+Per-replica delete-pod test for each Class A and Class B
+component. Document the expected re-ready time alongside the
+component row below. Components with documented SLAs that miss them
+are filed as Stage 1 blockers.
+
+## Runbooks for top failure modes
+
+Stage 1 DoD #5: "Runbooks exist in `docs/runbooks/` for the top
+failure modes hit while stabilizing."
+
+`docs/src/` is the canonical location (the spec says
+`docs/runbooks/` but the established convention here is
+`docs/src/`). Each failure mode hit during the audit gets either:
+
+- A new chapter under `docs/src/`, listed in `SUMMARY.md`, OR
+- A section appended to the most-relevant existing chapter (e.g.
+  `ai_architecture.md` for cross-cutting AI fleet failures).
+
+The minimum runbook shape: **symptom**, **how to confirm**,
+**root cause** (or "still unknown — see issue #N"), **recovery
+procedure**, **prevention** (if known).
+
+## Component inventory
+
+The full list, sourced from `ai_architecture.md`. Each row gets
+filled in by its verification PR. This table is the running state
+of Stage 1; PRs update it as components are verified.
+
+Legend: ✅ verified · 🟡 plumbed-cold verified · 🚧 in progress ·
+❌ blocking issue · ⏳ not yet audited · 🟥 aspirational (no
+audit).
+
+### Surfaces
+
+| Surface | Class | Status | Verifying PR |
+|---|---|---|---|
+| HA voice → langgraph-inbox.ts | A | ⏳ | — |
+| Zulip DM (Triager bot) | A | ⏳ | — |
+| Open WebUI chat | A | ⏳ | — |
+| Khoj UI | A | ⏳ | — |
+| AlertManager firing alert → HolmesGPT | A | ⏳ | — |
+| Cron schedules (Windmill + k8s CronJob) | A | ⏳ | — |
+| Operator tap on ntfy | A | ⏳ | — |
+
+### Bridges (Windmill TS workflows)
+
+| Workflow | Class | Status | Verifying PR |
+|---|---|---|---|
+| `langgraph-inbox.ts` | A | ⏳ | — |
+| `zulip-triager-webhook.ts` | A | ⏳ | — |
+| `alertmanager-holmesgpt-notify.ts` | A | ⏳ | — |
+| `langgraph-daily-digest.ts` | A | ⏳ | — |
+| `langgraph-cost-cap-watcher.ts` | A | ⏳ | — |
+| `langgraph-awaiting-user-sweep.ts` | A | ⏳ | — |
+| `langgraph-dlq-watcher.ts` | A | ⏳ | — |
+| `langgraph-approval-post.ts` | A | ⏳ | — |
+| `langgraph-approval-receive.ts` | A | ⏳ | — |
+| `paperless-rag-ingest.ts` | A | ⏳ | — |
+| `paperless-rag-tombstone.ts` | A | ⏳ | — |
+| `workaround-watcher.ts` | A | ⏳ | — |
+
+### Agents
+
+| Agent | Class | Status | Verifying PR |
+|---|---|---|---|
+| HolmesGPT | A | ⏳ | — |
+| langgraph-agents (substrate) | B | ⏳ | — |
+| supervisor (langgraph specialist) | B | ⏳ | — |
+| researcher | B | ⏳ | — |
+| coder | B | ⏳ | — |
+| reviewer | B | ⏳ | — |
+| triager | B | ⏳ | — |
+| reporter | B | ⏳ | — |
+| note-maker | B | ⏳ | — |
+| homelab-engineer | B | ⏳ | — |
+| smart-home-engineer | B | ⏳ | — |
+| ml-tuner | B | ⏳ | — |
+| errand-runner (local-only pin) | B | ⏳ | — |
+| property-coordinator | B | ⏳ | — |
+| health-tracker (local-only pin) | B | ⏳ | — |
+| claude-runner pr-triage | A | ⏳ | — |
+| claude-runner cost-cap-commentary | A | ⏳ | — |
+| doc-writer / Scribner | C | 🟥 n/a | — |
+
+### Inference backends
+
+| Backend | Class | Status | Verifying PR |
+|---|---|---|---|
+| ollama (P40) | A | ⏳ | — |
+| ollama-spark (GB10) | A | ⏳ | — |
+| Claude API (via langgraph) | B | ⏳ | — |
+| Claude Code (via claude-runner) | A | ⏳ | — |
+| tei-spark (reranker) | A | ⏳ | — |
+
+### Tool surfaces
+
+| Tool | Class | Status | Verifying PR |
+|---|---|---|---|
+| MCP Gateway (`mcp-gateway` + `-istio` + `-controller`) | A | ⏳ | — |
+| `arr-mcp` | A | ⏳ | — |
+| `chrome-mcp` | A | ⏳ | — |
+| `cilium-mcp` | A | ⏳ | — |
+| `github-mcp` | A | ⏳ | — |
+| `grafana-mcp` | A | ⏳ | — |
+| `ha-mcp` | A | ⏳ | — |
+| `immich-mcp` | A | ⏳ | — |
+| `kubectl-mcp` | A | ⏳ | — |
+| `memory-mcp` | A | ⏳ | — |
+| `netbox-mcp` | A | ⏳ | — |
+| `omada-mcp` | A | ⏳ | — |
+| `paperless-mcp` | A | ⏳ | — |
+| `prometheus-mcp` | A | ⏳ | — |
+| `searxng-mcp` | A | ⏳ | — |
+| `time-mcp` | A | ⏳ | — |
+| `windmill-mcp` | A | ❌ HR stalled | — |
+| Qdrant | A | ⏳ | — |
+| Postgres CNPG `langgraph-checkpoints` (task_queue + task_dlq + checkpoints) | A | ⏳ | — |
+| Postgres CNPG `langgraph-memory` (pgvector KG) | A | ⏳ | — |
+| Postgres CNPG `langfuse` | A | ⏳ | — |
+
+### Outputs
+
+| Output | Class | Status | Verifying PR |
+|---|---|---|---|
+| Obsidian vault (via `langgraph-vault` PVC) | A | ⏳ | — |
+| Zulip threads (ops + per-agent) | A | ⏳ | — |
+| Ntfy push (tap-to-approve) | A | ⏳ | — |
+| Langfuse traces (OTLP sink) | A | ⏳ | — |
+
+### Langfuse storage substrate
+
+| Component | Class | Status | Verifying PR |
+|---|---|---|---|
+| `langfuse-web` | A | ⏳ | — |
+| `langfuse-worker` | A | ⏳ (26 lifetime restarts, OOM pattern) | — |
+| `langfuse-clickhouse` (3-shard) | A | ⏳ | — |
+| `langfuse-redis` | A | ⏳ | — |
+| `langfuse-s3` | A | ⏳ | — |
+| `langfuse-zookeeper` (3-node) | A | ⏳ (zookeeper-2 OOM 2026-05-21) | — |
+
+## Initial state (2026-05-21 cluster survey)
+
+The Stage 1 baseline, captured before stabilization work begins.
+
+**Healthy (all `Running`/`Ready`, restart count acceptable):**
+
+- langgraph-agents (0.2.33, 0 restarts at audit time)
+- ollama, ollama-spark, tei-spark
+- khoj + khoj-oauth2-proxy
+- All 16 MCP servers reachable through `mcp-gateway`
+- HolmesGPT, claude-runner (cron-driven, no live pod required)
+- AlertManager (18d uptime)
+- All Langfuse pods running and `Ready`
+
+**Open issues identified by survey, blocking Stage 1 DoD:**
+
+1. **`mcp-system/windmill-mcp` HelmRelease stalled.** Condition
+   `Stalled / MissingRollbackTarget`: "missing target release for
+   rollback: cannot remediate failed release." Three upgrade
+   failures (timeout waiting for `Deployment …InProgress`). The
+   underlying Deployment is healthy (1/1 ready, 0 restarts, 157 m
+   uptime) — the failure is in Helm metadata only. Fix: clear the
+   failed history so Flux can re-converge.
+
+2. **`observability/grafana` HelmRelease stalled.** 3 upgrade
+   failures, rolled back to v41. Pod healthy. Observability path is
+   degraded — investigate separately.
+
+3. **`ai/langfuse-zookeeper-2` OOMKilled (2026-05-21 01:48 UTC).**
+   `exitCode=137`, one restart in 22 h. Critical alert still
+   firing.
+
+4. **`ai/langfuse-worker` OOM pattern.** 26 lifetime restarts,
+   exit-137 history; last restart 16 h ago. Currently stable.
+
+**Queue substrate baseline:**
+
+- `task_queue`: 5 done, 0 pending, 0 claimed. (Matches `langgraph-
+  agents` shipped cold.)
+- `task_dlq`: 0.
+
+**Cold-path baseline:**
+
+- `ENABLE_CLAUDE_API: false` — Claude API escalation not yet
+  proven by a live task. Stage 1 hot-path smoke test will toggle
+  this with cost caps in place.
+
+## How this doc evolves
+
+Every Stage 1 verification PR updates the table (status column +
+"Verifying PR" link) plus, where the audit surfaced a fixable
+issue, adds the symptom + recovery to the runbooks section.
+
+Gate 1 is reached when every row in every Class A and Class B
+table reads ✅ or 🟡, the smoke-test transcript is captured, and
+the top failure modes have entries in `docs/src/`.

--- a/goal.md
+++ b/goal.md
@@ -1,0 +1,177 @@
+# Goal: HomeAIOps to Production-Ready, Then Invert the Workflow
+
+## Context
+
+`CLAUDE.md` is the canonical context for this work. Read it first. It defines
+the architecture, the pipeline inputs, the workflows, what "working" means, and
+the DoD references this prompt points at.
+
+Conflict resolution order:
+
+- If this prompt and `CLAUDE.md` disagree on **facts about the system**,
+  `CLAUDE.md` wins.
+- If this prompt and `CLAUDE.md` disagree on **stage scoping or rules of
+  engagement**, this prompt wins.
+- If the **repo** and `CLAUDE.md` disagree, the repo wins. Flag the drift and
+  update `CLAUDE.md` as part of the relevant PR.
+
+Also read existing `TODO.md`, prior memories, and inline `TODO(homeaiops):`
+comments. Treat them as authoritative state on what's done and what's pending.
+
+## Why this run exists
+
+We've been going two steps forward, one back. The point of this run is to break
+that pattern. Verify before you declare done. Keep state honest as you go.
+Don't skip the gates between stages.
+
+## Rules of engagement (apply to all stages)
+
+- One PR per logical concern. Max 3 PRs open concurrently.
+- PR → wait for green CI → rebase on main if needed → merge.
+- No opportunistic refactors, dependency bumps, or scope creep. If you find
+  something out of scope that's broken, file an issue, don't fix it.
+- Bug triage: P0 (blocks current stage DoD) fix now. P1 file an issue and
+  continue. P2 add to `TODO.md`.
+- If CI is red and the cause isn't obvious flakiness, stop and tell me.
+- Update `TODO.md`, memories, inline `TODO`s, and `CLAUDE.md` as you close
+  items. A rich context doc that's drifted from reality is worse than a sparse
+  one — treat `CLAUDE.md` maintenance as part of the work, not an afterthought.
+- For each verification, paste the actual output in the PR. No "looks good" —
+  show the green.
+- Parallelize aggressively *within* a stage (independent components,
+  independent PRs). Do not parallelize *across* stages — the gates exist
+  because scaffolding a later stage while an earlier stage is flaky is the
+  exact pattern we're breaking.
+- When in doubt about scope, intent, or whether something counts as "done" —
+  ask. A two-line clarification beats a two-day detour.
+
+---
+
+## Stage 1 — Stabilize
+
+Audit every HomeAIOps component top-to-bottom against the DoD documented in
+`CLAUDE.md` and the repo. For each component: run the documented verification,
+paste evidence in the PR, fix what's broken.
+
+### Definition of done
+
+- [ ] All HomeAIOps components pass their documented health checks
+- [ ] End-to-end smoke test passes: task in → result out
+- [ ] Survives a `flux suspend` / `resume` cycle on the relevant kustomizations
+      without manual intervention
+- [ ] Survives a pod-level restart of each component
+- [ ] Runbooks exist in `docs/runbooks/` for the top failure modes hit while
+      stabilizing
+
+### Gate 1
+
+Stop here. Post the smoke test output and the runbook list. Wait for my
+approval before starting Stage 2.
+
+---
+
+## Stage 2 — Migrate workflows onto HomeAIOps
+
+### Capability gap analysis (do this first, before building)
+
+Produce a written gap analysis covering:
+
+- What my current Claude Code workflow provides (todos, task dispatch, session
+  history, anything else surfaced in memory or `CLAUDE.md`)
+- What HomeAIOps provides today
+- The gap, prioritized
+
+The CLI is **my** primary interface to the pipeline, replacing my current
+Claude Code workflow. It is **not** the pipeline's only input — the repo
+already defines other inputs that feed the same task store and execution path.
+Treat the CLI as a peer to those, not a replacement for them. Shared concerns
+(task schema, store, dispatch, result handling) belong in the pipeline; the
+CLI is a thin client on top.
+
+In the gap analysis, confirm: which existing inputs feed the pipeline today,
+what schema/contract they use, and where the CLI plugs into that same
+contract. If the contract is implicit or inconsistent across inputs, making
+it explicit is part of Stage 2 — but as a deliberate sub-task, not a drive-by
+refactor.
+
+Show me the gap analysis before you start closing it.
+
+### Then close the gaps
+
+- Build/finish the terminal CLI that submits tasks to the local AI pipeline.
+  Installed on `$PATH`, `--help` works, core commands documented.
+- Move todo management out of Claude Code into HomeAIOps' own store. Claude
+  Code becomes a consumer, not the store.
+- Each capability moves in its own PR with a documented rollback path.
+
+### Definition of done
+
+- [ ] CLI is the primary interface for submitting tasks to local AI
+- [ ] Todos live in HomeAIOps; Claude Code is a consumer, not the store
+- [ ] Existing non-CLI inputs still work end-to-end (verified, not assumed)
+      after the CLI lands
+- [ ] One full day of dogfooding without falling back to Claude Code for the
+      primary task flow
+
+### Gate 2
+
+Stop here. Post the day-of-dogfooding log. Wait for my approval before
+starting Stage 3.
+
+---
+
+## Stage 3 — Invert: local-first with Claude escalation
+
+Today I drive Claude Code, and Claude sometimes calls local infra. Target:
+I drive HomeAIOps, and HomeAIOps decides when to escalate to Claude.
+
+Routing, escalation, provenance, and cost visibility apply to **all** inputs
+into the pipeline, not just CLI-submitted tasks. The routing policy is
+input-agnostic: a task is a task regardless of whether it arrived via CLI or
+any other input defined in the repo. Provenance records the input source
+alongside the execution target so I can see, per input, what's running local
+vs. escalating.
+
+### Required pieces
+
+- **Routing policy.** Version-controlled file in the repo that decides
+  local vs. escalate based on explicit rules (task type, model capability,
+  context size, sensitivity). No learned router yet — explicit rules first.
+  Changing the file changes behavior.
+- **Escalation client.** HomeAIOps calls Claude as a subordinate worker. Use
+  Claude Code in headless mode for tool-using/coding tasks; use the raw
+  Anthropic API for classification, summarization, drafting. Document the
+  rule for which is used when.
+- **Provenance.** Every task result records where it ran (local model +
+  version, or Claude + model string) and which input it arrived from.
+- **Fallback on failure.** If local execution fails or returns low
+  confidence, auto-escalate with the failure context attached — don't restart
+  from a fresh prompt.
+- **Cost/usage visibility.** CLI subcommand showing local vs. escalated task
+  counts and Claude spend over the last N days. Without this, "local-first"
+  silently becomes "Claude-first with extra steps."
+- **Guardrail against silent Claude-creep.** Budget threshold; if escalation
+  rate or spend crosses it, surface a warning. (This is the failure mode I'm
+  most worried about — drift toward escalating everything.)
+
+### Definition of done
+
+- [ ] I issue tasks to the CLI by default for one full week (wall-clock; the
+      week ends when I confirm it, not when you think the work is done)
+- [ ] At least one task type round-trips local → escalate → result with no
+      intervention from me
+- [ ] Routing policy file is the single source of truth; behavior changes when
+      I edit it
+- [ ] Escalation and provenance work uniformly across all pipeline inputs, not
+      just CLI
+- [ ] Escalation rate and Claude spend are visible from the CLI
+- [ ] Runbook exists for "local infra is down, fall back to Claude Code
+      directly"
+
+---
+
+## Final note
+
+If something in this prompt contradicts what you find in `CLAUDE.md` or the
+repo, apply the conflict resolution order at the top and tell me what you
+found. Don't paper over it.


### PR DESCRIPTION
## Summary

Stage 1 of the HomeAIOps stabilization directive (`goal.md`, also in
this PR) requires verifying every AI-pipeline component against
"the DoD documented in `CLAUDE.md` and the repo." That DoD did not
exist as a single artifact. Per `goal.md` conflict resolution
(repo wins; flag drift and update CLAUDE.md as part of the relevant
PR), this PR is the missing artifact.

This PR is **scaffolding only** — no cluster changes, no Helm
upgrades, no kustomization touches.

## What's in the PR

- `goal.md` (existing local commit, restored to main): the
  stabilization + inversion directive.
- `docs/src/homeaiops_dod.md` (new): per-component-class DoD
  checklists (live / plumbed-cold / aspirational), full component
  inventory sourced from `ai_architecture.md`, the 2026-05-21
  cluster survey baseline, and how the doc evolves as Stage 1
  PRs land.
- `docs/src/SUMMARY.md`: mdbook entry under `AI Architecture`.
- `CLAUDE.md`: one-line Documentation-section pointer to the new
  DoD doc.

## Initial state captured (2026-05-21 cluster survey)

**Healthy:**

- langgraph-agents 0.2.33 — 0 restarts, queue substrate clean
  (`task_queue` 5 done / 0 pending / DLQ 0).
- All 16 MCP servers reachable through the gateway.
- Both ollama backends + tei-spark + all Langfuse pods Ready.
- AlertManager 18d uptime.

**Identified Stage 1 blockers (each gets its own PR):**

1. `mcp-system/windmill-mcp` HelmRelease `Stalled /
   MissingRollbackTarget` after 3 upgrade timeouts; Deployment is
   healthy (157m uptime, 0 restarts).
2. `observability/grafana` HelmRelease rolled back to v41 after 3
   upgrade failures; pod healthy.
3. `ai/langfuse-zookeeper-2` OOMKilled at 2026-05-21 01:48 UTC
   (exit 137, 1 restart in 22h).
4. `ai/langfuse-worker` 26-restart OOM pattern; last restart 16h
   ago, currently stable.

Followups (P2, separate issues to be filed if not already):
`KubeJobFailed` alerts on `kube-state-metrics` in home/automation/media.

## Verification

Pre-commit ran clean locally on the commit:

```
trim trailing whitespace.................................................Passed
detect private key.......................................................Passed
Detect hardcoded secrets.................................................Passed
yamllint.............................................(no files to check)Skipped
markdownlint-cli2........................................................Passed
README badges match repo reality.........................................Passed
README drift vs origin/main merge........................................Passed
```

## Test plan

- [ ] CI green (lint + docs-build + secret scans)
- [ ] mdbook renders the new page under "AI Architecture"
- [ ] No README drift triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)