### PR TITLE
feat(windmill/zulip): human-readable approval + completion DMs to Rob

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ Worker nodes attach to **iot** and **sec** VLANs via Multus for direct camera an
 | **Paperless-ngx** | Document scanning, OCR, tagging (CNPG-backed, offsite-backed) |
 | **Obsidian** + **obsidian-couchdb** | Notes sync (CouchDB w/ Cloudflare rate-limiting) |
 | **Zulip** | Self-hosted team chat (also wired into agent pipeline approvals) |
-| **Windmill** | Workflow automation; 12 checked-in TypeScript flows under `kubernetes/apps/home/windmill/workflows/` cover AlertManager → HolmesGPT, langgraph inbox/approval/digest/DLQ/cost-cap/awaiting-user, paperless RAG ingest+tombstone, Zulip triager webhook, and the workaround upstream-watcher |
+| **Windmill** | Workflow automation; 13 checked-in TypeScript flows under `kubernetes/apps/home/windmill/workflows/` cover AlertManager → HolmesGPT, langgraph inbox/approval/digest/DLQ/cost-cap/awaiting-user, paperless RAG ingest+tombstone, Zulip triager webhook, and the workaround upstream-watcher |
 | **ntfy** | Self-hosted push notifications (operator approvals via Android tap actions) |
 | **BentoPDF** | Self-hosted PDF toolkit |
 | **Kitchenowl** | Shopping lists + recipe / meal management |
@@ -324,7 +324,7 @@ flowchart TB
         AM[AlertManager]
     end
 
-    subgraph Bridges[Windmill bridges<br/>12 TS workflows]
+    subgraph Bridges[Windmill bridges<br/>13 TS workflows]
         WInbox[langgraph-inbox.ts]
         WAlert[alertmanager-holmesgpt-notify.ts]
         WApprove[langgraph-approval-post/receive.ts]
@@ -393,7 +393,7 @@ in 1Password.
 - **HolmesGPT** (`observability/`) — the only agent live in production. AlertManager firings reach it via Windmill's `alertmanager-holmesgpt-notify.ts`; it reasons over Prometheus + Loki + cluster state and posts a root-cause hypothesis to Zulip / ntfy. Open WebUI also surfaces it as a tool server.
 - **langgraph-agents** (`ai/`) — the FastAPI multi-agent runtime (`rwlove/langgraph-agents`, image `0.2.30`). Plumbed end-to-end (Postgres checkpoints + memory, live task-queue substrate in `postgres-langgraph-checkpoints`, vault PVCs, Windmill approval loop, cost caps in env) but cold: `ENABLE_CLAUDE_API: false` and no public route except `/approval`. Goes hot when the Claude key lands in 1Password.
 - **claude-runner** (`automation/`) — separate escalation lane. Two daily CronJobs (`pr-triage` 13:00 UTC, `cost-cap-commentary` 22:00 UTC) launch the Claude Code CLI with a `gh` MCP allowlist, post Zulip cards, then exit. Stateless; never consumes langgraph-agents.
-- **Windmill** (`home/`) — 12 checked-in TypeScript flows under `kubernetes/apps/home/windmill/workflows/` are the bridges that knit the surfaces above together. Every alert webhook, Zulip-triggered DM, approval round-trip, daily digest, DLQ retry, cost-cap pause, and Paperless RAG ingest is a `.ts` file there. n8n was retired during the ntfy migration.
+- **Windmill** (`home/`) — 13 checked-in TypeScript flows under `kubernetes/apps/home/windmill/workflows/` are the bridges that knit the surfaces above together. Every alert webhook, Zulip-triggered DM, approval round-trip, daily digest, DLQ retry, cost-cap pause, and Paperless RAG ingest is a `.ts` file there. n8n was retired during the ntfy migration.
 - **Langfuse** (`ai/`) — OTLP trace sink for langgraph-agents. Chart deploys ClickHouse + Valkey + MinIO bundled; Postgres comes from CNPG `postgres-langfuse`.
 - **memory-mcp** (`mcp-system/`) — cross-agent knowledge graph on `postgres-langgraph-memory` with pgvector(1024). bge-m3 embeds via Ollama-Spark. Same surface for langgraph agents and claude-runner.
 

