### PR TITLE
fix(holmesgpt): prompt surgery for tool-loop convergence

### DIFF
--- a/kubernetes/apps/home/windmill/workflows/alertmanager-holmesgpt-notify.ts
+++ b/kubernetes/apps/home/windmill/workflows/alertmanager-holmesgpt-notify.ts
@@ -28,7 +28,10 @@ export async function main(alerts?: AlertmanagerAlert[]) {
     // as `MCP error -32602`-style output and surfaces as "model
     // returned a tool-call instead of a summary." Tightening:
     //
-    //  - Explicit budget on tool calls (at most 2).
+    //  - Explicit budget on tool calls (at most 6, raised from 2
+    //    2026-05-23 — 2 was too tight for multi-step investigations
+    //    like SnmpExporterApcUpsAbsent that need `get pods` then
+    //    `describe pod` then `get events` to converge).
     //  - Explicit ban on additional tool calls after the budget.
     //  - Format pinned to a 2-line prose answer (root cause +
     //    remediation), forbidding JSON / structured output / further
@@ -36,14 +39,18 @@ export async function main(alerts?: AlertmanagerAlert[]) {
     //
     // Keep it short; long prompts are themselves a budget problem
     // (Holmes' system prompt + tool descriptions are already ~16K
-    // input tokens before this `ask`).
+    // input tokens before this `ask` — see OVERRIDE_MAX_CONTENT_SIZE
+    // in the HelmRelease, raised to 32K 2026-05-23 to give bigger
+    // tool-result payloads room to land).
     const ask = [
-        "Investigate this alert. Use AT MOST 2 tool calls",
-        "(typically kubectl_get_events on the namespace plus one other).",
+        "Investigate this alert. Use AT MOST 6 tool calls.",
+        "Reach for `kubectl_get_events`, `kubectl_get`, `kubectl_describe`,",
+        "and `kubectl_logs` as needed. Stop early when you have enough",
+        "evidence — converge as fast as the alert allows.",
         "",
-        "After the 2nd tool returns, you MUST produce your final answer",
-        "as plain text — NOT another tool call, NOT JSON, NOT structured",
-        "output. Stop calling tools and write prose.",
+        "After your investigation completes, you MUST produce your",
+        "final answer as plain text — NOT another tool call, NOT JSON,",
+        "NOT structured output. Stop calling tools and write prose.",
         "",
         "Final answer format (<500 characters total, two sentences max):",
         "  1) one sentence on the most likely root cause",
@@ -79,8 +86,23 @@ export async function main(alerts?: AlertmanagerAlert[]) {
         if (fallback && !isToolCallShape(fallback)) {
             message = `${fallback}\n\n_(Holmes' tool-loop wanted to: ${hint})_`;
         } else {
-            message = `⚠️ Holmes investigation incomplete — wanted to call ${hint}. ` +
-                `Re-prompt for prose also failed. Investigate manually.`;
+            // Both passes failed (empty `{}` or another tool_call shape).
+            // Don't let Rob receive an actionless card — include the
+            // alert metadata + what Holmes would have done next, so
+            // there's something to act on even when AI synthesis flopped.
+            // Tighter than the previous "Investigate manually." stub.
+            const summary = a.annotations.summary ?? a.annotations.description ?? "(no summary)";
+            message = [
+                `⚠️ Holmes couldn't synthesize a root cause. Alert details below — operator triage required.`,
+                ``,
+                `**Alert**: ${a.labels.alertname}`,
+                `**Severity**: ${a.labels.severity ?? "unknown"}`,
+                `**Namespace**: ${a.labels.namespace ?? "(global)"}`,
+                `**Pod**: ${a.labels.pod ?? "n/a"}`,
+                `**Summary**: ${summary}`,
+                ``,
+                `_(Holmes' tool-loop wanted to: ${hint} — try running it manually.)_`,
+            ].join("\n");
         }
     } else if (raw.length <= 1000) {
         message = raw;

--- a/kubernetes/apps/observability/holmesgpt/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/holmesgpt/app/helmrelease.yaml
@@ -59,7 +59,18 @@ spec:
               # right ceiling. Investigation transcript in #11961 body.
               MODEL: ollama/qwen2.5:32b
               OLLAMA_API_BASE: http://ollama-spark.ai.svc.cluster.local:11434
-              OVERRIDE_MAX_CONTENT_SIZE: "16384"
+              # Raised 16384 → 32768 on 2026-05-23 to give Holmes' tool-loop
+              # room. The prior 16K cap meant a kubectl_logs payload could
+              # exhaust context BEFORE the synthesis pass — Holmes then
+              # returned a raw tool_call JSON instead of prose. 32K stays
+              # well inside qwen2.5:32b's 128K capability and the Spark
+              # memory envelope. Per-call latency rises with context size
+              # (linear-ish for Ollama-served qwen2.5), so monitor for
+              # alerts that now blow the 600s LITELLM_REQUEST_TIMEOUT —
+              # extend that next if needed, not the model size.
+              # See [[reference_qwen25_72b_infeasible_on_spark]] in memory
+              # for why "just go bigger" isn't an option on Spark.
+              OVERRIDE_MAX_CONTENT_SIZE: "32768"
               OVERRIDE_MAX_OUTPUT_TOKEN: "4096"
               # Upstream default 600s. Verified safe on Spark +
               # qwen2.5:32b 2026-05-21: 18 LLM calls observed in a real


### PR DESCRIPTION
## Summary

Three changes to fix Holmes' empty-rootCause + tool-loop-wanted
cards. No model swap — `qwen2.5:32b` stays.

User reported screenshot of two ntfy cards showing the pattern:
1. **SnmpExporterApcUpsAbsent** — has analysis + a "_tool-loop wanted to_" trailer.
2. **BlackboxProbeFailed** — \`rootCause: {}\` (empty) + the same trailer.

Diagnosis (delegated to observability-operator):
- Holmes already has full kubectl read across the cluster (SA bound
  to ClusterRole \`view\` + custom \`holmesgpt-extra-read\`).
- The trailer isn't a permission failure — it's a tool-loop max_steps
  bailout where qwen2.5:32b emits a raw \`tool_call\` JSON instead of
  prose. The workflow detects this and re-prompts no-tools-prose-only.
- Empty \`rootCause: {}\` = both passes failed.

## What changed

| File | Change |
|---|---|
| \`alertmanager-holmesgpt-notify.ts\` | Prompt budget AT MOST **2 → 6** tool calls |
| \`helmrelease.yaml\` | \`OVERRIDE_MAX_CONTENT_SIZE\` **16384 → 32768** |
| \`alertmanager-holmesgpt-notify.ts\` | Final-failure card now includes alert name/severity/ns/pod/summary instead of just \"Investigate manually.\" |

## Why not 72b

The existing helmrelease comment (lines 45-59) explicitly named
\"prompt surgery (context trimming + tool-call budget) before a
>32b model is viable.\" Per Rob's correction 2026-05-23, 72b isn't
viable on Spark regardless of surgery — 128GB unified doesn't have
the headroom once KV cache + context + concurrent Spark workloads
are accounted for. So 32b stays; Claude API escalation remains the
next ceiling.

## Test plan

- [ ] CI green
- [ ] Flux reconciles HelmRelease; Holmes pod restarts cleanly
- [ ] After merge: \`wmill flow push\` to propagate the workflow change
- [ ] Watch next ~10 critical alerts — empty rootCause cards
      should disappear; tool-loop should converge more often
- [ ] If new alerts blow the 600s \`LITELLM_REQUEST_TIMEOUT\`, raise
      that next (not model size)

🤖 Generated with [Claude Code](https://claude.com/claude-code)