### PR TITLE
fix(media/flaresolverr): allow UDP/443 (HTTP/3 QUIC) egress to world

### DIFF
--- a/kubernetes/apps/media/flaresolverr/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/flaresolverr/app/cnp-allow.yaml
@@ -29,11 +29,17 @@ spec:
     # External: full headless-Chromium internet access to solve
     # Cloudflare challenges on whatever indexer URLs prowlarr passes
     # in. Target set is the entire CF-protected indexer corpus.
+    # UDP/443 covers HTTP/3 (QUIC) — modern Cloudflare-fronted sites
+    # advertise alt-svc: h3 and Chromium prefers it; without UDP/443
+    # the browser fails back to TCP/443 after timeouts (and Hubble
+    # logs steady POLICY_DENIED on UDP/443 to CF/Google IPs).
     - toEntities:
         - world
       toPorts:
         - ports:
             - port: "443"
               protocol: TCP
+            - port: "443"
+              protocol: UDP
             - port: "80"
               protocol: TCP


### PR DESCRIPTION
## Summary

- Hubble shows ~50 \`Policy denied DROPPED\` UDP/443 packets per 15 min from \`media/flaresolverr-0\` to Cloudflare and Google IP ranges (142.251.x, 104.21.x, 35.190.x).
- Modern CF-fronted indexer sites advertise \`alt-svc: h3\` and Chromium prefers HTTP/3; without UDP/443 in the allowlist the browser stalls and falls back to TCP/443 after timeout, slowing every CF-challenge solve.
- Adds UDP/443 to the existing world egress entry. TCP/443 and TCP/80 unchanged.

## Test plan

- [ ] Flux reconciles \`flaresolverr\` Kustomization.
- [ ] \`kubectl -n media get cnp flaresolverr-allow -o yaml\` shows UDP/443 in the world egress entry.
- [ ] \`hubble observe --since 5m --verdict DROPPED --from-pod media/flaresolverr-0\` shows no UDP/443 drops.
- [ ] Trigger a CF challenge via prowlarr; flaresolverr completes faster (no QUIC timeout fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)