### PR TITLE
fix(home/windmill): allowlist WINDMILL_TOKEN + HAI_CLI_TOKEN in scripts

### DIFF
--- a/kubernetes/apps/home/windmill/app/helmrelease.yaml
+++ b/kubernetes/apps/home/windmill/app/helmrelease.yaml
@@ -74,7 +74,7 @@ spec:
           # an explicit allowlist).
           extraEnv: &workflow_secrets
             - name: WHITELIST_ENVS
-              value: LANGGRAPH_APPROVAL_SIGNING_KEY,NTFY_URL,NTFY_WRITE_TOKEN,ZULIP_API_URL,ZULIP_BOT_EMAIL,ZULIP_BOT_API_KEY,ROB_ZULIP_USER_ID,PAPERLESS_TOKEN
+              value: LANGGRAPH_APPROVAL_SIGNING_KEY,NTFY_URL,NTFY_WRITE_TOKEN,ZULIP_API_URL,ZULIP_BOT_EMAIL,ZULIP_BOT_API_KEY,ROB_ZULIP_USER_ID,PAPERLESS_TOKEN,WINDMILL_TOKEN,HAI_CLI_TOKEN
             - name: LANGGRAPH_APPROVAL_SIGNING_KEY
               valueFrom:
                 secretKeyRef:
@@ -110,6 +110,24 @@ spec:
                 secretKeyRef:
                   name: windmill-workflows-secret
                   key: PAPERLESS_TOKEN
+            # WINDMILL_TOKEN: used by `windmill-failure-watcher` to query
+            # its own /api/w/.../jobs/list_completed. Sourced from the
+            # `windmill.windmill_api_token` 1P field (PR #11953).
+            - name: WINDMILL_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: windmill-workflows-secret
+                  key: WINDMILL_TOKEN
+            # HAI_CLI_TOKEN: used by workflows that call langgraph-agents
+            # /admin/* or /inbox (cost-cap-watcher, awaiting-user-sweep,
+            # daily-digest, dlq-watcher, zulip-triager-webhook). Sourced
+            # from the `hai-cli.TOKEN` 1P field — same value
+            # `langgraph-agents-secret` consumes (PR #11964).
+            - name: HAI_CLI_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: windmill-workflows-secret
+                  key: HAI_CLI_TOKEN
             - name: ROB_ZULIP_USER_ID
               valueFrom:
                 secretKeyRef:
@@ -147,13 +165,13 @@ spec:
         # Forward the actual client IP via the headers Envoy sets.
         enabled: true
 
-      # NOTE: Windmill's bootstrap admin is hardcoded by the binary to
-      # `admin@windmill.dev` with default password `changeme`. The
-      # chart does NOT expose an admin-password override (the
-      # `windmill.extraEnv` block has no analog in the chart). Operators
-      # must rotate the password immediately after first deploy via:
-      #   curl -X POST https://windmill.${SECRET_DOMAIN}/api/users/setpassword
-      # See ../README.md for the full bootstrap recipe.
+        # NOTE: Windmill's bootstrap admin is hardcoded by the binary to
+        # `admin@windmill.dev` with default password `changeme`. The
+        # chart does NOT expose an admin-password override (the
+        # `windmill.extraEnv` block has no analog in the chart). Operators
+        # must rotate the password immediately after first deploy via:
+        #   curl -X POST https://windmill.${SECRET_DOMAIN}/api/users/setpassword
+        # See ../README.md for the full bootstrap recipe.
 
     indexer:
       enabled: true


### PR DESCRIPTION
## Summary

PRs #11953 (WINDMILL_TOKEN) and #11964 (HAI_CLI_TOKEN) added env vars to `windmill-workflows-secret` and wired them into `extraEnv` on the worker pods. But Windmill's worker uses an explicit `WHITELIST_ENVS` allowlist — env vars NOT in the list are stripped from the script sandbox (nsjail-style isolation). The pod has the tokens; the scripts can't see them.

Confirmed: `windmill-failure-watcher` manual run just now returned `Error: WINDMILL_TOKEN env not set`. Similarly the 4 watchers from #11964 (`cost-cap-watcher`, `awaiting-user-sweep`, `daily-digest`, `dlq-watcher`) silently keep 401'ing because they can't see `HAI_CLI_TOKEN`.

## Change

- Append `WINDMILL_TOKEN,HAI_CLI_TOKEN` to `WHITELIST_ENVS` (single anchor, covers both worker + app pods).
- Drive-by: fix pre-existing `comments-indentation` warning at line 168 that blocked pre-commit on any edit to this file.

## Test plan

- [x] yamllint --strict passes
- [ ] After deploy + worker pod restart: `windmill-failure-watcher` manual run returns `{checked_n, grouped_n, ...}` instead of the env-not-set error
- [ ] `langgraph-cost-cap-watcher` next 4h tick returns a real `CostsResponse`