### PR TITLE
chore(windmill): re-pin renovate-triage to researcher

### DIFF
--- a/kubernetes/apps/home/windmill/workflows/langgraph-renovate-triage.ts
+++ b/kubernetes/apps/home/windmill/workflows/langgraph-renovate-triage.ts
@@ -10,8 +10,12 @@
 //   1. Fetch open PRs from rwlove/home-ops (anonymous GitHub API)
 //   2. Build a single prompt summarizing all PRs (one LLM call,
 //      avoids multi-task fan-out)
-//   3. POST to langgraph /inbox; triager routes to homelab-engineer
-//      (cluster context). homelab-engineer runs on Spark
+//   3. POST to langgraph /inbox; routing pinned to researcher
+//      (information-broker shape — verdict + sources). Was
+//      homelab-engineer pre-2026-05-23; that agent's safety-gated
+//      propose-then-execute shape doesn't fit triage-shaped asks
+//      (it drafts to vault + returns metadata, leaving the user
+//      without an inline verdict). Researcher runs on Spark
 //      qwen2.5:32b — typical wall time 3-5 min for ~5 PRs.
 //   4. Poll /admin/tasks/<id> until done (≤ 20 min budget)
 //   5. Compare verdict hash to prior run. If changed, DM Rob via
@@ -128,7 +132,14 @@ export async function main() {
             // Pin routing — qwen2.5:7b triager mis-routed this to
             // errand-runner (which is approval-gated). Requires
             // lga 0.2.40+ for the target_agent envelope field.
-            target_agent: "homelab-engineer",
+            //
+            // 2026-05-23: re-pinned homelab-engineer → researcher.
+            // Triage-shaped asks (give a verdict, cite the evidence)
+            // are researcher's lane. Homelab-engineer is configured
+            // for safety-gated propose-then-execute work; it drafts
+            // findings to vault and returns metadata, which leaves
+            // the DM without an inline verdict.
+            target_agent: "researcher",
             idempotency_key: taskId,
         }),
         signal: AbortSignal.timeout(15_000),
@@ -164,7 +175,7 @@ export async function main() {
         "",
         output,
         "",
-        `_Triaged by langgraph homelab-engineer. Task: \`${taskId}\`._`,
+        `_Triaged by langgraph researcher. Task: \`${taskId}\`._`,
     ].join("\n"));
 
     return {


### PR DESCRIPTION
## Summary

The hourly Renovate-triage workflow has been emitting useless DM bodies since it shipped — \`homelab finding: /vault/inbox/drafts/<id>.md (class=B, handoff=errand-runner)\` instead of the \`PR #N: <merge|wait|reject> — <rationale>\` verdict the prompt asks for.

**Root cause:** homelab-engineer is configured for safety-gated propose-then-execute work. Its node writes a finding draft to vault and returns metadata. Triage-shaped asks (give a verdict, cite evidence, no side effects) don't fit that shape.

**Fix:** re-pin \`target_agent\` from \`homelab-engineer\` → \`researcher\`. Researcher's SOUL: *"information broker… you produce options + evidence; the requesting agent decides."* Closer fit for triage.

## Caveat

Researcher ALSO writes to vault today and returns a metadata-shaped output (\`research complete: /vault/.../path.md (confidence=X, sources=Y)\`). The DM body may improve modestly (the framing is more user-relevant — "research" vs. "finding") but still won't render inline verdicts until we apply the [lga#65](https://github.com/rwlove/langgraph-agents/pull/65) note-maker pattern (emit drafted body to chat, not just the vault path) to researcher.

This PR is the smaller of the two-step fix. I'll wait for the 18:00 cron tick on v0.2.42 + the new reporter agent to confirm whether the deeper researcher node fix is also needed.

## Test plan

- [x] Pre-commit hooks pass.
- [ ] After deploy: 18:00 UTC cron triggers; verify the DM body comes from researcher (footer says "Triaged by langgraph researcher") and that content is at least more useful than the homelab-engineer metadata.
- [ ] If still bad: separate lga PR to make researcher emit findings body inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)