### PR TITLE
fix(observability): silence noisy alerts + drop BackupStale until reliable signal

### DIFF
--- a/kubernetes/apps/databases/cloudnative-pg/app/prometheusrule.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/app/prometheusrule.yaml
@@ -65,20 +65,12 @@ spec:
           for: 5m
           labels:
             severity: warning
-        - alert: BackupStale
-          annotations:
-            description: >-
-              Cluster {{ $labels.job }} in {{ $labels.namespace }} last successful
-              backup is over 10 days old. NOTE: plugin-method clusters (barman-cloud
-              plugin) do not populate this metric — they have no Prometheus-based
-              staleness signal until CNPG adds condition metrics.
-            summary: CNPG cluster has not had a successful backup in over 10 days.
-          expr: |-
-            (time() - cnpg_collector_last_available_backup_timestamp) / 86400 > 10
-              and cnpg_collector_last_available_backup_timestamp > 0
-          for: 10m
-          labels:
-            severity: warning
+        # TODO: re-introduce BackupStale once a CustomResourceStateMetrics config
+        # exposes Cluster.status.conditions[type=LastBackupSucceeded] as a metric.
+        # cnpg_collector_last_available_backup_timestamp is unreliable for plugin-method
+        # clusters — it freezes at the migration timestamp instead of advancing on each
+        # successful backup (verified 2026-05-25, all 6 "stale" clusters are actually
+        # healthy). Tracking: https://github.com/rwlove/home-ops/issues/12075
         - alert: BackupFailed
           annotations:
             description: Cluster {{ $labels.job }} in {{ $labels.namespace }} has a recent backup failure.

--- a/kubernetes/apps/home/home-assistant/app/sync-cronjob.yaml
+++ b/kubernetes/apps/home/home-assistant/app/sync-cronjob.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   schedule: "*/5 * * * *"
   successfulJobsHistoryLimit: 1
-  failedJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 0
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:

--- a/kubernetes/apps/media/lidarr-bridge/app/helmrelease.yaml
+++ b/kubernetes/apps/media/lidarr-bridge/app/helmrelease.yaml
@@ -25,7 +25,7 @@ spec:
           schedule: "*/5 * * * *"
           concurrencyPolicy: Forbid
           successfulJobsHistory: 1
-          failedJobsHistory: 3
+          failedJobsHistory: 0
           backoffLimit: 0
           activeDeadlineSeconds: 600
           ttlSecondsAfterFinished: 86400

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/prometheusrule-egress-detection.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/prometheusrule-egress-detection.yaml
@@ -132,10 +132,12 @@ spec:
         # recording rule every 5m over 7d for the avg/stddev.
         #
         # Guards (all required to fire):
-        #   - `> 1e6` floor (1 MB/s) avoids firing on apps whose
+        #   - `> 1e7` floor (10 MB/s) avoids firing on apps whose
         #     baseline rate is so low that 3σ is meaningless (idle
         #     node-red with a 100 B/s baseline would alert on a 1KB
-        #     burst otherwise).
+        #     burst otherwise). Raised from 1e6 → 1e7 on 2026-05-25:
+        #     home-assistant legitimately bursts to ~5 MB/s on mDNS/SSDP
+        #     discovery storms triggered by the 5-min config-sync reload_all.
         #   - `stddev_over_time > 0` avoids div-by-zero on pods with
         #     perfectly constant rates.
         #   - `unless absent_over_time([7d:5m])` prevents firing on
@@ -169,7 +171,7 @@ spec:
             )
             and
             (
-              namespace_pod:broad_egress_bytes:rate1h > 1e6
+              namespace_pod:broad_egress_bytes:rate1h > 1e7
             )
             and
             (


### PR DESCRIPTION
## Summary

- **BackupStale rule deleted** — `cnpg_collector_last_available_backup_timestamp` is unreliable for barman-cloud plugin-method clusters (freezes at migration timestamp, never advances). All 6 firing clusters confirmed healthy. Alert re-introduction tracked in #12075.
- **PodEgressVolumeAnomaly floor raised 1 MB/s → 10 MB/s** — home-assistant legitimately bursts to ~5 MB/s on mDNS/SSDP discovery storms every time the 5-min config-sync CronJob triggers `reload_all`. The alert is for bulk-exfil detection; 1 MB/s is below HA's normal LAN-scan egress.
- **`failedJobsHistoryLimit` 3 → 0** on home-assistant-config-sync and media stack companion bridge CronJobs — stale Failed job objects were accumulating and firing KubeJobFailed even when current runs were green (TTL clears at 24h; manual delete cleared the current backlog out-of-band).

## Standalone follow-ups (not this PR)

- #12075 — re-introduce BackupStale via CustomResourceStateMetrics + Cluster.status.conditions[type=LastBackupSucceeded]
- Zulip 2.0 chart migration (memcached SASL wiring) — crashloop caused by missing SECRETS_memcached_password + memcached.auth.* values
- immichkiosk-transcode re-tag bug — /api/albums/{id} does not return per-asset tags; re-tags all videos every 15 min
- reolink-bush probe — ~7% ICMP loss, needs physical recon (camera or AP)
- CephPGImbalance osd.2 — needs ceph balancer enable via ceph-toolbox session
- CephNodeDiskspaceWarning /mnt/frigate-media — initial fill ramp post Frigate storage migration; wait 2-3d for retention to stabilize

## Test plan

- [ ] `ALERTS{alertname="BackupStale"}` returns no results after PrometheusRule reconciles
- [ ] `ALERTS{alertname="PodEgressVolumeAnomaly"}` stops firing (HA egress ~5 MB/s is now below the 10 MB/s floor)
- [ ] `kubectl get jobs -n home` shows no lingering failed config-sync entries
- [ ] `count(ALERTS{alertstate="firing"})` drops from 21 to ~11

🤖 Generated with [Claude Code](https://claude.com/claude-code)