### PR TITLE
fix(home/windmill): remove deprecated Zulip 'stream' URL from approval ntfy push

### DIFF
--- a/kubernetes/apps/home/windmill/workflows/langgraph-approval-post.ts
+++ b/kubernetes/apps/home/windmill/workflows/langgraph-approval-post.ts
@@ -37,6 +37,19 @@ export async function main(task_id: string, paused_for: { approval_request: Appr
     const rejectTok = await signApprovalToken(task_id, r.action_class, serverName, method);
     const deferTok = await signApprovalToken(task_id, r.action_class, serverName, method);
 
+    // ntfy `click` URL is intentionally omitted. The previous value
+    // (`https://chat.thesteamedcrab.com/#narrow/stream/approvals/topic/…`)
+    // used the deprecated pre-2024 Zulip URL scheme; the current scheme
+    // is `#narrow/channel/<channel-id>-<name>/topic/<name>` and Zulip
+    // mobile / web reject the old `stream` form with "invalid URL".
+    // The Approve / Reject / Defer ntfy action buttons still work
+    // independently of the click target — they POST pre-signed HMAC
+    // tokens to the langgraph /approval endpoint directly.
+    //
+    // Adding a working click URL is a follow-up: needs the integer
+    // channel ID for the `approvals` stream and a robust topic
+    // encoding helper (Zulip uses a custom dotted-encoding scheme
+    // for topics that differs from encodeURIComponent).
     const ntfyResp = await publishNtfy({
         topic: "approvals",
         title: `🔔 Approval needed: Class ${r.action_class}`,
@@ -50,7 +63,6 @@ export async function main(task_id: string, paused_for: { approval_request: Appr
         priority: 5,
         tags: ["warning"],
         actions: buildApprovalActions(task_id, approveTok, rejectTok, deferTok),
-        click: `https://chat.thesteamedcrab.com/#narrow/stream/approvals/topic/${encodeURIComponent(topic)}`,
     });
 
     const zulipResp = await postZulipApprovalCard(task_id, r);


### PR DESCRIPTION
## Summary

Stage 1 smoke #2 (2026-05-21) surfaced this: tapping the ntfy
approval push on the phone opened a Zulip URL of the form
`https://chat.thesteamedcrab.com/#narrow/stream/approvals/topic/…`,
which uses the pre-2024 Zulip URL scheme. Current Zulip mobile /
web require `#narrow/channel/<channel-id>-<name>/topic/<name>`
and reject the older `stream` form with **"invalid URL"** (per
operator report).

## Fix

Drop the `click` URL from the ntfy push payload. The Approve /
Reject / Defer **action buttons** are independent of `click` —
they POST pre-signed HMAC tokens directly to the langgraph
`/approval` endpoint, so the human-in-the-loop workflow keeps
functioning. The user loses the "tap-to-open-topic" deep-link
convenience but gains a flow that doesn't trigger the error.

## Follow-up not in this PR

Adding a *working* click URL back needs:

- the integer channel ID for the `approvals` stream
  (`/api/v1/streams` with auth)
- a Zulip-correct topic encoder (Zulip uses custom dotted-
  encoding that differs from `encodeURIComponent` — e.g. `:`
  becomes `.3A`)

Tracking this as a small Stage 2 quality-of-life item — not
blocking, since the action buttons already deliver the core
approval UX.

## Test plan

- [ ] CI green
- [ ] Next approval-class task: ntfy push on phone, tap-to-open
      → opens chat homepage (or no-op) instead of "invalid URL"
- [ ] Approve / Reject / Defer action buttons still POST as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)