### PR TITLE
feat(media/immichkiosk-party): add Party Album slideshow for onn. 4K Plus

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ _Production-grade Kubernetes for a household._
 
 <br/>
 
-![apps](https://img.shields.io/badge/apps-181-blue?style=for-the-badge)
-![helmreleases](https://img.shields.io/badge/HelmReleases-191-326CE5?style=for-the-badge&logo=helm&logoColor=white)
+![apps](https://img.shields.io/badge/apps-182-blue?style=for-the-badge)
+![helmreleases](https://img.shields.io/badge/HelmReleases-193-326CE5?style=for-the-badge&logo=helm&logoColor=white)
 ![nodes](https://img.shields.io/badge/k8s_nodes-11-326CE5?style=for-the-badge&logo=kubernetes&logoColor=white)
 ![cnpg](https://img.shields.io/badge/Postgres_clusters-25-336791?style=for-the-badge&logo=postgresql&logoColor=white)
-![secrets](https://img.shields.io/badge/secrets-114-0572EC?style=for-the-badge&logo=1password&logoColor=white)
+![secrets](https://img.shields.io/badge/secrets-116-0572EC?style=for-the-badge&logo=1password&logoColor=white)
 ![age](https://img.shields.io/badge/cluster_age-5%2B_years-success?style=for-the-badge)
 
 </div>

--- a/kubernetes/apps/media/immichkiosk-party/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/immichkiosk-party/app/cnp-allow.yaml
@@ -1,0 +1,82 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: immichkiosk-party-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: immichkiosk-party
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal envoy gateway → immichkiosk-party:3000.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "3000"
+              protocol: TCP
+  egress:
+    # Kiosk reaches Immich via the public FQDN (KIOSK_IMMICH_URL is the
+    # public address; traffic loops back through the external envoy
+    # gateway on container port 10443). Matches the existing immichkiosk
+    # hairpin pattern.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "10443"
+              protocol: TCP
+    # Webhook to the curator on every asset.prefetch event.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: media
+            app.kubernetes.io/name: kiosk-party-curator
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: kiosk-party-curator-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: kiosk-party-curator
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # Webhook arrivals from the kiosk pod.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: media
+            app.kubernetes.io/name: immichkiosk-party
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+  egress:
+    # Curator talks to Immich in-cluster (not via public FQDN) — direct
+    # path is faster and more reliable for webhook-rate API calls.
+    # Immich's chart uses a non-standard label set: instance=immich,
+    # name=server (vs the per-app pattern most charts use).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: media
+            app.kubernetes.io/instance: immich
+            app.kubernetes.io/name: server
+      toPorts:
+        - ports:
+            - port: "2283"
+              protocol: TCP

--- a/kubernetes/apps/media/immichkiosk-party/app/externalsecret-curator.yaml
+++ b/kubernetes/apps/media/immichkiosk-party/app/externalsecret-curator.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: kiosk-party-curator
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: kiosk-party-curator
+    creationPolicy: Owner
+    template:
+      data:
+        IMMICH_API_KEY: "{{ .immichframe_apikey }}"
+  dataFrom:
+    - extract:
+        key: immich

--- a/kubernetes/apps/media/immichkiosk-party/app/externalsecret.yaml
+++ b/kubernetes/apps/media/immichkiosk-party/app/externalsecret.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: immichkiosk-party
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: immichkiosk-party
+    creationPolicy: Owner
+    template:
+      data:
+        KIOSK_IMMICH_API_KEY: "{{ .immichframe_apikey }}"
+        KIOSK_IMMICH_URL: "{{ .immich_url }}"
+  dataFrom:
+    - extract:
+        key: immich

--- a/kubernetes/apps/media/immichkiosk-party/app/helmrelease-curator.yaml
+++ b/kubernetes/apps/media/immichkiosk-party/app/helmrelease-curator.yaml
@@ -1,0 +1,82 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app kiosk-party-curator
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 30m
+  dependsOn:
+    - name: immich
+      namespace: media
+
+  values:
+    controllers:
+      kiosk-party-curator:
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+
+        containers:
+          app:
+            image:
+              repository: ghcr.io/rwlove/kiosk-party-curator
+              tag: v0.1.0@sha256:0de493bcfa448bbda505ffd8ca830d59a4e244c4dc713957d78ef51a7629af8c
+
+            env:
+              IMMICH_URL: "http://immich-server.media.svc.cluster.local:2283"
+              PARTY_ALBUM_ID: "59526fba-9726-4976-a6da-b7f71ebd16cd"
+              PLAYED_TAG_ID: "68c361ce-6c2c-49de-9b54-e72c66802757"
+              LOG_LEVEL: INFO
+
+            envFrom:
+              - secretRef:
+                  name: *app
+
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: 8080
+                  initialDelaySeconds: 10
+                  periodSeconds: 30
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: 8080
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+              seccompProfile:
+                type: RuntimeDefault
+
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 128Mi
+
+    service:
+      app:
+        controller: kiosk-party-curator
+        ports:
+          http:
+            port: &httpPort 8080

--- a/kubernetes/apps/media/immichkiosk-party/app/helmrelease.yaml
+++ b/kubernetes/apps/media/immichkiosk-party/app/helmrelease.yaml
@@ -1,0 +1,150 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app immichkiosk-party
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 30m
+  dependsOn:
+    - name: immich
+      namespace: media
+
+  values:
+    controllers:
+      immichkiosk-party:
+        type: statefulset
+
+        containers:
+          app:
+            image:
+              repository: ghcr.io/damongolding/immich-kiosk
+              tag: 0.38.1@sha256:28cf751b556e5c9fefc18f0c2b0ed2d6fe672df734ca3c860d6adc9b2b7fdffb
+
+            env:
+              # Required settings
+              # KIOSK_IMMICH_API_KEY: FROM SECRET
+              # KIOSK_IMMICH_URL: FROM SECRET
+              KIOSK_DEBUG: true
+              # Clock
+              KIOSK_SHOW_TIME: false
+              KIOSK_TIME_FORMAT: 24
+              KIOSK_SHOW_DATE: false
+              KIOSK_DATE_FORMAT: "DDDD DD MMMM YYYY"
+              # Kiosk behaviour
+              KIOSK_DURATION: 30
+              KIOSK_DISABLE_SCREENSAVER: false
+              KIOSK_OPTIMIZE_IMAGES: false
+              KIOSK_USE_GPU: true
+              # Asset sources — Party Album, excluding assets already shown
+              # this cycle. kiosk-party-curator tags shown assets and clears
+              # the tag when the unplayed pool is exhausted.
+              KIOSK_SHOW_ARCHIVED: false
+              KIOSK_ALBUMS: "59526fba-9726-4976-a6da-b7f71ebd16cd"
+              KIOSK_ALBUM_ORDER: random
+              KIOSK_EXCLUDED_TAGS: "kiosk-party-shown"
+              KIOSK_MEMORIES: false
+              # FILTER
+              KIOSK_DATE_FILTER: ""
+              # UI
+              KIOSK_DISABLE_NAVIGATION: false
+              KIOSK_DISABLE_UI: false
+              KIOSK_FRAMELESS: false
+              KIOSK_HIDE_CURSOR: false
+              KIOSK_FONT_SIZE: 120
+              KIOSK_BACKGROUND_BLUR: true
+              KIOSK_THEME: fade
+              KIOSK_LAYOUT: splitview
+              # Sleep mode
+              KIOSK_SLEEP_START: 22
+              KIOSK_SLEEP_END: 7
+              # Transition options
+              KIOSK_TRANSITION: cross-fade
+              KIOSK_FADE_TRANSITION_DURATION: 1
+              KIOSK_CROSS_FADE_TRANSITION_DURATION: 1
+              # Image display settings
+              KIOSK_SHOW_PROGRESS_BAR: true
+              KIOSK_IMAGE_FIT: contain
+              KIOSK_IMAGE_EFFECT: smart-zoom
+              KIOSK_IMAGE_EFFECT_AMOUNT: 100
+              KIOSK_USE_ORIGINAL_IMAGE: false
+              # Video display settings
+              KIOSK_ALBUM_VIDEO: true
+              # Image metadata
+              KIOSK_SHOW_ALBUM_NAME: false
+              KIOSK_SHOW_PERSON_NAME: true
+              KIOSK_SHOW_IMAGE_TIME: false
+              KIOSK_IMAGE_TIME_FORMAT: 12
+              KIOSK_SHOW_IMAGE_DATE: true
+              KIOSK_IMAGE_DATE_FORMAT: "DDDD, MMMM DD, YYYY"
+              KIOSK_SHOW_IMAGE_DESCRIPTION: false
+              KIOSK_SHOW_IMAGE_EXIF: false
+              KIOSK_SHOW_IMAGE_LOCATION: true
+              KIOSK_HIDE_COUNTRIES: "HIDDEN_COUNTRY,HIDDEN_COUNTRY"
+              KIOSK_SHOW_IMAGE_ID: false
+              KIOSK_SHOW_MORE_INFO: true
+              KIOSK_SHOW_MORE_INFO_IMAGE_LINK: true
+              KIOSK_SHOW_MORE_INFO_QR_CODE: true
+              KIOSK_SHOW_PERSON_AGE: true
+              # Kiosk settings — smaller fetch buffer + cache off so newly
+              # added Party Album photos enter the unplayed pool within
+              # one cycle, not eight hours later.
+              KIOSK_WATCH_CONFIG: false
+              KIOSK_FETCHED_ASSETS_SIZE: 100
+              KIOSK_HTTP_TIMEOUT: 20
+              KIOSK_PASSWORD: ""
+              KIOSK_CACHE: false
+              KIOSK_PREFETCH: true
+              KIOSK_ASSET_WEIGHTING: false
+              KIOSK_PORT: 3000
+              KIOSK_SHOW_USER: false
+
+            envFrom:
+              - secretRef:
+                  name: *app
+
+            resources:
+              requests:
+                cpu: 15m
+                memory: 1Gi
+              limits:
+                memory: 1Gi
+
+    service:
+      app:
+        controller: immichkiosk-party
+        ports:
+          http:
+            port: &httpPort 3000
+
+    persistence:
+      config-file:
+        type: configMap
+        name: immichkiosk-party-config
+        advancedMounts:
+          immichkiosk-party:
+            app:
+              - path: /config/config.yaml
+                subPath: config.yaml
+                readOnly: true
+
+    route:
+      app:
+        annotations:
+          glance/name: "Party Slideshow"
+          glance/show: "true"
+          glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/immich-kiosk.png"
+          glance/id: "Media"
+        hostnames:
+          - "party-slideshow.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: *httpPort

--- a/kubernetes/apps/media/immichkiosk-party/app/kustomization.yaml
+++ b/kubernetes/apps/media/immichkiosk-party/app/kustomization.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../components/repos/app-template
+resources:
+  - ./cnp-allow.yaml
+  - ./externalsecret-curator.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease-curator.yaml
+  - ./helmrelease.yaml
+configMapGenerator:
+  - name: immichkiosk-party-config
+    files:
+      - config.yaml=./resources/config.yaml
+generatorOptions:
+  disableNameSuffixHash: true

--- a/kubernetes/apps/media/immichkiosk-party/app/resources/config.yaml
+++ b/kubernetes/apps/media/immichkiosk-party/app/resources/config.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/damongolding/immich-kiosk/main/config.schema.json
+#
+# immich-kiosk config — webhook spec only. All other settings come from
+# KIOSK_* env vars in helmrelease.yaml (viper auto-binds scalars via env
+# prefix; arrays-of-objects like webhooks must come from YAML).
+webhooks:
+  - url: "http://kiosk-party-curator.media.svc.cluster.local:8080/webhook"
+    event: "asset.prefetch"
+    secret: ""

--- a/kubernetes/apps/media/immichkiosk-party/ks.yaml
+++ b/kubernetes/apps/media/immichkiosk-party/ks.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app immichkiosk-party
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: media
+  path: ./kubernetes/apps/media/immichkiosk-party/app
+  interval: 30m
+  timeout: 3m
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: onepassword-connect
+      namespace: external-secrets
+    - name: immich
+      namespace: media

--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -27,6 +27,7 @@ resources:
   - ./immich-power-tools/ks.yaml
   - ./immich/ks.yaml
   - ./immichkiosk/ks.yaml
+  - ./immichkiosk-party/ks.yaml
   - ./janitorr/ks.yaml
   - ./jellyfin/ks.yaml
   - ./kodi-playback-watcher/ks.yaml


### PR DESCRIPTION
## Summary

Second immich-kiosk deployment, independent of the existing Frameo content path, with a webhook-driven curator giving shuffle-without-replacement semantics for a curated **Party Album** in Immich. Powers a dedicated slideshow on the onn. 4K Plus (Denon HDMI 6).

- **`immichkiosk-party`** HelmRelease — kiosk pinned to `KIOSK_ALBUMS=<Party Album UUID>`, `KIOSK_EXCLUDED_TAGS=kiosk-party-shown`, `KIOSK_CACHE=false`, `KIOSK_FETCHED_ASSETS_SIZE=100` so newly-added photos enter the unplayed pool within one cycle. Hostname `party-slideshow.${SECRET_DOMAIN}`. Overlay env vars carry over: date, location, person-name + age, smart-zoom Ken Burns effect, cross-fade transitions.
- **`kiosk-party-curator`** HelmRelease — small FastAPI service (`ghcr.io/rwlove/kiosk-party-curator:v0.1.0`). Receives kiosk `asset.prefetch` webhooks, tags shown assets, clears the tag when the unplayed pool exhausts (cycle reset). Stateless — state lives in Immich. Image built by [rwlove/containers#30](https://github.com/rwlove/containers/pull/30).
- **ConfigMap** mount at `/config/config.yaml` carries the kiosk webhook spec (the one thing kiosk can't take via env var; viper auto-env binds scalars only).
- **CNPs**: kiosk reaches Immich via the public FQDN hairpin (matching the existing immichkiosk pattern) and webhooks the curator on :8080. Curator talks to immich-server in-cluster on :2283.
- **ExternalSecrets** reuse the existing 1P `immich` item's `immichframe_apikey` — no new credential.

## Why

`immich-kiosk`'s `KIOSK_ALBUM_ORDER: random` draws with replacement (verified in upstream `internal/config/config.go` — accepted values are `random | ascending | descending | newest | oldest`, no shuffle mode). To get "every album photo plays once before any repeat, and newly-added photos enter the unplayed pool immediately," the curator combines kiosk's `excluded_tags` filter with webhook-driven tag rotation.

Album + tag already created in Immich:
- Album `Party Album` — `59526fba-9726-4976-a6da-b7f71ebd16cd`
- Tag `kiosk-party-shown` — `68c361ce-6c2c-49de-9b54-e72c66802757`

## Test plan

- [ ] CI passes (lint, schemas, flux-local, image-registry, scrub, secrets, CodeQL)
- [ ] Flux reconciles `immichkiosk-party` and `kiosk-party-curator` HelmReleases to `Ready: True` after merge
- [ ] HTTPRoute live: `curl -k https://party-slideshow.${SECRET_DOMAIN}` returns kiosk UI
- [ ] Curator healthcheck: `kubectl exec -n media deploy/kiosk-party-curator -- curl -s http://localhost:8080/healthz` → 200
- [ ] Add a few photos to Party Album in Immich, then open `https://party-slideshow.${SECRET_DOMAIN}` in a browser. After ~30s the curator log shows `webhook event=asset.prefetch` and the shown asset gets the `kiosk-party-shown` tag in Immich
- [ ] Watch through N photos (N = album size); every asset appears exactly once before any repeat
- [ ] Cycle reset: after exhaustion, curator logs `pool exhausted (N/N played); clearing tag` and the tag is removed from all album assets
- [ ] onn. device pickup: in ImmichFrame on the onn., change server URL to `https://party-slideshow.${SECRET_DOMAIN}` (no auth secret needed). Slideshow runs with date/location/people+ages overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)