### PR TITLE
fix(media/immichkiosk-party): bump kiosk-party-curator to v0.1.1

### DIFF
--- a/kubernetes/apps/media/immichkiosk-party/app/helmrelease-curator.yaml
+++ b/kubernetes/apps/media/immichkiosk-party/app/helmrelease-curator.yaml
@@ -26,7 +26,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/kiosk-party-curator
-              tag: v0.1.0@sha256:0de493bcfa448bbda505ffd8ca830d59a4e244c4dc713957d78ef51a7629af8c
+              tag: v0.1.1@sha256:f7dda1b62bffc38eba35b88be3f984cfd0b2ec03d23e25ca2394da95b7f3b6e7
 
             env:
               IMMICH_URL: "http://immich-server.media.svc.cluster.local:2283"


### PR DESCRIPTION
## Summary

Bumps `ghcr.io/rwlove/kiosk-party-curator` from `v0.1.0` → `v0.1.1` to pick up [rwlove/containers#31](https://github.com/rwlove/containers/pull/31).

## Why

The v0.1.0 curator counted "unplayed" assets by reading the `tags` field from `GET /api/albums/<id>` — but that Immich endpoint always returns `tags: null` on each asset. The curator therefore always read 0 tagged / 109 unplayed, the "pool exhausted → clear tag" branch never fired, and with kiosk's `KIOSK_EXCLUDED_TAGS` filter active the slideshow would have gone dark after the curator finished tagging every asset (~50 min at 30s/photo).

v0.1.1 switches the tagged-count query to `POST /api/search/metadata` with `albumIds + tagIds`, which does return accurate results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)