### PR TITLE
fix(home/windmill): conclusion-first DM + target_agent pins + ADMIN_NAME

### DIFF
--- a/kubernetes/apps/home/windmill/app/externalsecret-workflows.yaml
+++ b/kubernetes/apps/home/windmill/app/externalsecret-workflows.yaml
@@ -55,8 +55,19 @@ spec:
         # If the field is missing or empty, the watcher fails fast with
         # "WINDMILL_TOKEN env not set" — other workflows are unaffected.
         WINDMILL_TOKEN: "{{ .windmill_api_token }}"
+        # Admin's display name — used ONLY by user-facing DM/notification
+        # templates (langgraph-completion-post.ts, etc.). Per the user-
+        # class architecture, repo files use the literal token `ADMIN`
+        # at the runtime config layer; the actual name is interpolated
+        # here at the wrapper/render boundary only. Sourced from the
+        # `langgraph-agents.admin_name` 1P field.
+        ADMIN_NAME: "{{ .admin_name }}"
   dataFrom:
-    # LANGGRAPH_APPROVAL_SIGNING_KEY
+    # LANGGRAPH_APPROVAL_SIGNING_KEY + admin_name
+    # (admin_name lives on the langgraph-agents 1P item — single source
+    # of truth, same item already extracted here. Restricted-tier PII;
+    # used ONLY by render-layer templates, never injected into agent
+    # system prompts.)
     - extract:
         key: langgraph-agents
     # NTFY_WRITE_TOKEN

--- a/kubernetes/apps/home/windmill/app/helmrelease.yaml
+++ b/kubernetes/apps/home/windmill/app/helmrelease.yaml
@@ -74,7 +74,7 @@ spec:
           # an explicit allowlist).
           extraEnv: &workflow_secrets
             - name: WHITELIST_ENVS
-              value: LANGGRAPH_APPROVAL_SIGNING_KEY,NTFY_URL,NTFY_WRITE_TOKEN,ZULIP_API_URL,ZULIP_BOT_EMAIL,ZULIP_BOT_API_KEY,ROB_ZULIP_USER_ID,PAPERLESS_TOKEN,WINDMILL_TOKEN,HAI_CLI_TOKEN
+              value: LANGGRAPH_APPROVAL_SIGNING_KEY,NTFY_URL,NTFY_WRITE_TOKEN,ZULIP_API_URL,ZULIP_BOT_EMAIL,ZULIP_BOT_API_KEY,ROB_ZULIP_USER_ID,PAPERLESS_TOKEN,WINDMILL_TOKEN,HAI_CLI_TOKEN,ADMIN_NAME
             - name: LANGGRAPH_APPROVAL_SIGNING_KEY
               valueFrom:
                 secretKeyRef:
@@ -133,6 +133,15 @@ spec:
                 secretKeyRef:
                   name: windmill-workflows-secret
                   key: ROB_ZULIP_USER_ID
+            # Admin's display name — used ONLY by user-facing DM/notification
+            # templates at the render boundary. NOT injected into agent
+            # system prompts (per the user-class architecture in
+            # langgraph-agents/agents/_shared/USER.md).
+            - name: ADMIN_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: windmill-workflows-secret
+                  key: ADMIN_NAME
         # Native worker — runs Bash/PowerShell/etc. without nsjail.
         - name: native
           replicas: 1

--- a/kubernetes/apps/home/windmill/workflows/alertmanager-holmesgpt-notify.ts
+++ b/kubernetes/apps/home/windmill/workflows/alertmanager-holmesgpt-notify.ts
@@ -202,6 +202,11 @@ async function routeToSpecialist(
                 source: "holmesgpt",
                 user: "rob",
                 content,
+                // Pin routing by namespace — see NAMESPACE_SPECIALIST
+                // map above. Requires lga 0.2.40+. Bypasses the
+                // qwen2.5:7b triager's known mis-routing of
+                // alert-investigation prompts.
+                target_agent: suggested,
                 idempotency_key: taskId,
                 priority: a.labels.severity === "critical" ? "high" : "normal",
             }),

