### PR TITLE
feat(collab/open-webui): pin RAG embedding to ollama-spark

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ Worker nodes attach to **iot** and **sec** VLANs via Multus for direct camera an
 | **Paperless-ngx** | Document scanning, OCR, tagging (CNPG-backed, offsite-backed) |
 | **Obsidian** + **obsidian-couchdb** | Notes sync (CouchDB w/ Cloudflare rate-limiting) |
 | **Zulip** | Self-hosted team chat (also wired into agent pipeline approvals) |
-| **Windmill** | Workflow automation; 13 checked-in TypeScript flows under `kubernetes/apps/home/windmill/workflows/` cover AlertManager → HolmesGPT, langgraph inbox/approval/digest/DLQ/cost-cap/awaiting-user, paperless RAG ingest+tombstone, Zulip triager webhook, and the workaround upstream-watcher |
+| **Windmill** | Workflow automation; 14 checked-in TypeScript flows under `kubernetes/apps/home/windmill/workflows/` cover AlertManager → HolmesGPT, langgraph inbox/approval/digest/DLQ/cost-cap/awaiting-user, paperless RAG ingest+tombstone, Zulip triager webhook, and the workaround upstream-watcher |
 | **ntfy** | Self-hosted push notifications (operator approvals via Android tap actions) |
 | **BentoPDF** | Self-hosted PDF toolkit |
 | **Kitchenowl** | Shopping lists + recipe / meal management |
@@ -324,7 +324,7 @@ flowchart TB
         AM[AlertManager]
     end
 
-    subgraph Bridges[Windmill bridges<br/>13 TS workflows]
+    subgraph Bridges[Windmill bridges<br/>14 TS workflows]
         WInbox[langgraph-inbox.ts]
         WAlert[alertmanager-holmesgpt-notify.ts]
         WApprove[langgraph-approval-post/receive.ts]
@@ -393,7 +393,7 @@ in 1Password.
 - **HolmesGPT** (`observability/`) — the only agent live in production. AlertManager firings reach it via Windmill's `alertmanager-holmesgpt-notify.ts`; it reasons over Prometheus + Loki + cluster state and posts a root-cause hypothesis to Zulip / ntfy. Open WebUI also surfaces it as a tool server.
 - **langgraph-agents** (`ai/`) — the FastAPI multi-agent runtime (`rwlove/langgraph-agents`, image `0.2.30`). Plumbed end-to-end (Postgres checkpoints + memory, live task-queue substrate in `postgres-langgraph-checkpoints`, vault PVCs, Windmill approval loop, cost caps in env) but cold: `ENABLE_CLAUDE_API: false` and no public route except `/approval`. Goes hot when the Claude key lands in 1Password.
 - **claude-runner** (`automation/`) — separate escalation lane. Two daily CronJobs (`pr-triage` 13:00 UTC, `cost-cap-commentary` 22:00 UTC) launch the Claude Code CLI with a `gh` MCP allowlist, post Zulip cards, then exit. Stateless; never consumes langgraph-agents.
-- **Windmill** (`home/`) — 13 checked-in TypeScript flows under `kubernetes/apps/home/windmill/workflows/` are the bridges that knit the surfaces above together. Every alert webhook, Zulip-triggered DM, approval round-trip, daily digest, DLQ retry, cost-cap pause, and Paperless RAG ingest is a `.ts` file there. n8n was retired during the ntfy migration.
+- **Windmill** (`home/`) — 14 checked-in TypeScript flows under `kubernetes/apps/home/windmill/workflows/` are the bridges that knit the surfaces above together. Every alert webhook, Zulip-triggered DM, approval round-trip, daily digest, DLQ retry, cost-cap pause, and Paperless RAG ingest is a `.ts` file there. n8n was retired during the ntfy migration.
 - **Langfuse** (`ai/`) — OTLP trace sink for langgraph-agents. Chart deploys ClickHouse + Valkey + MinIO bundled; Postgres comes from CNPG `postgres-langfuse`.
 - **memory-mcp** (`mcp-system/`) — cross-agent knowledge graph on `postgres-langgraph-memory` with pgvector(1024). bge-m3 embeds via Ollama-Spark. Same surface for langgraph agents and claude-runner.
 

