### PR TITLE
fix(automation/claude-runner): skip k8tz injection (PodSecurity violation)

### DIFF
--- a/kubernetes/apps/automation/claude-runner/app/cronjob-cost-cap-commentary.yaml
+++ b/kubernetes/apps/automation/claude-runner/app/cronjob-cost-cap-commentary.yaml
@@ -27,6 +27,11 @@ spec:
         metadata:
           labels:
             app.kubernetes.io/name: claude-runner-cost-cap-commentary
+          annotations:
+            # See sibling cronjob-pr-triage.yaml for the explanation.
+            # tl;dr: k8tz's injected initContainer fails PodSecurity
+            # `restricted` admission on this namespace; skip injection.
+            k8tz.io/inject: "false"
         spec:
           serviceAccountName: claude-runner-cost-cap-commentary
           automountServiceAccountToken: false

--- a/kubernetes/apps/automation/claude-runner/app/cronjob-pr-triage.yaml
+++ b/kubernetes/apps/automation/claude-runner/app/cronjob-pr-triage.yaml
@@ -29,6 +29,17 @@ spec:
         metadata:
           labels:
             app.kubernetes.io/name: claude-runner-pr-triage
+          annotations:
+            # Skip k8tz timezone-sidecar injection. The injected k8tz
+            # initContainer doesn't set securityContext.runAsNonRoot=true,
+            # which `automation`'s pod-security enforce=restricted policy
+            # rejects — every CronJob fire produced a series of
+            # `pods is forbidden: violates PodSecurity` events and the
+            # Job ended Failed with no pod ever scheduled (PodSecurity
+            # admission rejected before scheduling). Symptom was a
+            # Pushover storm of KubeJobFailed on 2026-05-22.
+            # k8tz isn't needed here — the runner sets TZ via env.
+            k8tz.io/inject: "false"
         spec:
           serviceAccountName: claude-runner-pr-triage
           automountServiceAccountToken: false


### PR DESCRIPTION
## Summary

Both `claude-runner-pr-triage` and `claude-runner-cost-cap-commentary` CronJobs have been silently failing for an unknown duration. Pushover KubeJobFailed alerts started flooding once the failures accumulated (FIRING:5 → FIRING:6 visible on Rob's phone today).

## Root cause

The `automation` namespace enforces `pod-security.kubernetes.io/enforce=restricted` + `enforce-version=latest`. The k8tz MutatingWebhook injects a timezone initContainer (`k8tz`) into every CronJob pod — but the injected container has no `securityContext`, specifically no `runAsNonRoot=true`. Result: every pod-create is rejected with:

```
pods "...-pzwsn" is forbidden: violates PodSecurity "restricted:latest":
  runAsNonRoot != true (pod or container "k8tz" must set
  securityContext.runAsNonRoot=true)
```

The Job retries 6+ times within 100s, all rejected, then marks the Job as Failed. KubeJobFailed alerts. Pushover storm. No pod ever scheduled, so no logs to inspect.

## Fix

k8tz honors a per-pod annotation `k8tz.io/inject: "false"` that skips injection. Added to both CronJob pod templates. The runner doesn't need k8tz — timezone can come from the `TZ` env var on the runner container itself (current image defaults to UTC; that's fine for the cost-cap commentary and PR triage tasks which don't depend on local time).

## What this doesn't fix

The deeper k8tz bug — its injected sidecar fails PodSecurity in any `restricted` namespace. Worth a separate upstream issue, but for now the narrow fix is sufficient.

## Test plan

- [x] yamllint passes
- [x] Reproduced the failure live with `kubectl create job --from=cronjob/...` → confirmed `FailedCreate` events listing k8tz securityContext violation
- [x] Deleted the two stuck Failed Jobs (`claude-runner-pr-triage-29657580`, `claude-runner-cost-cap-commentary-29656680`) — KubeJobFailed cleared
- [ ] After merge + Flux + next scheduled run: pod actually schedules, runner executes