### PR TITLE
chore(windmill): AGENT_LABEL reporter→historian after lga rename

### DIFF
--- a/kubernetes/apps/home/windmill/workflows/langgraph-completion-post.ts
+++ b/kubernetes/apps/home/windmill/workflows/langgraph-completion-post.ts
@@ -102,7 +102,7 @@ const AGENT_LABEL: Record<string, string> = {
     "triager": "Triager",
     "supervisor": "Supervisor",
     "reviewer": "Reviewer",
-    "reporter": "Reporter",
+    "historian": "Historian",
     "researcher": "Researcher",
     "note-maker": "Note maker",
     "coder": "Coder",


### PR DESCRIPTION
## Summary

lga v0.2.41 renamed the daily-digest agent from \`reporter\` to \`historian\` ([lga#76](https://github.com/rwlove/langgraph-agents/pull/76)). This 1-line PR bumps the \`AGENT_LABEL\` map in the Windmill completion-post webhook so DMs render "Historian" instead of falling back to the raw agent ID.

## Coordination

Land this around the same time as the Renovate-driven \`langgraph-agents: 0.2.40 → 0.2.41\` bump. The two changes go together:

- lga ships the rename → cluster emits \`target_agent=historian\`
- this PR adjusts the DM label to match

If they don't land in the same window, the worst case is a brief period where DMs from the historian render with the raw \`historian\` ID instead of the "Historian" label. Cosmetic only.

The \`reporter\` name will return in a follow-up PR for the new final-hop messenger agent.

## Test plan

- [x] Pre-commit hooks pass.
- [ ] After deploy + next historian run: verify DM renders "Historian" in the meta footer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)