### PR TITLE
revert(observability/holmesgpt): back to qwen2.5:32b — 72b too slow

### DIFF
--- a/kubernetes/apps/observability/holmesgpt/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/holmesgpt/app/helmrelease.yaml
@@ -42,27 +42,29 @@ spec:
               - python
               - /app/server.py
             env:
-              # Upgraded 2026-05-22 from qwen2.5:32b → qwen2.5:72b for
-              # alert-triage reasoning quality. HolmesGPT is the only
-              # hot 32b consumer on Spark today (Open WebUI chat default
-              # is also 32b, but interactive — different latency budget),
-              # so this is the biggest available reasoning-quality
-              # lever pre-Spark-cluster-expansion. Tradeoff: 72b weights
-              # are ~47 GB (vs ~20 GB for 32b), per-call latency rises
-              # ~1.5–2× under same prompt shape. The 600s LITELLM_TIMEOUT
-              # remains comfortable (32b max-call was 92s; 72b at same
-              # prompt shape extrapolates to <200s).
-              MODEL: ollama/qwen2.5:72b
+              # REVERTED 2026-05-22 from qwen2.5:72b → qwen2.5:32b after
+              # measuring real Spark inference speed under Holmes' tool-
+              # loop. PR #11959 bumped to 72b on the theory that quality
+              # would lift; in practice 72b at q4 runs ~4 tok/s on
+              # GB10 vs ~12 tok/s for 32b (3× slower per token), and
+              # Holmes' first LLM call alone took 9m36s processing 16K
+              # context + tool-plan generation. The tool-loop then
+              # consumed 37K chars of kubectl_logs output into the next
+              # call, which never completed before the 600s workflow
+              # timeout. Conclusion: Holmes' prompt shape is not
+              # 72b-friendly — too much context up-front, too many
+              # tool-loop iterations. The architecture would need
+              # prompt surgery (context trimming + tool-call budget)
+              # before a >32b model is viable. Until then, 32b is the
+              # right ceiling. Investigation transcript in #11961 body.
+              MODEL: ollama/qwen2.5:32b
               OLLAMA_API_BASE: http://ollama-spark.ai.svc.cluster.local:11434
               OVERRIDE_MAX_CONTENT_SIZE: "16384"
               OVERRIDE_MAX_OUTPUT_TOKEN: "4096"
               # Upstream default 600s. Verified safe on Spark +
               # qwen2.5:32b 2026-05-21: 18 LLM calls observed in a real
               # multi-tool investigation, per-call max 92s (16K-prompt /
-              # 4K-output round-trip). 600s gives ~6.5× headroom; the
-              # 1500s band-aid (PR #11651, sized for P40 qwen2.5:7b)
-              # and the 900s soak step (PR #11803) are both retired.
-              # Holding 600s through the 32b→72b bump.
+              # 4K-output round-trip). 600s gives ~6.5× headroom.
               LITELLM_REQUEST_TIMEOUT: "600"
               LITELLM_TIMEOUT: "600"
               HOLMES_HOST: 0.0.0.0


### PR DESCRIPTION
## Summary

Reverts HolmesGPT's MODEL env from `ollama/qwen2.5:72b` (PR #11959) back to `ollama/qwen2.5:32b`. Measured 72b inference under real Holmes load and it does not fit the tool-loop architecture.

## Evidence

Synthetic alert sent to the bridge at 13:09:13Z after 72b was deployed and pod ready. Workflow timed out at 600s with zero output. Holmes pod logs show:

```
09:09:15  Alert received: Verify72bDeploy
09:09:17  Toolsets ready, first LLM call starts (qwen2.5:72b)
09:18:53  First LLM call returns — 9m36s for tool-plan generation
09:18:53  TodoWrite tool runs (in-process, 0s)
09:19:12  Second LLM call returns — 19s for tool-call decision
09:19:12  bash tool runs: kubectl_get_events + kubectl_logs verify
09:19:12  Tool output: 37,963 chars (236 lines) ← unbounded
09:19:12+ Third LLM call processing 37K context... never finishes before 600s wall
```

Raw inference test on `ollama-spark`:
```
qwen2.5:72b  →  3.98 tok/s   (47 GB resident on GB10)
qwen2.5:32b  →  ~12 tok/s    (per prior measurements)
```

## Why the architecture isn't ready for >32b

Three structural blockers:
1. **First LLM call alone** processes ~16K context (tool descriptions + system prompt + alert payload) → 9m+ at 4 tok/s
2. **No tool-output truncation** — `kubectl_logs` returned 37K chars verbatim into the next call
3. **No tool-call budget enforcement** — Holmes happily iterates

A future PR can do prompt surgery (tool-desc minification, tool-output summarization, hard-cap on call count) before reattempting a >32b model.

## Preserved from PR #11959

- **bge-m3 RAG traffic on Spark** (PR #11958) — unchanged, still a real win
- **ollama-spark memory limit 64Gi → 80Gi** — cheap defensive headroom on a 124 GB node, leaving as-is

## Test plan

- [ ] After merge + Flux + Holmes pod restart: synthetic alert produces non-empty analysis in <120s
- [ ] First real alertmanager-triggered investigation produces non-empty `analysis` (measured via `holmes_chars > 0` in Windmill result)