--- a/kubernetes/apps/ai/langgraph-agents/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/externalsecret.yaml
@@ -69,6 +69,17 @@ spec:
         APPROVAL_POST_WEBHOOK_URL: http://windmill-app.home.svc.cluster.local:8000/api/w/lovenet/jobs/run/p/f/lovenet/langgraph-approval-post
         APPROVAL_POST_WEBHOOK_TOKEN: "{{ .alertmanager_webhook_token }}"
 
+        # Completion-post webhook — POSTs to a Windmill workflow when
+        # a task transitions to status=done in the queue. The workflow
+        # DMs Rob (Zulip user 8) with a human-readable card: which
+        # agent finished, the original prompt, the output. Same auth
+        # token as APPROVAL_POST_WEBHOOK_TOKEN (single rotation
+        # surface). When unset, the worker silently skips — older
+        # versions of home-ops without the completion-post workflow
+        # remain backward-compatible.
+        COMPLETION_POST_WEBHOOK_URL: http://windmill-app.home.svc.cluster.local:8000/api/w/lovenet/jobs/run/p/f/lovenet/langgraph-completion-post
+        COMPLETION_POST_WEBHOOK_TOKEN: "{{ .alertmanager_webhook_token }}"
+
         # Stage 2 — Bearer token the `hai` CLI presents on /inbox and
         # /admin/* endpoints. Validated by the middleware in
         # agents/api/auth.py. Sourced from the `hai-cli` 1P item created

--- a/kubernetes/apps/home/windmill/workflows/langgraph-approval-post.ts
+++ b/kubernetes/apps/home/windmill/workflows/langgraph-approval-post.ts
@@ -5,12 +5,16 @@
 //      action buttons. Each button POSTs a *pre-signed* HMAC token
 //      directly to https://langgraph.${SECRET_DOMAIN}/approval, which
 //      is path-restricted to the /approval endpoint only.
-//   2. Zulip → #approvals — desktop fallback via emoji reaction
-//      (handled by langgraph-approval-receive). Also serves as the
-//      audit trail for the action class + payload summary.
+//   2. Zulip — DM to Robert (user 8) carrying the human-readable
+//      approval card with magic-link buttons. Replaces the previous
+//      stream-post-to-#approvals: stream posts required a subscription
+//      Rob didn't have, and the in-cluster service URL was rejected
+//      by Zulip's ALLOWED_HOSTS without an explicit Host header.
 //
-// Replaces the n8n flow "LangGraph → Approval post to Zulip" and the
-// prior Pushover-shape (PR #11672) that only carried a no-action push.
+// `content` (the original user prompt) is carried in the inbound
+// payload so the card can show "You asked: ..." — closes the gap
+// where a bare ULID had no human-mappable context. langgraph-agents
+// 0.2.39+ populates the field; older versions degrade gracefully.
 
 import { crypto } from "https://deno.land/std@0.224.0/crypto/mod.ts";
 
@@ -23,10 +27,13 @@ type ApprovalRequest = {
     cost_estimate_usd?: number;
 };
 
