### PR TITLE
feat(observability/holmesgpt): bump model to qwen2.5:72b on Spark

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ Worker nodes attach to **iot** and **sec** VLANs via Multus for direct camera an
 | **Paperless-ngx** | Document scanning, OCR, tagging (CNPG-backed, offsite-backed) |
 | **Obsidian** + **obsidian-couchdb** | Notes sync (CouchDB w/ Cloudflare rate-limiting) |
 | **Zulip** | Self-hosted team chat (also wired into agent pipeline approvals) |
-| **Windmill** | Workflow automation; 13 checked-in TypeScript flows under `kubernetes/apps/home/windmill/workflows/` cover AlertManager → HolmesGPT, langgraph inbox/approval/digest/DLQ/cost-cap/awaiting-user, paperless RAG ingest+tombstone, Zulip triager webhook, and the workaround upstream-watcher |
+| **Windmill** | Workflow automation; 14 checked-in TypeScript flows under `kubernetes/apps/home/windmill/workflows/` cover AlertManager → HolmesGPT, langgraph inbox/approval/digest/DLQ/cost-cap/awaiting-user, paperless RAG ingest+tombstone, Zulip triager webhook, and the workaround upstream-watcher |
 | **ntfy** | Self-hosted push notifications (operator approvals via Android tap actions) |
 | **BentoPDF** | Self-hosted PDF toolkit |
 | **Kitchenowl** | Shopping lists + recipe / meal management |
@@ -324,7 +324,7 @@ flowchart TB
         AM[AlertManager]
     end
 
-    subgraph Bridges[Windmill bridges<br/>13 TS workflows]
+    subgraph Bridges[Windmill bridges<br/>14 TS workflows]
         WInbox[langgraph-inbox.ts]
         WAlert[alertmanager-holmesgpt-notify.ts]
         WApprove[langgraph-approval-post/receive.ts]
@@ -393,7 +393,7 @@ in 1Password.
 - **HolmesGPT** (`observability/`) — the only agent live in production. AlertManager firings reach it via Windmill's `alertmanager-holmesgpt-notify.ts`; it reasons over Prometheus + Loki + cluster state and posts a root-cause hypothesis to Zulip / ntfy. Open WebUI also surfaces it as a tool server.
 - **langgraph-agents** (`ai/`) — the FastAPI multi-agent runtime (`rwlove/langgraph-agents`, image `0.2.30`). Plumbed end-to-end (Postgres checkpoints + memory, live task-queue substrate in `postgres-langgraph-checkpoints`, vault PVCs, Windmill approval loop, cost caps in env) but cold: `ENABLE_CLAUDE_API: false` and no public route except `/approval`. Goes hot when the Claude key lands in 1Password.
 - **claude-runner** (`automation/`) — separate escalation lane. Two daily CronJobs (`pr-triage` 13:00 UTC, `cost-cap-commentary` 22:00 UTC) launch the Claude Code CLI with a `gh` MCP allowlist, post Zulip cards, then exit. Stateless; never consumes langgraph-agents.
-- **Windmill** (`home/`) — 13 checked-in TypeScript flows under `kubernetes/apps/home/windmill/workflows/` are the bridges that knit the surfaces above together. Every alert webhook, Zulip-triggered DM, approval round-trip, daily digest, DLQ retry, cost-cap pause, and Paperless RAG ingest is a `.ts` file there. n8n was retired during the ntfy migration.
+- **Windmill** (`home/`) — 14 checked-in TypeScript flows under `kubernetes/apps/home/windmill/workflows/` are the bridges that knit the surfaces above together. Every alert webhook, Zulip-triggered DM, approval round-trip, daily digest, DLQ retry, cost-cap pause, and Paperless RAG ingest is a `.ts` file there. n8n was retired during the ntfy migration.
 - **Langfuse** (`ai/`) — OTLP trace sink for langgraph-agents. Chart deploys ClickHouse + Valkey + MinIO bundled; Postgres comes from CNPG `postgres-langfuse`.
 - **memory-mcp** (`mcp-system/`) — cross-agent knowledge graph on `postgres-langgraph-memory` with pgvector(1024). bge-m3 embeds via Ollama-Spark. Same surface for langgraph agents and claude-runner.
 

