### PR TITLE
docs(stage3): add routing policy ConfigMap and runbook

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -94,6 +94,7 @@ nav:
       - homeaiops_dod.md
       - stage2_gap_analysis.md
       - workflow_automation.md
+      - routing_policy.md
       - khoj.md
       - memory_mcp.md
       - mcp_observability.md

--- a/docs/src/routing_policy.md
+++ b/docs/src/routing_policy.md
@@ -1,0 +1,260 @@
+# Routing Policy — Local vs Claude Escalation
+
+## What this is
+
+`kubernetes/apps/ai/langgraph-agents/routing-policy.yaml` is the
+version-controlled source of truth for how HomeAIOps decides whether
+a task runs on a local Ollama model or escalates to the Anthropic
+Claude API.
+
+The policy is an explicit ruleset — no learned router yet. First-match
+wins. Changing the file changes behavior (once the Stage 3 execution
+work wires the ConfigMap into the runtime; see **Status** below).
+
+This is a Stage 3 artifact. Per `goal.md`:
+
+> "Version-controlled file in the repo that decides local vs. escalate
+> based on explicit rules (task type, model capability, context size,
+> sensitivity). No learned router yet — explicit rules first. Changing
+> the file changes behavior."
+
+## Status
+
+**Draft / not yet wired (as of initial commit).**
+
+The ConfigMap is committed to the repo and will be reconciled by Flux
+into the `ai` namespace, but the langgraph-agents runtime does not yet
+read it. Routing decisions are still made by the hardcoded `AGENT_GROUP`
+dict and `llm()` factory in `src/agents/llm.py`. Wiring the
+ConfigMap into the runtime is Stage 3 execution work, gated on Gate 2
+(dogfooding sign-off).
+
+Until wiring lands, this file is the declarative statement of *intent* —
+the target routing behavior that code will be written to enforce.
+
+## Where it lives
+
+```text
+kubernetes/apps/ai/langgraph-agents/
+├── routing-policy.yaml        ← ConfigMap (this policy)
+├── ks.yaml
+└── app/
+    ├── helmrelease.yaml
+    └── kustomization.yaml
+```
+
+The ConfigMap is at the `langgraph-agents/` level rather than `app/`
+because it is not yet part of the Flux-reconciled `app` path
+(`spec.path: ./kubernetes/apps/ai/langgraph-agents/app`). Once the
+runtime wiring is ready, it will move into `app/` and be added to
+`app/kustomization.yaml`.
+
+## How to change the policy
+
+1. Edit `kubernetes/apps/ai/langgraph-agents/routing-policy.yaml`.
+   The YAML inside the ConfigMap's `data.routing-policy.yaml` key is
+   the ruleset.
+2. Open a PR. CI lints the file; a reviewer checks that no rule
+   accidentally routes restricted-tier data to Claude.
+3. Merge. Flux reconciles the ConfigMap into the `ai` namespace.
+4. The langgraph-agents pod does **not** need to restart — the runtime
+   (once wired) will hot-reload the policy from the mounted ConfigMap.
+
+No code change is required to add, remove, or reorder rules once the
+runtime wiring lands.
+
+## Rule evaluation
+
+Rules are evaluated in document order. The first rule whose `match`
+block matches all specified keys wins. If no rule matches, the `default`
+route applies (currently `local-spark`, i.e. qwen2.5:32b on Spark).
+
+**Match keys** (all optional; combined with AND):
+
+| Key | Type | Example |
+|---|---|---|
+| `task_class` | string | `summarization`, `architecture`, `code-edit` |
+| `agent_id` | string | `health-tracker`, `coder`, `triager` |
+| `data_tier` | string | `public`, `internal`, `restricted` |
+| `context_tokens` | object | `{gt: 50000}` |
+| `escalate_flag` | bool | `true` |
+| `spark_healthy` | bool | `false` (runtime-resolved) |
+| `p40_healthy` | bool | `false` (runtime-resolved) |
+
+**Route values:**
+
+| Value | Hardware | Model |
+|---|---|---|
+| `local-p40` | P40 (Pascal, 24 GB) | `qwen2.5:7b` |
+| `local-spark` | DGX Spark (GB10) | `qwen2.5:32b` |
+| `local-spark-coder` | DGX Spark (GB10) | `qwen2.5-coder:32b` |
+| `claude` | Anthropic API | `claude-sonnet-4-6` (default) |
+| `local-only` | whichever path is healthy | per rule; raises if both down |
+
+## Current rules — rationale
+
+### Hard pins (never escalate)
+
+- **`health-tracker` → `local-only`**: Health data never leaves the
+  cluster. Hard constraint in `IDENTITY.md`; cannot be overridden by
+  any other rule.
+- **`data_tier: restricted` → `local-only`**: Restricted-tier tasks
+  are already blocked at runtime by `redaction.py`, but the policy
+  makes the intent explicit and greppable.
+
+### Explicit escalation
+
+When a node calls `llm(agent_id, escalate=True)` and the data tier
+permits remote emission, the policy routes to `claude-sonnet-4-6`.
+Cost caps in `settings.py` still apply regardless.
+
+### Task class routing
+
+Local-first classes (no context size or quality argument for Claude):
+
+| Task class | Route | Reason |
+|---|---|---|
+| `summarization` | `local-spark` | 32b handles well; no escalation needed |
+| `classification` | `local-p40` | Binary/short-label; 7b sufficient |
+| `log-triage` | `local-spark` | Error-pattern extraction; 32b |
+| `doc-drift` | `local-p40` | Structural conformance; 7b |
+| `note-taking` | `local-p40` | Simple drafting; 7b |
+| `alert-triage` | `local-spark` | Needs reasoning; 32b |
+| `code-edit` | `local-spark-coder` | Dedicated coder model |
+| `code-review` | `local-spark-coder` | Dedicated coder model |
+| `image-generation` | `local-spark` | ComfyUI prompt composition |
+
+Claude-first classes (complexity or novelty exceeds reliable local
+capability):
+
+| Task class | Route | Reason |
+|---|---|---|
+| `architecture` | `claude` | Novel decisions; local models insufficient |
+| `research` | `claude` | Open-ended; benefits from broad knowledge + tool use |
+
+### Context size threshold
+
+Requests exceeding 50,000 tokens escalate to Claude (`claude-sonnet-4-6`).
+The 50k threshold reflects qwen2.5:32b's reliable quality window —
+the model's nominal context is 128k, but quality degrades significantly
+above ~64k. 50k is a conservative gate that avoids truncation or quality
+collapse on borderline cases.
+
+Adjust the threshold in the policy YAML; no code change needed.
+
+### Degraded mode
+
+When both Ollama endpoints (Spark and P40) are unhealthy, `public` and
+`internal` tier tasks escalate to Claude. `restricted` tier tasks fail
+with an error rather than escalate. This mirrors the
+`degraded_mode_escalation_enabled` env-var behavior in `llm.py` and
+makes it policy-explicit.
+
+### Agent-specific overrides
+
+Every agent in `AGENT_GROUP` (in `llm.py`) has a matching rule that
+pins it to the same group. These rules make the agent→model assignment
+greppable from the policy file without needing to read Python source.
+
+P40 (`qwen2.5:7b`) agents: `triager`, `note-maker`, `errand-runner`,
+`property-coordinator`, `doc-writer`, `health-tracker`.
+
+Spark general (`qwen2.5:32b`) agents: `historian`, `researcher`,
+`supervisor`, `reporter`, `homelab-engineer`, `network-operator`,
+`storage-operator`, `smart-home-operator`, `ml-operator`,
+`observability-operator`, `security`, `auditor`, `artist`.
+
+Spark coder (`qwen2.5-coder:32b`) agents: `coder`, `reviewer`.
+
+## Cost / spend guardrails
+
+The policy file declares the guardrail thresholds for documentation and
+future code use. Current values (match `helmrelease.yaml` env vars):
+
+| Guardrail | Value |
+|---|---|
+| Per-task cap | $5.00 USD |
+| Per-agent daily cap | $10.00 USD |
+| Global daily cap | $30.00 USD |
+| Escalation rate warn | 20% of tasks |
+| Escalation spend warn | $10.00 USD/day |
+
+**These are not yet enforced by the policy file itself.** Runtime
+enforcement lives in `settings.py` + `observability.py` in langgraph-agents.
+The policy fields are future wiring targets.
+
+## Verifying routing decisions
+
+Once the runtime wiring lands, every routing decision will be logged with
+the matched rule and reason. Until then, verify by reading the current
+hardcoded `AGENT_GROUP` dict in
+`langgraph-agents/src/agents/llm.py`.
+
+### Check current effective routing (pre-wiring)
+
+```sh
+# What group is each agent assigned to today?
+kubectl exec -n ai deploy/langgraph-agents -- \
+  python3 -c "from agents.llm import AGENT_GROUP; import json; print(json.dumps(AGENT_GROUP, indent=2))"
+```
+
+### Check escalation spend
+
+```sh
+# Total Claude spend today (from Prometheus)
+kubectl exec -n ai deploy/langgraph-agents -- \
+  python3 -c "from agents.observability import global_claude_spend_usd; print(global_claude_spend_usd())"
+
+# Or query Prometheus directly:
+# langgraph_cost_usd_total{group="claude"}
+```
+
+### Check that a restricted-tier task does not escalate
+
+```sh
+# Trigger a test task with data_tier=restricted and escalate=True.
+# Expected result: RestrictedTierEmissionBlocked exception in logs;
+#   no ANTHROPIC_API_KEY call made; spend counter unchanged.
+kubectl logs -n ai deploy/langgraph-agents --since=2m | grep -i "restricted\|emission_blocked"
+```
+
+## Runbook — "local infra is down, fall back to Claude Code directly"
+
+When both Ollama endpoints are down AND the task cannot wait for
+degraded-mode escalation through the pipeline (e.g., the queue worker
+itself is unhealthy):
+
+1. Confirm both Ollama endpoints are unhealthy:
+
+   ```sh
+   curl -s http://ollama.ai.svc.cluster.local:11434/api/tags | jq '.models | length'
+   curl -s http://ollama-spark.ai.svc.cluster.local:11434/api/tags | jq '.models | length'
+   # If either curl times out or returns 0 models, that path is down.
+   ```
+
+2. Work directly in Claude Code against the repo. The routing policy
+   does not gate Claude Code sessions — it gates the in-cluster pipeline.
+
+3. File the outage as a P0 if Spark is down (primary inference for most
+   agents), P1 if only P40 is down (affects triager / errand-runner /
+   note-maker class agents).
+
+4. When local inference recovers, tasks parked with
+   `status=awaiting_ollama_recovery` in `task_queue` will be retried
+   automatically by the queue poller.
+
+5. Check the guardrail spend after recovery — if degraded-mode escalation
+   ran for an extended period, the global daily spend counter may be
+   elevated. The Grafana `aihomeops-state` dashboard shows per-day Claude
+   spend and escalation rate.
+
+## See also
+
+- `docs/src/ai_architecture.md` — component map showing where the router
+  sits in the pipeline
+- `docs/src/homeaiops_dod.md` — Stage 3 definition of done
+- `kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml` — current
+  cost cap env vars (until wired from this ConfigMap)
+- `langgraph-agents/src/agents/llm.py` — current routing implementation
+- `langgraph-agents/src/agents/redaction.py` — restricted-tier emission gate
+- `goal.md` — Stage 3 routing, escalation, and provenance requirements