-// Body keys from langgraph-agents: task_id + paused_for.
-export async function main(task_id: string, paused_for: { approval_request: ApprovalRequest }) {
+// Body keys from langgraph-agents: task_id + paused_for + content (0.2.39+).
+export async function main(
+    task_id: string,
+    paused_for: { approval_request: ApprovalRequest },
+    content?: string,
+) {
     const r = paused_for.approval_request;
-    const topic = `${task_id} — Class ${r.action_class}: ${r.target}`;
 
     // Pre-sign three tokens (one per verdict). The /approval endpoint
     // verifies via HMAC-SHA256 + checks the task is paused — only one
@@ -37,37 +44,108 @@ export async function main(task_id: string, paused_for: { approval_request: Appr
     const rejectTok = await signApprovalToken(task_id, r.action_class, serverName, method);
     const deferTok = await signApprovalToken(task_id, r.action_class, serverName, method);
 
-    // ntfy `click` URL is intentionally omitted. The previous value
-    // (`https://chat.thesteamedcrab.com/#narrow/stream/approvals/topic/…`)
-    // used the deprecated pre-2024 Zulip URL scheme; the current scheme
-    // is `#narrow/channel/<channel-id>-<name>/topic/<name>` and Zulip
-    // mobile / web reject the old `stream` form with "invalid URL".
-    // The Approve / Reject / Defer ntfy action buttons still work
-    // independently of the click target — they POST pre-signed HMAC
-    // tokens to the langgraph /approval endpoint directly.
-    //
-    // Adding a working click URL is a follow-up: needs the integer
-    // channel ID for the `approvals` stream and a robust topic
-    // encoding helper (Zulip uses a custom dotted-encoding scheme
-    // for topics that differs from encodeURIComponent).
+    // Phone push — ntfy keeps its mobile-button UX. Title now uses
+    // the human-readable class label instead of bare "Class C".
+    const classLabel = ACTION_CLASS_LABEL[r.action_class] ?? `Class ${r.action_class}`;
+    const agentLabel = AGENT_LABEL[r.proposed_by] ?? r.proposed_by;
     const ntfyResp = await publishNtfy({
         topic: "approvals",
-        title: `🔔 Approval needed: Class ${r.action_class}`,
+        title: `${ACTION_CLASS_EMOJI[r.action_class] ?? "🔔"} ${agentLabel} needs approval`,
         message: [
-            `Task: ${task_id}`,
-            `Target: ${r.target}`,
-            `Summary: ${r.payload_summary}`,
+            content ? `You asked: ${truncate(content, 200)}` : `Task: ${task_id}`,
+            `Proposed: ${humanizeTarget(r.target)}`,
+            `Class: ${classLabel}`,
             `Undo: ${r.undo_path ?? "(none)"}`,
             `Cost: $${r.cost_estimate_usd ?? 0}`,
         ].join("\n"),
-        priority: 5,
-        tags: ["warning"],
+        priority: r.action_class === "D" ? 5 : 4,
+        tags: r.action_class === "D" ? ["warning", "rotating_light"] : ["warning"],
         actions: buildApprovalActions(task_id, approveTok, rejectTok, deferTok),
     });
 
-    const zulipResp = await postZulipApprovalCard(task_id, r);
+    // Desktop — DM to Rob with the rich card.
+    const zulipResp = await postZulipApprovalDM(
+        task_id,
+        r,
+        content,
+        approveTok,
+        rejectTok,
+        deferTok,
+    );
 
-    return { task_id, topic, ntfy: ntfyResp, zulip: zulipResp };
+    return { task_id, ntfy: ntfyResp, zulip: zulipResp };
+}
+
+// ---------- Humanizers ----------
+
+// Action class semantics in this fleet (see homelab_dod / state.py):
+//   A — observation / read-only (auto-approved)
+//   B — single-side write, fully reversible
+//   C — multi-side or reviewable change
+//   D — destructive / irreversible (always approval-gated)
+const ACTION_CLASS_EMOJI: Record<string, string> = {
+    A: "🟢",
+    B: "🟢",
+    C: "🟡",
+    D: "🔴",
+};
+
+const ACTION_CLASS_LABEL: Record<string, string> = {
+    A: "🟢 A — routine",
+    B: "🟢 B — reversible write",
+    C: "🟡 C — reviewable change",
+    D: "🔴 D — destructive / irreversible",
+};
+
+// Translate agent IDs into operator-facing role names. Keep keys aligned
+// with src/agents/state.py ALL_AGENT_IDS in langgraph-agents.
+const AGENT_LABEL: Record<string, string> = {
+    "triager": "Triager",
+    "supervisor": "Supervisor",
+    "reviewer": "Reviewer",
+    "reporter": "Reporter",
+    "researcher": "Researcher",
+    "note-maker": "Note maker",
+    "coder": "Coder",
+    "errand-runner": "Errand runner",
+    "homelab-engineer": "Homelab agent",
+    "network-operator": "Network agent",
+    "storage-operator": "Storage agent",
+    "smart-home-operator": "Smart-home agent",
+    "ml-operator": "ML agent",
+    "observability-operator": "Observability agent",
+};
+
+// Translate MCP tool targets like "kubectl-mcp.kubectl_apply" into a
+// short verb phrase. Falls back to the bare target when unknown.
+function humanizeTarget(target: string): string {
+    const map: Record<string, string> = {
+        "kubectl-mcp.kubectl_apply": "apply a kubectl manifest",
+        "kubectl-mcp.kubectl_delete": "delete a Kubernetes resource",
+        "kubectl-mcp.kubectl_scale": "scale a workload",
+        "kubectl-mcp.kubectl_restart_deployment": "restart a deployment",
+        "ha-mcp.call_service": "call a Home Assistant service",
+        "ha-mcp.ha_call_service": "call a Home Assistant service",
+        "ha-mcp.ha_set_entity": "change a Home Assistant entity",
+        "ha-mcp.ha_set_helper": "change a Home Assistant helper",
+        "omada-mcp.applyConfig": "apply an Omada network change",
+    };
+    if (map[target]) return map[target];
+    // Generic fallback — split server/method, e.g. "foo-mcp.bar_baz"
+    // → "use foo-mcp to bar baz".
+    const dot = target.indexOf(".");
+    if (dot > 0) {
+        const server = target.slice(0, dot);
+        const method = target.slice(dot + 1).replace(/_/g, " ");
+        return `use ${server} to ${method}`;
+    }
+    return target;
+}
+
+function truncate(s: string, n: number): string {
+    if (!s) return "";
+    const oneLine = s.replace(/\r?\n+/g, " ").trim();
+    return oneLine.length > n ? oneLine.slice(0, n - 1) + "…" : oneLine;
 }
 
 // ---------- ntfy ----------
@@ -170,37 +248,88 @@ async function hmacSha256Hex(secret: string, msg: string): Promise<string> {
     return Array.from(new Uint8Array(sig)).map((b) => b.toString(16).padStart(2, "0")).join("");
 }
 
-// ---------- Zulip (audit + emoji fallback) ----------
+// ---------- Zulip DM to Rob ----------
 
-async function postZulipApprovalCard(task_id: string, r: ApprovalRequest) {
-    const topic = `${task_id} — Class ${r.action_class}: ${r.target}`;
-    const content = [
-        `**Task:** \`${task_id}\``,
-        `**Proposed by:** ${r.proposed_by}`,
-        `**Action class:** ${r.action_class}`,
-        `**Target:** \`${r.target}\``,
-        `**Summary:** ${r.payload_summary}`,
-        `**Undo path:** ${r.undo_path ?? "_(none — will escalate to Class D)_"}`,
-        `**Cost estimate:** $${r.cost_estimate_usd ?? 0}`,
-        "",
-        "Tap an action on the ntfy push, **or** @-mention from a desktop:",
-        "  @**Approval Receiver** approve",
-        "  @**Approval Receiver** reject",
-        "  @**Approval Receiver** defer",
-    ].join("\n");
+async function postZulipApprovalDM(
+    task_id: string,
+    r: ApprovalRequest,
+    content: string | undefined,
+    approveTok: string,
+    rejectTok: string,
+    deferTok: string,
+) {
+    const agentLabel = AGENT_LABEL[r.proposed_by] ?? r.proposed_by;
+    const classLabel = ACTION_CLASS_LABEL[r.action_class] ?? `Class ${r.action_class}`;
+    const approvalUrl = `https://langgraph.${Deno.env.get("SECRET_DOMAIN") ?? "thesteamedcrab.com"}/approval`;
+    // Magic-link bodies — pre-signed HMAC tokens. /approval endpoint
+    // accepts both POST-from-ntfy and GET-by-link (the langgraph-agents
+    // side handles the GET variant; HMAC binding makes link leaks
+    // single-use). See errand_runner._verify_approval_token.
+    const approveLink = `${approvalUrl}?task_id=${encodeURIComponent(task_id)}&reaction=approve&approval_token=${encodeURIComponent(approveTok)}&actor=rob`;
+    const rejectLink = `${approvalUrl}?task_id=${encodeURIComponent(task_id)}&reaction=reject&approval_token=${encodeURIComponent(rejectTok)}&actor=rob`;
+    const deferLink = `${approvalUrl}?task_id=${encodeURIComponent(task_id)}&reaction=defer&approval_token=${encodeURIComponent(deferTok)}&actor=rob`;
+
+    const lines: string[] = [];
+    if (content) {
+        lines.push(`**You asked:** ${truncate(content, 200)}`);
+        lines.push("");
+    }
+    lines.push(`${classLabel}`);
+    lines.push("");
+    lines.push(`**${agentLabel}** wants to **${humanizeTarget(r.target)}**:`);
+    lines.push("");
+    lines.push("```quote");
+    lines.push(truncate(r.payload_summary, 600));
+    lines.push("```");
+    lines.push("");
+    lines.push(
+        `**Cost:** $${r.cost_estimate_usd ?? 0}  •  **Undo:** ${r.undo_path ?? "_not available_"}`,
+    );
+    lines.push("");
+    lines.push(
+        `→ [Approve](${approveLink})  •  [Reject](${rejectLink})  •  [Defer 4h](${deferLink})`,
+    );
+    lines.push("");
+    lines.push(`_Or reply to this DM:_ \`approve ${task_id}\` / \`reject ${task_id}\` / \`defer ${task_id}\``);
+
+    const content_md = lines.join("\n");
 
     const email = Deno.env.get("ZULIP_BOT_EMAIL");
     const apiKey = Deno.env.get("ZULIP_BOT_API_KEY");
     if (!email || !apiKey) throw new Error("ZULIP_BOT_EMAIL / ZULIP_BOT_API_KEY env not set");
-    const auth = "Basic " + btoa(`${email}:${apiKey}`);
+    const robId = parseInt(Deno.env.get("ROB_ZULIP_USER_ID") ?? "8", 10);
+    return await postZulip({ to: `[${robId}]`, type: "private", content: content_md, email, apiKey });
+}
+
+// Shared Zulip POST. Sets `Host: chat.<domain>` explicitly because the
+// in-cluster service URL isn't in Zulip's ALLOWED_HOSTS — without this
+// every request gets a 400 before the API handler sees it (same bug
+// class as langgraph-agents PR #64). This bit the previous version
+// silently: postZulipApprovalCard logged `"zulip": {}` for two months.
+export async function postZulip(args: {
+    to: string;
+    type: "private" | "stream";
+    topic?: string;
+    content: string;
+    email: string;
+    apiKey: string;
+}) {
+    const auth = "Basic " + btoa(`${args.email}:${args.apiKey}`);
     const zulipApiUrl = Deno.env.get("ZULIP_API_URL") ?? "http://zulip.collab.svc.cluster.local";
-    const form = new URLSearchParams({ type: "stream", to: "approvals", topic, content });
+    const zulipHostHeader = Deno.env.get("ZULIP_HOST_HEADER") ?? `chat.${Deno.env.get("SECRET_DOMAIN") ?? "thesteamedcrab.com"}`;
+    const params: Record<string, string> = { type: args.type, to: args.to, content: args.content };
+    if (args.topic) params.topic = args.topic;
+    const form = new URLSearchParams(params);
     const zr = await fetch(`${zulipApiUrl}/api/v1/messages`, {
         method: "POST",
-        headers: { Authorization: auth, "Content-Type": "application/x-www-form-urlencoded" },
+        headers: {
+            Authorization: auth,
+            "Content-Type": "application/x-www-form-urlencoded",
+            Host: zulipHostHeader,
+        },
         body: form,
         signal: AbortSignal.timeout(30_000),
     });
     const zResult = await zr.json().catch(() => ({}));
-    return zResult.result ?? zResult;
+    return { status: zr.status, ok: zr.ok, ...zResult };
 }

--- a/kubernetes/apps/home/windmill/workflows/langgraph-completion-post.ts
+++ b/kubernetes/apps/home/windmill/workflows/langgraph-completion-post.ts
@@ -1,0 +1,130 @@
+// Webhook entry from langgraph-agents when a task completes
+// (status → done in the queue, no pending interrupt).
+//
+// Emits a Zulip DM to Rob with a human-readable completion card:
+//   - which agent ran it (target_agent)
+//   - the original prompt (content)
+//   - the output, truncated
+//   - duration
+//   - link to `hai task show <id>` for the full output
+//
+// Companion to langgraph-approval-post: that handler covers paused
+// tasks; this one covers terminal-success. Failure/dlq is handled
+// by langgraph-dlq-watcher and doesn't fan out here.
+//
+// Sets explicit Host header on the Zulip POST — the in-cluster
+// service URL isn't in Zulip's ALLOWED_HOSTS (same bug as PR #64).
+
+type CompletionPayload = {
+    task_id: string;
+    target_agent?: string;
+    content?: string;
+    output?: string;
+    duration_s?: number;
+};
+
+export async function main(
+    task_id: string,
+    target_agent?: string,
+    content?: string,
+    output?: string,
+    duration_s?: number,
+) {
+    const agentLabel = AGENT_LABEL[target_agent ?? ""] ?? target_agent ?? "Agent";
+    const haiUrl = `https://hai.${Deno.env.get("SECRET_DOMAIN") ?? "thesteamedcrab.com"}/admin/tasks/${encodeURIComponent(task_id)}`;
+
+    const lines: string[] = [];
+    if (content) {
+        lines.push(`**You asked:** ${truncate(content, 200)}`);
+        lines.push("");
+    }
+    lines.push(`✅ **${agentLabel}** finished${duration_s ? ` in ${formatDuration(duration_s)}` : ""}.`);
+    if (output) {
+        lines.push("");
+        lines.push("```quote");
+        lines.push(truncate(output, 800));
+        lines.push("```");
+    }
+    lines.push("");
+    lines.push(`_Full output:_ \`hai task show ${task_id}\` or [open in API](${haiUrl})`);
+
+    const content_md = lines.join("\n");
+
+    const email = Deno.env.get("ZULIP_BOT_EMAIL");
+    const apiKey = Deno.env.get("ZULIP_BOT_API_KEY");
+    if (!email || !apiKey) throw new Error("ZULIP_BOT_EMAIL / ZULIP_BOT_API_KEY env not set");
+    const robId = parseInt(Deno.env.get("ROB_ZULIP_USER_ID") ?? "8", 10);
+
+    const zulipResp = await postZulip({
+        to: `[${robId}]`,
+        type: "private",
+        content: content_md,
+        email,
+        apiKey,
+    });
+
+    return { task_id, target_agent, zulip: zulipResp };
+}
+
+// ---------- Humanizers ----------
+
+const AGENT_LABEL: Record<string, string> = {
+    "triager": "Triager",
+    "supervisor": "Supervisor",
+    "reviewer": "Reviewer",
+    "reporter": "Reporter",
+    "researcher": "Researcher",
+    "note-maker": "Note maker",
+    "coder": "Coder",
+    "errand-runner": "Errand runner",
+    "homelab-engineer": "Homelab agent",
+    "network-operator": "Network agent",
+    "storage-operator": "Storage agent",
+    "smart-home-operator": "Smart-home agent",
+    "ml-operator": "ML agent",
+    "observability-operator": "Observability agent",
+};
+
+function truncate(s: string, n: number): string {
+    if (!s) return "";
+    const oneLine = s.replace(/\r?\n+/g, "\n").trim();
+    return oneLine.length > n ? oneLine.slice(0, n - 1) + "…" : oneLine;
+}
+
+function formatDuration(seconds: number): string {
+    if (seconds < 60) return `${Math.round(seconds)}s`;
+    const m = Math.floor(seconds / 60);
+    const s = Math.round(seconds % 60);
+    return s > 0 ? `${m}m ${s}s` : `${m}m`;
+}
+
+// ---------- Zulip ----------
+
+export async function postZulip(args: {
+    to: string;
+    type: "private" | "stream";
+    topic?: string;
+    content: string;
+    email: string;
+    apiKey: string;
+}) {
+    const auth = "Basic " + btoa(`${args.email}:${args.apiKey}`);
+    const zulipApiUrl = Deno.env.get("ZULIP_API_URL") ?? "http://zulip.collab.svc.cluster.local";
+    const zulipHostHeader = Deno.env.get("ZULIP_HOST_HEADER") ??
+        `chat.${Deno.env.get("SECRET_DOMAIN") ?? "thesteamedcrab.com"}`;
+    const params: Record<string, string> = { type: args.type, to: args.to, content: args.content };
+    if (args.topic) params.topic = args.topic;
+    const form = new URLSearchParams(params);
+    const zr = await fetch(`${zulipApiUrl}/api/v1/messages`, {
+        method: "POST",
+        headers: {
+            Authorization: auth,
+            "Content-Type": "application/x-www-form-urlencoded",
+            Host: zulipHostHeader,
+        },
+        body: form,
+        signal: AbortSignal.timeout(30_000),
+    });
+    const zResult = await zr.json().catch(() => ({}));
+    return { status: zr.status, ok: zr.ok, ...zResult };
+}

--- a/kubernetes/apps/home/windmill/workflows/zulip-triager-webhook.ts
+++ b/kubernetes/apps/home/windmill/workflows/zulip-triager-webhook.ts
@@ -46,6 +46,17 @@ export async function main(
         };
     }
 
+    // Approval-verb fallback path. The approval DM card includes
+    //   `_Or reply to this DM:_ approve <task_id> / reject / defer`
+    // and this branch handles those replies in the same DM channel
+    // the card was sent in. Magic-link buttons in the card cover the
+    // primary path; this is the no-link / paste-from-history fallback.
+    const verb = parseApprovalVerb(text);
+    if (verb) {
+        const dispatch = await dispatchApprovalVerb(verb);
+        return { response_string: dispatch };
+    }
+
     const task_id = `zulip-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 
     // KNOWN ISSUE: langgraph-agents /inbox handler hangs after
@@ -102,4 +113,117 @@ export async function main(
             ? `📥 dispatched · task \`${task_id}\` · _(processing async — reply will appear here when ready)_`
             : `⚠️ task \`${task_id}\` — failed to dispatch`,
     };
+}
+
+// ---------- Approval verb dispatch ----------
+
+type ApprovalVerb = { reaction: "approve" | "reject" | "defer"; task_id: string };
+
+// Recognize  `approve <task_id>` / `reject <task_id>` / `defer <task_id>`
+// at the start of the message, possibly preceded by an @-mention
+// (e.g. "@**triager-bot** approve 01KS...").
+function parseApprovalVerb(text: string): ApprovalVerb | null {
+    const cleaned = text.replace(/^\s*@\*\*[^*]+\*\*\s*/, "").trim();
+    const m = cleaned.match(/^(approve|reject|defer)\s+([A-Za-z0-9_-]+)\s*$/i);
+    if (!m) return null;
+    return { reaction: m[1].toLowerCase() as ApprovalVerb["reaction"], task_id: m[2] };
+}
+
+async function dispatchApprovalVerb(verb: ApprovalVerb): Promise<string> {
+    // Round-trip via existing endpoints — no new langgraph-agents API:
+    //   1. GET /admin/tasks/<id> to read the pending interrupt's
+    //      action_class + target (we need them to bind the HMAC).
+    //   2. Sign an HMAC token with LANGGRAPH_APPROVAL_SIGNING_KEY,
+    //      identical to what langgraph-approval-post does for the
+    //      magic links + ntfy buttons.
+    //   3. POST to /approval with the standard body shape.
+    const lgaBase = "http://langgraph-agents.ai.svc.cluster.local:8765";
+    const haiToken = Deno.env.get("HAI_CLI_TOKEN");
+    if (!haiToken) {
+        return `⚠️ HAI_CLI_TOKEN env not set on this workflow. Use the [Approve] link in the original card instead.`;
+    }
+
+    let interrupt: { action_class?: string; target?: string } | null = null;
+    try {
+        const r = await fetch(`${lgaBase}/admin/tasks/${encodeURIComponent(verb.task_id)}`, {
+            headers: { Authorization: `Bearer ${haiToken}` },
+            signal: AbortSignal.timeout(10_000),
+        });
+        if (!r.ok) {
+            return `⚠️ task \`${verb.task_id}\` lookup returned ${r.status}`;
+        }
+        const j = await r.json();
+        const interrupts = j?.checkpointer?.interrupts ?? [];
+        for (const i of interrupts) {
+            if (i?.value?.action_class) {
+                interrupt = i.value;
+                break;
+            }
+        }
+    } catch (e) {
+        return `⚠️ task lookup failed · ${(e as Error).message ?? "unknown"}`;
+    }
+    if (!interrupt || !interrupt.target || !interrupt.action_class) {
+        return `⚠️ task \`${verb.task_id}\` has no pending approval interrupt`;
+    }
+
+    const [serverName, ...rest] = interrupt.target.split(".");
+    const method = rest.join(".");
+    const token = await signApprovalToken(
+        verb.task_id,
+        interrupt.action_class,
+        serverName,
+        method,
+    );
+
+    const approvalUrl = `https://langgraph.${Deno.env.get("SECRET_DOMAIN") ?? "thesteamedcrab.com"}/approval`;
+    try {
+        const r = await fetch(approvalUrl, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                task_id: verb.task_id,
+                reaction: verb.reaction,
+                approval_token: token,
+                actor: "rob",
+            }),
+            signal: AbortSignal.timeout(10_000),
+        });
+        if (r.ok) {
+            return `✅ \`${verb.reaction}\` dispatched for task \`${verb.task_id}\``;
+        }
+        const body = await r.text().catch(() => "");
+        return `⚠️ /approval returned ${r.status} · ${body.slice(0, 200)}`;
+    } catch (e) {
+        return `⚠️ /approval call failed · ${(e as Error).message ?? "unknown"}`;
+    }
+}
+
+// HMAC-SHA256 token signing — matches langgraph-approval-post.ts
+// and the langgraph-agents errand_runner._verify_approval_token.
+async function signApprovalToken(
+    task_id: string,
+    action_class: string,
+    server: string,
+    method: string,
+): Promise<string> {
+    const secret = Deno.env.get("LANGGRAPH_APPROVAL_SIGNING_KEY");
+    if (!secret) throw new Error("LANGGRAPH_APPROVAL_SIGNING_KEY env not set");
+    const nonceBytes = new Uint8Array(8);
+    crypto.getRandomValues(nonceBytes);
+    const nonce = Array.from(nonceBytes).map((b) => b.toString(16).padStart(2, "0")).join("");
+    const payload = `${task_id}|${action_class}|${server}|${method}|${nonce}`;
+    const enc = new TextEncoder();
+    const key = await crypto.subtle.importKey(
+        "raw",
+        enc.encode(secret),
+        { name: "HMAC", hash: "SHA-256" },
+        false,
+        ["sign"],
+    );
+    const sig = await crypto.subtle.sign("HMAC", key, enc.encode(payload));
+    const sigHex = Array.from(new Uint8Array(sig))
+        .map((b) => b.toString(16).padStart(2, "0"))
+        .join("");
+    return `${payload}:${sigHex}`;
 }