--- a/kubernetes/apps/ai/ollama-spark/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/ollama-spark/app/helmrelease.yaml
@@ -59,10 +59,23 @@ spec:
               OLLAMA_CONTEXT_LENGTH: 16384
               OLLAMA_NUM_PARALLEL: 4
               # Spark's 128 GB unified memory comfortably runs 30b-class
-              # models concurrently. P40-era cap of 1 lifted. Bumped
-              # 2 → 3 to leave headroom during the Spark-unblocks-RAG
-              # embedder benchmark (chat + two candidate embedders
-              # loaded concurrently).
+              # models concurrently. P40-era cap of 1 lifted.
+              # 2026-05-22: held at 3 through HolmesGPT 32b→72b upgrade.
+              # Working set is bge-m3 (always-warm, RAG + wedge probe)
+              # + qwen2.5:72b (HolmesGPT) + qwen2.5:32b (Open WebUI
+              # default chat). max=3 forces ollama to evict the
+              # rarely-used coder:32b under pressure rather than evict
+              # bge-m3 — which would wedge RAG and the wedge probe.
+              # Worst-case unified-memory residence reported by
+              # /api/ps: ~66 GB (72b) + ~22 GB (32b) + 1.3 GB (bge-m3)
+              # ≈ 89 GB of the 128 GB node. The pod cgroup RSS stays
+              # much lower (~14 GB observed with 72b loaded) because
+              # CUDA-mapped model weights on Grace-Blackwell unified
+              # memory don't bill against the kubelet's pod accounting.
+              # Pod limit bumped 64Gi → 80Gi as defensive headroom for
+              # ollama runtime + 16K context KV cache (q8) across
+              # NUM_PARALLEL=4 slots — not strictly required by the
+              # measured RSS but cheap on a 128 GB node.
               OLLAMA_MAX_LOADED_MODELS: 3
 
             resources:
@@ -71,7 +84,7 @@ spec:
                 cpu: 2000m
                 nvidia.com/gpu: 1
               limits:
-                memory: 64Gi
+                memory: 80Gi
                 nvidia.com/gpu: 1
 
             securityContext:

--- a/kubernetes/apps/observability/holmesgpt/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/holmesgpt/app/helmrelease.yaml
@@ -42,7 +42,17 @@ spec:
               - python
               - /app/server.py
             env:
-              MODEL: ollama/qwen2.5:32b
+              # Upgraded 2026-05-22 from qwen2.5:32b → qwen2.5:72b for
+              # alert-triage reasoning quality. HolmesGPT is the only
+              # hot 32b consumer on Spark today (Open WebUI chat default
+              # is also 32b, but interactive — different latency budget),
+              # so this is the biggest available reasoning-quality
+              # lever pre-Spark-cluster-expansion. Tradeoff: 72b weights
+              # are ~47 GB (vs ~20 GB for 32b), per-call latency rises
+              # ~1.5–2× under same prompt shape. The 600s LITELLM_TIMEOUT
+              # remains comfortable (32b max-call was 92s; 72b at same
+              # prompt shape extrapolates to <200s).
+              MODEL: ollama/qwen2.5:72b
               OLLAMA_API_BASE: http://ollama-spark.ai.svc.cluster.local:11434
               OVERRIDE_MAX_CONTENT_SIZE: "16384"
               OVERRIDE_MAX_OUTPUT_TOKEN: "4096"
@@ -52,6 +62,7 @@ spec:
               # 4K-output round-trip). 600s gives ~6.5× headroom; the
               # 1500s band-aid (PR #11651, sized for P40 qwen2.5:7b)
               # and the 900s soak step (PR #11803) are both retired.
+              # Holding 600s through the 32b→72b bump.
               LITELLM_REQUEST_TIMEOUT: "600"
               LITELLM_TIMEOUT: "600"
               HOLMES_HOST: 0.0.0.0


### PR DESCRIPTION
## Summary

