### PR TITLE
fix(home/windmill): inject HAI_CLI_TOKEN bearer on lga /admin + /inbox calls

### DIFF
--- a/kubernetes/apps/home/windmill/app/externalsecret-workflows.yaml
+++ b/kubernetes/apps/home/windmill/app/externalsecret-workflows.yaml
@@ -43,6 +43,11 @@ spec:
         # (`paperless` / field `mcp_token`) that mcp-system/paperless-mcp
         # already uses — keeping a single token-rotation surface.
         PAPERLESS_TOKEN: "{{ .paperless_mcp_token }}"
+        # HAI CLI Bearer token. Required for any Windmill workflow that calls
+        # langgraph-agents /admin/* or /inbox endpoints (cost-cap-watcher,
+        # awaiting-user-sweep, daily-digest, dlq-watcher). Sourced from the
+        # same `hai-cli` 1P item langgraph-agents-secret reads.
+        HAI_CLI_TOKEN: "{{ .TOKEN }}"
         # Windmill API token used by the windmill-failure-watcher
         # workflow to query its own /api/w/lovenet/jobs/list_completed.
         # Mint via /api/users/tokens/create as admin@windmill.dev and
@@ -72,3 +77,7 @@ spec:
     # comment above).
     - extract:
         key: windmill
+    # HAI_CLI_TOKEN (field `TOKEN` on the `hai-cli` 1P item, shared with
+    # langgraph-agents-secret — single rotation surface).
+    - extract:
+        key: hai-cli

--- a/kubernetes/apps/home/windmill/workflows/langgraph-awaiting-user-sweep.ts
+++ b/kubernetes/apps/home/windmill/workflows/langgraph-awaiting-user-sweep.ts
@@ -18,10 +18,20 @@ const MIN_30 = 30 * 60 * 1000;
 const HR_4 = 4 * 60 * 60 * 1000;
 const DAY_7 = 7 * 24 * 60 * 60 * 1000;
 
