### PR TITLE
docs(homeaiops): Batch 2 — Flux suspend/resume cycle results

### DIFF
--- a/docs/src/homeaiops_dod.md
+++ b/docs/src/homeaiops_dod.md
@@ -393,6 +393,37 @@ No AI-pipeline component has > 5 lifetime restarts; the previous
 worker (26 restarts, exit-137 OOM) was replaced cleanly under
 [#11922](https://github.com/rwlove/home-ops/pull/11922).
 
+### Batch 2 — 2026-05-21 Flux suspend/resume cycle
+
+Evidence for DoD #3: every AI-pipeline Kustomization survives a
+suspend/resume cycle without manual intervention. Procedure per
+Kustomization: `flux suspend ks <name>`, wait 30 s, `flux resume
+ks <name>`, watch for `Ready=True` again. Captured cycle time =
+`flux suspend` → `Ready=True` (includes the deliberate 30 s pause).
+
+Representative sample covering inference, agents, MCP fleet, and
+the cron-driven Claude lane:
+
+```text
+ai/langgraph-agents      Ready=True at t+37s
+ai/ollama-spark          Ready=True at t+38s
+ai/tei-spark             Ready=True at t+37s
+mcp-system/memory-mcp    Ready=True at t+37s
+mcp-system/mcp-gateway   Ready=True at t+64s
+observability/holmesgpt  Ready=True at t+37s
+automation/claude-runner Ready=True at t+38s
+```
+
+All 7 Kustomizations resumed cleanly. No manual touch needed;
+no dependent resources entered transient `NotReady`. The
+`mcp-gateway` outlier at 64 s is consistent with its three-HR
+inventory (gateway + istio + controller) which takes longer to
+reconcile than a single-HR Kustomization.
+
+Full-fleet sweep deferred to a follow-up after first running the
+E2E smoke test (DoD #2) — keeping the maintenance-window blast
+radius narrow while Claude API enablement is in flight.
+
 ## Runbooks
 
 Failure modes encountered during Stage 1, with confirmation and


### PR DESCRIPTION
## Summary

Stage 1 DoD #3 evidence: every AI-pipeline Kustomization survives
a `flux suspend` / `flux resume` cycle without manual intervention.

Representative sample (7 Kustomizations covering inference layer,
agent layer, MCP fleet, observability, and the cron-driven Claude
lane). Procedure: `flux suspend ks` → wait 30 s → `flux resume ks`
→ watch for `Ready=True`.

## Results

```text
ai/langgraph-agents      Ready=True at t+37s
ai/ollama-spark          Ready=True at t+38s
ai/tei-spark             Ready=True at t+37s
mcp-system/memory-mcp    Ready=True at t+37s
mcp-system/mcp-gateway   Ready=True at t+64s
observability/holmesgpt  Ready=True at t+37s
automation/claude-runner Ready=True at t+38s
```

All 7 resumed cleanly. No manual touch, no dependent resources
flapped to `NotReady`. The `mcp-gateway` outlier at 64 s is
consistent with its three-HR inventory taking longer to reconcile.

## Why a sample, not the full fleet

Keeping concurrent disruption narrow while the E2E smoke test is
in flight (Claude API enablement). Full-fleet sweep follows after
smoke. Both are still pre-Gate-1.

## Test plan

- [ ] CI green
- [ ] mdbook renders new Batch 2 section
- [ ] No regression of windmill-mcp ✅ row

🤖 Generated with [Claude Code](https://claude.com/claude-code)