- HolmesGPT MODEL upgrade: `qwen2.5:32b` → `qwen2.5:72b`. Holmes is the only hot 32b consumer on Spark today, so this is the biggest available reasoning-quality lever for alert triage pre-Spark-cluster-expansion.
- ollama-spark pod memory limit bumped 64Gi → 80Gi as defensive headroom (current pod RSS is only ~14 GB with 72b loaded — CUDA-mapped weights on Grace-Blackwell unified memory don't bill against the pod cgroup, so the limit was never the real budget. 80Gi gives 16 GB of cushion for non-CUDA buffers / KV cache outside the GPU pool).
- `OLLAMA_MAX_LOADED_MODELS` held at 3 (explicit reasoning in helmrelease comment — see PR diff).
- 1-line README drift fix (13→14 Windmill workflows, same fix as #11958 — whichever lands second is a no-op).

## Pre-flight done

- `ollama pull qwen2.5:72b` on `ollama-spark` completed at 2026-05-22 08:43 ET.
- Disk: 47 GB on PVC. PVC fill went from 39 GB → 86 GB (~85% full — flagged below).
- Smoke test (cold-load + 3-word generation):
  - `load_duration`: 42.9s (cold pull from PVC)
  - `prompt_eval_count`: 39 tokens, `prompt_eval_duration`: 322ms
  - `eval_count`: 4 tokens, `eval_duration`: 691ms (~5.8 tok/s output)
- Pod memory under load (72b + bge-m3 resident): 14 GB pod RSS (cgroup); 66 GB + 1.3 GB allocated per `/api/ps` (unified memory); 105 GB free on node.

## OLLAMA_MAX_LOADED_MODELS decision — held at 3

Three always-warm models in the steady state:
1. `bge-m3` — RAG embedder + wedge probe heartbeat
2. `qwen2.5:72b` — HolmesGPT alert triage
3. `qwen2.5:32b` — Open WebUI default chat

`qwen2.5-coder:32b` is on disk but **not wired into any HelmRelease**. Cold-load on demand is acceptable.

Critically: `max=3` ensures bge-m3 never gets evicted when both 72b and 32b are warm — if bge-m3 evicted, the synthetic wedge probe would fail and fire SparkOllamaWedged. Holding the floor at 3 forces Ollama to evict whichever 30b-class model is colder when memory pressure rises.

Bumping to 4 (keeping coder warm too) costs ~22 GB unified memory for an on-demand consumer that nothing currently calls — not worth the eviction-risk delta.

## Watch items / known risks

- **PVC fill is 85%**. qwen2.5:72b is 47 GB and the model PVC is 100 GB. We have ~13 GB headroom. Pulling another large model (or another 72b-class variant) would push over. Monitor via `df -h /models` if more models are added.
- **First Holmes alert after deploy hits ~43s cold-load**. The 600s `LITELLM_TIMEOUT` covers this comfortably. Real-traffic Holmes calls at 16K-prompt/4K-output extrapolate to ~200-300s on 72b — well under the timeout but worth measuring after the first real multi-tool investigation.
- **Open WebUI default chat (32b) will hit cold-load** the first time someone uses chat after Holmes loads 72b and Ollama evicts something. The wedge probe keeps bge-m3 warm; 32b will reload on the first user message. Acceptable.

## Rollback

Revert this commit. Holmes flips back to `qwen2.5:32b`. ollama-spark pod limit reverts to 64Gi (above current RSS so safe).

The qwen2.5:72b artifact remains on disk after rollback (47 GB on the PVC at 85% full). Remove manually if PVC pressure becomes a concern:

```bash
kubectl exec -n ai ollama-spark-0 -- ollama rm qwen2.5:72b
```

## Verification

```bash
flux reconcile ks ollama-spark -n flux-system
flux reconcile ks holmesgpt -n flux-system

kubectl rollout status sts/ollama-spark -n ai
kubectl rollout status deploy/holmesgpt -n observability

# Confirm Holmes is talking to 72b:
kubectl logs -n observability deploy/holmesgpt | grep -i 'qwen\|model'

# Trigger a synthetic Holmes call via the UI or a test alert.
# Expect first call ~50s, subsequent calls 30-90s typical for
# real multi-tool investigations.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)