### PR TITLE
fix(home/windmill): re-prompt Holmes for prose when first call returns tool-call

### DIFF
--- a/kubernetes/apps/home/windmill/workflows/alertmanager-holmesgpt-notify.ts
+++ b/kubernetes/apps/home/windmill/workflows/alertmanager-holmesgpt-notify.ts
@@ -61,26 +61,27 @@ export async function main(alerts?: AlertmanagerAlert[]) {
     ].join("\n");
 
     // HolmesGPT REST: POST /api/chat
-    const hg = await fetch(
-        "http://holmesgpt.observability.svc.cluster.local:8080/api/chat",
-        {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ ask }),
-            signal: AbortSignal.timeout(600_000),
-        },
-    );
-    const data = await hg.json().catch(() => ({}));
-    const raw = String(data.analysis ?? data.response ?? "").trim();
+    const raw = await askHolmes(ask);
 
     let message: string;
     if (!raw) {
         message = "⚠️ HolmesGPT returned no analysis. Check the Windmill execution.";
-    } else if (
-        /^[:\s]*\{/.test(raw) &&
-        /"(suggested_prefixes|tool_call_id|function)"\s*:/.test(raw.slice(0, 200))
-    ) {
-        message = `⚠️ HolmesGPT model returned a tool-call instead of a summary.`;
+    } else if (isToolCallShape(raw)) {
+        // qwen2.5:32b at the tool-loop's max_steps sometimes returns a
+        // raw tool_call JSON instead of synthesizing prose. PR #11973
+        // tried to fix this from the prompt side; didn't take. Now:
+        // (1) surface WHAT Holmes wanted to call so the operator gets
+        //     an actionable hint instead of a useless warning, and
+        // (2) re-call Holmes with a no-tools follow-up asking only
+        //     for a prose best-guess from the alert metadata.
+        const hint = describeToolCall(raw);
+        const fallback = await askHolmes(noToolsPrompt(a));
+        if (fallback && !isToolCallShape(fallback)) {
+            message = `${fallback}\n\n_(Holmes' tool-loop wanted to: ${hint})_`;
+        } else {
+            message = `⚠️ Holmes investigation incomplete — wanted to call ${hint}. ` +
+                `Re-prompt for prose also failed. Investigate manually.`;
+        }
     } else if (raw.length <= 1000) {
         message = raw;
     } else {
@@ -101,6 +102,68 @@ export async function main(alerts?: AlertmanagerAlert[]) {
     });
 
     return { alertname: a.labels.alertname, holmes_chars: raw.length, ntfy: notifyResp };
+}
+
+// ---------- Holmes helpers ----------
+
+async function askHolmes(ask: string): Promise<string> {
+    const hg = await fetch(
+        "http://holmesgpt.observability.svc.cluster.local:8080/api/chat",
+        {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ ask }),
+            signal: AbortSignal.timeout(600_000),
+        },
+    );
+    const data = await hg.json().catch(() => ({}));
+    return String(data.analysis ?? data.response ?? "").trim();
+}
+
+function isToolCallShape(raw: string): boolean {
+    return /^[:\s]*\{/.test(raw) &&
+        /"(suggested_prefixes|tool_call_id|function)"\s*:/.test(raw.slice(0, 200));
+}
+
+// Parse the tool_call JSON Holmes returned and produce a human-readable
+// one-liner describing what tool it wanted to invoke. The shape varies
+// by model — qwen2.5 OpenAI-compat returns
+//   `{"function": {"name": "foo", "arguments": "{...}"}}`
+// or the wrapped streaming form
+//   `{"tool_calls":[{"function":{"name":"foo","arguments":"{...}"}}]}`
+// — fall back to the bare alertname when nothing parses.
+function describeToolCall(raw: string): string {
+    try {
+        const j = JSON.parse(raw);
+        const fn = j?.function ?? j?.tool_calls?.[0]?.function ?? j?.suggested_prefixes;
+        if (typeof fn === "string") return fn; // suggested_prefixes shape
+        if (fn?.name) {
+            const args = typeof fn.arguments === "string" ? fn.arguments : JSON.stringify(fn.arguments ?? {});
+            return `\`${fn.name}(${args.slice(0, 120)})\``;
+        }
+    } catch (_) { /* ignore JSON errors — fall through */ }
+    return "another tool (couldn't parse)";
+}
+
+// No-tools follow-up prompt — used when the first call returns a
+// tool_call shape. We can't continue the prior investigation (Holmes
+// /api/chat is stateless across calls), so this asks for a prose
+// best-guess from the alert metadata only.
+function noToolsPrompt(a: AlertmanagerAlert): string {
+    return [
+        "Earlier my investigation didn't synthesize a prose summary.",
+        "DO NOT call any tools. Respond ONLY in plain English prose.",
+        "Based ONLY on the alert metadata below, give 1 sentence on the",
+        "most likely root cause and 1 sentence on the remediation.",
+        "<300 characters total. No JSON. No tool calls.",
+        "",
+        `Alert: ${a.labels.alertname}`,
+        `Severity: ${a.labels.severity ?? "unknown"}`,
+        `Namespace: ${a.labels.namespace ?? "unknown"}`,
+        `Pod: ${a.labels.pod ?? "n/a"}`,
+        `Summary: ${a.annotations.summary ?? "(none)"}`,
+        `Description: ${a.annotations.description ?? "(none)"}`,
+    ].join("\n");
 }
 
 async function publishNtfy(args: {


### PR DESCRIPTION
## Summary

PR #11973 (prompt tightening) didn't actually fix the "HolmesGPT model returned a tool-call instead of a summary" notifications — Rob still saw them on real alerts after the deploy. qwen2.5:32b at tool-loop max_steps still returns raw tool_call JSON regardless of the prompt's explicit "no JSON, no tool calls" instruction.

This PR doesn't try to fix Holmes' tool-loop. Instead it gracefully recovers in the workflow:

1. **First call** unchanged (full investigation with tools allowed).
2. **If response is tool-call shape**, extract WHAT Holmes wanted to call next so the operator gets an actionable hint (e.g., `kubectl_get_logs("pod=foo")`) instead of a useless warning.
3. **Re-call Holmes** with a fresh `noToolsPrompt(alert)` that explicitly forbids tools and asks for prose-only best-guess from alert metadata. Holmes /api/chat is stateless so the re-call has no tool results to summarize, but it can still produce a useful "based on the alert labels, likely root cause is X" answer.
4. **Compose final message**: `<prose answer>\n\n_(Holmes' tool-loop wanted to: <hint>)_` — best of both: a real-sounding analysis plus the operator hint.
5. **If both calls fail**: structured warning that names the wanted tool, telling Rob to investigate manually.

## Why this approach

- Holmes runtime change (LiteLLM `tool_choice: "none"` on final step) is the upstream-correct fix but requires a Holmes code change.
- Switching model is the simplest fix but we don't have a non-tool-prone chat model loaded today.
- Workflow-side re-prompt is bespoke glue, slightly against the Layer 3 "project features over bespoke glue" principle — but it's surgical (single workflow, ~50 lines), and the alternative is silent notification regressions.

Tracked as a workaround to remove when Holmes ships its own no-tools-on-final-step path.

## Test plan

- [x] Type check
- [ ] After deploy + wmill sync: synthetic alert that previously returned tool-call shape now ntfy's prose + hint. If Holmes happens to synthesize on first call, no behavior change.