### PR TITLE
fix(observability): allow windmill workers ingress to prometheus:9090

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/cnp-allow.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/cnp-allow.yaml
@@ -24,6 +24,11 @@ spec:
     # prometheus-mcp → prometheus:9090 (MCP backend queries Prometheus
     # via PROMETHEUS_URL; egress side already allowed in
     # mcp-system/prometheus-mcp-allow).
+    # windmill (home ns) → prometheus:9090 (operator weekly drift
+    # crons pre-fetch Prom data and pass it in /inbox content as
+    # Path-2 of the tool-binding gap workaround — see
+    # [[reference_agent_fleet_tool_binding_gap]] memory and
+    # PR #12029 for the windmill-side egress rule).
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: network
@@ -34,6 +39,13 @@ spec:
         - matchLabels:
             io.kubernetes.pod.namespace: mcp-system
             app.kubernetes.io/name: prometheus-mcp
+        - matchExpressions:
+            - key: io.kubernetes.pod.namespace
+              operator: In
+              values: [home]
+            - key: app.kubernetes.io/name
+              operator: In
+              values: [windmill-app, windmill-workers, windmill-extra]
       toPorts:
         - ports:
             - port: "9090"


### PR DESCRIPTION
## Summary

PR #12029 added the **windmill-side egress** rule for Path-2 Prom
enrichment, but missed the **prometheus-side ingress** rule. Result:
Path-2 queries time out, agent receives empty evidence, output is
useless.

Verified empirically tonight (2026-05-25 04:18 UTC):
- \`kubectl exec -n home deploy/windmill-app -- curl prom:9090\` → exit 28 (timeout)
- Live storage-weekly task showed all 5 queries timed out in the prompt
- Resulting agent finding was blank-fielded just like before Path-2

Both rules are required for the round-trip to work.

## Selector

\`matchExpressions\` covers all three windmill workload types
(\`windmill-app\`, \`windmill-workers\`, \`windmill-extra\`) under
one ingress clause.

## Test plan

- [ ] CI green
- [ ] After Flux reconcile: \`kubectl exec deploy/windmill-app -- curl prom\` → 200
- [ ] Re-fire storage-weekly; evidence block populated with real PVC/Ceph/Longhorn/CNPG numbers
- [ ] Agent output has populated fields (not blank)

🤖 Generated with [Claude Code](https://claude.com/claude-code)