### PR TITLE
fix(ai/langfuse): set explicit zookeeper + worker memory bounds

### DIFF
--- a/kubernetes/apps/ai/langfuse/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langfuse/app/helmrelease.yaml
@@ -53,6 +53,21 @@ spec:
       auth:
         existingSecret: langfuse-secret
         existingSecretKey: CLICKHOUSE_PASSWORD
+      # Bitnami clickhouse subchart bundles zookeeper at the
+      # "micro" resourcesPreset (256Mi req / 384Mi limit). All
+      # three replicas were sitting at 90–99 % of the 384Mi limit
+      # under steady-state traffic (audit on 2026-05-21 — see
+      # docs/src/homeaiops_dod.md initial-state survey, item 3).
+      # zookeeper-2 was OOMKilled at 01:48 UTC the same day.
+      # Bumping to 768Mi req / 1Gi limit gives ~2.6× headroom
+      # over observed steady-state.
+      zookeeper:
+        resources:
+          requests:
+            cpu: 250m
+            memory: 768Mi
+          limits:
+            memory: 1Gi
     redis:
       deploy: true
       auth:
@@ -71,6 +86,18 @@ spec:
         replicas: 1
       worker:
         replicas: 1
+        # The worker container shipped with no resources block at
+        # all — `resources: {}` in the running pod spec. 26
+        # lifetime restarts with exit-137 came from node-level
+        # OOM pressure with no pod-level bound. Setting request
+        # +  limit constrains the failure to a single pod and
+        # gives the cluster something to schedule against.
+        resources:
+          requests:
+            cpu: 100m
+            memory: 512Mi
+          limits:
+            memory: 1Gi
       # SALT / ENCRYPTION_KEY / NextAuth must use the chart's native
       # `secretKeyRef` plumbing — the chart's worker/deployment.yaml
       # renders these as secret env refs and aborts `helm template`


### PR DESCRIPTION
## Summary

Stage 1 stabilization PR. Two narrow resource adds, both surfaced
by the 2026-05-21 audit (see `docs/src/homeaiops_dod.md`
initial-state items 3 + 4):

### 1. `clickhouse.zookeeper.resources`

Bitnami's bundled zookeeper subchart ships with the `micro`
resourcesPreset → 256 Mi req / 384 Mi limit. Audit data:

```
NAME                   MEMORY(bytes)   LIMIT
langfuse-zookeeper-0   365Mi           384Mi (95%)
langfuse-zookeeper-1   381Mi           384Mi (99%)
langfuse-zookeeper-2   348Mi           384Mi (90%)
```

zookeeper-2 was already OOMKilled at 01:48 UTC on audit day.
zookeeper-1 at 99 % of limit is OOM-imminent.

This PR sets `768 Mi req / 1 Gi limit` — ~2.6× headroom over
observed steady-state.

### 2. `langfuse.worker.resources`

The worker container shipped with `resources: {}` — no limit
at all:

```json
{ "container": "langfuse-worker", "resources": {} }
```

26 lifetime restarts, all exit-137 — these are node-level OOM
kills, not pod-level limit kills. Setting `100 m / 512 Mi req,
1 Gi limit` bounds the failure to one pod and gives the scheduler
something to plan around.

## Risk

Both changes increase memory **request**, which means scheduler
pressure goes up modestly. Worker requests jump from 0 → 512 Mi
(one pod). Each zookeeper request jumps 256 Mi → 768 Mi (three
pods, +1.5 Gi total). The cluster has plenty of headroom for this.

Helm upgrade rolls the zookeeper StatefulSet and worker
Deployment. ~2-3 min of zookeeper churn — ClickHouse can lose its
ZK quorum briefly. Langfuse trace ingest will pause during the
rollover; existing traces unaffected. Worker rollover is a
straight Deployment rolling-update, ~30 s.

## Verification

Pre-commit clean.

## Test plan

- [ ] CI green (Flux Local validates helm template)
- [ ] Post-merge: `kubectl top pod -n ai -l app.kubernetes.io/component=zookeeper` shows new headroom
- [ ] Post-merge: worker pod has non-empty `resources` in `kubectl get pod -o json`
- [ ] DoD doc table updated in a follow-up PR after settle

🤖 Generated with [Claude Code](https://claude.com/claude-code)