### PR TITLE
fix(windmill): pin daily-digest to historian (was triager-routed)

### DIFF
--- a/kubernetes/apps/home/windmill/workflows/langgraph-daily-digest.ts
+++ b/kubernetes/apps/home/windmill/workflows/langgraph-daily-digest.ts
@@ -40,12 +40,21 @@ export async function main() {
     const client_task_id = `digest-${date}`;
 
     // Step 1: enqueue the digest task. Returns 202 + queue_task_id.
+    //
+    // `target_agent: "historian"` pins the daily-digest cron to the
+    // historian agent (its docstring: "activity log curator + daily/
+    // weekly/monthly accomplishment digests"). Without the pin, the
+    // qwen2.5:7b triager has to pick "historian" out of 20 alternatives
+    // from the prompt "Generate today's daily digest" — high enough
+    // mis-routing risk that a single bad routing decision on the
+    // 22:00 cron means Rob's daily summary doesn't arrive. Cheap fix.
     const lgResp = await fetch(`${LG_BASE}/inbox`, {
         method: "POST",
         headers: { ...lgaHeaders(), "Content-Type": "application/json" },
         body: JSON.stringify({
             task_id: client_task_id,
-            source: "test",
+            source: "scheduled",
+            target_agent: "historian",
             content: "Generate today's daily digest from the per-agent activity logs.",
             user: "rob",
         }),


### PR DESCRIPTION
## Summary

Two-line change to remove brittle triager routing on the daily
digest cron. Per the fleet trigger audit (2026-05-23), this was
identified as the #1 quickest reliability win.

| Before | After |
|---|---|
| \`source: \"test\"\` | \`source: \"scheduled\"\` |
| (no target_agent) | \`target_agent: \"historian\"\` |

\`langgraph-daily-digest.ts\` posts to \`/inbox\` daily 22:00 ET
without pinning a target. The qwen2.5:7b triager then has to pick
\"historian\" out of 20 alternatives. Today most of the time
that works — but one bad routing decision = Rob's daily summary
doesn't arrive.

Historian's persona docstring is \"activity log curator + daily/
weekly/monthly accomplishment digests\" — matches the cron's
intent exactly.

## Test plan

- [ ] CI green
- [ ] After merge: \`wmill flow push\` to propagate (workflow source
      lives in Git but Windmill runs from its own DB)
- [ ] Tomorrow's 22:00 ET digest arrives in Zulip #digests as usual
      (no visible behavior change for happy path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)