### PR TITLE
fix(databases/cnpg): correct BackupFailed alert to use changes() not increase()

### DIFF
--- a/kubernetes/apps/databases/cloudnative-pg/app/prometheusrule.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/app/prometheusrule.yaml
@@ -84,7 +84,7 @@ spec:
             description: Cluster {{ $labels.job }} in {{ $labels.namespace }} has a recent backup failure.
             summary: CNPG cluster backup failed recently.
           expr: |-
-            increase(cnpg_collector_last_failed_backup_timestamp[25h]) > 0
+            changes(cnpg_collector_last_failed_backup_timestamp[25h]) > 0
           for: 10m
           labels:
             severity: warning


### PR DESCRIPTION
## Summary

- Fixes `BackupFailed` alert expression: `increase()` on a timestamp gauge reads near 0 once the value stabilizes, so the alert never fires after the initial failure window. `changes()` correctly detects when the failure timestamp changes to a new value (new failure event recorded).

## Background

Caught immediately after #12062 merged — querying Prometheus showed 18 clusters with `last_failed_backup_timestamp > 0` but the alert was not firing for any of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)