--- a/kubernetes/apps/ai/langgraph-agents/routing-policy.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/routing-policy.yaml
@@ -1,0 +1,345 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/configmap-v1.json
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: langgraph-routing-policy
+  namespace: ai
+data:
+  routing-policy.yaml: |
+    # HomeAIOps routing policy — local vs Claude escalation
+    # Version-controlled. Changing this file changes routing behavior.
+    # Stage 3 — initial explicit rules (no learned router yet).
+    #
+    # Rule evaluation order: first match wins.
+    # If no rule matches, `default` applies.
+    #
+    # Supported match keys (all optional, combined with AND):
+    #   task_class    — summarization | classification | code-edit | code-review |
+    #                   architecture | tool-use | note-taking | log-triage |
+    #                   doc-drift | alert-triage | image-generation | research
+    #   agent_id      — exact agent name from AGENT_GROUP in llm.py
+    #   data_tier     — public | internal | restricted
+    #   context_tokens — {gt: N} threshold check
+    #   escalate_flag — true | false (explicit escalate=True from caller)
+    #   spark_healthy — true | false (resolved at runtime by health check)
+    #   p40_healthy   — true | false (resolved at runtime by health check)
+    #
+    # Supported route values:
+    #   local-p40          — Ollama on P40, qwen2.5:7b
+    #   local-spark        — Ollama on Spark, qwen2.5:32b
+    #   local-spark-coder  — Ollama on Spark, qwen2.5-coder:32b
+    #   claude             — Anthropic API (model selected by `model` field)
+    #   local-only         — never escalates; raises if both local paths down
+    #
+    # `reason` is free-text, logged with every routing decision.
+
+    version: "1"
+    default: local-spark
+
+    rules:
+
+      # -----------------------------------------------------------------------
+      # HARD PINS — never touch Claude regardless of any other signal
+      # -----------------------------------------------------------------------
+
+      # Health data is covered by the privacy constraint in IDENTITY.md:
+      # health information never leaves the cluster. No escalation path exists.
+      - match:
+          agent_id: health-tracker
+        route: local-only
+        model: qwen2.5:7b
+        reason: "Privacy hard-pin — health data never sent to remote models"
+
+      # Restricted-tier tasks are blocked from remote model emission by
+      # redaction.py at runtime, but also declared here so the router's
+      # own log shows the intent clearly and so a future code-driven
+      # router can enforce this without re-reading the redaction layer.
+      - match:
+          data_tier: restricted
+        route: local-only
+        model: qwen2.5:32b
+        reason: "Restricted data tier — HOMELAB-SPEC Layer 2 #1 + Layer 5 classification"
+
+      # -----------------------------------------------------------------------
+      # EXPLICIT ESCALATION — caller sets escalate=True
+      # -----------------------------------------------------------------------
+
+      # When a node explicitly requests escalation AND the data tier permits it,
+      # route to Claude. The cost caps in settings.py still apply; this rule
+      # does not bypass them.
+      - match:
+          escalate_flag: true
+          data_tier: public
+        route: claude
+        model: claude-sonnet-4-6
+        reason: "Explicit escalation requested; public-tier data safe for remote model"
+
+      - match:
+          escalate_flag: true
+          data_tier: internal
+        route: claude
+        model: claude-sonnet-4-6
+        reason: "Explicit escalation requested; internal-tier data acceptable for remote model"
+
+      # -----------------------------------------------------------------------
+      # TASK CLASS — always local (well within local model capability)
+      # -----------------------------------------------------------------------
+
+      - match:
+          task_class: summarization
+        route: local-spark
+        model: qwen2.5:32b
+        reason: "Summarization is well within 32b capability; no escalation needed"
+
+      - match:
+          task_class: classification
+        route: local-p40
+        model: qwen2.5:7b
+        reason: "Binary/short-label classification is Haiku-equivalent work; 7b sufficient"
+
+      - match:
+          task_class: log-triage
+        route: local-spark
+        model: qwen2.5:32b
+        reason: "Log error-pattern extraction; local model handles well"
+
+      - match:
+          task_class: doc-drift
+        route: local-p40
+        model: qwen2.5:7b
+        reason: "Structural conformance check against a list; 7b sufficient"
+
+      - match:
+          task_class: note-taking
+        route: local-p40
+        model: qwen2.5:7b
+        reason: "Simple note drafting; 7b produces acceptable quality"
+
+      - match:
+          task_class: alert-triage
+        route: local-spark
+        model: qwen2.5:32b
+        reason: "Alert analysis needs reasoning depth; Spark 32b preferred over 7b"
+
+      # -----------------------------------------------------------------------
+      # TASK CLASS — prefer local, escalate only when needed
+      # -----------------------------------------------------------------------
+
+      - match:
+          task_class: code-edit
+        route: local-spark-coder
+        model: qwen2.5-coder:32b
+        reason: "Code edits go to the coder model on Spark; escalate only via explicit flag"
+
+      - match:
+          task_class: code-review
+        route: local-spark-coder
+        model: qwen2.5-coder:32b
+        reason: "Code review goes to coder model; escalate only via explicit flag"
+
+      - match:
+          task_class: image-generation
+        route: local-spark
+        model: qwen2.5:32b
+        reason: "Prompt composition for ComfyUI; stays local"
+
+      # -----------------------------------------------------------------------
+      # TASK CLASS — escalate to Claude (complex / novel / multi-file)
+      # -----------------------------------------------------------------------
+
+      - match:
+          task_class: architecture
+        route: claude
+        model: claude-sonnet-4-6
+        reason: "Architecture decisions need Claude-level reasoning; local models insufficient"
+
+      - match:
+          task_class: research
+        route: claude
+        model: claude-sonnet-4-6
+        reason: "Open-ended research benefits from Claude's broad knowledge and tool use"
+
+      # -----------------------------------------------------------------------
+      # CONTEXT SIZE — escalate when context exceeds local model windows
+      # -----------------------------------------------------------------------
+
+      # qwen2.5:7b context window is 128k tokens, but quality degrades
+      # significantly above ~32k. Spark 32b handles up to ~64k reliably.
+      # Above 50k tokens, escalate to Claude (200k+ context window).
+      - match:
+          context_tokens:
+            gt: 50000
+        route: claude
+        model: claude-sonnet-4-6
+        reason: "Context exceeds reliable local model window (50k token threshold)"
+
+      # -----------------------------------------------------------------------
+      # DEGRADED MODE — both local paths down, escalation allowed
+      # -----------------------------------------------------------------------
+
+      # When both Ollama endpoints are unhealthy AND escalation is not forbidden
+      # by the data tier, allow Claude to take over. This mirrors the
+      # degraded_mode_escalation_enabled setting in llm.py and makes the
+      # policy explicit rather than a buried env-var behavior.
+      - match:
+          spark_healthy: false
+          p40_healthy: false
+          data_tier: public
+        route: claude
+        model: claude-sonnet-4-6
+        reason: "Both local inference paths down; degraded-mode escalation to Claude"
+
+      - match:
+          spark_healthy: false
+          p40_healthy: false
+          data_tier: internal
+        route: claude
+        model: claude-sonnet-4-6
+        reason: "Both local inference paths down; degraded-mode escalation to Claude"
+
+      # Degraded mode with restricted data: surface error, do not escalate.
+      - match:
+          spark_healthy: false
+          p40_healthy: false
+          data_tier: restricted
+        route: local-only
+        model: qwen2.5:7b
+        reason: "Local paths down but data tier is restricted — reject rather than escalate"
+
+      # -----------------------------------------------------------------------
+      # AGENT-SPECIFIC OVERRIDES — matches AGENT_GROUP in llm.py
+      # -----------------------------------------------------------------------
+
+      - match:
+          agent_id: triager
+        route: local-p40
+        model: qwen2.5:7b
+        reason: "Triager is a mechanical routing step; 7b sufficient"
+
+      - match:
+          agent_id: note-maker
+        route: local-p40
+        model: qwen2.5:7b
+        reason: "Note-maker produces short structured output; 7b sufficient"
+
+      - match:
+          agent_id: errand-runner
+        route: local-p40
+        model: qwen2.5:7b
+        reason: "Errand-runner executes approved actions; mechanical work suits 7b"
+
+      - match:
+          agent_id: property-coordinator
+        route: local-p40
+        model: qwen2.5:7b
+        reason: "Property coordination tasks are structured; 7b sufficient"
+
+      - match:
+          agent_id: doc-writer
+        route: local-p40
+        model: qwen2.5:7b
+        reason: "Doc-writer (aspirational); 7b placeholder until capacity is known"
+
+      - match:
+          agent_id: historian
+        route: local-spark
+        model: qwen2.5:32b
+        reason: "Historian produces vault summaries; 32b for quality prose"
+
+      - match:
+          agent_id: researcher
+        route: local-spark
+        model: qwen2.5:32b
+        reason: "Researcher needs structured-output reasoning depth"
+
+      - match:
+          agent_id: supervisor
+        route: local-spark
+        model: qwen2.5:32b
+        reason: "Supervisor orchestrates sub-agents; needs 32b reasoning"
+
+      - match:
+          agent_id: reporter
+        route: local-spark
+        model: qwen2.5:32b
+        reason: "Reporter formats rich-text DMs; 32b for link-formatting precision"
+
+      - match:
+          agent_id: homelab-engineer
+        route: local-spark
+        model: qwen2.5:32b
+        reason: "Homelab-engineer handles complex cluster analysis"
+
+      - match:
+          agent_id: network-operator
+        route: local-spark
+        model: qwen2.5:32b
+        reason: "Network analysis needs structured reasoning depth"
+
+      - match:
+          agent_id: storage-operator
+        route: local-spark
+        model: qwen2.5:32b
+        reason: "Storage analysis needs structured reasoning depth"
+
+      - match:
+          agent_id: smart-home-operator
+        route: local-spark
+        model: qwen2.5:32b
+        reason: "HA/Frigate operations need reasoning depth"
+
+      - match:
+          agent_id: ml-operator
+        route: local-spark
+        model: qwen2.5:32b
+        reason: "ML tuning decisions need 32b reasoning"
+
+      - match:
+          agent_id: observability-operator
+        route: local-spark
+        model: qwen2.5:32b
+        reason: "Observability analysis needs structured reasoning"
+
+      - match:
+          agent_id: security
+        route: local-spark
+        model: qwen2.5:32b
+        reason: "Security analysis needs nuance in observation vs inference"
+
+      - match:
+          agent_id: auditor
+        route: local-spark
+        model: qwen2.5:32b
+        reason: "Auditor needs precision citing CVEs and scoring exposure"
+
+      - match:
+          agent_id: artist
+        route: local-spark
+        model: qwen2.5:32b
+        reason: "Prompt composition benefits from Spark's prompt-engineering perf"
+
+      - match:
+          agent_id: coder
+        route: local-spark-coder
+        model: qwen2.5-coder:32b
+        reason: "Coder uses dedicated coder model on Spark"
+
+      - match:
+          agent_id: reviewer
+        route: local-spark-coder
+        model: qwen2.5-coder:32b
+        reason: "Reviewer uses dedicated coder model on Spark"
+
+    # -----------------------------------------------------------------------
+    # COST / SPEND GUARDRAILS
+    # These are declared here for documentation; enforcement is in settings.py.
+    # Changing these values here does NOT change runtime behavior until the
+    # router code reads them from this ConfigMap (Stage 3 execution work).
+    # -----------------------------------------------------------------------
+    guardrails:
+      cost_cap_per_task_usd: 5.0
+      cost_cap_per_agent_daily_usd: 10.0
+      cost_cap_global_daily_usd: 30.0
+      escalation_rate_warn_pct: 20
+      escalation_spend_warn_usd_per_day: 10.0


