### PR TITLE
feat(ai/langgraph-agents): flip ENABLE_CLAUDE_API to true — hot path on

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
@@ -33,7 +33,15 @@ spec:
               # Services so no overrides are needed here. The legacy
               # OLLAMA_BASE_URL setting was deprecated in v0.2.x and
               # removed in this PR.
-              ENABLE_CLAUDE_API: "false"  # flip to true once Claude key is in 1Password
+              # Hot path enabled 2026-05-21 (#11923 single-sourced the key
+              # from the `claude-runner` 1P item; the resulting Secret
+              # carries the live 108-byte sk-ant-… value).
+              #
+              # Cost ceilings enforced in-cluster (see COST_CAP_* below):
+              # $5/task, $10/agent/day, $30/global/day. To revert, flip
+              # this to "false" and reapply — escalation will fall back
+              # to local models within the next request.
+              ENABLE_CLAUDE_API: "true"
 
               # --- memory embedder ---
               # MCPMemoryStore writes via direct SQL to


### PR DESCRIPTION
## ⚠️ Operator review before merge

This is the gate flip that brings the Claude API escalation path
hot for the langgraph-agents fleet. Pre-conditions are now all
satisfied:

- ✅ Anthropic key in 1P `claude-runner.anthropic_api_key`
  (108 bytes, in use by claude-runner CronJobs daily)
- ✅ Key single-sourced into `langgraph-agents-secret` via #11923
  (verified: \`kubectl get secret -n ai langgraph-agents-secret -o
  jsonpath='{.data.ANTHROPIC_API_KEY}' | base64 -d | wc -c\` → 108)
- ✅ Cost caps configured in same env block:
  - \`COST_CAP_PER_TASK_USD: "5.0"\`
  - \`COST_CAP_PER_AGENT_DAILY_USD: "10.0"\`
  - \`COST_CAP_GLOBAL_DAILY_USD: "30.0"\`
- ✅ Cap watcher Windmill workflow (\`langgraph-cost-cap-watcher.ts\`)
  is deployed and reconciled
- ✅ ai_architecture.md and homeaiops_dod.md already document the
  hot path; this PR brings cluster reality in line with the docs

## What happens on merge

1. Flux reconciles the HelmRelease.
2. langgraph-agents pod rolls (reloader catches the env change via
   the `reloader.stakater.com/auto: "true"` annotation on the
   controller).
3. From the next request that escalates (uncertainty score, or
   `requires_cloud` tag), the agent fleet calls the Anthropic API
   with the cluster-side budget enforcement still in place.

## Cost ceiling (worst case)

The hardest ceiling is \`COST_CAP_GLOBAL_DAILY_USD: "30.0"\`. Beyond
that, the cap watcher pauses the queue. So the worst-case overrun
in a 24h window is **$30** before the in-cluster brake fires —
and the Windmill watcher pages Pushover when the threshold is
hit.

## Reversion

```yaml
ENABLE_CLAUDE_API: "false"
```

→ reapply. Within the next request, escalation falls back to a
local model (qwen2.5:32b on ollama-spark). No warm-up needed.

## Hold for operator approval

I deliberately did **not** auto-merge this PR. Confirm in a
comment / merge directly when ready, and I'll run the post-merge
E2E smoke test (Zulip DM via cluster-internal API to the Triager
bot → langgraph specialist → Claude API → vault file + Zulip
reply) and post the transcript + Langfuse trace ID as the Stage 1
DoD #2 evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)