### PR TITLE
chore(windmill): simplify completion-post template; reporter renders body

### DIFF
--- a/kubernetes/apps/home/windmill/workflows/langgraph-completion-post.ts
+++ b/kubernetes/apps/home/windmill/workflows/langgraph-completion-post.ts
@@ -1,12 +1,11 @@
 // Webhook entry from langgraph-agents when a task completes
 // (status → done in the queue, no pending interrupt).
 //
-// Emits a Zulip DM to Rob with a human-readable completion card:
-//   - which agent ran it (target_agent)
-//   - the original prompt (content)
-//   - the output, truncated
-//   - duration
-//   - link to `hai task show <id>` for the full output
+// Emits a Zulip DM to ADMIN with a completion card whose body is the
+// `reporter` agent's rich-text rendering (lga v0.2.42+). Reporter is
+// the universal final hop, so `output` is already conclusion-first
+// markdown with clickable obsidian:// vault links + labeled URLs —
+// this template appends only a compact meta footer.
 //
 // Companion to langgraph-approval-post: that handler covers paused
 // tasks; this one covers terminal-success. Failure/dlq is handled
@@ -39,31 +38,21 @@ export async function main(
     // wall of prompt text that the operator already wrote (or that the
     // workflow generated). Result: every DM looked the same.
     //
-    // New shape:
-    //   [conclusion line — first line of agent output, bolded]
-    //   <rest of output as blockquote, truncated>
+    // As of lga v0.2.42, the `reporter` agent is the universal final hop —
+    // every chain's terminal `output` is reporter's own rich-text rendering
+    // (bold-first-line conclusion + clickable obsidian:// + labeled URLs per
+    // reporter's SOUL). So this template no longer applies the conclusion-
+    // first heuristic; it emits reporter's output verbatim and just appends
+    // the meta footer.
+    //
+    // Shape:
+    //   <reporter's rich-text body, as-is>
     //   ---
     //   _meta: agent, duration, [optional one-line task hint], hai link_
     const lines: string[] = [];
     const out = (output ?? "").trim();
     if (out) {
-        // Pull the first meaningful line as the conclusion. Skip leading
-        // blanks and YAML frontmatter delimiters; take the first non-
-        // header content line.
-        const firstLine = out
-            .split(/\r?\n/)
-            .map((l) => l.trim())
-            .find((l) => l.length > 0 && !l.startsWith("---") && !l.startsWith("#")) ??
-            out.slice(0, 120);
-        lines.push(`**${truncate(firstLine, 220)}**`);
-
-        const rest = out.split(/\r?\n/).slice(out.split(/\r?\n/).indexOf(firstLine) + 1).join("\n").trim();
-        if (rest) {
-            lines.push("");
-            lines.push("```quote");
-            lines.push(truncate(rest, 700));
-            lines.push("```");
-        }
+        lines.push(out);
     } else {
         lines.push(`✅ **${agentLabel}** finished — no output.`);
     }
@@ -103,6 +92,7 @@ const AGENT_LABEL: Record<string, string> = {
     "supervisor": "Supervisor",
     "reviewer": "Reviewer",
     "historian": "Historian",
+    "reporter": "Reporter",
     "researcher": "Researcher",
     "note-maker": "Note maker",
     "coder": "Coder",


### PR DESCRIPTION
## Summary

lga v0.2.42 makes \`reporter\` the universal final hop of every task chain — every task's terminal \`output\` is reporter's own rich-text rendering (bold-first-line conclusion + clickable \`obsidian://\` + labeled URLs per reporter's SOUL).

This PR makes two cleanups in \`langgraph-completion-post.ts\`:

1. **Drop the conclusion-first heuristic.** The template used to split the first line + bold it + wrap the rest in a blockquote. Reporter does that work now via its SOUL. Keeping the heuristic was redundant and would mangle multi-paragraph reporter outputs by stripping structure.
2. **Re-add \`AGENT_LABEL["reporter"] = "Reporter"\`** — removed in #11994 when the old daily-digest \`reporter\` was renamed to \`historian\`. The new reporter agent now needs the label for direct-target cases (cosmetic — without it, the meta footer would render the raw \`reporter\` ID instead of the friendly label).

## Behavior

Before:
\`\`\`
**<bold first line of output>**
\`\`\`quote
<rest of output, truncated to 700 chars>
\`\`\`
---
_meta footer_
\`\`\`

After:
\`\`\`
<reporter's full rich-text output verbatim>
---
_meta footer_
\`\`\`

Reporter's SOUL already guarantees bold-conclusion-first shape; this template just stops second-guessing it.

## Test plan

- [x] Pre-commit hooks pass.
- [ ] Post-deploy: trigger a synthetic Renovate triage; verify DM body is reporter's full rendering (with clickable obsidian:// links) instead of a truncated blockquote.
- [ ] Direct-target test: fire a task with \`target_agent: "reporter"\`; verify the footer renders "Reporter" not the raw ID.

🤖 Generated with [Claude Code](https://claude.com/claude-code)