--- a/kubernetes/apps/collab/open-webui/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/open-webui/app/helmrelease.yaml
@@ -46,6 +46,20 @@ spec:
               OPENAI_API_KEYS: sk-langgraph-agents-cluster-internal
               ENABLE_RAG_WEB_SEARCH: true
               RAG_EMBEDDING_ENGINE: ollama
+              # Pin RAG embedding traffic to Spark. Without this,
+              # open-webui v0.9.5 falls back to OLLAMA_BASE_URL
+              # (default '/ollama' → first persisted endpoint in
+              # webui.db), which currently resolves to the P40. That
+              # puts bge-m3 on the P40 chat hot path, where Immich
+              # CLIP and whisper bursts evict it and trigger cold-load
+              # latency on every RAG call. Spark already serves
+              # embedders for memory-mcp, paperless RAG (Windmill),
+              # and langgraph-agents — this aligns Open WebUI with
+              # that fleet. bge-m3 is kept steady-resident on Spark
+              # by the blackbox synthetic embed probe (5-min cadence,
+              # doubles as wedge detector — see ollama-spark
+              # prometheusrule.yaml).
+              RAG_OLLAMA_BASE_URL: http://ollama-spark.ai.svc.cluster.local:11434
               # Phase A benchmark (2026-05-20, 50-doc Paperless eval)
               # showed bge-m3 (1024-dim) beats nomic-embed-text (768) by
               # +23 MRR@10 pts. The cluster moves to bge-m3 for new


### PR DESCRIPTION
## Summary

Pin Open WebUI's RAG embedding URL to `ollama-spark` so bge-m3 stays resident on Spark instead of cold-loading on the P40 mid-RAG-call.

## What changed

- Added `RAG_OLLAMA_BASE_URL: http://ollama-spark.ai.svc.cluster.local:11434` to the open-webui HelmRelease env.
- 1-line README drift fix (13 → 14 Windmill workflows) — pre-commit was blocking on this orthogonal drift from #11953/#11954; folded in to unblock landing.

## Why

Despite `OLLAMA_BASE_URLS` listing Spark first, Open WebUI v0.9.5 routes RAG embedding via the `RAG_OLLAMA_BASE_URL` env (a separate `PersistentConfig`). Without that var set, the fallback chain is:

```
RAG_OLLAMA_BASE_URL (unset)
  → OLLAMA_BASE_URL (defaults to '/ollama')
  → first persisted ollama endpoint in webui.db
    (which has been the P40 since first deploy)
```

So bge-m3 ends up resident on the P40 — where Immich CLIP and whisper bursts evict it on `OLLAMA_MAX_LOADED_MODELS=1`, causing cold-load latency every RAG call.

Confirmed via `/api/ps` 2026-05-22: bge-m3 active on both backends (Spark via wedge probe, P40 via Open WebUI traffic). The rest of the bge-m3 fleet (memory-mcp, paperless RAG ingest, langgraph-agents) already targets Spark explicitly — this aligns Open WebUI with them.

## Cost / downtime

- Pod restart for env change (~30s, single replica StatefulSet).
- No data loss (RAG_OLLAMA_BASE_URL doesn't change embedding semantics; bge-m3 model + embedding dimensions unchanged).
- P40 bge-m3 evicts naturally after 5-min idle TTL once nothing else hits it.

## Rollback

Drop the `RAG_OLLAMA_BASE_URL` line, restart pod. Old behavior restores.

## Verification

```bash
flux reconcile kustomization open-webui -n flux-system
kubectl rollout status -n collab sts open-webui

# After 5 min idle, P40 should no longer hold bge-m3:
kubectl run probe -n ai --rm -i --restart=Never --image=curlimages/curl:latest \
  --command -- sh -c 'curl -s http://ollama.ai.svc.cluster.local:11434/api/ps; \
  echo; curl -s http://ollama-spark.ai.svc.cluster.local:11434/api/ps'

# Trigger a RAG call from Open WebUI (any saved-knowledge chat) and verify
# Spark logs show /api/embed traffic.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)