### PR TITLE
fix(windmill): simplify DM meta footer to one clickable line

### DIFF
--- a/kubernetes/apps/home/windmill/workflows/langgraph-completion-post.ts
+++ b/kubernetes/apps/home/windmill/workflows/langgraph-completion-post.ts
@@ -57,21 +57,22 @@ export async function main(
         lines.push(`✅ **${agentLabel}** finished — no output.`);
     }
 
-    // Compact meta footer — one line, much smaller than the prior
-    // "You asked: <full prompt>" block.
+    // Compact meta footer — one line, clickable. Italic uses `*...*`
+    // (Zulip's renderer treats `_..._` as literal underscores).
     //
-    // Italic uses `*...*`, NOT `_..._`. Zulip's markdown renderer
-    // recognizes asterisk-italics but treats single-underscores as
-    // literal characters. The prior `_..._` wrapping showed the
-    // underscores verbatim in the DM (ugly noise around the agent
-    // label / duration / task hint / hai link).
+    // Dropped from previous shape (visible-noise audit 2026-05-23):
+    //   - "task: <truncated content>" — body already conveys the ask
+    //   - "ADMIN — full output:" salutation — this IS a DM to ADMIN
+    //   - bare `hai task show <ULID>` — duplicates the URL link target
+    //   - separate "api" mini-link — promoted to the main "open task"
+    //
+    // Kept: agent label (debugging), duration (cost/latency signal),
+    // one clickable URL (HTTPS so it works on every surface incl.
+    // Gmail forwards).
     lines.push("");
     lines.push("---");
-    const taskHint = content
-        ? `*${agentLabel}, ${duration_s ? formatDuration(duration_s) : "done"} · task: ${truncate(content, 80)}*`
-        : `*${agentLabel}, ${duration_s ? formatDuration(duration_s) : "done"}*`;
-    lines.push(taskHint);
-    lines.push(`*${adminName} — full output: \`hai task show ${task_id}\` · [api](${haiUrl})*`);
+    const durStr = duration_s ? formatDuration(duration_s) : "done";
+    lines.push(`*${agentLabel} · ${durStr} · [open task ↗](${haiUrl})*`);
 
     const content_md = lines.join("\n");
 


### PR DESCRIPTION
## Summary

After ADMIN dogfood-review of the 18:01 UTC DM (the synthetic researcher-triage output), the meta footer carried more noise than information:

\`\`\`
*Researcher, 52s · task: Triage these 2 open PRs at rwlove/home-ops...*
*Rob — full output: \`hai task show 01KSAYVF4ZESTEP2XPNFN1NX45\` · [api](https://...)*
\`\`\`

Dropped:
- **Truncated content echo** — body already conveys the ask via the verdicts.
- **\`Rob —\` salutation** — the DM IS to ADMIN.
- **Bare \`hai task show <ULID>\`** — duplicates the URL link target; ULIDs are visually noisy.
- **Separate \`[api]\` mini-link** — promoted to the only "open task" link.

Kept:
\`\`\`
*<Agent> · <duration> · [open task ↗](https://hai.<domain>/admin/tasks/<id>)*
\`\`\`

Companion to lga PR for reporter SOUL update (drops \`obsidian://\` links that break in Gmail forwards). Both ship together for the next renovate-triage cron tick.

## Test plan

- [x] Pre-commit hooks pass.
- [ ] Next DM (from the 19:00 UTC renovate-triage cron, ~37 min): verify footer is one short clickable line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)