### PR TITLE
fix(home/windmill): Holmes prompt — explicit ban on tool-call as final response

### DIFF
--- a/kubernetes/apps/home/windmill/workflows/alertmanager-holmesgpt-notify.ts
+++ b/kubernetes/apps/home/windmill/workflows/alertmanager-holmesgpt-notify.ts
@@ -22,11 +22,35 @@ export async function main(alerts?: AlertmanagerAlert[]) {
         return { skip: true, reason: "no alerts in payload" };
     }
 
+    // Constrained prompt — the earlier shape ("answer in <500 chars
+    // total") wasn't enough to keep qwen2.5:32b from emitting a
+    // raw tool-call JSON as its "answer," which the workflow detects
+    // as `MCP error -32602`-style output and surfaces as "model
+    // returned a tool-call instead of a summary." Tightening:
+    //
+    //  - Explicit budget on tool calls (at most 2).
+    //  - Explicit ban on additional tool calls after the budget.
+    //  - Format pinned to a 2-line prose answer (root cause +
+    //    remediation), forbidding JSON / structured output / further
+    //    tool invocations in the final response.
+    //
+    // Keep it short; long prompts are themselves a budget problem
+    // (Holmes' system prompt + tool descriptions are already ~16K
+    // input tokens before this `ask`).
     const ask = [
-        "IMPORTANT: Be concise. Investigate this alert in <=2 tool calls",
-        "(kubectl_get_events on the namespace plus one other). Then answer",
-        "in <500 chars total: 1 sentence root cause + 1 sentence remediation.",
-        "Do not iterate further.",
+        "Investigate this alert. Use AT MOST 2 tool calls",
+        "(typically kubectl_get_events on the namespace plus one other).",
+        "",
+        "After the 2nd tool returns, you MUST produce your final answer",
+        "as plain text — NOT another tool call, NOT JSON, NOT structured",
+        "output. Stop calling tools and write prose.",
+        "",
+        "Final answer format (<500 characters total, two sentences max):",
+        "  1) one sentence on the most likely root cause",
+        "  2) one sentence on the remediation",
+        "",
+        "Do not output any JSON. Do not output any tool_call objects.",
+        "Do not iterate further. Respond in prose only.",
         "",
         `Alert: ${a.labels.alertname}`,
         `Severity: ${a.labels.severity ?? "unknown"}`,


### PR DESCRIPTION
## Summary

Rob saw an ntfy alert "HolmesGPT model returned a tool-call instead of a summary" after a synthetic test on 2026-05-22. The workflow correctly detects when Holmes returns a tool-call JSON shape instead of a prose summary — the bug is upstream: qwen2.5:32b's tool-loop terminated with another tool-call attempt instead of synthesizing a textual answer.

The prior prompt ("answer in <500 chars total") didn't explicitly forbid further tool calls or structured output, so the model defaulted to its native tool-calling response shape. The runtime's tool-loop then returned that raw JSON as the "analysis."

## Fix

Tighten the prompt sent to Holmes' `/api/chat`:

- Explicit budget: "AT MOST 2 tool calls"
- After the budget: "produce your final answer as plain text — NOT another tool call, NOT JSON, NOT structured output. Stop calling tools and write prose."
- Pin format: 2-sentence prose (root cause + remediation), <500 chars
- Explicit ban: "Do not output any JSON. Do not output any tool_call objects. Do not iterate further. Respond in prose only."

Kept the prompt short on purpose — long prompts are themselves a budget problem (Holmes' system prompt + tool descriptions already total ~16K input tokens before this `ask`).

## What this doesn't fix

If qwen2.5:32b ignores the explicit instruction (small models often do), we'd need to either:
- Use LiteLLM's `tool_choice: "none"` for the final synthesis call (Holmes-side change)
- Add a workflow-side re-prompt that asks Holmes to summarize when it detects the JSON shape

Defer those if this prompt change is sufficient.

## Test plan

- [x] yamllint passes
- [x] Workflow source pushed; needs separate `wmill sync` to Windmill (the standing gap)
- [ ] After deploy: synthetic alert returns prose, not the "tool-call instead of summary" message