### PR TITLE
fix(media/music-assistant): allow UDP/1900 (SSDP / UPnP) egress to world

### DIFF
--- a/kubernetes/apps/media/music-assistant/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/music-assistant/app/cnp-allow.yaml
@@ -43,6 +43,12 @@ spec:
     # mDNS-style LAN discovery to local devices (Sonos, Chromecast,
     # AirPlay). Provider set + LAN device set both rotate; world keeps
     # the policy maintenance-free.
+    # UDP/1900 covers SSDP / UPnP discovery — Sonos, DLNA renderers,
+    # and Chromecast announce themselves via 239.255.255.250:1900.
+    # Cilium classifies the multicast destination as `world`.
+    # (IGMP membership reports to 224.0.0.22 also drop with
+    # CT_UNKNOWN_L4_PROTOCOL — that's a Cilium datapath limitation,
+    # no CNP knob; accepted as a known cost.)
     - toEntities:
         - world
       toPorts:
@@ -51,6 +57,8 @@ spec:
               protocol: TCP
             - port: "80"
               protocol: TCP
+            - port: "1900"
+              protocol: UDP
     # Music-assistant calls back into Home Assistant (callback events,
     # entity-state subscriptions) — HA REST + WebSocket on :8123.
     - toEndpoints:


### PR DESCRIPTION
## Summary

- Hubble shows \`Policy denied DROPPED\` UDP/1900 packets from \`media/music-assistant-0\` to the SSDP multicast address 239.255.255.250:1900.
- music-assistant's Sonos, DLNA, and Chromecast integrations rely on SSDP/UPnP discovery to find local renderers, and Cilium classifies the multicast destination as \`world\`.
- Adds UDP/1900 to the existing world egress entry.

## Known cost

The companion IGMP membership-report drops to 224.0.0.22 (CT_UNKNOWN_L4_PROTOCOL) cannot be allowed at the CNP layer — Cilium's conntrack does not understand IGMP and there is no policy knob for it. Accepting these drops as a Cilium datapath limitation; multicast group join is typically optional for the SSDP responder path since 1900 traffic is also forwarded via the LAN router to UPnP-aware switches.

## Test plan

- [ ] Flux reconciles \`music-assistant\` Kustomization.
- [ ] \`kubectl -n media get cnp music-assistant-allow -o yaml\` shows UDP/1900 in the world egress entry.
- [ ] \`hubble observe --since 5m --verdict DROPPED --from-pod media/music-assistant-0\` shows no UDP/1900 drops (IGMP drops to 224.0.0.22 expected to remain).
- [ ] music-assistant's UPnP-discoverable renderers (Sonos, Chromecast) appear in the MA UI device list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)