### PR TITLE
feat(home/windmill): failure-rate watcher + auto-DM on flapping workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ Worker nodes attach to **iot** and **sec** VLANs via Multus for direct camera an
 | **Paperless-ngx** | Document scanning, OCR, tagging (CNPG-backed, offsite-backed) |
 | **Obsidian** + **obsidian-couchdb** | Notes sync (CouchDB w/ Cloudflare rate-limiting) |
 | **Zulip** | Self-hosted team chat (also wired into agent pipeline approvals) |
-| **Windmill** | Workflow automation; 12 checked-in TypeScript flows under `kubernetes/apps/home/windmill/workflows/` cover AlertManager → HolmesGPT, langgraph inbox/approval/digest/DLQ/cost-cap/awaiting-user, paperless RAG ingest+tombstone, Zulip triager webhook, and the workaround upstream-watcher |
+| **Windmill** | Workflow automation; 13 checked-in TypeScript flows under `kubernetes/apps/home/windmill/workflows/` cover AlertManager → HolmesGPT, langgraph inbox/approval/digest/DLQ/cost-cap/awaiting-user, paperless RAG ingest+tombstone, Zulip triager webhook, and the workaround upstream-watcher |
 | **ntfy** | Self-hosted push notifications (operator approvals via Android tap actions) |
 | **BentoPDF** | Self-hosted PDF toolkit |
 | **Kitchenowl** | Shopping lists + recipe / meal management |
@@ -324,7 +324,7 @@ flowchart TB
         AM[AlertManager]
     end
 
-    subgraph Bridges[Windmill bridges<br/>12 TS workflows]
+    subgraph Bridges[Windmill bridges<br/>13 TS workflows]
         WInbox[langgraph-inbox.ts]
         WAlert[alertmanager-holmesgpt-notify.ts]
         WApprove[langgraph-approval-post/receive.ts]
@@ -393,7 +393,7 @@ in 1Password.
 - **HolmesGPT** (`observability/`) — the only agent live in production. AlertManager firings reach it via Windmill's `alertmanager-holmesgpt-notify.ts`; it reasons over Prometheus + Loki + cluster state and posts a root-cause hypothesis to Zulip / ntfy. Open WebUI also surfaces it as a tool server.
 - **langgraph-agents** (`ai/`) — the FastAPI multi-agent runtime (`rwlove/langgraph-agents`, image `0.2.30`). Plumbed end-to-end (Postgres checkpoints + memory, live task-queue substrate in `postgres-langgraph-checkpoints`, vault PVCs, Windmill approval loop, cost caps in env) but cold: `ENABLE_CLAUDE_API: false` and no public route except `/approval`. Goes hot when the Claude key lands in 1Password.
 - **claude-runner** (`automation/`) — separate escalation lane. Two daily CronJobs (`pr-triage` 13:00 UTC, `cost-cap-commentary` 22:00 UTC) launch the Claude Code CLI with a `gh` MCP allowlist, post Zulip cards, then exit. Stateless; never consumes langgraph-agents.
-- **Windmill** (`home/`) — 12 checked-in TypeScript flows under `kubernetes/apps/home/windmill/workflows/` are the bridges that knit the surfaces above together. Every alert webhook, Zulip-triggered DM, approval round-trip, daily digest, DLQ retry, cost-cap pause, and Paperless RAG ingest is a `.ts` file there. n8n was retired during the ntfy migration.
+- **Windmill** (`home/`) — 13 checked-in TypeScript flows under `kubernetes/apps/home/windmill/workflows/` are the bridges that knit the surfaces above together. Every alert webhook, Zulip-triggered DM, approval round-trip, daily digest, DLQ retry, cost-cap pause, and Paperless RAG ingest is a `.ts` file there. n8n was retired during the ntfy migration.
 - **Langfuse** (`ai/`) — OTLP trace sink for langgraph-agents. Chart deploys ClickHouse + Valkey + MinIO bundled; Postgres comes from CNPG `postgres-langfuse`.
 - **memory-mcp** (`mcp-system/`) — cross-agent knowledge graph on `postgres-langgraph-memory` with pgvector(1024). bge-m3 embeds via Ollama-Spark. Same surface for langgraph agents and claude-runner.
 

