### PR TITLE
fix(collab/paperless): allow Gmail IMAPs egress (TCP/993 → world)

### DIFF
--- a/kubernetes/apps/collab/paperless/app/cnp-allow.yaml
+++ b/kubernetes/apps/collab/paperless/app/cnp-allow.yaml
@@ -47,10 +47,10 @@ spec:
         - ports:
             - port: "8000"
               protocol: TCP
-    # Cross-ns: paperless-mcp's PAPERLESS_URL points at the external
-    # FQDN which traverses envoy back to paperless. Internal callers
-    # speaking directly to paperless:8000 (if any are added later)
-    # would also land here.
+  # Cross-ns: paperless-mcp's PAPERLESS_URL points at the external
+  # FQDN which traverses envoy back to paperless. Internal callers
+  # speaking directly to paperless:8000 (if any are added later)
+  # would also land here.
   egress:
     # CNPG cluster postgres-paperless in databases ns (Pattern B).
     - toEndpoints:
@@ -60,6 +60,16 @@ spec:
       toPorts:
         - ports:
             - port: "5432"
+              protocol: TCP
+    # Gmail IMAPs — paperless-ngx mail-account ingester (PAPERLESS_CONSUMER_*)
+    # polls imap.gmail.com:993 for new mail. imap.gmail.com resolves to
+    # GCP IPs (currently 142.251.x.x range); world is the only practical
+    # match since the resolved IP rotates within the Google IP pool.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "993"
               protocol: TCP
     # Redis broker via shared dragonfly (PAPERLESS_REDIS).
     - toEndpoints:


### PR DESCRIPTION
## Summary

- Hubble shows steady \`Policy denied DROPPED\` SYNs from \`collab/paperless-0\` → \`142.251.167.108:993\` (imap.gmail.com). paperless-ngx mail-account ingester polls Gmail over IMAPs and was hitting default-deny.
- Adds a \`toEntities: [world]\` TCP/993 egress entry. imap.gmail.com resolves into the Google IP pool which rotates within a wide CIDR — per-CIDR allow isn't practical.
- Re-indents a pre-existing trailing comment between the ingress and egress blocks to satisfy yamllint \`--strict\` (the pre-commit hook flags it as soon as the file is touched).

## Why

Discovered during a cluster-wide CNP drop sweep alongside PR #11934. Paperless's mail account integration is configured and expected to work.

## Test plan

- [ ] Flux reconciles \`paperless\` Kustomization.
- [ ] \`kubectl -n collab get cnp paperless-allow -o yaml\` shows the new TCP/993 world egress entry.
- [ ] \`hubble observe --since 5m --verdict DROPPED --from-pod collab/paperless-0\` shows no port-993 drops.
- [ ] Paperless mail-account fetch succeeds (check paperless logs for IMAP poll cycles, or trigger a manual fetch from the UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)