### PR TITLE
feat(home/frigate): alert on unauthorized egress (catch next wled-bush burst)

### DIFF
--- a/kubernetes/apps/home/frigate/app/prometheusrule.yaml
+++ b/kubernetes/apps/home/frigate/app/prometheusrule.yaml
@@ -72,3 +72,45 @@ spec:
           for: 15m
           labels:
             severity: warning
+    - name: frigate.network
+      rules:
+        # Forensic catcher for the unidentified 2026-05-21 burst where
+        # frigate-0 attempted TCP SYNs to wled-bush (10.10.20.41) on :80
+        # and :21324. Static config, db, env, logs all checked clean; the
+        # trigger went to an API endpoint that doesn't show in the nginx
+        # access log. Burst was one-shot but we haven't pinned the cause.
+        #
+        # This alert fires on any policy-denied egress from a home-ns pod
+        # on worker4 to a `world` destination over TCP. worker4 is where
+        # frigate-0 lives; the only other home-ns pods there
+        # (emqx-1 / smtp-relay-0 / ntfy / windmill-oauth2-proxy) don't
+        # have policy-denied egress paths in steady state. When this
+        # fires, grab Hubble flows on cilium-8nxm5 within the next ~30s
+        # before the ring buffer ages out:
+        #   kubectl -n kube-system exec ds/cilium -c cilium-agent -- \
+        #     hubble observe --since 5m --from-pod home/frigate-0 --verdict DROPPED
+        - alert: FrigateUnauthorizedEgressAttempt
+          annotations:
+            summary: home-ns pod on worker4 attempted policy-denied TCP egress to world
+            description: |
+              Frigate (or another home-ns pod on worker4) tried a TCP connection
+              that Cilium denied at the egress policy. Most likely candidate is
+              frigate-0 probing an unauthorized destination — this is the same
+              shape as the 2026-05-21 22:10 UTC burst to wled-bush. Pull Hubble
+              flows on cilium-8nxm5 within ~30s to capture the destination
+              before the ring buffer rotates: `kubectl -n kube-system exec ds/cilium
+              -c cilium-agent -- hubble observe --since 5m --from-pod home/frigate-0
+              --verdict DROPPED`. Save the output before responding.
+          expr: |
+            sum by (node) (
+              rate(hubble_drop_total{
+                source_namespace="home",
+                destination_namespace="",
+                node="worker4.thesteamedcrab.com",
+                protocol="TCP",
+                reason="POLICY_DENIED"
+              }[5m])
+            ) > 0
+          for: 1m
+          labels:
+            severity: warning


### PR DESCRIPTION
## Summary

- Forensic catcher for the unidentified **2026-05-21 22:10 UTC burst** where \`frigate-0\` attempted TCP SYNs to \`wled-bush\` (10.10.20.41) on :80 and :21324.
- Static config, db, env, Python log, nginx access log all checked clean; the trigger went to an API endpoint that doesn't appear in any log we have. The burst was one-shot and hasn't recurred — cause is **unpinned**.
- Adds \`FrigateUnauthorizedEgressAttempt\` — fires on any policy-denied TCP egress from \`home\` ns to \`world\` on \`worker4\` (frigate's node). The other home-ns pods on worker4 (\`emqx-1\`, \`smtp-relay-0\`, \`ntfy\`, \`windmill-oauth2-proxy\`) don't have policy-denied egress paths in steady state, so this signal is clean.

## How it helps next time

When this fires, the alert description tells the operator to immediately pull Hubble flows on the cilium agent for worker4:

\`\`\`
kubectl -n kube-system exec ds/cilium -c cilium-agent -- \\
  hubble observe --since 5m --from-pod home/frigate-0 --verdict DROPPED
\`\`\`

The cilium agent's ring buffer rotates fast — capturing within ~30s of the alert is the best chance to identify the destination IP/port and source identity before the evidence ages out.

## Why this scope

\`hubble_drop_total\` only labels by \`source_namespace\`, \`destination_namespace\`, \`protocol\`, \`reason\`, \`node\` — no per-pod label. The tightest scope we can write is "home-ns pod on worker4 doing policy-denied TCP to world". Frigate is the dominant home-ns pod on worker4 with policy gaps to world, so a fire is ~always frigate-driven.

## Test plan

- [ ] Flux reconciles the PrometheusRule.
- [ ] Prometheus picks up the new rule: \`kubectl -n observability exec prometheus-... -- promtool query instant http://localhost:9090 'ALERTS{alertname="FrigateUnauthorizedEgressAttempt"}'\`
- [ ] Verify no false positive in normal operation (alert should stay \`inactive\` since recent CNP fixes addressed the actual home-ns drops).
- [ ] (Optional, manual repro) Trigger by calling \`/api/onvif/probe?host=10.10.20.41\` from inside the frigate pod — alert should fire within 1 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)