### PR DESCRIPTION
## Summary

Stage 2 of HomeAIOps stabilization. Closes the "I didn't get any Zulip notifications" gap caught dogfooding. Three coordinated changes:

### 1. Approval DM redesign — `langgraph-approval-post.ts`

**Root-cause fix**: previous Zulip post POST'd to the in-cluster URL `zulip.collab.svc.cluster.local`, which Zulip 400'd because the hostname isn't in `ALLOWED_HOSTS`. Same bug class as lga PR #64. Workflow result was silently `{"zulip": {}}` for 2+ months — last successful #approvals post: 2026-05-19. Fix: explicit `Host: chat.${SECRET_DOMAIN}` on every Zulip POST.

**Channel**: stream `#approvals` → DM to Rob (user 8). Rob isn't subscribed to the stream; the DM goes through regardless.

**Card content** — human-readable:
- "**You asked:** <original prompt>" (carried in the payload from lga 0.2.39+)
- Action-class emoji + plain label: 🟢 routine / 🟡 reviewable / 🔴 destructive
- Agent role: `homelab-engineer` → "Homelab agent"
- Target verb phrase: `kubectl-mcp.kubectl_apply` → "apply a kubectl manifest"
- Payload summary as a blockquote
- Magic-link buttons (HMAC-signed) for Approve / Reject / Defer 4h
- DM-reply fallback hint

