### PR TITLE
feat(ai): add hai-web-oauth2-proxy for browser admin view

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ _Production-grade Kubernetes for a household._
 
 <br/>
 
-![apps](https://img.shields.io/badge/apps-182-blue?style=for-the-badge)
-![helmreleases](https://img.shields.io/badge/HelmReleases-194-326CE5?style=for-the-badge&logo=helm&logoColor=white)
+![apps](https://img.shields.io/badge/apps-183-blue?style=for-the-badge)
+![helmreleases](https://img.shields.io/badge/HelmReleases-195-326CE5?style=for-the-badge&logo=helm&logoColor=white)
 ![nodes](https://img.shields.io/badge/k8s_nodes-11-326CE5?style=for-the-badge&logo=kubernetes&logoColor=white)
 ![cnpg](https://img.shields.io/badge/Postgres_clusters-25-336791?style=for-the-badge&logo=postgresql&logoColor=white)
-![secrets](https://img.shields.io/badge/secrets-115-0572EC?style=for-the-badge&logo=1password&logoColor=white)
+![secrets](https://img.shields.io/badge/secrets-116-0572EC?style=for-the-badge&logo=1password&logoColor=white)
 ![age](https://img.shields.io/badge/cluster_age-5%2B_years-success?style=for-the-badge)
 
 </div>

--- a/kubernetes/apps/ai/hai-web-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/hai-web-oauth2-proxy/app/cnp-allow.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: hai-web-oauth2-proxy-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: hai-web-oauth2-proxy
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on external gateway → hai-web-oauth2-proxy:4180.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "4180"
+              protocol: TCP
+  egress:
+    # OIDC discovery + token exchange against Authelia at
+    # auth.${SECRET_DOMAIN}. Split-horizon DNS returns the envoy LB IP;
+    # Cilium socket-lb rewrites to envoy pod IP + targetPort 10443
+    # BEFORE policy evaluation. Same pattern as khoj-oauth2-proxy.
+    #
+    # Upstream → langgraph-agents.ai.svc.cluster.local:8765 is
+    # intra-namespace, covered by baseline allow-intra-namespace.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "10443"
+              protocol: TCP

--- a/kubernetes/apps/ai/hai-web-oauth2-proxy/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/hai-web-oauth2-proxy/app/externalsecret.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: hai-web-oauth2-proxy
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: hai-web-oauth2-proxy-secret
+    creationPolicy: Owner
+    template:
+      data:
+        OAUTH2_PROXY_CLIENT_SECRET: "{{ .OAUTH_CLIENT_SECRET }}"
+        OAUTH2_PROXY_COOKIE_SECRET: "{{ .COOKIE_SECRET }}"
+  dataFrom:
+    - extract:
+        key: hai-web-oauth2-proxy

--- a/kubernetes/apps/ai/hai-web-oauth2-proxy/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hai-web-oauth2-proxy/app/helmrelease.yaml
@@ -1,0 +1,110 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app hai-web-oauth2-proxy
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 30m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+      strategy: rollback
+  values:
+    controllers:
+      hai-web-oauth2-proxy:
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 2000
+            runAsGroup: 2000
+            fsGroup: 2000
+            fsGroupChangePolicy: OnRootMismatch
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: quay.io/oauth2-proxy/oauth2-proxy
+              tag: v7.15.2
+            args:
+              - --provider=oidc
+              - --oidc-issuer-url=https://auth.${SECRET_DOMAIN}
+              - --client-id=hai-web-oauth2-proxy
+              - --redirect-url=https://hai-web.${SECRET_DOMAIN}/oauth2/callback
+              - --upstream=http://langgraph-agents.ai.svc.cluster.local:8765
+              - --http-address=0.0.0.0:4180
+              - --cookie-name=_oauth2_proxy_hai_web
+              - --cookie-secure=true
+              - --cookie-samesite=lax
+              - --email-domain=*
+              - --whitelist-domain=.${SECRET_DOMAIN}
+              - --reverse-proxy=true
+              - --pass-user-headers=true
+              - --set-xauthrequest=true
+              - --skip-provider-button=true
+              - --scope=openid email profile groups
+              - --code-challenge-method=S256
+              # hai-web is the BROWSER admin view. Unlike hai-cli, this
+              # ingress requires Authelia on every request — that's the
+              # whole point. The langgraph-agents middleware accepts
+              # either Bearer (CLI on hai.*) or oauth2-proxy headers
+              # (browser session on hai-web.*); see
+              # src/agents/api/auth.py for the dual-auth contract.
+              #
+              # Only the probe endpoints are exempted from auth — same
+              # rationale as every other oauth2-proxy in the cluster.
+              - --skip-auth-route=^/health(z)?$
+              - --skip-auth-route=^/ready(z)?$
+              - --skip-auth-route=^/metrics$
+              # langgraph-agents holds the request while the queue
+              # dispatches; first cold-load of a specialist model on
+              # ollama-spark can push past 30s. 300s matches the
+              # langgraph /inbox synchronous response budget.
+              - --upstream-timeout=300s
+            envFrom:
+              - secretRef:
+                  name: hai-web-oauth2-proxy-secret
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 128Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - ALL
+              readOnlyRootFilesystem: true
+              seccompProfile:
+                type: RuntimeDefault
+    service:
+      app:
+        controller: hai-web-oauth2-proxy
+        ports:
+          http:
+            port: 4180
+    route:
+      app:
+        annotations:
+          glance/name: "hai CLI"
+          glance/show: "true"
+          glance/id: "AI"
+        hostnames:
+          - hai-web.${SECRET_DOMAIN}
+        parentRefs:
+          - name: internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: 4180

--- a/kubernetes/apps/ai/hai-web-oauth2-proxy/app/kustomization.yaml
+++ b/kubernetes/apps/ai/hai-web-oauth2-proxy/app/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../components/repos/app-template
+resources:
+  - ./cnp-allow.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/ai/hai-web-oauth2-proxy/ks.yaml
+++ b/kubernetes/apps/ai/hai-web-oauth2-proxy/ks.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app hai-web-oauth2-proxy
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: ai
+  path: ./kubernetes/apps/ai/hai-web-oauth2-proxy/app
+  interval: 1h
+  timeout: 5m
+  prune: true
+  wait: true
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: authelia
+      namespace: auth
+  retryInterval: 2m

--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -25,3 +25,4 @@ resources:
   - ./khoj/ks.yaml
   - ./khoj-oauth2-proxy/ks.yaml
   - ./hai-cli-oauth2-proxy/ks.yaml
+  - ./hai-web-oauth2-proxy/ks.yaml


### PR DESCRIPTION
## Summary

Splits the public langgraph-agents ingress into two surfaces so DM
links work on phones/browsers without giving up the Bearer-only CLI
path:

- **`hai.${SECRET_DOMAIN}`** (existing) — Bearer-only CLI path.
  `hai-cli-oauth2-proxy` keeps the `--skip-auth-route` carve-outs for
  `/inbox` + `/admin/*` so the `hai` CLI's Bearer token reaches the
  backend unmodified.
- **`hai-web.${SECRET_DOMAIN}`** (NEW, this PR) — browser admin view.
  Authelia is required on every path; only `/healthz`, `/readyz`,
  `/metrics` are exempted. Forwards `X-Forwarded-Email` after auth.

## Why

User reported the `[open task ↗]` link in Zulip DM footers hit
`{"detail":"missing or malformed Authorization header"}` from the
phone — the link targets `hai.${SECRET_DOMAIN}` which is the CLI's
Bearer-only path. The fix is a separate browser surface that uses
Authelia properly. This PR is **PR-A** (cluster-side); **PR-B** will
flip the DM URL template to `hai-web.${SECRET_DOMAIN}` once this is
live.

## What's already done out-of-band

- New Authelia OIDC client `hai-web-oauth2-proxy` provisioned via 1P
  (argon2id-hashed secret in `authelia.OIDC_CLIENTS_YAML`).
- New 1P item `hai-web-oauth2-proxy` with `OAUTH_CLIENT_SECRET` and
  `COOKIE_SECRET`, ready for the ExternalSecret in this PR.
- langgraph-agents `auth.py` middleware already accepts either Bearer
  OR `X-Forwarded-Email` / `X-Auth-Request-Email` headers (PR #84
  upstream).

## Test plan

- [ ] CI green
- [ ] Flux reconciles new `hai-web-oauth2-proxy` Kustomization
- [ ] oauth2-proxy pod healthy + envoy can reach it
- [ ] Browser → `https://hai-web.${SECRET_DOMAIN}/` → Authelia login
      → admin view loads
- [ ] Existing `https://hai.${SECRET_DOMAIN}/inbox` Bearer flow still
      works (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)