### PR TITLE
fix(observability/kube-prometheus-stack): allow prometheus-mcp ingress to :9090

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/cnp-allow.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/cnp-allow.yaml
@@ -21,6 +21,9 @@ spec:
     # Home Assistant prometheus sensor → prometheus:9090 (direct pull
     # from home ns for the HA `prometheus` integration; egress side
     # was punched through in PR #11699).
+    # prometheus-mcp → prometheus:9090 (MCP backend queries Prometheus
+    # via PROMETHEUS_URL; egress side already allowed in
+    # mcp-system/prometheus-mcp-allow).
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: network
@@ -28,6 +31,9 @@ spec:
         - matchLabels:
             io.kubernetes.pod.namespace: home
             app.kubernetes.io/name: home-assistant
+        - matchLabels:
+            io.kubernetes.pod.namespace: mcp-system
+            app.kubernetes.io/name: prometheus-mcp
       toPorts:
         - ports:
             - port: "9090"


### PR DESCRIPTION
## Summary

- Hubble shows steady `Policy denied DROPPED` SYNs from `mcp-system/prometheus-mcp` → `observability/prometheus-kube-prometheus-stack-0:9090`.
- Source egress in `mcp-system/prometheus-mcp-allow` already permits the call; destination ingress in `observability/prometheus-allow` whitelisted only `network/envoy` and `home/home-assistant`. CNPs need both sides.
- Adds a third `fromEndpoints` entry for `mcp-system/prometheus-mcp` (label `app.kubernetes.io/name: prometheus-mcp`) to the existing :9090 ingress rule.

## Why

Same both-sides-CNP failure mode as the holmesgpt drop fixed in PR #11889. The MCP backend pod queries Prometheus via `PROMETHEUS_URL`; without the destination ingress hole the call never lands.

## Test plan

- [ ] Flux reconciles `kube-prometheus-stack` Kustomization.
- [ ] `kubectl -n observability get cnp prometheus-allow -o yaml` shows the new `fromEndpoints` entry.
- [ ] `hubble observe --since 5m --verdict DROPPED --to-namespace observability` from any cilium agent on the worker hosting `prometheus-mcp-*` returns empty for the mcp-system → prometheus pair.
- [ ] `prometheus-mcp` tool calls via the gateway succeed against live Prometheus (e.g., `execute_query`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)