### PR TITLE
fix(lint): clear remaining yamllint + markdownlint errors repo-wide

### DIFF
--- a/.agents/instructions/helmfile.sorting.instructions.md
+++ b/.agents/instructions/helmfile.sorting.instructions.md
@@ -23,6 +23,7 @@ Whenever asked to sort these files, follow these instructions:
 This section gives instructions specifically for HelmReleases that are based on the `app-template` chart. These can be identified by the presence of a sidecar `ocirepository.yaml` file that references `oci://ghcr.io/bjw-s-labs/helm/app-template` in the `url` field.
 
 ### Sorting rules
+
 Whenever asked to sort these files, follow these instructions:
 
 - Whenever there is an `enabled` field, it should be the first field within its section.

--- a/.agents/skills/expose-app.md
+++ b/.agents/skills/expose-app.md
@@ -23,6 +23,7 @@ Canonical recent reference: PR #11148 — flux-webhook on `external`.
   Phase 3 waves.
 
 **Don't use this skill for**:
+
 - Adding the cert-manager annotations to a Gateway (that's Phase 0,
   done once per Gateway).
 - istio Gateway routes — they're deferred to Phase 4.0 of the
@@ -116,15 +117,19 @@ app-template `helmrelease.yaml`):
 One PR per app during the canary. Batches of 5 during Phase 3 waves.
 
 Commit message form:
-```
+
+```text
 feat(network): cert migration canary — <app> on per-app listener
 ```
+
 or for waves:
-```
+
+```text
 feat(network): per-app TLS migration wave N (X/Y)
 ```
 
 The PR body should call out:
+
 - which Gateway is being touched
 - the specific app(s)
 - a rollback note: revert the PR, the route falls back to whatever

--- a/.agents/skills/flux-suspend.md
+++ b/.agents/skills/flux-suspend.md
@@ -11,12 +11,13 @@ maintenance, or to keep Flux from clobbering an in-flight workaround.
 
 If you see this in `git log`, **do not "fix" it**:
 
-```
+```text
 abc1234 new: disable-<app>          # commit that pauses reconciliation
 def5678 Revert "disable-<app>"      # commit that unpauses
 ```
 
 Without explicit user instruction, never:
+
 - Revert a `disable-<app>` commit.
 - Run `flux resume` on a suspended Kustomization or HelmRelease.
 - Edit `spec.suspend` in a manifest.
@@ -34,37 +35,42 @@ For an app's HelmRelease, set `spec.suspend: true` (or comment out the
 ks.yaml entry in the parent `kustomization.yaml`) on a branch named
 `disable-<app>` and commit with a message like:
 
-```
+```text
 new: disable-<app>
 
 <reason — e.g. "manual hand-edit during X migration">
 ```
 
 For imperative-only emergencies:
-```
+
+```sh
 flux suspend kustomization <name> -n flux-system
 flux suspend helmrelease <name> -n <namespace>
 ```
+
 But follow up by committing the suspend so it's tracked in Git.
 
 ## Resuming
 
 Revert the suspend commit:
-```
+
+```sh
 git revert <disable-commit-sha>
 ```
+
 The commit message should be left as the default
 `Revert "disable-<app>"` — that's the searchable pattern.
 
 For imperative-only resume:
-```
+
+```sh
 flux resume kustomization <name> -n flux-system
 flux resume helmrelease <name> -n <namespace>
 ```
 
 ## Inspecting suspend state
 
-```
+```sh
 # Everything that's currently suspended
 flux get all -A --status-selector ready=false | grep -i suspend
 

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -23,6 +23,7 @@ rules:
   quoted-strings:
     quote-type: double
     required: false
+    allow-quoted-quotes: true
   truthy:
     allowed-values:
       - "true"

--- a/kubernetes/apps/auth/authelia/app/externalsecret.yaml
+++ b/kubernetes/apps/auth/authelia/app/externalsecret.yaml
@@ -47,7 +47,7 @@ spec:
         # client_secret argon2id hashes don't sit in git. Mounted as
         # /secrets/clients.yml and merged into the main config via --config.
         # SECRET_DOMAIN is pre-substituted in 1P (no flux postBuild reach here).
-        clients.yml: '{{ .OIDC_CLIENTS_YAML }}'
+        clients.yml: "{{ .OIDC_CLIENTS_YAML }}"
         # Postgres init container needs these
         INIT_POSTGRES_DBNAME: "authelia"
         INIT_POSTGRES_HOST: "postgres-authelia-rw.databases.svc.cluster.local"

--- a/kubernetes/apps/home/node-red/README.md
+++ b/kubernetes/apps/home/node-red/README.md
@@ -1,3 +1,3 @@
 As per the below instructions, install the 'node-red-contrib-home-assistant-websocket' plugin via the Palette Manager.
 
-https://zachowj.github.io/node-red-contrib-home-assistant-websocket/guide/#using-the-palette-manager
+<https://zachowj.github.io/node-red-contrib-home-assistant-websocket/guide/#using-the-palette-manager>


### PR DESCRIPTION
## Summary

- After PR #12052 cleared the Frigate snapshot, only ~20 small lint errors remained across the repo. Clear them as one sweep so the baseline is zero and any future PR failure is signal.
- YAML: `allow-quoted-quotes: true` in `.yamllint.yaml` (lets values with embedded `\"` legitimately use single quotes); swap one single→double quote on a no-embedded-quotes value in authelia externalsecret.
- Markdown: wrap a bare URL (MD034); fix blank-line-after-heading (MD022); add language hints (MD040) and surrounding blank lines (MD031/MD032) on two `.agents/skills/` files.

## Test plan

- [x] `pre-commit run --files <changed>` green
- [x] `yamllint --strict --config-file .yamllint.yaml .` exits 0 across the whole tree (excluding `.claude/worktrees/`)
- [ ] CI lint green