### PR TITLE
fix(ai/langgraph-agents): single-source Anthropic key from claude-runner 1P item

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/externalsecret.yaml
@@ -17,7 +17,13 @@ spec:
         # Anthropic Claude API. Optional — agents that opt in (coder, errand-runner,
         # homelab/smart-home/property-engineer, ml-tuner) use this. health-tracker
         # is architecturally blocked from importing the anthropic SDK at all.
-        ANTHROPIC_API_KEY: "{{ .ANTHROPIC_API_KEY }}"
+        #
+        # Single source of truth: the `anthropic_api_key` field on the 1P
+        # `claude-runner` item — shared with the `automation/claude-runner`
+        # ExternalSecret. Rotating that one field rotates both lanes.
+        # (Previous home was an empty `ANTHROPIC_API_KEY` field on the
+        # `langgraph-agents` item; that field can be removed in 1P.)
+        ANTHROPIC_API_KEY: "{{ .anthropic_api_key }}"
 
         # Pushover Tier 1 escalations. Reuses the alertmanager-secret keys.
         PUSHOVER_APP_TOKEN: "{{ .PUSHOVER_APP_TOKEN }}"
@@ -73,3 +79,7 @@ spec:
     # from the same token alertmanager uses to invoke HolmesGPT).
     - extract:
         key: windmill
+    # Anthropic Claude API key, shared with claude-runner. Single
+    # rotation surface (see ANTHROPIC_API_KEY template above).
+    - extract:
+        key: claude-runner


### PR DESCRIPTION
## Summary

Stage 1 unblocker for the E2E smoke test. The langgraph-agents
ExternalSecret was pointing at an empty `ANTHROPIC_API_KEY` field
on the 1P `langgraph-agents` item, while the actual live key has
been in the `claude-runner` 1P item under field `anthropic_api_key`
(lowercase) — used daily by the `automation/claude-runner`
CronJobs.

Two lanes, same secret, two places to rotate is exactly the
single-rotation-surface antipattern we already avoid for the
Windmill webhook token.

## Change

- `dataFrom`: adds a 4th `extract: key: claude-runner` entry
- Template: `ANTHROPIC_API_KEY` maps from `{{ .anthropic_api_key }}` (lowercase)

## Verification done locally

```text
=== langgraph-agents-secret ANTHROPIC_API_KEY BEFORE ===
decoded length: 0 bytes  (1P field was empty)

=== claude-runner-secret ANTHROPIC_API_KEY (already working) ===
decoded length: 108 bytes  (real sk-ant-… key)
```

## What happens on merge

1. Flux reconciles the ExternalSecret CR.
2. external-secrets-operator refreshes (≤5 min, or `kubectl
   annotate externalsecret -n ai langgraph-agents
   force-sync=$(date +%s) --overwrite` to poke now).
3. `kubectl get secret -n ai langgraph-agents-secret \\
   -o jsonpath='{.data.ANTHROPIC_API_KEY}' | base64 -d | wc -c`
   should print > 80.

After step 3 succeeds, a one-line follow-up PR flips
`ENABLE_CLAUDE_API: "false"` → `"true"` to bring the path hot.

## Test plan

- [ ] CI green
- [ ] Post-merge: `ANTHROPIC_API_KEY` secret value length > 80 bytes
- [ ] No effect on running pods (cold gate stays cold until follow-up PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)