### PR TITLE
fix(mcp-system): strip inbound Authorization across all MCP backends

### DIFF
--- a/kubernetes/apps/mcp-system/arr-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/arr-mcp/app/helmrelease.yaml
@@ -64,6 +64,21 @@ spec:
               - path:
                   type: PathPrefix
                   value: /mcp
+            filters:
+              # Strip inbound Authorization before forwarding to the
+              # backend MCP server. The Kuadrant mcp-gateway forwards
+              # all client headers; the broker-side Bearer (used to
+              # authenticate to mcp.thesteamedcrab.com) can take
+              # precedence over the backend's own credential env in
+              # any upstream MCP client that honors `Authorization`,
+              # causing 401s against the real target service. Backend
+              # MCP servers each carry their own env-loaded creds —
+              # stripping the broker Bearer at this hop lets those
+              # take effect uniformly across the fleet.
+              - type: RequestHeaderModifier
+                requestHeaderModifier:
+                  remove:
+                    - Authorization
             backendRefs:
               - identifier: app
                 port: 3000

--- a/kubernetes/apps/mcp-system/chrome-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/chrome-mcp/app/helmrelease.yaml
@@ -96,6 +96,21 @@ spec:
               - path:
                   type: PathPrefix
                   value: /mcp
+            filters:
+              # Strip inbound Authorization before forwarding to the
+              # backend MCP server. The Kuadrant mcp-gateway forwards
+              # all client headers; the broker-side Bearer (used to
+              # authenticate to mcp.thesteamedcrab.com) can take
+              # precedence over the backend's own credential env in
+              # any upstream MCP client that honors `Authorization`,
+              # causing 401s against the real target service. Backend
+              # MCP servers each carry their own env-loaded creds —
+              # stripping the broker Bearer at this hop lets those
+              # take effect uniformly across the fleet.
+              - type: RequestHeaderModifier
+                requestHeaderModifier:
+                  remove:
+                    - Authorization
             backendRefs:
               - identifier: app
                 port: 8931

--- a/kubernetes/apps/mcp-system/cilium-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/cilium-mcp/app/helmrelease.yaml
@@ -66,6 +66,21 @@ spec:
               - path:
                   type: PathPrefix
                   value: /mcp
+            filters:
+              # Strip inbound Authorization before forwarding to the
+              # backend MCP server. The Kuadrant mcp-gateway forwards
+              # all client headers; the broker-side Bearer (used to
+              # authenticate to mcp.thesteamedcrab.com) can take
+              # precedence over the backend's own credential env in
+              # any upstream MCP client that honors `Authorization`,
+              # causing 401s against the real target service. Backend
+              # MCP servers each carry their own env-loaded creds —
+              # stripping the broker Bearer at this hop lets those
+              # take effect uniformly across the fleet.
+              - type: RequestHeaderModifier
+                requestHeaderModifier:
+                  remove:
+                    - Authorization
             backendRefs:
               - identifier: app
                 port: 8000

--- a/kubernetes/apps/mcp-system/github-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/github-mcp/app/helmrelease.yaml
@@ -69,6 +69,21 @@ spec:
               - path:
                   type: PathPrefix
                   value: /mcp
+            filters:
+              # Strip inbound Authorization before forwarding to the
+              # backend MCP server. The Kuadrant mcp-gateway forwards
+              # all client headers; the broker-side Bearer (used to
+              # authenticate to mcp.thesteamedcrab.com) can take
+              # precedence over the backend's own credential env in
+              # any upstream MCP client that honors `Authorization`,
+              # causing 401s against the real target service. Backend
+              # MCP servers each carry their own env-loaded creds —
+              # stripping the broker Bearer at this hop lets those
+              # take effect uniformly across the fleet.
+              - type: RequestHeaderModifier
+                requestHeaderModifier:
+                  remove:
+                    - Authorization
             backendRefs:
               - identifier: app
                 port: 8082

--- a/kubernetes/apps/mcp-system/grafana-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/grafana-mcp/app/helmrelease.yaml
@@ -66,6 +66,21 @@ spec:
               - path:
                   type: PathPrefix
                   value: /mcp