+// HAI_CLI_TOKEN gates /admin/* + /inbox on langgraph-agents since 0.2.38
+// (PR-C bearer-auth middleware). Inject the token into every call to the
+// in-cluster langgraph-agents Service URL. Returns an empty header dict
+// when the env is unset (dev / pre-deployment) — server-side falls back
+// to allow-all in that mode, so the workflow stays functional.
+function lgaHeaders(): Record<string, string> {
+    const tok = Deno.env.get("HAI_CLI_TOKEN");
+    return tok ? { Authorization: `Bearer ${tok}` } : {};
+}
+
 export async function main() {
     const r = await fetch(
         "http://langgraph-agents.ai.svc.cluster.local:8765/admin/tasks",
-        { signal: AbortSignal.timeout(30_000) },
+        { signal: AbortSignal.timeout(30_000), headers: lgaHeaders() },
     );
     if (!r.ok) {
         return { skip: true, reason: `GET /admin/tasks → ${r.status}` };
@@ -68,7 +78,7 @@ async function handle(t: Task, tier: "30min" | "4h" | "7d", age: number) {
             }/timeout-tier`,
             {
                 method: "POST",
-                headers: { "Content-Type": "application/json" },
+                headers: { ...lgaHeaders(), "Content-Type": "application/json" },
                 body: JSON.stringify({ tier: "4h" }),
                 signal: AbortSignal.timeout(30_000),
             },
@@ -82,7 +92,7 @@ async function handle(t: Task, tier: "30min" | "4h" | "7d", age: number) {
         }/cancel`,
         {
             method: "POST",
-            headers: { "Content-Type": "application/json" },
+            headers: { ...lgaHeaders(), "Content-Type": "application/json" },
             body: JSON.stringify({ reason: "7-day timeout; auto-cancelled by awaiting-user sweep" }),
             signal: AbortSignal.timeout(30_000),
         },

--- a/kubernetes/apps/home/windmill/workflows/langgraph-cost-cap-watcher.ts
+++ b/kubernetes/apps/home/windmill/workflows/langgraph-cost-cap-watcher.ts
@@ -13,10 +13,20 @@ type CostsResponse = {
     per_agent?: Record<string, number>;
 };
 
+// HAI_CLI_TOKEN gates /admin/* + /inbox on langgraph-agents since 0.2.38
+// (PR-C bearer-auth middleware). Inject the token into every call to the
+// in-cluster langgraph-agents Service URL. Returns an empty header dict
+// when the env is unset (dev / pre-deployment) — server-side falls back
+// to allow-all in that mode, so the workflow stays functional.
+function lgaHeaders(): Record<string, string> {
+    const tok = Deno.env.get("HAI_CLI_TOKEN");
+    return tok ? { Authorization: `Bearer ${tok}` } : {};
+}
+
 export async function main() {
     const r = await fetch(
         "http://langgraph-agents.ai.svc.cluster.local:8765/admin/costs/today",
-        { signal: AbortSignal.timeout(30_000) },
+        { signal: AbortSignal.timeout(30_000), headers: lgaHeaders() },
     );
     if (!r.ok) {
         return { skip: true, reason: `endpoint returned ${r.status}` };

--- a/kubernetes/apps/home/windmill/workflows/langgraph-daily-digest.ts
+++ b/kubernetes/apps/home/windmill/workflows/langgraph-daily-digest.ts
@@ -25,6 +25,16 @@ const LG_BASE = "http://langgraph-agents.ai.svc.cluster.local:8765";
 const POLL_INTERVAL_MS = 5_000;
 const POLL_TIMEOUT_MS = 600_000; // 10 min; the digest is the longest /inbox we run
 
+// HAI_CLI_TOKEN gates /admin/* + /inbox on langgraph-agents since 0.2.38
+// (PR-C bearer-auth middleware). Inject the token into every call to the
+// in-cluster langgraph-agents Service URL. Returns an empty header dict
+// when the env is unset (dev / pre-deployment) — server-side falls back
+// to allow-all in that mode, so the workflow stays functional.
+function lgaHeaders(): Record<string, string> {
+    const tok = Deno.env.get("HAI_CLI_TOKEN");
+    return tok ? { Authorization: `Bearer ${tok}` } : {};
+}
+
 export async function main() {
     const date = new Date().toISOString().slice(0, 10);
     const client_task_id = `digest-${date}`;
@@ -32,7 +42,7 @@ export async function main() {
     // Step 1: enqueue the digest task. Returns 202 + queue_task_id.
     const lgResp = await fetch(`${LG_BASE}/inbox`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { ...lgaHeaders(), "Content-Type": "application/json" },
         body: JSON.stringify({
             task_id: client_task_id,
             source: "test",
@@ -92,7 +102,7 @@ async function pollForOutput(taskId: string): Promise<string | null> {
     while (Date.now() < deadline) {
         const r = await fetch(
             `${LG_BASE}/admin/tasks/${encodeURIComponent(taskId)}`,
-            { signal: AbortSignal.timeout(15_000) },
+            { signal: AbortSignal.timeout(15_000), headers: lgaHeaders() },
         );
         if (!r.ok) {
             if (r.status === 404) {

--- a/kubernetes/apps/home/windmill/workflows/langgraph-dlq-watcher.ts
+++ b/kubernetes/apps/home/windmill/workflows/langgraph-dlq-watcher.ts
@@ -24,13 +24,23 @@ type DlqEntry = {
 const LG_BASE = "http://langgraph-agents.ai.svc.cluster.local:8765";
 const STATE_KEY = "f/lovenet/langgraph_dlq_last_seen_id";
 
+// HAI_CLI_TOKEN gates /admin/* + /inbox on langgraph-agents since 0.2.38
+// (PR-C bearer-auth middleware). Inject the token into every call to the
+// in-cluster langgraph-agents Service URL. Returns an empty header dict
+// when the env is unset (dev / pre-deployment) — server-side falls back
+// to allow-all in that mode, so the workflow stays functional.
+function lgaHeaders(): Record<string, string> {
+    const tok = Deno.env.get("HAI_CLI_TOKEN");
+    return tok ? { Authorization: `Bearer ${tok}` } : {};
+}
+
 export async function main() {
     const lastSeen = await getLastSeen();
 
     const url = lastSeen
         ? `${LG_BASE}/admin/dlq?since_id=${encodeURIComponent(lastSeen)}&limit=20`
         : `${LG_BASE}/admin/dlq?limit=20`;
-    const resp = await fetch(url, { signal: AbortSignal.timeout(15_000) });
+    const resp = await fetch(url, { signal: AbortSignal.timeout(15_000), headers: lgaHeaders() });
     if (!resp.ok) {
         return { skip: true, reason: `GET /admin/dlq returned HTTP ${resp.status}` };
     }


### PR DESCRIPTION
## Summary

PR-C earlier this session added Bearer-token middleware to langgraph-agents (`/inbox` and `/admin/*` protected by `HAI_CLI_TOKEN`). The token was only added to `langgraph-agents-secret` — not `windmill-workflows-secret`. **Every Windmill workflow that polls langgraph's admin endpoints has been silently 401'ing since lga 0.2.38 rolled out.**

Confirmed failures over the last 24h:
- `langgraph-cost-cap-watcher`: returns `{"skip": true, "reason": "endpoint returned 401"}` every 4h
- `langgraph-awaiting-user-sweep`: presumed same shape (skips silently)
- `langgraph-daily-digest`: would fail mid-flow on first poll
- `langgraph-dlq-watcher`: similar

Result: cost-cap notifications, awaiting-user escalations, daily digests, and DLQ alerting are all dead. None of them fire any visible error.

## Change

1. Add `HAI_CLI_TOKEN` to `windmill-workflows-secret` via existing ExternalSecret (sourced from the `hai-cli.TOKEN` 1P field — single rotation surface, same value `langgraph-agents-secret` consumes).
2. Add a small `lgaHeaders()` helper inline in each affected workflow that returns `{ Authorization: 'Bearer ${HAI_CLI_TOKEN}' }` (empty dict if env unset, preserving dev-mode behavior).
3. Patch each `fetch(...)` call to langgraph-agents to spread `lgaHeaders()` into the request headers.

Affected workflows: `cost-cap-watcher` (1 site), `awaiting-user-sweep` (3 sites), `daily-digest` (2 sites), `dlq-watcher` (1 site).

## Discovered

Robert mentioned a phrase "Agents are over-budget due to the MCP surface" — I couldn't trace where that text actually surfaced (not in Windmill output, Zulip messages, langgraph logs, or vault drafts). But searching for it exposed that `langgraph-cost-cap-watcher` — the workflow whose job is exactly that kind of alert — has been silently dead.

## Test plan

- [x] yamllint --strict passes
- [ ] Post-deploy + post-Windmill-sync: `langgraph-cost-cap-watcher` returns a real `CostsResponse`, not `endpoint returned 401`
- [ ] First `awaiting-user-sweep` after merge logs `Found N paused threads` instead of skipping with 401