--- a/kubernetes/apps/home/windmill/workflows/langgraph-completion-post.ts
+++ b/kubernetes/apps/home/windmill/workflows/langgraph-completion-post.ts
@@ -32,21 +32,51 @@ export async function main(
 ) {
     const agentLabel = AGENT_LABEL[target_agent ?? ""] ?? target_agent ?? "Agent";
     const haiUrl = `https://hai.${Deno.env.get("SECRET_DOMAIN") ?? "thesteamedcrab.com"}/admin/tasks/${encodeURIComponent(task_id)}`;
+    const adminName = Deno.env.get("ADMIN_NAME") ?? "the admin";
 
+    // Lead with the agent's CONCLUSION, not the verbose prompt.
+    // The prior template buried the actual answer under a "You asked:"
+    // wall of prompt text that the operator already wrote (or that the
+    // workflow generated). Result: every DM looked the same.
+    //
+    // New shape:
+    //   [conclusion line — first line of agent output, bolded]
+    //   <rest of output as blockquote, truncated>
+    //   ---
+    //   _meta: agent, duration, [optional one-line task hint], hai link_
     const lines: string[] = [];
-    if (content) {
-        lines.push(`**You asked:** ${truncate(content, 200)}`);
-        lines.push("");
+    const out = (output ?? "").trim();
+    if (out) {
+        // Pull the first meaningful line as the conclusion. Skip leading
+        // blanks and YAML frontmatter delimiters; take the first non-
+        // header content line.
+        const firstLine = out
+            .split(/\r?\n/)
+            .map((l) => l.trim())
+            .find((l) => l.length > 0 && !l.startsWith("---") && !l.startsWith("#")) ??
+            out.slice(0, 120);
+        lines.push(`**${truncate(firstLine, 220)}**`);
+
+        const rest = out.split(/\r?\n/).slice(out.split(/\r?\n/).indexOf(firstLine) + 1).join("\n").trim();
+        if (rest) {
+            lines.push("");
+            lines.push("```quote");
+            lines.push(truncate(rest, 700));
+            lines.push("```");
+        }
+    } else {
+        lines.push(`✅ **${agentLabel}** finished — no output.`);
     }
-    lines.push(`✅ **${agentLabel}** finished${duration_s ? ` in ${formatDuration(duration_s)}` : ""}.`);
-    if (output) {
-        lines.push("");
-        lines.push("```quote");
-        lines.push(truncate(output, 800));
-        lines.push("```");
-    }
+
+    // Compact meta footer — one line, much smaller than the prior
+    // "You asked: <full prompt>" block.
     lines.push("");
-    lines.push(`_Full output:_ \`hai task show ${task_id}\` or [open in API](${haiUrl})`);
+    lines.push("---");
+    const taskHint = content
+        ? `_${agentLabel}, ${duration_s ? formatDuration(duration_s) : "done"} · task: ${truncate(content, 80)}_`
+        : `_${agentLabel}, ${duration_s ? formatDuration(duration_s) : "done"}_`;
+    lines.push(taskHint);
+    lines.push(`_${adminName} — full output: \`hai task show ${task_id}\` · [api](${haiUrl})_`);
 
     const content_md = lines.join("\n");
 

--- a/kubernetes/apps/home/windmill/workflows/langgraph-renovate-triage.ts
+++ b/kubernetes/apps/home/windmill/workflows/langgraph-renovate-triage.ts
@@ -125,7 +125,11 @@ export async function main() {
             source: "cli",
             user: "rob",
             content: ask,
-            idempotency_key: taskId, // one triage per day
+            // Pin routing — qwen2.5:7b triager mis-routed this to
+            // errand-runner (which is approval-gated). Requires
+            // lga 0.2.40+ for the target_agent envelope field.
+            target_agent: "homelab-engineer",
+            idempotency_key: taskId,
         }),
         signal: AbortSignal.timeout(15_000),
     });


### PR DESCRIPTION
## Summary

Rob's three complaints ("approval messages never come," "notifications meaningless," "no place to see state") have a shared root cause: the triager mis-routes triage-style prompts to errand-runner, which produces useless error output that the DM template buries under a verbose "You asked: <full prompt>" wrapper. Three coordinated fixes here:

## A. Pin routing via `target_agent` (requires lga 0.2.40+ from #72)

- `langgraph-renovate-triage.ts` → `target_agent: "homelab-engineer"`
- `alertmanager-holmesgpt-notify.ts` → `target_agent: suggested` (the existing NAMESPACE_SPECIALIST map)

The triager skips its LLM call when the envelope already pins routing. Specialists actually get the work.

## B. Conclusion-first completion-post template

Old shape:
```
**You asked:** <full prompt verbatim>
✅ <Agent> finished in 1m 19s.
> <output blockquote>
_Full output: hai task show ..._
```

New shape:
```
**<first meaningful line of agent output>**
> <rest of output blockquote>
---
_<Agent>, <duration> · task: <prompt first 80 chars>_
_<admin_name> — full output: hai task show ... · api_
```

The agent's CONCLUSION leads. The prompt drops to a one-line meta footer.

## C. ADMIN_NAME wiring (user-facing render layer only)

- New `ADMIN_NAME` env on Windmill app + worker pods (sourced from `langgraph-agents.admin_name` 1P field, already populated)
- Added to `WHITELIST_ENVS` so scripts can read it
- `langgraph-completion-post.ts` renders `${adminName}` in the meta footer

Names are NEVER injected into agent system prompts (per the user-class architecture from lga#71). Substitution happens once, at the DM wrapper boundary.

## What this depends on

- **lga#72** (`target_agent` envelope field) — merged. Image v0.2.40 building. Renovate will bump home-ops.
- **lga#71** (`_shared/USER.md` rewrite) — open, not blocking this PR (lga doesn't yet read the new files; that's stage 2 of the migration).

After this lands + lga 0.2.40 deploys + I push the workflows to Windmill, the next Renovate triage run should:
1. Skip the triager (target_agent pinned)
2. Route directly to homelab-engineer
3. Produce verdicts (not the "no approval_request in state" error)
4. DM lands conclusion-first
5. `${adminName}` renders in the meta footer

## Test plan

- [x] yamllint passes
- [x] No literal names in repo source files (renovate-triage workflow's user field stays "rob" — that's a runtime user identifier, not a name; same with ROB_ZULIP_USER_ID env name. Worth renaming in a future PR.)
- [ ] After deploy: verify next Renovate triage routes to homelab-engineer (`hai task show <id>` → target_agent)
- [ ] Verify DM has conclusion-first shape
- [ ] Verify admin name renders