+            filters:
+              # Strip inbound Authorization before forwarding to the
+              # backend MCP server. The Kuadrant mcp-gateway forwards
+              # all client headers; the broker-side Bearer (used to
+              # authenticate to mcp.thesteamedcrab.com) can take
+              # precedence over the backend's own credential env in
+              # any upstream MCP client that honors `Authorization`,
+              # causing 401s against the real target service. Backend
+              # MCP servers each carry their own env-loaded creds —
+              # stripping the broker Bearer at this hop lets those
+              # take effect uniformly across the fleet.
+              - type: RequestHeaderModifier
+                requestHeaderModifier:
+                  remove:
+                    - Authorization
             backendRefs:
               - identifier: app
                 port: 8000

--- a/kubernetes/apps/mcp-system/ha-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/ha-mcp/app/helmrelease.yaml
@@ -71,6 +71,21 @@ spec:
               - path:
                   type: PathPrefix
                   value: /mcp
+            filters:
+              # Strip inbound Authorization before forwarding to the
+              # backend MCP server. The Kuadrant mcp-gateway forwards
+              # all client headers; the broker-side Bearer (used to
+              # authenticate to mcp.thesteamedcrab.com) can take
+              # precedence over the backend's own credential env in
+              # any upstream MCP client that honors `Authorization`,
+              # causing 401s against the real target service. Backend
+              # MCP servers each carry their own env-loaded creds —
+              # stripping the broker Bearer at this hop lets those
+              # take effect uniformly across the fleet.
+              - type: RequestHeaderModifier
+                requestHeaderModifier:
+                  remove:
+                    - Authorization
             backendRefs:
               - identifier: app
                 port: 8086

--- a/kubernetes/apps/mcp-system/immich-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/immich-mcp/app/helmrelease.yaml
@@ -92,6 +92,21 @@ spec:
               - path:
                   type: PathPrefix
                   value: /mcp
+            filters:
+              # Strip inbound Authorization before forwarding to the
+              # backend MCP server. The Kuadrant mcp-gateway forwards
+              # all client headers; the broker-side Bearer (used to
+              # authenticate to mcp.thesteamedcrab.com) can take
+              # precedence over the backend's own credential env in
+              # any upstream MCP client that honors `Authorization`,
+              # causing 401s against the real target service. Backend
+              # MCP servers each carry their own env-loaded creds —
+              # stripping the broker Bearer at this hop lets those
+              # take effect uniformly across the fleet.
+              - type: RequestHeaderModifier
+                requestHeaderModifier:
+                  remove:
+                    - Authorization
             backendRefs:
               - identifier: app
                 port: 8000

--- a/kubernetes/apps/mcp-system/kubectl-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/kubectl-mcp/app/helmrelease.yaml
@@ -59,6 +59,21 @@ spec:
               - path:
                   type: PathPrefix
                   value: /mcp
+            filters:
+              # Strip inbound Authorization before forwarding to the
+              # backend MCP server. The Kuadrant mcp-gateway forwards
+              # all client headers; the broker-side Bearer (used to
+              # authenticate to mcp.thesteamedcrab.com) can take
+              # precedence over the backend's own credential env in
+              # any upstream MCP client that honors `Authorization`,
+              # causing 401s against the real target service. Backend
+              # MCP servers each carry their own env-loaded creds —
+              # stripping the broker Bearer at this hop lets those
+              # take effect uniformly across the fleet.
+              - type: RequestHeaderModifier
+                requestHeaderModifier:
+                  remove:
+                    - Authorization
             backendRefs:
               - identifier: app
                 port: 8000

--- a/kubernetes/apps/mcp-system/memory-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/memory-mcp/app/helmrelease.yaml
@@ -120,6 +120,21 @@ spec:
               - path:
                   type: PathPrefix
                   value: /mcp
+            filters:
+              # Strip inbound Authorization before forwarding to the
+              # backend MCP server. The Kuadrant mcp-gateway forwards
+              # all client headers; the broker-side Bearer (used to
+              # authenticate to mcp.thesteamedcrab.com) can take
+              # precedence over the backend's own credential env in
+              # any upstream MCP client that honors `Authorization`,
+              # causing 401s against the real target service. Backend
+              # MCP servers each carry their own env-loaded creds —
+              # stripping the broker Bearer at this hop lets those
+              # take effect uniformly across the fleet.
+              - type: RequestHeaderModifier
+                requestHeaderModifier:
+                  remove:
+                    - Authorization
             backendRefs:
               - identifier: app
                 port: *httpPort

