### PR TITLE
fix(mcp-system/windmill-mcp): bump spec.timeout to 15m + stalled-HR runbook

### DIFF
--- a/docs/src/homeaiops_dod.md
+++ b/docs/src/homeaiops_dod.md
@@ -331,3 +331,92 @@ issue, adds the symptom + recovery to the runbooks section.
 Gate 1 is reached when every row in every Class A and Class B
 table reads ✅ or 🟡, the smoke-test transcript is captured, and
 the top failure modes have entries in `docs/src/`.
+
+## Runbooks
+
+Failure modes encountered during Stage 1, with confirmation and
+recovery steps.
+
+### Stalled HelmRelease with `MissingRollbackTarget`
+
+**Symptom.** A HelmRelease shows `Ready=False` with condition
+`Stalled / MissingRollbackTarget`: "Failed to perform remediation:
+missing target release for rollback: cannot remediate failed
+release." `helm history -n <ns> <release>` shows **every** release
+in `failed` state — there is no successful version to roll back
+to. Underlying resources (Deployment, Service, etc.) may
+nevertheless be live and serving traffic.
+
+**How to confirm.**
+
+```sh
+kubectl get helmrelease -n <ns> <name> -o json \
+  | jq '.status.conditions[] | select(.type=="Stalled")'
+helm history <release> -n <ns>
+```
+
+If all release versions are `failed` and the underlying
+Deployment is `Available`, the chart's resources have converged
+despite Helm's history saying otherwise — Helm's wait/timeout
+fired before the pod became `Ready`.
+
+**Root cause.** The HelmRelease's effective install/upgrade
+timeout (`spec.timeout`, default 5 m) is shorter than the time
+the first Deployment took to become `Ready`. Common drivers:
+Istio sidecar warmup, slow image pull on first install, slow
+ExternalSecret resolution. Once the first install fails, Flux
+attempts retries; each retry also times out, and after the
+configured `retries` count the release is `Stalled` with no
+healthy version to remediate to.
+
+**Prevention.** Set `spec.timeout` on the HelmRelease to cover
+the slowest-realistic warmup for the workload (15 m is a safe
+default for Istio-injected pods). See
+`kubernetes/apps/mcp-system/windmill-mcp/app/helmrelease.yaml`
+for the canonical example.
+
+**Recovery.** *Destructive — propose to operator before running.*
+The Deployment and friends already exist; we need to make Helm's
+storage agree.
+
+1. Suspend Flux reconciliation so it doesn't fight the cleanup:
+
+   ```sh
+   flux suspend hr <name> -n <ns>
+   ```
+
+2. Verify the underlying Deployment is healthy:
+
+   ```sh
+   kubectl get deploy,svc,sa,httproute -n <ns> \
+     -l app.kubernetes.io/instance=<name>
+   ```
+
+3. Delete the chart resources and the failed Helm history
+   secrets together — Helm won't adopt resources it doesn't own,
+   so a brief downtime is unavoidable:
+
+   ```sh
+   kubectl delete deployment,svc,sa,httproute \
+     -n <ns> -l app.kubernetes.io/instance=<name>
+   kubectl delete secret -n <ns> -l owner=helm,name=<name>
+   ```
+
+4. Resume Flux and force reconcile; the HR will do a clean
+   `helm install`:
+
+   ```sh
+   flux resume hr <name> -n <ns>
+   flux reconcile hr <name> -n <ns> --force
+   ```
+
+5. Verify the HR becomes `Ready=True` within the new
+   `spec.timeout` window:
+
+   ```sh
+   kubectl get hr -n <ns> <name> -w
+   ```
+
+Time budget: 2–3 m of downtime per HR. Pick a maintenance
+window per `CLAUDE.md` if the component is operator- or
+Renee-facing.

--- a/kubernetes/apps/mcp-system/windmill-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/windmill-mcp/app/helmrelease.yaml
@@ -9,6 +9,14 @@ spec:
     kind: OCIRepository
     name: app-template
   interval: 1h
+  # Default Flux timeout is 5m; first install of this HR timed out on
+  # 2026-05-21 (Istio sidecar warmup pushed the pod past 5m to Ready).
+  # All three subsequent install/upgrade attempts also hit 5m and left
+  # the HR Stalled / MissingRollbackTarget. Bumping to 15m gives the
+  # sidecar room without affecting steady-state behaviour. See
+  # `docs/src/homeaiops_dod.md` → Runbooks → "Stalled HelmRelease with
+  # MissingRollbackTarget" for the recovery procedure.
+  timeout: 15m
   values:
     defaultPodOptions:
       securityContext:


### PR DESCRIPTION
## Summary

Stage 1 stabilization — first concrete fix on the windmill-mcp
HelmRelease, which is currently `Stalled / MissingRollbackTarget`
after three 5-min install/upgrade timeouts on 2026-05-21.

The Deployment, Service, SA, and HTTPRoute are all live and
serving traffic; the failure is purely in Helm's release metadata.
This PR is the **preventive + documentation** half:

1. `helmrelease.yaml`: `spec.timeout: 15m` (default is 5 m; first
   install hit `5m1.98s` with the Deployment still `InProgress`
   under Istio sidecar warmup).
2. `homeaiops_dod.md`: new "Runbooks" section with the
   "Stalled HelmRelease with `MissingRollbackTarget`" procedure
   — symptom, confirmation, root cause, prevention, recovery.

This PR does **not** clear the existing stalled state on the live
cluster. The recovery procedure is destructive (delete chart
resources + Helm history secrets, then clean reinstall) and is
marked propose-then-execute per HOMELAB-SPEC. The destructive
cleanup runs out-of-band after operator approval; see the runbook
section for the procedure.

## Why now

`goal.md` Stage 1 DoD #1 requires every component's documented
health check to pass. windmill-mcp's HR fails `Ready=True`, so it
blocks Stage 1 completion. Bumping the timeout prevents recurrence
after we clean up the existing state.

## Verification

Pre-commit ran clean locally:

```
check yaml...............................................................Passed
yamllint.................................................................Passed
markdownlint-cli2........................................................Passed
README badges match repo reality.........................................Passed
CiliumNetworkPolicy has rules............................................Passed
No literal credentials in staged YAML....................................Passed
```

Cluster state at PR time (windmill-mcp Deployment, 0 restarts):

```
NAME                           READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/windmill-mcp   1/1     1            1           14h
pod/windmill-mcp-76fbdbdd5d-59pw9   1/1   Running    0          157m
```

HR `Stalled` condition that this prevents recurrence of:

```json
{
  "type": "Stalled",
  "status": "True",
  "reason": "MissingRollbackTarget",
  "message": "Failed to perform remediation: missing target release for rollback: cannot remediate failed release"
}
```

## Test plan

- [ ] CI green
- [ ] After merge: out-of-band recovery (operator approval) clears
      the stalled state, HR converges to `Ready=True` within 15 m,
      DoD table row for windmill-mcp updates ⏳ → ✅ in a follow-up PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)