### PR TITLE
feat(windmill): point DM [open task ↗] at hai-web.* (Authelia)

### DIFF
--- a/kubernetes/apps/home/windmill/workflows/langgraph-completion-post.ts
+++ b/kubernetes/apps/home/windmill/workflows/langgraph-completion-post.ts
@@ -30,7 +30,7 @@ export async function main(
     duration_s?: number,
 ) {
     const agentLabel = AGENT_LABEL[target_agent ?? ""] ?? target_agent ?? "Agent";
-    const haiUrl = `https://hai.${Deno.env.get("SECRET_DOMAIN") ?? "thesteamedcrab.com"}/admin/tasks/${encodeURIComponent(task_id)}`;
+    const haiUrl = `https://hai-web.${Deno.env.get("SECRET_DOMAIN") ?? "thesteamedcrab.com"}/admin/tasks/${encodeURIComponent(task_id)}`;
     const adminName = Deno.env.get("ADMIN_NAME") ?? "the admin";
 
     // Lead with the agent's CONCLUSION, not the verbose prompt.


### PR DESCRIPTION
## Summary

Flip the DM completion-footer link from `hai.${SECRET_DOMAIN}`
(Bearer-only CLI path) to `hai-web.${SECRET_DOMAIN}` (Authelia
browser path) so the link works on phones.

## Depends on

**home-ops #12013** — adds the `hai-web-oauth2-proxy` deployment.
This PR is queued behind it; merging this before #12013 is live
would break the link entirely.

## After merge

The workflow source lives in Git but Windmill runs from its own DB.
A `wmill flow push` (or equivalent) must run to propagate the new
template to the live workflow.

## Test plan

- [ ] CI green
- [ ] PR-A (#12013) verified live (oauth2-proxy + Flux reconciled)
- [ ] Workflow pushed to Windmill via `wmill flow push`
- [ ] Trigger a synthetic agent task → DM arrives → footer link goes
      to `hai-web.${SECRET_DOMAIN}` → opens fine on phone via
      Authelia

🤖 Generated with [Claude Code](https://claude.com/claude-code)