### PR TITLE
fix(mcp-system/paperless-mcp): strip Authorization header before forwarding

### DIFF
--- a/kubernetes/apps/mcp-system/paperless-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/paperless-mcp/app/helmrelease.yaml
@@ -65,6 +65,22 @@ spec:
               - path:
                   type: PathPrefix
                   value: /mcp
+            filters:
+              # Strip the broker-side Authorization header before
+              # forwarding to paperless-mcp. The Kuadrant mcp-gateway
+              # passes inbound headers through; paperless-mcp's HTTP
+              # client honors the inbound `Authorization: Bearer …`
+              # (the token used by clients to authenticate to
+              # mcp.thesteamedcrab.com) instead of its own
+              # PAPERLESS_API_KEY env, and Paperless-ngx rejects the
+              # broker Bearer as "Invalid token" (401).
+              # Removing Authorization lets paperless-mcp fall back to
+              # its env-loaded API key, which is the correct credential
+              # for Paperless-ngx.
+              - type: RequestHeaderModifier
+                requestHeaderModifier:
+                  remove:
+                    - Authorization
             backendRefs:
               - identifier: app
                 port: 3000


### PR DESCRIPTION
## Summary

Claude in `home-assistant-config` workspace diagnosed: paperless tools load (28 visible via lovenet-gateway) but every call returns 401 "Invalid token" from Paperless-ngx.

Root cause: the Kuadrant `mcp-gateway` forwards inbound HTTP headers to backing MCP servers. Clients authenticate to the public `mcp.thesteamedcrab.com` broker with a Bearer token; that header propagates through to `paperless-mcp`. paperless-mcp's HTTP client honors the inbound `Authorization` header **instead of** its env-loaded `PAPERLESS_API_KEY`, and Paperless-ngx 401s the broker Bearer.

Same upstream bug pattern is likely latent on other MCP servers whose HTTP clients have this Bearer-precedence behavior — but paperless-mcp is the one we caught.

## Fix

Add a `RequestHeaderModifier` filter to the paperless-mcp `HTTPRoute`:

```yaml
filters:
  - type: RequestHeaderModifier
    requestHeaderModifier:
      remove:
        - Authorization
```

The Bearer was only meaningful at the broker→gateway boundary. paperless-mcp doesn't consume it for any legitimate auth purpose; stripping it removes the precedence conflict and lets paperless-mcp's PAPERLESS_API_KEY env take effect.

## Test plan

- [x] yamllint passes
- [x] In-cluster probes (already verified): direct call from langgraph-agents pod to mcp-gateway-istio with NO Authorization → paperless_list_documents returns 168 docs, paperless_search_documents finds matches. This confirms paperless-mcp works perfectly when Authorization is absent — the strip is the right fix.
- [ ] After deploy: Claude session in any workspace calling paperless tools via lovenet-gateway → returns real document data, not 401.

## Related

If other MCP servers (ha-mcp, immich-mcp, etc.) hit the same symptom under Claude-broker traffic, the same one-line filter fix applies. Pattern worth carrying forward.