--- a/kubernetes/apps/home/windmill/app/externalsecret-workflows.yaml
+++ b/kubernetes/apps/home/windmill/app/externalsecret-workflows.yaml
@@ -43,6 +43,13 @@ spec:
         # (`paperless` / field `mcp_token`) that mcp-system/paperless-mcp
         # already uses — keeping a single token-rotation surface.
         PAPERLESS_TOKEN: "{{ .paperless_mcp_token }}"
+        # Windmill API token used by the windmill-failure-watcher
+        # workflow to query its own /api/w/lovenet/jobs/list_completed.
+        # Mint via /api/users/tokens/create as admin@windmill.dev and
+        # save into the `windmill` 1P item as field `windmill_api_token`.
+        # If the field is missing or empty, the watcher fails fast with
+        # "WINDMILL_TOKEN env not set" — other workflows are unaffected.
+        WINDMILL_TOKEN: "{{ .windmill_api_token }}"
   dataFrom:
     # LANGGRAPH_APPROVAL_SIGNING_KEY
     - extract:
@@ -61,3 +68,7 @@ spec:
         - regexp:
             source: "(.*)"
             target: "paperless_$1"
+    # windmill_api_token — for self-introspection (see WINDMILL_TOKEN
+    # comment above).
+    - extract:
+        key: windmill

