### PR TITLE
fix(home/home-assistant): allow mDNS multicast discovery on eth0 (UDP/5353)

### DIFF
--- a/kubernetes/apps/home/home-assistant/app/cnp-allow.yaml
+++ b/kubernetes/apps/home/home-assistant/app/cnp-allow.yaml
@@ -195,8 +195,16 @@ spec:
         - ports:
             - port: "11434"
               protocol: TCP
-    # NOTE: Home Assistant has multus-attached secondary NICs on the
-    # IoT and SECURITY VLANs (hass-iot-static, hass-security-static).
-    # Discovery (mDNS, broadcasts, device polling) over those NICs
-    # bypasses Cilium entirely; only eth0 (apiserver, DNS, cross-ns,
-    # external) is governed here.
+    # mDNS multicast discovery over eth0. HA's zeroconf integration
+    # sends queries to 224.0.0.251:5353; Cilium classifies the multicast
+    # destination as `world`. The multus IoT/SECURITY VLAN secondary
+    # NICs (hass-iot-static, hass-security-static) handle the bulk of
+    # LAN discovery and bypass Cilium entirely — only eth0 (apiserver,
+    # DNS, cross-ns, external) is governed here, including this mDNS
+    # path through default-deny.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "5353"
+              protocol: UDP


### PR DESCRIPTION
## Summary

- Hubble shows steady \`Policy denied DROPPED\` UDPs from \`home/home-assistant-0:5353\` → \`224.0.0.251:5353\` (mDNS multicast). HA's zeroconf integration fires on eth0 in addition to the multus IoT/SECURITY VLAN secondary NICs (which bypass Cilium).
- Cilium classifies the multicast destination as \`world\`. Adds a \`toEntities: [world]\` UDP/5353 egress entry covering the eth0 path.
- Folds the pre-existing trailing "multus NICs bypass Cilium" NOTE into the new mDNS comment block. yamllint \`--strict\` rejects trailing comments at EOF that don't align with preceding content indentation; the consolidation keeps the same information attached to a list item where it satisfies the rule.

## Why

Discovered during a cluster-wide CNP drop sweep alongside PR #11934. mDNS discovery on eth0 is intentional — HA's zeroconf integration uses it for in-cluster service discovery in addition to the LAN discovery handled by the multus secondary NICs.

## Test plan

- [ ] Flux reconciles \`home-assistant\` Kustomization.
- [ ] \`kubectl -n home get cnp home-assistant-allow -o yaml\` shows the new UDP/5353 world egress entry.
- [ ] \`hubble observe --since 5m --verdict DROPPED --from-pod home/home-assistant-0\` shows no port-5353 UDP drops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)