### PR TITLE
docs(homeaiops): Stage 1 Gate signoff + Stage 2 status update

### DIFF
--- a/docs/src/homeaiops_dod.md
+++ b/docs/src/homeaiops_dod.md
@@ -25,8 +25,32 @@ PR cites for "done."
 Per `goal.md` Gate 1: *"Stop here. Post the smoke test output and
 the runbook list. Wait for my approval before starting Stage 2."*
 Smoke evidence is in Batch 4 below; runbook list is the two
-entries at the bottom of this doc. **Awaiting operator approval
-to proceed to Stage 2.**
+entries at the bottom of this doc.
+
+**Gate 1: ✅ signed off by operator on 2026-05-23.**
+
+A second wave of UX-shaped Stage-1 work landed 2026-05-23 — the
+original DoD verified technical readiness, but dogfooding surfaced
+three gaps the rubric didn't catch (meaningless notifications,
+missing system-state dashboard, triager mis-routing on PR triage).
+These closed in the same session before signoff:
+
+- Reporter agent → universal final hop translates raw specialist
+  output into rich-text Zulip DMs with clickable `obsidian://` vault
+  references + labeled URLs (lga#73/#75/#76/#77 + home-ops#11997).
+- `target_agent` envelope field lets callers pin specialist routing
+  past the triager (lga#72 + home-ops#11990).
+- `aihomeops-state` Grafana dashboard surfaces queue depth, task
+  state, escalation gates, and cost in a single pane (home-ops#11989).
+- Agent definitions migrated from vault into the repo
+  (lga#71/#73/#75) — persona changes now ship as PRs with full
+  review + image-tag traceability.
+- `ADMIN_NAME` interpolated at the DM render boundary only
+  (home-ops#11990) — repo files stay generic; the name lives in
+  1Password (materialized by the ExternalSecret).
+
+**Proceeding to Stage 2 capability gap analysis** per `goal.md`
+("Show me the gap analysis before you start closing it.")
 
 ## Per-component-class checklist
 

--- a/docs/src/stage2_gap_analysis.md
+++ b/docs/src/stage2_gap_analysis.md
@@ -370,6 +370,67 @@ Rob answered Q1-Q5:
 
 I'll go with **(1)** for v1 unless you say otherwise. The token can be replaced with device flow in a later iteration.
 
+## 10. Status as of 2026-05-23 (post Stage-1 Gate signoff)
+
+Build sequence steps 1-5 from §9 are complete. Verification:
+
+| Step | Status | Evidence |
+|---|---|---|
+| #1 lga PR-A — `"cli"` source enum + `/admin/tasks/<id>` + todo table | ✅ | `src/agents/state.py::Source` includes `"cli"`; `src/agents/api/todos.py` present; lga PRs #66-#68 merged |
+| #2 home-ops PR-B — `hai.${SECRET_DOMAIN}` route + auth + DNS | ✅ | `hai.thesteamedcrab.com` resolves to the cluster gateway; CLI auth works against it |
+| #3 lga PR-C — `hai` CLI in `cli/` subdir with subcommands | ✅ | `which hai` → `/home/rwlove/.local/bin/hai`; `task add/tail/ls/show`, `todo add/ls/done`, `cost`, `auth` all present |
+| #4 Image release | ✅ | tags v0.2.34 through v0.2.42 published |
+| #5 home-ops image bump (Renovate auto) | ✅ | cluster pod on v0.2.42 as of 2026-05-23 17:08Z |
+
+Plus Stage-1.5 UX work landed 2026-05-23 (additive to the original
+plan — closing gaps that emerged from real Stage-1 dogfooding):
+
+- Reporter agent → universal final hop renders raw specialist output
+  as rich-text Zulip DMs with clickable `obsidian://` vault links +
+  labeled URLs (lga#73/#75/#76/#77 + home-ops#11997).
+- Agent definitions migrated from vault into the lga repo — persona
+  changes ship as PRs with image-tag traceability (lga#71/#73/#75).
+- `ADMIN_NAME` interpolated at the DM render boundary only —
+  repo files stay generic per [[user_class_architecture]]
+  (home-ops#11990).
+- `aihomeops-state` Grafana dashboard — single-pane view of queue
+  depth, task state, escalation gates, cost (home-ops#11989).
+- Smart-home `device-intent-map.yaml` + drift-detect Windmill
+  workflow (lga#78 + home-ops#11998).
+
+### What remains for Stage 2 DoD
+
+**Step 6: Dogfood day.** Wall-clock day where ADMIN uses `hai` for
+the work that previously would have been Claude Code sessions.
+Per §9 Q5 decision: acceptance is ADMIN's credible end-of-day
+"I used `hai` for everything I'd have asked Claude Code."
+
+**Step 7: Gate 2 evidence PR.** Post-dogfood:
+
+- Log of the day's `hai` usage
+- Any fall-back-to-Claude-Code events (each is a P0/P1 gap the
+  analysis missed)
+- Confirmation that other non-CLI inputs still work (Zulip DM,
+  Renovate-triage, AlertManager→HolmesGPT, daily-digest)
+
+### Gaps still recommended to close before the dogfood day
+
+Re-reading §4 against current state, two items from earlier tiers
+remain actionable:
+
+- **Tier 1 #2 (conversation continuity / `conversation_id`):** still
+  not built. For multi-turn workflows where ADMIN wants
+  follow-ups on the same context, today each `hai task add` is
+  independent. Decide whether this is a v1 gap or punt to v2 based
+  on what the dogfood day surfaces.
+- **Tier 2 #6 (cost local-vs-escalated breakdown):** `hai cost`
+  exists; verify it shows local-vs-escalated split (data is in
+  Langfuse + `accumulated_cost_usd`).
+
+No new gaps surfaced from the Stage-1.5 work that aren't already in
+§4. The reporter agent / DM rendering / dashboard / intent map are
+all complementary to (not duplicative of) the CLI work.
+
 ## End
 
 Build starts after this PR merges.


### PR DESCRIPTION
## Summary

Two docs updates:

1. **\`homeaiops_dod.md\`** — record Gate 1 signoff (2026-05-23) and note the Stage-1.5 UX work that landed before signoff (reporter agent, ADMIN_NAME, dashboard, agent-definitions migration).
2. **\`stage2_gap_analysis.md\`** — add §10 "Status as of 2026-05-23." Build sequence steps 1-5 from operator decisions (§9) verified complete; only Step 6 (dogfood day) + Step 7 (Gate 2 evidence PR) remain.

## Where we are now

| Stage | Status |
|---|---|
| Stage 1 — Stabilize | ✅ Gate 1 signed off |
| Stage 2 — Migrate workflows onto HomeAIOps | 🟡 Build sequence complete; awaiting dogfood day |
| Stage 3 — Invert | ⏳ Pieces exist; not started formally |

## Next action

The dogfood day is the operator's action — a wall-clock day using \`hai\` for everything that would otherwise have been a Claude Code session. Per §9 Q5: acceptance is "I used \`hai\` for everything I'd have asked Claude Code."

## Test plan

- [x] Pre-commit hooks pass (markdownlint included).
- [x] No new files; both edited files already in mkdocs nav.
- [ ] No behavior change — pure documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)