### PR TITLE
fix(mcp): correct comfyui-mcp image tag to v0.5.0

### DIFF
--- a/kubernetes/apps/mcp-system/comfyui-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/comfyui-mcp/app/helmrelease.yaml
@@ -28,7 +28,7 @@ spec:
               repository: ghcr.io/rwlove/comfyui-mcp
               # Pinned to the first release built from rwlove/containers
               # PR #32; Renovate manages bumps after the image lands.
-              tag: 0.5.0
+              tag: v0.5.0
             env:
               # Streamable-HTTP transport (artokun added 2026-05-21).
               # See: rwlove/containers/comfyui-mcp/README.md


### PR DESCRIPTION
## Summary

- Image tag `0.5.0` does not exist in `ghcr.io/rwlove/comfyui-mcp`; only `v0.5.0` and `latest` are published
- Pod was stuck in `ImagePullBackOff` due to the missing tag
- Single-line fix: `0.5.0` → `v0.5.0` in the HelmRelease

## Test plan

- [ ] Flux reconciles the HelmRelease without error
- [ ] comfyui-mcp pod transitions from `ImagePullBackOff` to `Running`

🤖 Generated with [Claude Code](https://claude.com/claude-code)