### PR TITLE
fix(home/frigate): align PV/PVC capacity with actual mirror LV

### DIFF
--- a/kubernetes/apps/home/frigate/app/nfs-pvc.yaml
+++ b/kubernetes/apps/home/frigate/app/nfs-pvc.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   storageClassName: frigate-recordings-storage-class
   capacity:
-    storage: 5300G
+    storage: 2000G
   accessModes:
     - ReadWriteOnce
   nfs:
@@ -27,7 +27,7 @@ spec:
   volumeMode: Filesystem
   resources:
     requests:
-      storage: 5300G
+      storage: 2000G
   volumeName: frigate-recordings-pv
   storageClassName: frigate-recordings-storage-class
 
@@ -41,7 +41,7 @@ metadata:
 spec:
   storageClassName: frigate-clips-storage-class
   capacity:
-    storage: 700G
+    storage: 400G
   accessModes:
     - ReadWriteOnce
   nfs:
@@ -59,7 +59,7 @@ spec:
   volumeMode: Filesystem
   resources:
     requests:
-      storage: 700G
+      storage: 400G
   volumeName: frigate-clips-pv
   storageClassName: frigate-clips-storage-class
 


### PR DESCRIPTION
## Summary

- Migrated frigate-recordings storage on 2026-05-23 from 6.4T linear LV → 2.5T raid1 mirror (sdc1+sdd1) + 100G NVMe writecache
- XFS project quotas on the new mirror: 2T for recordings, 400G for clips
- PV/PVC capacity labels still said 5300G / 700G — misleading in \`kubectl get pv\`
- This PR aligns the declared capacity with the actual quota-bounded storage

NFS PV capacity is not enforced by Kubernetes, so this is cosmetic — but keeps live state honest.

## Test plan

- [ ] CI yaml-lint passes
- [ ] Post-merge: live PV/PVC swap (delete old + apply new) — PV.capacity is immutable, so this requires deleting + recreating the bound objects with the new values
- [ ] Frigate-0 pod restarts cleanly on the new PVCs

🤖 Generated with [Claude Code](https://claude.com/claude-code)