### PR TITLE
feat(windmill): weekly storage-operator drift cron

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ Worker nodes attach to **iot** and **sec** VLANs via Multus for direct camera an
 | **Paperless-ngx** | Document scanning, OCR, tagging (CNPG-backed, offsite-backed) |
 | **Obsidian** + **obsidian-couchdb** | Notes sync (CouchDB w/ Cloudflare rate-limiting) |
 | **Zulip** | Self-hosted team chat (also wired into agent pipeline approvals) |
-| **Windmill** | Workflow automation; 18 checked-in TypeScript flows under `kubernetes/apps/home/windmill/workflows/` cover AlertManager → HolmesGPT, langgraph inbox/approval/digest/DLQ/cost-cap/awaiting-user/reviewer-weekly, paperless RAG ingest+tombstone, Zulip triager webhook, the workaround upstream-watcher, and the errand-runner approval-flow smoke driver |
+| **Windmill** | Workflow automation; 19 checked-in TypeScript flows under `kubernetes/apps/home/windmill/workflows/` cover AlertManager → HolmesGPT, langgraph inbox/approval/digest/DLQ/cost-cap/awaiting-user/reviewer-weekly, weekly storage-health sweep, paperless RAG ingest+tombstone, Zulip triager webhook, the workaround upstream-watcher, and the errand-runner approval-flow smoke driver |
 | **ntfy** | Self-hosted push notifications (operator approvals via Android tap actions) |
 | **BentoPDF** | Self-hosted PDF toolkit |
 | **Kitchenowl** | Shopping lists + recipe / meal management |
@@ -323,7 +323,7 @@ flowchart TB
         AM[AlertManager]
     end
 
-    subgraph Bridges[Windmill bridges<br/>18 TS workflows]
+    subgraph Bridges[Windmill bridges<br/>19 TS workflows]
         WInbox[langgraph-inbox.ts]
         WAlert[alertmanager-holmesgpt-notify.ts]
         WApprove[langgraph-approval-post/receive.ts]
@@ -387,7 +387,7 @@ in 1Password.
 - **Khoj** (`ai/`) — parallel personal-AI surface for notes + docs. Self-contained: own embedding pipeline (default gte-small, optionally ollama nomic-embed-text), chat via Ollama-P40. Does **not** consume MCP gateway or langgraph-agents.
 - **HolmesGPT** (`observability/`) — the only agent live in production. AlertManager firings reach it via Windmill's `alertmanager-holmesgpt-notify.ts`; it reasons over Prometheus + Loki + cluster state and posts a root-cause hypothesis to Zulip / ntfy. Open WebUI also surfaces it as a tool server.
 - **langgraph-agents** (`ai/`) — the FastAPI multi-agent runtime (`rwlove/langgraph-agents`, image `0.2.33`). Plumbed end-to-end (Postgres checkpoints + memory, live task-queue substrate in `postgres-langgraph-checkpoints`, vault PVCs, Windmill approval loop, cost caps in env) but cold: `ENABLE_CLAUDE_API: false` and no production triggers. Public ingress splits CLI traffic (`hai.${SECRET_DOMAIN}`, Bearer-only) from browser traffic (`hai-web.${SECRET_DOMAIN}`, Authelia). Goes hot when the Claude key lands in 1Password.
-- **Windmill** (`home/`) — 18 checked-in TypeScript flows under `kubernetes/apps/home/windmill/workflows/` are the bridges that knit the surfaces above together. Every alert webhook, Zulip-triggered DM, approval round-trip, daily digest, weekly vault-hygiene sweep, DLQ retry, cost-cap pause, Paperless RAG ingest, and the errand-runner approval-flow smoke driver is a `.ts` file there.
+- **Windmill** (`home/`) — 19 checked-in TypeScript flows under `kubernetes/apps/home/windmill/workflows/` are the bridges that knit the surfaces above together. Every alert webhook, Zulip-triggered DM, approval round-trip, daily digest, weekly vault-hygiene sweep, weekly storage-health sweep, DLQ retry, cost-cap pause, Paperless RAG ingest, and the errand-runner approval-flow smoke driver is a `.ts` file there.
 - **Langfuse** (`ai/`) — OTLP trace sink for langgraph-agents. Chart deploys ClickHouse + Valkey + MinIO bundled; Postgres comes from CNPG `postgres-langfuse`.
 - **memory-mcp** (`mcp-system/`) — cross-agent knowledge graph on `postgres-langgraph-memory` with pgvector(1024). bge-m3 embeds via Ollama-Spark.
 

