### PR TITLE
fix(collab/zulip): allow in-cluster Service hostname in ALLOWED_HOSTS

### DIFF
--- a/kubernetes/apps/collab/zulip/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/zulip/app/helmrelease.yaml
@@ -87,17 +87,17 @@ spec:
       name: zulip-secret
       valuesKey: ZULIP_ORG_KEY
       targetPath: zulip.environment.SECRETS_zulip_org_key
-    # RabbitMQ password + erlang cookie come from `zulip-secret` via the
-    # Bitnami `existingPasswordSecret` / `existingErlangSecret` features
-    # (configured in spec.values.rabbitmq.auth below). The chart's
-    # _helpers.tpl renders SECRETS_rabbitmq_password as a valueFrom
-    # secretKeyRef when those values are set — so the env wiring is
-    # native, no manual STS patches needed.
-    #
-    # We can't use Flux valuesFrom with `targetPath: rabbitmq.auth.password`
-    # because the substitution silently drops to "" on Bitnami subchart
-    # paths at install AND on subsequent upgrades (configDigest sticks
-    # in-sync). See project_flux_valuesfrom_subchart_drop in memory.
+      # RabbitMQ password + erlang cookie come from `zulip-secret` via the
+      # Bitnami `existingPasswordSecret` / `existingErlangSecret` features
+      # (configured in spec.values.rabbitmq.auth below). The chart's
+      # _helpers.tpl renders SECRETS_rabbitmq_password as a valueFrom
+      # secretKeyRef when those values are set — so the env wiring is
+      # native, no manual STS patches needed.
+      #
+      # We can't use Flux valuesFrom with `targetPath: rabbitmq.auth.password`
+      # because the substitution silently drops to "" on Bitnami subchart
+      # paths at install AND on subsequent upgrades (configDigest sticks
+      # in-sync). See project_flux_valuesfrom_subchart_drop in memory.
 
   values:
     image:
@@ -132,6 +132,19 @@ spec:
     zulip:
       environment:
         SETTING_EXTERNAL_HOST: chat.${SECRET_DOMAIN}
+        # Route in-cluster traffic (Windmill workflows, langgraph-
+        # agents pods) hitting http://zulip.collab.svc.cluster.local
+        # to the Lovenet realm. Without this, Django's ALLOWED_HOSTS
+        # rejects those requests with a generic 400 — confirmed by
+        # the post-deploy synthetic on 2026-05-22 where every
+        # Windmill→Zulip POST returned `{"zulip": {ok: false,
+        # status: 400}}`. Deno's `fetch` can't override the `Host`
+        # header (forbidden header name per WHATWG Fetch spec), so
+        # the fix has to come from Zulip's side. Empty subdomain `""`
+        # maps the Service hostname to the same Lovenet realm
+        # (zerver_realm.id=2, string_id='') the public hostname
+        # already routes to — no second realm is created.
+        SETTING_REALM_HOSTS: "{\"zulip.collab.svc.cluster.local\": \"\"}"
         # SETTING_ZULIP_ADMINISTRATOR + SECRETS_secret_key are populated by
         # spec.valuesFrom from the zulip-secret. Do NOT add inline placeholders
         # here — empirically they pinned SETTING_ZULIP_ADMINISTRATOR to the


### PR DESCRIPTION
## Summary

Every Windmill→Zulip POST has been silently 400'ing for months. Symptom: workflow result shows `"zulip": {ok: false, status: 400}` with no detail. Root cause: Django's ALLOWED_HOSTS only contains `chat.${SECRET_DOMAIN}` (via `SETTING_EXTERNAL_HOST`), so any in-cluster request hitting `zulip.collab.svc.cluster.local` gets rejected before any handler runs.

The standard cluster-internal-URL workaround (per memory `reference_zulip_base_url_host_header_fix`) is to override the `Host` header per request. That works from Python's `httpx` (which `agents.tools.zulip.send_dm` uses successfully). It does NOT work from TypeScript/Deno: `Host` is in the WHATWG Fetch spec's forbidden-header list, and Deno's `fetch` silently strips it. Every Windmill workflow's attempt to set `Host: chat.${SECRET_DOMAIN}` was a no-op.

## Change

One env var added to the Zulip HelmRelease:

```yaml
SETTING_REALM_HOSTS: "{\"zulip.collab.svc.cluster.local\": \"\"}"
```

Empty subdomain `""` maps the Service hostname to the existing Lovenet realm (`zerver_realm.id=2`, `string_id=''`) — no new realm, no new ingress, no bot-cred changes.

Drive-by: fixed two pre-existing `comments-indentation` yamllint warnings on lines 90+ and 97+ that were blocking pre-commit on any edit to this file.

## Fixes (post-deploy)

- Approval DM cards (`langgraph-approval-post.ts`)
- Completion DM cards (`langgraph-completion-post.ts`)
- HolmesGPT investigation summary in Zulip (`alertmanager-holmesgpt-notify.ts`)
- Any future Deno-based Zulip post

## Maintenance window

Zulip is Renee-facing → Tuesday 02:00–04:00 ET window per CLAUDE.md. Change is config-only with a single ~30s pod restart. Holding merge unless explicitly overridden — next window: Tuesday 2026-05-26.

## Test plan

- [x] Reproduced 400 with a probe confirming Deno drops `Host`
- [x] Confirmed Lovenet realm has `string_id=''`
- [x] yamllint --strict passes
- [ ] Post-deploy: synthetic POST to `langgraph-completion-post` returns `"zulip": {ok: true, status: 200}` with a `msg_id`
- [ ] `hai task add "smoke"` produces a Zulip DM from triager-bot when the task completes