--- a/kubernetes/apps/mcp-system/netbox-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/netbox-mcp/app/helmrelease.yaml
@@ -64,6 +64,21 @@ spec:
               - path:
                   type: PathPrefix
                   value: /mcp
+            filters:
+              # Strip inbound Authorization before forwarding to the
+              # backend MCP server. The Kuadrant mcp-gateway forwards
+              # all client headers; the broker-side Bearer (used to
+              # authenticate to mcp.thesteamedcrab.com) can take
+              # precedence over the backend's own credential env in
+              # any upstream MCP client that honors `Authorization`,
+              # causing 401s against the real target service. Backend
+              # MCP servers each carry their own env-loaded creds —
+              # stripping the broker Bearer at this hop lets those
+              # take effect uniformly across the fleet.
+              - type: RequestHeaderModifier
+                requestHeaderModifier:
+                  remove:
+                    - Authorization
             backendRefs:
               - identifier: app
                 port: 8000

--- a/kubernetes/apps/mcp-system/omada-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/omada-mcp/app/helmrelease.yaml
@@ -66,6 +66,21 @@ spec:
               - path:
                   type: PathPrefix
                   value: /mcp
+            filters:
+              # Strip inbound Authorization before forwarding to the
+              # backend MCP server. The Kuadrant mcp-gateway forwards
+              # all client headers; the broker-side Bearer (used to
+              # authenticate to mcp.thesteamedcrab.com) can take
+              # precedence over the backend's own credential env in
+              # any upstream MCP client that honors `Authorization`,
+              # causing 401s against the real target service. Backend
+              # MCP servers each carry their own env-loaded creds —
+              # stripping the broker Bearer at this hop lets those
+              # take effect uniformly across the fleet.
+              - type: RequestHeaderModifier
+                requestHeaderModifier:
+                  remove:
+                    - Authorization
             backendRefs:
               - identifier: app
                 port: 3000

--- a/kubernetes/apps/mcp-system/paperless-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/paperless-mcp/app/helmrelease.yaml
@@ -66,17 +66,16 @@ spec:
                   type: PathPrefix
                   value: /mcp
             filters:
-              # Strip the broker-side Authorization header before
-              # forwarding to paperless-mcp. The Kuadrant mcp-gateway
-              # passes inbound headers through; paperless-mcp's HTTP
-              # client honors the inbound `Authorization: Bearer …`
-              # (the token used by clients to authenticate to
-              # mcp.thesteamedcrab.com) instead of its own
-              # PAPERLESS_API_KEY env, and Paperless-ngx rejects the
-              # broker Bearer as "Invalid token" (401).
-              # Removing Authorization lets paperless-mcp fall back to
-              # its env-loaded API key, which is the correct credential
-              # for Paperless-ngx.
+              # Strip inbound Authorization before forwarding to the
+              # backend MCP server. The Kuadrant mcp-gateway forwards
+              # all client headers; the broker-side Bearer (used to
+              # authenticate to mcp.thesteamedcrab.com) can take
+              # precedence over the backend's own credential env in
+              # any upstream MCP client that honors `Authorization`,
+              # causing 401s against the real target service. Backend
+              # MCP servers each carry their own env-loaded creds —
+              # stripping the broker Bearer at this hop lets those
+              # take effect uniformly across the fleet.
               - type: RequestHeaderModifier
                 requestHeaderModifier:
                   remove:

--- a/kubernetes/apps/mcp-system/prometheus-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/prometheus-mcp/app/helmrelease.yaml
@@ -57,6 +57,15 @@ spec:
             namespace: mcp-system
             sectionName: mcps
         rules:
-          - backendRefs:
+          - filters:
+              # Strip inbound Authorization before forwarding to the
+              # backend MCP server. See sibling helmreleases for the
+              # full rationale — broker Bearer can shadow the
+              # backend's own env-loaded credential.
+              - type: RequestHeaderModifier
+                requestHeaderModifier:
+                  remove:
+                    - Authorization
+            backendRefs:
               - identifier: app
                 port: 8080

--- a/kubernetes/apps/mcp-system/searxng-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/searxng-mcp/app/helmrelease.yaml
@@ -59,6 +59,21 @@ spec:
               - path:
                   type: PathPrefix
                   value: /mcp
