### PR TITLE
fix(home/home-assistant): allow SSDP UDP 1900 egress to world

### DIFF
--- a/kubernetes/apps/home/home-assistant/app/cnp-allow.yaml
+++ b/kubernetes/apps/home/home-assistant/app/cnp-allow.yaml
@@ -202,9 +202,18 @@ spec:
     # LAN discovery and bypass Cilium entirely — only eth0 (apiserver,
     # DNS, cross-ns, external) is governed here, including this mDNS
     # path through default-deny.
+    #
+    # SSDP/UPnP discovery on UDP 1900. HA's `ssdp` integration sends
+    # M-SEARCH to 239.255.255.250 (multicast) and 255.255.255.255
+    # (broadcast) for Sonos, Roku, smart-TV, DLNA renderer discovery.
+    # Without this, boot-time integration scans generate 1000+
+    # POLICY_DENIED drops in 2m and trip CiliumPolicyDropBurst →
+    # Pushover (incident 2026-05-22).
     - toEntities:
         - world
       toPorts:
         - ports:
             - port: "5353"
+              protocol: UDP
+            - port: "1900"
               protocol: UDP


### PR DESCRIPTION
## Summary

Adds UDP 1900 (SSDP/UPnP discovery) to the existing `toEntities: world` block in `home-assistant-allow` CNP.

HA's `ssdp` integration sends M-SEARCH discovery to UDP 1900 on both 239.255.255.250 (multicast) and 255.255.255.255 (broadcast) for Sonos, Roku, smart-TV, and DLNA renderer discovery. Without an egress allow rule, default-deny drops these silently at BPF, and boot-time integration scans generate >1000 POLICY_DENIED drops in 2m — enough to trip `CiliumPolicyDropBurst` and page via Pushover (observed 2026-05-22).

## Test plan

- [x] Verified via `hubble observe --pod home/home-assistant-0 --verdict DROPPED` against a fresh HA restart — SSDP was the only POLICY_DENIED class on the eth0 path.
- [x] All pre-commit hooks pass (CNP validator, yamllint, README drift).
- [ ] After merge + Flux reconcile, next HA restart should not trip `CiliumPolicyDropBurst`.

## Notes

The IGMP drops (`CT_UNKNOWN_L4_PROTOCOL`) also seen during the capture are unrelated — Cilium conntrack can't track IGMP regardless of policy. Low-volume, below alert threshold, separate datapath limitation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)