### PR DESCRIPTION
## Summary

- Adds `kubernetes/apps/ai/langgraph-agents/routing-policy.yaml` — a ConfigMap containing the explicit local-vs-Claude routing ruleset for the HomeAIOps pipeline (Stage 3 requirement from `goal.md`).
- Adds `docs/src/routing_policy.md` — operator runbook explaining the policy structure, current rules, how to change them, how to verify routing decisions, and a fallback runbook for "local infra is down."
- Adds `routing_policy.md` to the mkdocs nav under **AI & Workflow**.

## This is a draft/doc PR only

The langgraph-agents runtime does **not** yet read this ConfigMap. Routing decisions are still made by the hardcoded `AGENT_GROUP` dict and `llm()` factory in `src/agents/llm.py`. Wiring the ConfigMap into the runtime is Stage 3 execution work, gated on Gate 2 (dogfooding sign-off).

This PR establishes the declarative intent — the target routing behavior the code will be written to enforce.

## Rules defined

**Hard pins (local-only, no escalation ever):**
- `health-tracker` — privacy hard-pin; health data never leaves the cluster
- `data_tier: restricted` — HOMELAB-SPEC Layer 2 #1 + Layer 5

**Always-local task classes:** summarization, classification, log-triage, doc-drift, note-taking, alert-triage, code-edit, code-review, image-generation

**Always-Claude task classes:** architecture, research

**Context size threshold:** >50k tokens → claude-sonnet-4-6 (Spark 32b quality degrades above ~64k; 50k is a conservative gate)

**Degraded mode:** both Ollama endpoints down + public/internal tier → claude-sonnet-4-6; restricted tier → fail rather than escalate

**Agent-specific overrides:** every agent in `AGENT_GROUP` has a matching rule making the agent→model assignment greppable without reading Python source

**Guardrails declared** (not yet enforced by policy; runtime enforcement still in `settings.py`): $5/task, $10/agent/day, $30/global/day; 20% escalation rate warning, $10/day spend warning

## Test plan

- [ ] CI lint passes (yamllint + markdownlint)
- [ ] Verify `routing_policy.md` renders correctly in the mkdocs preview
- [ ] Confirm no restricted-tier patterns appear in the new files

🤖 Generated with [Claude Code](https://claude.com/claude-code)