### 2. New `langgraph-completion-post.ts`

Symmetric DM when a task finishes. "You asked", "✅ <Agent> finished in 1m 40s", output blockquote, `hai task show <id>` hint.

### 3. `zulip-triager-webhook.ts` DM-reply fallback

Recognizes `approve|reject|defer <task_id>` at the start of a DM to triager-bot. Looks up the pending interrupt via `/admin/tasks/<id>`, signs HMAC in-workflow, POSTs to `/approval`. New env: `HAI_CLI_TOKEN` for the lookup.

### 4. ExternalSecret

Adds `COMPLETION_POST_WEBHOOK_URL` + `COMPLETION_POST_WEBHOOK_TOKEN` to `langgraph-agents-secret`. Token reuses existing `windmill.alertmanager_webhook_token`.

## Companion PR

langgraph-agents [PR #70](https://github.com/rwlove/langgraph-agents/pull/70) — lga side: `_post_completion` hook + `content` on approval-post payload. v0.2.39+ activates "You asked: ..." line; older versions degrade gracefully.

## Post-merge

These workflow source files still need `wmill sync` to push them to Windmill. Track B (PR #11953) adds a watchdog so the next time we forget, we get a Zulip DM instead of 24h of silence.

## Test plan

- [x] Type-check via deno locally
- [x] README workflow count 12 → 13
- [ ] After deploy + wmill sync + lga 0.2.39 ships: `hai task add "smoke"` produces a completion DM within 60s
- [ ] Synthetic approval interrupt produces a DM with magic-link buttons that work