### PR TITLE
feat(grafana): add Claude tokens/cost-by-model panels to langgraph-agents dashboard

### DIFF
--- a/kubernetes/apps/observability/grafana/dashboards/langgraph-agents.json
+++ b/kubernetes/apps/observability/grafana/dashboards/langgraph-agents.json
@@ -606,6 +606,137 @@
       ],
       "title": "Task trail viewer (set $task_id)",
       "type": "logs"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Token volume consumed per Claude model family over the selected time range. Breaks down Opus/Sonnet/Haiku so routing changes are visible as proportion shifts. Uses group=\"claude\" filter — local Ollama calls (zero-cost) are excluded.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "tokens",
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 50
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "calcs": [
+            "sum"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "sum by (model, direction) (increase(langgraph_tokens_total{group=\"claude\",agent=~\"$agent\"}[$__range]))",
+          "legendFormat": "{{model}} {{direction}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Claude tokens by model (selected range)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "USD cost per Claude model per day. Driven by langgraph_cost_usd_total — populated since v0.2.52 which added Anthropic pricing to the metrics callback. Use this to verify that opusplan→sonnet routing changes reduce spend.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "USD/day",
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 5
+              },
+              {
+                "color": "red",
+                "value": 20
+              }
+            ]
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 50
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "calcs": [
+            "sum"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "sum by (model) (increase(langgraph_cost_usd_total{group=\"claude\",agent=~\"$agent\"}[1d]))",
+          "legendFormat": "{{model}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Claude cost by model (USD/day)",
+      "type": "timeseries"
     }
   ],
   "refresh": "30s",
@@ -720,6 +851,6 @@
   "timezone": "America/New_York",
   "title": "LangGraph Agents",
   "uid": "langgraph-agents",
-  "version": 2,
+  "version": 3,
   "weekStart": ""
 }


### PR DESCRIPTION
## Summary

- Adds two panels to the existing langgraph-agents Grafana dashboard (version 2 → 3):
  - **Claude tokens by model (selected range)** — `increase(langgraph_tokens_total{group="claude"}[$__range])` grouped by `model` and `direction`, showing Opus/Sonnet/Haiku volume proportions
  - **Claude cost by model (USD/day)** — `increase(langgraph_cost_usd_total{group="claude"}[1d])` grouped by `model`, showing daily dollar spend per model family

## Dependency

Requires [langgraph-agents PR #96](https://github.com/rwlove/langgraph-agents/pull/96) to be deployed first. That PR populates `langgraph_cost_usd_total` with real values — before it, cost_usd was always 0.0 in the callback, so the cost panel would show a flat zero line.

The tokens panel is useful immediately (token counts were always emitted correctly via `langgraph_tokens_total`).

## Why

Tier 1 of the model-optimization roadmap (`project_todo_anthropic_cost_telemetry`). Without this, routing changes (opusplan → sonnet for execution, haiku for mechanical ops) have no feedback loop — there's no panel to verify that Opus usage dropped after a routing change lands.

## Test plan

- [ ] langgraph-agents PR #96 deployed (v0.2.52+)
- [ ] Grafana dashboard reloads from main (happens automatically via `url:` reference in helmrelease)
- [ ] "Claude cost by model" panel shows non-zero values when Claude is invoked
- [ ] "Claude tokens by model" panel shows token volume split by model

🤖 Generated with [Claude Code](https://claude.com/claude-code)