### PR TITLE
fix(media/immichkiosk-party): serve original-resolution images

### DIFF
--- a/kubernetes/apps/media/immichkiosk-party/app/helmrelease.yaml
+++ b/kubernetes/apps/media/immichkiosk-party/app/helmrelease.yaml
@@ -70,7 +70,7 @@ spec:
               KIOSK_IMAGE_FIT: contain
               KIOSK_IMAGE_EFFECT: smart-zoom
               KIOSK_IMAGE_EFFECT_AMOUNT: 100
-              KIOSK_USE_ORIGINAL_IMAGE: false
+              KIOSK_USE_ORIGINAL_IMAGE: true
               # Video display settings
               KIOSK_ALBUM_VIDEO: true
               # Image metadata


### PR DESCRIPTION
## Summary

`KIOSK_USE_ORIGINAL_IMAGE: false → true`.

With `false`, the kiosk serves Immich's preview/thumbnail size which renders visibly blurry on the family-room TV. Original-res is well within the onn.'s 1080p budget and the Wi-Fi bandwidth on `ap-familyroom`.

Confirmed via live `kubectl patch` (now persisting to Git so Flux doesn't revert it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)