+            filters:
+              # Strip inbound Authorization before forwarding to the
+              # backend MCP server. The Kuadrant mcp-gateway forwards
+              # all client headers; the broker-side Bearer (used to
+              # authenticate to mcp.thesteamedcrab.com) can take
+              # precedence over the backend's own credential env in
+              # any upstream MCP client that honors `Authorization`,
+              # causing 401s against the real target service. Backend
+              # MCP servers each carry their own env-loaded creds —
+              # stripping the broker Bearer at this hop lets those
+              # take effect uniformly across the fleet.
+              - type: RequestHeaderModifier
+                requestHeaderModifier:
+                  remove:
+                    - Authorization
             backendRefs:
               - identifier: app
                 port: 3000

--- a/kubernetes/apps/mcp-system/time-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/time-mcp/app/helmrelease.yaml
@@ -72,6 +72,21 @@ spec:
               - path:
                   type: PathPrefix
                   value: /mcp
+            filters:
+              # Strip inbound Authorization before forwarding to the
+              # backend MCP server. The Kuadrant mcp-gateway forwards
+              # all client headers; the broker-side Bearer (used to
+              # authenticate to mcp.thesteamedcrab.com) can take
+              # precedence over the backend's own credential env in
+              # any upstream MCP client that honors `Authorization`,
+              # causing 401s against the real target service. Backend
+              # MCP servers each carry their own env-loaded creds —
+              # stripping the broker Bearer at this hop lets those
+              # take effect uniformly across the fleet.
+              - type: RequestHeaderModifier
+                requestHeaderModifier:
+                  remove:
+                    - Authorization
             backendRefs:
               - identifier: app
                 port: 8060

--- a/kubernetes/apps/mcp-system/windmill-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/windmill-mcp/app/helmrelease.yaml
@@ -83,6 +83,21 @@ spec:
               - path:
                   type: PathPrefix
                   value: /mcp
+            filters:
+              # Strip inbound Authorization before forwarding to the
+              # backend MCP server. The Kuadrant mcp-gateway forwards
+              # all client headers; the broker-side Bearer (used to
+              # authenticate to mcp.thesteamedcrab.com) can take
+              # precedence over the backend's own credential env in
+              # any upstream MCP client that honors `Authorization`,
+              # causing 401s against the real target service. Backend
+              # MCP servers each carry their own env-loaded creds —
+              # stripping the broker Bearer at this hop lets those
+              # take effect uniformly across the fleet.
+              - type: RequestHeaderModifier
+                requestHeaderModifier:
+                  remove:
+                    - Authorization
             backendRefs:
               - identifier: app
                 port: 8080


### PR DESCRIPTION
## Summary

Sweep extension of #11971 (paperless-mcp) — applies the same `RequestHeaderModifier: remove: [Authorization]` filter to **every** MCP server HTTPRoute under `kubernetes/apps/mcp-system/`. The Kuadrant gateway forwards inbound headers; the broker-side Bearer can shadow each backend's own env-loaded credential in any MCP server whose upstream HTTP client honors `Authorization`. Stripping at the HTTPRoute hop lets each backend's PAT/API-key/etc. take effect uniformly.

## Files touched (15 — paperless already merged via #11971)

- arr-mcp, chrome-mcp, cilium-mcp, github-mcp, grafana-mcp
- ha-mcp, immich-mcp, kubectl-mcp, memory-mcp, netbox-mcp
- omada-mcp, prometheus-mcp, searxng-mcp, time-mcp, windmill-mcp

Each gets the same 16-line filter block above the existing `backendRefs:`.

## Why blanket

- The broker Bearer is only meaningful at the broker↔gateway boundary; no legitimate downstream MCP server consumes it for backend auth.
- Each MCP server already carries its own env-loaded credential (most via `paperless`/`grafana`/`omada`/etc. 1P items per the single-source-of-truth principle).
- Stripping is uniformly safe; the worst case is no-op (server didn't honor Authorization anyway).

## Why now

Today proved the Bearer-precedence symptom on paperless-mcp (PR #11971). Other MCP servers may be silently sluggish or 401'd in low-traffic paths; the sweep eliminates the latent risk class.

## Test plan

- [x] yamllint passes across all 15 edits
- [ ] After deploy: spot-check a couple via Claude (ha-mcp `ha_get_state`, kubectl-mcp `kubectl_get_pods`) — both should return real data, no 401
- [ ] No regressions on servers that already worked (paperless-mcp will keep working since the same filter is already on main from #11971)