### PR TITLE
fix(ai/windmill): storage-weekly uses correct Barman backup metric

### DIFF
--- a/kubernetes/apps/home/windmill/workflows/langgraph-storage-weekly.ts
+++ b/kubernetes/apps/home/windmill/workflows/langgraph-storage-weekly.ts
@@ -153,8 +153,13 @@ export async function main() {
             "(time() - longhorn_recurring_job_last_success_time) / 86400",
         ),
         // CNPG Barman last-successful-backup age (seconds → days).
+        // NB: `cnpg_collector_last_failed_backup_timestamp` is the LAST
+        // FAILED backup (defaults to 0 when no failures recorded), not
+        // the most-recent success. The Barman-managed equivalent of
+        // "last successful backup" is the metric below — exported by
+        // the barman-cloud sidecar per CNPG cluster.
         promQuery(
-            "(time() - cnpg_collector_last_failed_backup_timestamp) / 86400",
+            "(time() - barman_cloud_cloudnative_pg_io_last_available_backup_timestamp) / 86400",
         ),
     ]);
 


### PR DESCRIPTION
## Summary

- Replace `cnpg_collector_last_failed_backup_timestamp` (last FAILED; defaults to 0) with `barman_cloud_cloudnative_pg_io_last_available_backup_timestamp` (last successful backup) in `langgraph-storage-weekly.ts`
- Fixes the "20598 days ago" false positive that flagged every healthy postgres-* cluster as missing a backup in the weekly storage-health digest

## Why

The previous metric defaulted to 0 for every cluster with no recorded failures, which the days-since-success math then rendered as a ~56-year-old timestamp. The pre-fetched evidence block was telling storage-operator that every CNPG cluster had been broken since 1970 — the LLM was correctly flagging them, the input was wrong.

The new metric is the one Barman + cnpg-i-barman-cloud actually exports for "last successful base/WAL backup."

## Test plan

- [x] PromQL spot-check: `barman_cloud_cloudnative_pg_io_last_available_backup_timestamp` resolves and returns recent epochs for active clusters
- [ ] Post-merge: push the workflow to the live Windmill DB (`tools/push-windmill-workflow.sh` or equivalent)
- [ ] Sunday 07:00 ET cron fire — confirm the "CNPG Barman backup days-since-last-success" block lists actual days, not 20598

🤖 Generated with [Claude Code](https://claude.com/claude-code)