--- a/kubernetes/apps/home/windmill/workflows/windmill-failure-watcher.ts
+++ b/kubernetes/apps/home/windmill/workflows/windmill-failure-watcher.ts
@@ -1,0 +1,223 @@
+// Periodic self-check: detect Windmill scripts that are failing at a
+// high rate and notify Rob via ntfy + Zulip DM.
+//
+// Why: PR #11894 fixed alertmanager-holmesgpt-notify in git on
+// 2026-05-21, but the change was never pushed to Windmill via
+// `wmill sync`. Every alertmanager → Holmes call failed silently for
+// 24+ hours. There was no detection because the alert path itself
+// was broken — the bridge that would have notified Rob was the thing
+// failing. This watcher closes that gap.
+//
+// Trigger: Windmill cron, recommended */5 * * * *. Schedule lives in
+// Windmill state (set via /api/w/lovenet/schedules/create); not part
+// of the git checkout. See PR description for the one-time bootstrap.
+//
+// Notification budget: at most one DM per script_path per hour, even
+// if failures keep accumulating, to avoid notification floods. The
+// per-hour dedup is in-memory (script invocation state — Windmill
+// persists `state` across invocations of the same script when
+// invoked via setState/getState helpers from npm:windmill-client).
+//
+// Self-recursion risk: if this watcher itself fails, no one knows.
+// Mitigation: BlackboxProbe on windmill /api/version catches the
+// "Windmill is down" case; the watcher's own failures show up in
+// `wmill flows runs` and the langgraph-dlq-watcher Pushover.
+
+import * as wmill from "npm:windmill-client@1.527.0";
+
+type CompletedJob = {
+    id: string;
+    script_path?: string;
+    runnable_path?: string;
+    success: boolean;
+    started_at: string;
+    duration_ms: number;
+};
+
+const WORKSPACE = "lovenet";
+const WMILL_BASE = "http://windmill-app.home.svc.cluster.local:8000";
+const LOOKBACK_MIN = 60;
+const MIN_INVOCATIONS = 3;
+const FAILURE_RATE_THRESHOLD = 0.5;
+const NOTIFY_COOLDOWN_S = 3600;
+
+// Scripts we expect to fail occasionally (DLQ scans, smoke probes) —
+// surface them only if failure rate stays >90% over the window, to
+// avoid flapping when one bad poll trips the regular threshold.
+const TOLERANT_PATHS = new Set([
+    "f/lovenet/langgraph-dlq-watcher",
+]);
+const TOLERANT_THRESHOLD = 0.9;
+
+type WatcherState = {
+    last_notified_at?: Record<string, number>;
+};
+
+export async function main() {
+    const token = Deno.env.get("WINDMILL_TOKEN");
+    if (!token) throw new Error("WINDMILL_TOKEN env not set");
+
+    const sinceMs = Date.now() - LOOKBACK_MIN * 60 * 1000;
+    const startedAfter = new Date(sinceMs).toISOString();
+
+    const jobs = await fetchJobs(token, startedAfter);
+    const grouped = groupByPath(jobs);
+    const issues = grouped.filter(matchesThreshold);
+
+    const state = (await wmill.getState()) as WatcherState | null;
+    const lastNotified = state?.last_notified_at ?? {};
+    const nowS = Math.floor(Date.now() / 1000);
+
+    const dueForNotify = issues.filter((g) => {
+        const last = lastNotified[g.path] ?? 0;
+        return nowS - last >= NOTIFY_COOLDOWN_S;
+    });
+
+    const updatedLastNotified = { ...lastNotified };
+    for (const g of dueForNotify) {
+        updatedLastNotified[g.path] = nowS;
+    }
+    await wmill.setState({
+        last_notified_at: updatedLastNotified,
+    } satisfies WatcherState);
+
+    if (dueForNotify.length === 0) {
+        return {
+            checked_n: jobs.length,
+            grouped_n: grouped.length,
+            issues_n: issues.length,
+            new_notifications: 0,
+        };
+    }
+
+    await notify(dueForNotify);
+
+    return {
+        checked_n: jobs.length,
+        grouped_n: grouped.length,
+        issues_n: issues.length,
+        new_notifications: dueForNotify.length,
+        notified_paths: dueForNotify.map((g) => g.path),
+    };
+}
+
+// ---------- Job fetch ----------
+
+async function fetchJobs(token: string, startedAfter: string): Promise<CompletedJob[]> {
+    const url = `${WMILL_BASE}/api/w/${WORKSPACE}/jobs/list_completed`
+        + `?per_page=500&started_after=${encodeURIComponent(startedAfter)}`
+        + `&job_kinds=script`;
+    const r = await fetch(url, {
+        headers: { Authorization: `Bearer ${token}` },
+        signal: AbortSignal.timeout(15_000),
+    });
+    if (!r.ok) {
+        throw new Error(`jobs/list_completed returned ${r.status}`);
+    }
+    const data = await r.json();
+    return Array.isArray(data) ? data : [];
+}
+
+// ---------- Grouping + threshold ----------
+
+type Grouped = {
+    path: string;
+    total: number;
+    failed: number;
+    failure_rate: number;
+    sample_error?: string;
+};
+
+function groupByPath(jobs: CompletedJob[]): Grouped[] {
+    const byPath = new Map<string, { total: number; failed: number }>();
+    for (const j of jobs) {
+        const path = j.script_path ?? j.runnable_path ?? "(unknown)";
+        // Skip the watcher itself — would create a feedback loop on
+        // any false-positive.
+        if (path === "f/lovenet/windmill-failure-watcher") continue;
+        const bucket = byPath.get(path) ?? { total: 0, failed: 0 };
+        bucket.total += 1;
+        if (!j.success) bucket.failed += 1;
+        byPath.set(path, bucket);
+    }
+    return Array.from(byPath.entries()).map(([path, b]) => ({
+        path,
+        total: b.total,
+        failed: b.failed,
+        failure_rate: b.total === 0 ? 0 : b.failed / b.total,
+    }));
+}
+
+function matchesThreshold(g: Grouped): boolean {
+    if (g.total < MIN_INVOCATIONS) return false;
+    const threshold = TOLERANT_PATHS.has(g.path) ? TOLERANT_THRESHOLD : FAILURE_RATE_THRESHOLD;
+    return g.failure_rate >= threshold;
+}
+
+// ---------- Notify ----------
+
+async function notify(groups: Grouped[]) {
+    const lines = [
+        `🚨 **Windmill workflow failures** (last ${LOOKBACK_MIN} min)`,
+        "",
+    ];
+    for (const g of groups) {
+        const pct = Math.round(g.failure_rate * 100);
+        lines.push(`- \`${g.path.replace(/^f\/lovenet\//, "")}\` — ${g.failed}/${g.total} failed (${pct}%)`);
+    }
+    lines.push("");
+    lines.push("Inspect: `wmill flows runs` or Windmill UI → Jobs page");
+
+    await Promise.allSettled([
+        publishNtfy({
+            topic: "alerts",
+            title: `🚨 Windmill workflows failing: ${groups.length}`,
+            message: lines.join("\n"),
+            priority: 4,
+            tags: ["warning", "windmill"],
+        }),
+        postZulipDM(lines.join("\n")),
+    ]);
+}
+
+async function publishNtfy(args: {
+    topic: string;
+    title: string;
+    message: string;
+    priority: number;
+    tags: string[];
+}) {
+    const url = Deno.env.get("NTFY_URL") ?? "https://ntfy.thesteamedcrab.com";
+    const token = Deno.env.get("NTFY_WRITE_TOKEN");
+    if (!token) throw new Error("NTFY_WRITE_TOKEN env not set");
+    const r = await fetch(url, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+        body: JSON.stringify(args),
+        signal: AbortSignal.timeout(15_000),
+    });
+    return { status: r.status, ok: r.ok };
+}
+
+async function postZulipDM(content: string) {
+    const email = Deno.env.get("ZULIP_BOT_EMAIL");
+    const apiKey = Deno.env.get("ZULIP_BOT_API_KEY");
+    if (!email || !apiKey) throw new Error("ZULIP_BOT_EMAIL / ZULIP_BOT_API_KEY env not set");
+    const robId = parseInt(Deno.env.get("ROB_ZULIP_USER_ID") ?? "8", 10);
+    const zulipApiUrl = Deno.env.get("ZULIP_API_URL") ?? "http://zulip.collab.svc.cluster.local";
+    const zulipHostHeader = Deno.env.get("ZULIP_HOST_HEADER")
+        ?? `chat.${Deno.env.get("SECRET_DOMAIN") ?? "thesteamedcrab.com"}`;
+    const auth = "Basic " + btoa(`${email}:${apiKey}`);
+    const form = new URLSearchParams({ type: "private", to: `[${robId}]`, content });
+    const r = await fetch(`${zulipApiUrl}/api/v1/messages`, {
+        method: "POST",
+        headers: {
+            Authorization: auth,
+            "Content-Type": "application/x-www-form-urlencoded",
+            Host: zulipHostHeader,
+        },
+        body: form,
+        signal: AbortSignal.timeout(15_000),
+    });
+    return { status: r.status, ok: r.ok };
+}


