### PR TITLE
fix(home/frigate): durably restore yamllint-disable header on config snapshot

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,14 +19,15 @@ repos:
         args: [--allow-multiple-documents]
         # mkdocs.yml uses PyYAML !!python/name: tags for Material's
         # emoji extension config — safe-load rejects them.
-        exclude: ^(.*\.sops\..*|.*/resources/.*|docs/mkdocs\.yml)$
+        # frigate snapshots are Frigate-emitted, not hand-authored.
+        exclude: ^(.*\.sops\..*|.*/resources/.*|docs/mkdocs\.yml|kubernetes/apps/home/frigate/snapshots/.*)$
       - id: check-json
       - id: check-merge-conflict
       - id: check-symlinks
       - id: end-of-file-fixer
-        exclude: ^(.*\.sops\..*|.*/resources/.*)$
+        exclude: ^(.*\.sops\..*|.*/resources/.*|kubernetes/apps/home/frigate/snapshots/.*)$
       - id: trailing-whitespace
-        exclude: ^(.*\.sops\..*|.*/resources/.*)$
+        exclude: ^(.*\.sops\..*|.*/resources/.*|kubernetes/apps/home/frigate/snapshots/.*)$
       - id: detect-private-key
 
   # Secret scan — mirrors `.github/workflows/gitleaks.yaml`

--- a/kubernetes/apps/home/frigate/app/snapshot-script-cm.yaml
+++ b/kubernetes/apps/home/frigate/app/snapshot-script-cm.yaml
@@ -101,7 +101,19 @@ data:
 
       DEST="$WORK/repo/$SNAPSHOT_PATH"
       mkdir -p "$(dirname "$DEST")"
-      cp "$CONFIG_FILE" "$DEST"
+      # Prepend yamllint-disable header. The snapshot is Frigate-emitted and
+      # doesn't conform to repo-wide yamllint rules; without this header,
+      # every regenerated snapshot trips ~30 lint errors. Kept inside the
+      # script (not patched onto the file post-hoc) so it survives every
+      # snapshot regeneration.
+      {
+        echo "# yamllint disable"
+        echo "# This file is a snapshot of Frigate's live /config/config.yml,"
+        echo "# written by Frigate itself via the UI / API config setter."
+        echo "# Not hand-authored YAML; not Flux-reconciled. Lint rules around"
+        echo "# quoted-strings / comment-spacing don't apply."
+        cat "$CONFIG_FILE"
+      } > "$DEST"
 
       if git diff --quiet; then
         echo "No diff; nothing to commit."

--- a/kubernetes/apps/home/frigate/snapshots/config.yml
+++ b/kubernetes/apps/home/frigate/snapshots/config.yml
@@ -1,3 +1,8 @@
+# yamllint disable
+# This file is a snapshot of Frigate's live /config/config.yml, written by
+# Frigate itself via the UI / API config setter. Not hand-authored YAML; not
+# Flux-reconciled. Lint rules around quoted-strings / comment-spacing don't
+# apply.
 mqtt:
   host: emqx.home.svc.cluster.local
   topic_prefix: frigate


### PR DESCRIPTION
## Summary

- Snapshot CronJob's `cp` was clobbering the yamllint-disable header PR #11933 added — leaving the Frigate-emitted file failing ~30 yamllint errors on every nightly regen.
- Re-add the header to the current snapshot.
- Move header injection into `snapshot.sh` so every regeneration prepends it (durable across the 03:00 cron loop).
- Exclude `kubernetes/apps/home/frigate/snapshots/` from pre-commit `check-yaml`, `end-of-file-fixer`, and `trailing-whitespace` so author-time hygiene hooks stop fighting Frigate's output.

## Test plan

- [x] `pre-commit run --files <changed>` green
- [x] `yamllint --config-file .yamllint.yaml kubernetes/apps/home/frigate/snapshots/config.yml` clean
- [ ] CI lint green
- [ ] Tomorrow's snapshot at 03:00 preserves the header