### PR TITLE
fix(renovate): look up ZOT-routed charts at upstream, not ZOT

### DIFF
--- a/.github/renovate/customManagers.json5
+++ b/.github/renovate/customManagers.json5
@@ -11,6 +11,32 @@
         "oci://(?<depName>[^:]+):(?<currentValue>\\S+)",
       ],
       datasourceTemplate: "docker",
+    },
+    {
+      customType: "regex",
+      // OCIRepository / chartRef routed through the in-cluster ZOT
+      // pull-through cache (kube-system/zot:5000). ZOT's onDemand sync
+      // only proxies *manifest* GETs, not /v2/<image>/tags/list — so
+      // Renovate's built-in flux manager (which queries the URL
+      // verbatim) gets `no-result` for every chart. Strip the ZOT
+      // prefix here so Renovate looks up tags from the real upstream
+      // registry, while Flux keeps pulling through ZOT. The
+      // packageRules entry that disables the flux-manager lookup for
+      // `zot.kube-system.svc.cluster.local:5000/*` lives in
+      // packageRules.json5.
+      description: "OCIRepository / chartRef routed through in-cluster ZOT — look up tags from upstream registry, not ZOT.",
+      managerFilePatterns: [
+        "/^kubernetes/.+\\.ya?ml$/",
+      ],
+      matchStrings: [
+        // `ref.tag` precedes `url` (this repo's convention — see
+        // flux.sorting.instructions.md and every existing
+        // OCIRepository file).
+        "ref:\\s*\\n\\s+tag:\\s+(?<currentValue>\\S+)[\\s\\S]*?url:\\s*oci://zot\\.kube-system\\.svc\\.cluster\\.local:5000/(?<depName>\\S+)",
+        // Defensive — reversed ordering if a future file flips it.
+        "url:\\s*oci://zot\\.kube-system\\.svc\\.cluster\\.local:5000/(?<depName>\\S+)[\\s\\S]*?ref:\\s*\\n\\s+tag:\\s+(?<currentValue>\\S+)",
+      ],
+      datasourceTemplate: "docker",
     }
   ]
 }

--- a/.github/renovate/packageRules.json5
+++ b/.github/renovate/packageRules.json5
@@ -58,6 +58,19 @@
       matchDatasources: ["docker"],
       versioning: "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(-(?<compatibility>rc|beta)(?<build>\\d+))?$",
       matchPackageNames: ["ghcr.io/blakeblackshear/frigate"]
+    },
+    {
+      // Suppresses the built-in flux manager's failing lookup for
+      // OCIRepositories pointing at `oci://zot.kube-system...:5000/*`.
+      // The companion customManager in customManagers.json5 captures
+      // the upstream path as depName and queries the real registry
+      // for tags — keep that path enabled, disable only the
+      // ZOT-prefixed duplicate.
+      description: "Suppress flux-manager lookups for ZOT-prefixed OCIRepositories — customManager handles upstream resolution.",
+      matchPackageNames: [
+        "/^zot\\.kube-system\\.svc\\.cluster\\.local:5000\\//",
+      ],
+      enabled: false
     }
   ]
 }


### PR DESCRIPTION
## Summary

- The Renovate Dependency Dashboard (#10329) reports 30 chart lookup failures, all of the shape `Failed to look up docker package zot.kube-system.svc.cluster.local:5000/<upstream>/<chart>: no-result`. As a side-effect Renovate has stopped opening update PRs for those charts.
- Root cause: PR #11697 routed 30+ OCIRepositories through the in-cluster ZOT pull-through cache. Renovate's built-in flux manager reads `spec.url` verbatim and hits ZOT's `/v2/<image>/tags/list`, but ZOT's `onDemand` sync only proxies *manifest* GETs — the tags list is whatever's already cached locally, which for never-pulled charts is empty.
- Two-part Renovate-only fix: a `customManager` that captures `ref.tag` + strips the ZOT service prefix from the URL (so depName resolves at the real upstream registry), plus a `packageRules` entry that disables the duplicate flux-manager lookup for any depName still starting with the ZOT prefix.

OCIRepository URLs and ZOT itself are untouched — Flux pulls keep flowing through ZOT.

## Test plan

- [ ] CI: yamllint, markdownlint, renovate-config-validator (if wired) all pass.
- [ ] After merge to `main`: hit the renovate-operator webhook (`renovate.${SECRET_DOMAIN}`) to force a discovery + executor run.
- [ ] Watch executor pod logs: `kubectl -n renovate logs -l renovate-operator.mogenius.com/job-type=executor -f` — expect a successful `cert-manager` lookup at `quay.io`, not `zot.kube-system...`.
- [ ] Refresh dashboard #10329 — the "Failed to look up" WARN block (30 entries) should clear.
- [ ] Confirm chart update PRs resume landing (e.g. for charts that had pending upstream releases like `kube-prometheus-stack`, `app-template`).
- [ ] Sanity-check non-ZOT lookups (container images, GitHub Actions) continue to get PRs — the disable rule is regex-scoped to the ZOT prefix only.
- [ ] If the dashboard's "Error obtaining docker token" WARN line persists after one full run, follow up separately (likely DOCKERHUB_TOKEN rotation or `RENOVATE_HOST_RULES` issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)