### PR DESCRIPTION
## Summary

Closes the gap that left Robert blind to a 24+ hour silent outage of the alertmanager → HolmesGPT path. PR #11894 fixed the workflow's arg-shape in git on 2026-05-21 but nobody ran `wmill sync` to push the fix to Windmill. Every alertmanager → Holmes call failed silently for ~24 hours with `TypeError: Cannot read properties of undefined (reading 'alerts')`. The bridge that *would* have notified Robert *was* the failing workflow, so the failure was invisible.

## Approach

New workflow `f/lovenet/windmill-failure-watcher`:
- Runs every 5 min on a Windmill cron schedule (set up post-merge — see below)
- Queries Windmill's own `/api/w/lovenet/jobs/list_completed` for the last hour
- Groups by script_path, computes failure rate
- DMs Robert + posts ntfy when ≥50% (or ≥90% for inherently-flaky like `langgraph-dlq-watcher`) and ≥3 invocations in the window
- Per-script-per-hour notification cooldown via Windmill `setState/getState`
- Excludes itself from the scan (no self-recursion)

## Files

- `kubernetes/apps/home/windmill/workflows/windmill-failure-watcher.ts` — new
- `kubernetes/apps/home/windmill/app/externalsecret-workflows.yaml` — adds `WINDMILL_TOKEN` from `windmill.windmill_api_token`
- `README.md` — workflow count 12 → 13

## Post-merge activation (one-time)

1. ✅ 1P `windmill.windmill_api_token` is already populated.
2. ⚠️ Push the script to Windmill (the very gap this PR closes). Until we wire `wmill sync` into CI, this is manual: Windmill UI → Scripts → `f/lovenet/windmill-failure-watcher` → "Save + Deploy".
3. ⚠️ Create the cron schedule: Windmill UI → Schedules → Add → schedule `*/5 * * * *` TZ `America/New_York` → target `f/lovenet/windmill-failure-watcher`, args `{}`, enabled.

## Test plan

- [x] Type-check the script locally (deno)
- [x] Hash diff vs existing `windmill-workflows-secret` shows only `WINDMILL_TOKEN` addition
- [ ] After (1)-(3) above: force one run, expect `{checked_n: N, grouped_n: K, issues_n: 0, new_notifications: 0}`
- [ ] Inject a synthetic failing script and confirm Robert gets a DM within 5 min

## Follow-up

The cleanest fix for the underlying class of bug is `wmill sync` running in CI on every home-ops merge. Adding it is a separate PR (touches `.github/workflows/`).