### PR TITLE
fix(home/windmill): correct watchdog jobs endpoint

### DIFF
--- a/kubernetes/apps/home/windmill/workflows/windmill-failure-watcher.ts
+++ b/kubernetes/apps/home/windmill/workflows/windmill-failure-watcher.ts
@@ -104,7 +104,11 @@ export async function main() {
 // ---------- Job fetch ----------
 
 async function fetchJobs(token: string, startedAfter: string): Promise<CompletedJob[]> {
-    const url = `${WMILL_BASE}/api/w/${WORKSPACE}/jobs/list_completed`
+    // Windmill's API path is `/jobs/completed/list`, NOT `/jobs/list_completed`
+    // (the latter 404s). The `/jobs/list` endpoint exists but mixes running
+    // + completed; completed/list filters to terminal jobs and accepts the
+    // `started_after` filter we need.
+    const url = `${WMILL_BASE}/api/w/${WORKSPACE}/jobs/completed/list`
         + `?per_page=500&started_after=${encodeURIComponent(startedAfter)}`
         + `&job_kinds=script`;
     const r = await fetch(url, {
@@ -112,7 +116,7 @@ async function fetchJobs(token: string, startedAfter: string): Promise<Completed
         signal: AbortSignal.timeout(15_000),
     });
     if (!r.ok) {
-        throw new Error(`jobs/list_completed returned ${r.status}`);
+        throw new Error(`jobs/completed/list returned ${r.status}`);
     }
     const data = await r.json();
     return Array.isArray(data) ? data : [];


### PR DESCRIPTION
## Summary

`windmill-failure-watcher.ts` calls `/api/w/lovenet/jobs/list_completed` — that endpoint doesn't exist. Real path per Windmill's OpenAPI is `/api/w/lovenet/jobs/completed/list`. Fix: rename.

Confirmed manually post-#11966 deploy: the watchdog could see its `WINDMILL_TOKEN` env (whitelist fix worked) but immediately threw `jobs/list_completed returned 404`. The companion `langgraph-cost-cap-watcher` worked correctly in the same test run (returned `{cap: 30, pct: 0, tier: "ok", spent: 0}`), so this is isolated to my own endpoint typo.

## Test plan

- [ ] Post-deploy: manual run of `windmill-failure-watcher` returns `{checked_n, grouped_n, issues_n, new_notifications}`
- [ ] Cron tick every 5 min fires without error