--- a/kubernetes/apps/home/windmill/workflows/langgraph-storage-weekly.ts
+++ b/kubernetes/apps/home/windmill/workflows/langgraph-storage-weekly.ts
@@ -1,0 +1,199 @@
+// Cron: weekly, Sunday 07:00 America/New_York.
+//
+// Fires the `storage-operator` agent on a weekly storage health
+// sweep. Class A only — storage-operator drafts findings; any
+// Class C remediation it proposes would route through errand-runner
+// with the eight-clause execution gate. This cron's job is the
+// surveillance, not the action.
+//
+// What the sweep checks:
+//   - PV / PVC fill rates across ceph-block, Longhorn, NFS-backed
+//   - Longhorn recurring-job success (daily snapshot, weekly +
+//     monthly backup labels) per the storage-class instructions
+//   - CNPG Barman backup recency for the 25 Postgres clusters
+//   - Ceph OSD health + PG state + capacity headroom
+//   - Garage substrate (NFS-backed) PVC fill + S3 endpoint reachability
+//   - NFS mount health (beast `mass_storage` RAID6, brain
+//     `mass_storage` RAID6) — storage-class.instructions.md is the
+//     authoritative durability matrix
+//
+// Pinned `target_agent: "storage-operator"` to bypass triager
+// mis-routing (same pattern as historian + reviewer crons).
+//
+// Result lands in Zulip stream #digests, topic
+// `storage-health-YYYY-Www`. Findings are passed through the reporter
+// agent (universal final-hop user-facing messenger) so the body is
+// already markdown-shaped for Zulip.
+
+type InboxResp = { task_id?: string; status?: string };
+type AdminTaskResp = {
+    task_id?: string;
+    queue?: {
+        status?: string;
+        result?: { output?: string } | null;
+        last_error?: string | null;
+    };
+    checkpointer?: { values?: { output?: string } };
+};
+
+const LG_BASE = "http://langgraph-agents.ai.svc.cluster.local:8765";
+const POLL_INTERVAL_MS = 5_000;
+const POLL_TIMEOUT_MS = 900_000; // 15 min — storage-operator may walk many
+                                  // resources (25 CNPG clusters, Ceph state,
+                                  // Longhorn volumes); give it room
+
+function lgaHeaders(): Record<string, string> {
+    const tok = Deno.env.get("HAI_CLI_TOKEN");
+    return tok ? { Authorization: `Bearer ${tok}` } : {};
+}
+
+// ISO week — same helper shape as langgraph-reviewer-weekly.ts. Kept
+// inlined rather than shared so each workflow stays self-contained
+// (Windmill ts files don't import from each other).
+function isoWeek(d: Date): { year: number; week: number } {
+    const utc = new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()));
+    const dayNum = utc.getUTCDay() || 7;
+    utc.setUTCDate(utc.getUTCDate() + 4 - dayNum);
+    const yearStart = new Date(Date.UTC(utc.getUTCFullYear(), 0, 1));
+    const weekNum = Math.ceil(
+        (((utc.getTime() - yearStart.getTime()) / 86400000) + 1) / 7,
+    );
+    return { year: utc.getUTCFullYear(), week: weekNum };
+}
+
+export async function main() {
+    const now = new Date();
+    const date = now.toISOString().slice(0, 10);
+    const { year, week } = isoWeek(now);
+    const weekStr = `${year}-W${String(week).padStart(2, "0")}`;
+    const client_task_id = `storage-health-${weekStr}`;
+
+    // Storage-operator's persona expects a clear scope statement plus
+    // an explicit "Class A only" constraint to keep the sweep from
+    // overreaching into proposed remediations the operator hasn't
+    // signed off on. The agent's eight-clause execution gate would
+    // catch most overreach anyway, but a clear scope hint reduces
+    // wasted reasoning on bigger gate evaluations.
+    const promptBody = [
+        "WEEKLY STORAGE HEALTH SWEEP — Class A analysis only.",
+        "",
+        "Walk the cluster storage hierarchy and report findings.",
+        "Anything you'd recommend changing, list as Class A findings",
+        "with file paths and rationale — do NOT escalate to Class C/D",
+        "in this run (a follow-up task can be filed for any single",
+        "finding the operator chooses to act on).",
+        "",
+        "Coverage:",
+        "  1. PV / PVC fill: any volume >80% used? List with %.",
+        "  2. Longhorn: recurring weekly-backups + monthly-backups",
+        "     have they actually run in the last cadence window?",
+        "     Any failed jobs in the last 7d?",
+        "  3. CNPG Barman: last successful backup per cluster",
+        "     (postgres-*). Any cluster missing a backup in 48h+?",
+        "  4. Ceph: cluster status, OSD up/in count, near-full warns,",
+        "     pg states (active+clean vs degraded/remapped).",
+        "  5. Garage: substrate PVC fill (garage-data, garage-meta),",
+        "     S3 endpoint reachable.",
+        "  6. NFS: mounts on consumer pods responding (no stale",
+        "     handles, no permission-denied loops).",
+        "",
+        "Output: ranked findings (highest-risk first), each with",
+        "evidence + a one-sentence \"why it matters\" + a single",
+        "recommended next step (no auto-actions, just guidance).",
+        "",
+        "Reference: storage-class.instructions.md for the durability",
+        "matrix per backend.",
+    ].join("\n");
+
+    const lgResp = await fetch(`${LG_BASE}/inbox`, {
+        method: "POST",
+        headers: { ...lgaHeaders(), "Content-Type": "application/json" },
+        body: JSON.stringify({
+            task_id: client_task_id,
+            source: "scheduled",
+            target_agent: "storage-operator",
+            content: promptBody,
+            user: "rob",
+        }),
+        signal: AbortSignal.timeout(30_000),
+    });
+    if (!lgResp.ok) {
+        throw new Error(`/inbox enqueue failed: HTTP ${lgResp.status}`);
+    }
+    const lg: InboxResp = (await lgResp.json().catch(() => ({}))) as InboxResp;
+    const queue_task_id = lg.task_id;
+    if (!queue_task_id) {
+        throw new Error(`/inbox response missing task_id: ${JSON.stringify(lg)}`);
+    }
+
+    const output = await pollForOutput(queue_task_id);
+
+    const content = output ||
+        `Weekly storage health sweep complete; storage-operator wrote ` +
+            `findings to vault. (No prose summary returned; check ` +
+            `vault/reports/storage-health-${weekStr}.md.)`;
+
+    // Post to Zulip stream #digests, topic storage-health-YYYY-Www.
+    const email = Deno.env.get("ZULIP_BOT_EMAIL");
+    const apiKey = Deno.env.get("ZULIP_BOT_API_KEY");
+    if (!email || !apiKey) throw new Error("ZULIP_BOT_EMAIL / ZULIP_BOT_API_KEY env not set");
+    const auth = "Basic " + btoa(`${email}:${apiKey}`);
+    const zulipApiUrl = Deno.env.get("ZULIP_API_URL") ?? "http://zulip.collab.svc.cluster.local";
+    const form = new URLSearchParams({
+        type: "stream",
+        to: "digests",
+        topic: `storage-health-${weekStr}`,
+        content,
+    });
+    const zr = await fetch(`${zulipApiUrl}/api/v1/messages`, {
+        method: "POST",
+        headers: {
+            Authorization: auth,
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: form,
+        signal: AbortSignal.timeout(30_000),
+    });
+    const zResult = await zr.json().catch(() => ({}));
+
+    return {
+        client_task_id,
+        queue_task_id,
+        week: weekStr,
+        date,
+        zulip: zResult.result ?? zResult,
+    };
+}
+
+async function pollForOutput(taskId: string): Promise<string | null> {
+    const deadline = Date.now() + POLL_TIMEOUT_MS;
+    while (Date.now() < deadline) {
+        const r = await fetch(
+            `${LG_BASE}/admin/tasks/${encodeURIComponent(taskId)}`,
+            { signal: AbortSignal.timeout(15_000), headers: lgaHeaders() },
+        );
+        if (!r.ok) {
+            if (r.status === 404) {
+                await sleep(POLL_INTERVAL_MS);
+                continue;
+            }
+            throw new Error(`/admin/tasks/${taskId} returned HTTP ${r.status}`);
+        }
+        const body = (await r.json().catch(() => ({}))) as AdminTaskResp;
+        const status = body.queue?.status;
+        if (status === "done") {
+            const queued_output = body.queue?.result?.output;
+            const cp_output = body.checkpointer?.values?.output;
+            return queued_output ?? cp_output ?? null;
+        }
+        if (body.queue?.last_error) {
+            throw new Error(`task ${taskId} failed: ${body.queue.last_error}`);
+        }
+        await sleep(POLL_INTERVAL_MS);
+    }
+    throw new Error(`poll timeout waiting for task ${taskId} (${POLL_TIMEOUT_MS}ms)`);
+}
+
+function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
## Summary

Fires the \`storage-operator\` agent on a weekly Class-A storage
health sweep. Cron: Sunday 07:00 ET — start of the week so any
findings are actionable Monday.

Per the fleet trigger audit (2026-05-23), this was priority #8 —
all tools (kubectl + prom + grafana) already wired, no errand-runner
dependency for Class-A output, no approval-flow gate.

## Coverage

| # | Check | Why |
|---|---|---|
| 1 | PV/PVC fill rates | Flag any volume >80% |
| 2 | Longhorn recurring jobs (weekly + monthly backups) | Catch backup-job failure before next disaster |
| 3 | CNPG Barman backup recency (25 clusters) | DR signal; flag any >48h |
| 4 | Ceph health (OSD, PG, near-full) | Catch silent degradation |
| 5 | Garage substrate (PVC fill + S3 reach) | Offsite DR target health |
| 6 | NFS mount health | beast + brain mass_storage RAID6 + Frigate paths |

## Class A only

The cron explicitly constrains storage-operator to Class A
(analysis only). The agent's eight-clause execution gate would
catch most overreach anyway; the explicit scope hint reduces wasted
reasoning.

## Test plan

- [ ] CI green
- [ ] After merge: \`wmill flow push\` to propagate
- [ ] First Sunday 07:00 ET fire: digest arrives in Zulip
      \`#digests / storage-health-YYYY-Www\` topic
- [ ] If findings are noisy or shallow, tune the prompt body
      (separate iteration; not gating)

🤖 Generated with [Claude Code](https://claude.com/claude-code)