### PR TITLE
fix(media/immich): scale machine-learning to 1 replica

### DIFF
--- a/kubernetes/apps/media/immich/app/helmrelease.yaml
+++ b/kubernetes/apps/media/immich/app/helmrelease.yaml
@@ -149,7 +149,7 @@ spec:
 
             priorityClassName: ai-gpu-critical
 
-          replicas: 2
+          replicas: 1
           strategy: RollingUpdate
           type: statefulset
 


### PR DESCRIPTION
## Summary

- Drop `immich-machine-learning` StatefulSet from 2 replicas to 1.
- Two replicas on one P40 (worker8) were each holding a SigLIP2 visual encoder + lazy-loaded antelopev2 face session, driving the card to ~95% VRAM.
- Result: ONNX `BFCArena` OOMs on `AssetDetectFaces` (~62 failed assets clustered at 2026-05-21 20:14 UTC). Failed jobs do not auto-retry.

## Why now

One replica is sufficient until the ML migration to Spark lands separately. Two replicas competing for a single shared GPU is pure waste.

## Test plan

- [ ] Flux reconciles HelmRelease cleanly (no schema regression).
- [ ] StatefulSet settles at 1/1 Ready.
- [ ] `nvidia-smi` on worker8 shows ~10+ GiB reclaimed.
- [ ] Manual re-queue of Face Detection "Missing" completes without OOM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)