### PR TITLE
chore(observability/holmesgpt): hide from Glance — API-only, no webui

### DIFF
--- a/kubernetes/apps/observability/holmesgpt/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/holmesgpt/app/helmrelease.yaml
@@ -89,10 +89,12 @@ spec:
             port: 8080
     route:
       app:
-        annotations:
-          glance/name: "HolmesGPT"
-          glance/show: "true"
-          glance/id: "Observability"
+        # No `glance/*` annotations: HolmesGPT is API-only (no webui).
+        # The HTTPRoute exists to back the alertmanager → HolmesGPT
+        # path and the Open WebUI tool-server registration. Visiting
+        # the hostname in a browser returns FastAPI's default 404 at
+        # `/`. The chat surface for Holmes is Open WebUI's tool
+        # picker, not a direct dashboard.
         hostnames:
           - "holmesgpt.${SECRET_DOMAIN}"
         parentRefs:


### PR DESCRIPTION
## Summary

Rob spotted that visiting `holmesgpt.thesteamedcrab.com` from Glance returns `{"detail":"Not Found"}`. That's FastAPI's default 404 at `/`. HolmesGPT only exposes `/api/chat`, `/api/model`, `/healthz`, `/readyz` — **no webui**.

Removed all three `glance/*` annotations from the HolmesGPT HTTPRoute. The route itself stays — it still backs:
1. The AlertManager → HolmesGPT investigation path
2. The Open WebUI tool-server registration (HolmesGPT is registered as a tool in `kubernetes/apps/collab/open-webui/app/helmrelease.yaml`)

The "chat with Holmes" UX is unchanged: pick HolmesGPT from Open WebUI's tool picker at `chat.${SECRET_DOMAIN}`.

## Files

- `kubernetes/apps/observability/holmesgpt/app/helmrelease.yaml` — strip `glance/{name,show,id}` annotations, add inline comment explaining why.

## Test plan

- [x] yamllint + helmrelease schema pass
- [ ] After deploy: `glance.${SECRET_DOMAIN}` no longer shows the HolmesGPT tile
- [ ] HolmesGPT's `/api/chat` still responds to AlertManager-routed investigations