### PR TITLE
fix(ci): normalize docker.io/<image> to docker.io/library/<image>

### DIFF
--- a/tools/check-image-registry.sh
+++ b/tools/check-image-registry.sh
@@ -64,11 +64,16 @@ for image in "${images[@]}"; do
     continue
   fi
 
-  # Normalize bare docker.io paths: `foo/bar` → `docker.io/foo/bar`,
-  # `busybox` → `docker.io/library/busybox`. The allowlist uses the
-  # fully-qualified docker.io form for clarity.
+  # Normalize bare docker.io paths to their fully-qualified
+  # `docker.io/<namespace>/<image>` form. Docker Hub treats unspecified
+  # namespace as `library/`, so all four of these are equivalent:
+  #   busybox / library/busybox / docker.io/busybox / docker.io/library/busybox
+  # The allowlist uses the `docker.io/library/...` form for clarity.
   case "$bare" in
-    *.*/* ) ;;                                    # already has registry host
+    docker.io/*/* ) ;;                            # `docker.io/org/img` — canonical
+    docker.io/* )
+      bare="docker.io/library/${bare#docker.io/}" ;;  # `docker.io/img` → `docker.io/library/img`
+    *.*/* ) ;;                                    # other registry host
     */* )   bare="docker.io/$bare" ;;             # `org/img`
     * )     bare="docker.io/library/$bare" ;;     # `img`
   esac


### PR DESCRIPTION
## Summary

- `tools/check-image-registry.sh` only folded the no-host forms (`busybox`, `library/busybox`) to canonical `docker.io/library/...`. Charts that emit `registry: docker.io` + `repository: busybox` produced `docker.io/busybox`, which matched the catch-all `*.*/*` case and stayed unchanged — so the prefix never matched the `docker.io/library/busybox` allowlist entry.
- Same gap would have hit `docker.io/alpine`, `docker.io/python`, `docker.io/couchdb` if any chart ever emitted them that way.
- Surfaced by netbox-chart 8.3.0 (#12045): the chart's busybox bump 1.37.0 → 1.38.0 looked new and tripped `Check new images`.

After the fix, all four equivalent forms (`busybox`, `library/busybox`, `docker.io/busybox`, `docker.io/library/busybox`) normalize to `docker.io/library/busybox` and match the existing allowlist entry.

## Test plan

- [x] `echo '["docker.io/busybox:1.38.0","docker.io/library/busybox:1.38.0","busybox:1.38.0","library/busybox:1.38.0","docker.io/alpine:3.19","docker.io/org/img:1","ghcr.io/foo/bar:1"]' | ./tools/check-image-registry.sh --json` — only `docker.io/org/img:1` flagged (correct; not allowlisted).
- [ ] Re-run `Image Registry Check` on #12045 (rebase against this once merged) — should pass.