### PR TITLE
fix(databases/cnpg): add BackupStale and BackupFailed alert rules

### DIFF
--- a/kubernetes/apps/databases/cloudnative-pg/app/prometheusrule.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/app/prometheusrule.yaml
@@ -65,3 +65,26 @@ spec:
           for: 5m
           labels:
             severity: warning
+        - alert: BackupStale
+          annotations:
+            description: >-
+              Cluster {{ $labels.job }} in {{ $labels.namespace }} last successful
+              backup is over 10 days old. NOTE: plugin-method clusters (barman-cloud
+              plugin) do not populate this metric — they have no Prometheus-based
+              staleness signal until CNPG adds condition metrics.
+            summary: CNPG cluster has not had a successful backup in over 10 days.
+          expr: |-
+            (time() - cnpg_collector_last_available_backup_timestamp) / 86400 > 10
+              and cnpg_collector_last_available_backup_timestamp > 0
+          for: 10m
+          labels:
+            severity: warning
+        - alert: BackupFailed
+          annotations:
+            description: Cluster {{ $labels.job }} in {{ $labels.namespace }} has a recent backup failure.
+            summary: CNPG cluster backup failed recently.
+          expr: |-
+            increase(cnpg_collector_last_failed_backup_timestamp[25h]) > 0
+          for: 10m
+          labels:
+            severity: warning


### PR DESCRIPTION
## Summary

- Adds `BackupStale` alert: fires when `cnpg_collector_last_available_backup_timestamp > 0` and the value is older than 10 days. The `> 0` guard prevents false-firing on plugin-method clusters (barman-cloud plugin does not populate this field).
- Adds `BackupFailed` alert: fires when `cnpg_collector_last_failed_backup_timestamp` increases within a 25h window, catching active backup failures regardless of backup method.

## Background

Investigation triggered by a storage-operator sweep showing `cnpg_collector_last_successful_backup_timestamp = 0` ("20598 days ago") for postgres-nametag and postgres-netbox. Both clusters are healthy — the metric is not updated by the barman-cloud plugin method. The `BackupStale` alert is designed to avoid this false-alarm class. Plugin-method cluster blind spot is documented in the alert description.

## Test plan

- [ ] CI lint passes
- [ ] Alert fires correctly in Prometheus (BackupStale: any barmanObjectStore cluster with stale field; BackupFailed: on next backup failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)