### PR TITLE
fix(windmill): rename zulip bot reference n8n-bot → windmill-bot

### DIFF
--- a/kubernetes/apps/home/windmill/app/externalsecret-workflows.yaml
+++ b/kubernetes/apps/home/windmill/app/externalsecret-workflows.yaml
@@ -75,7 +75,7 @@ spec:
         key: ntfy
     # ZULIP_BOT_* + ROB_ZULIP_USER_ID
     - extract:
-        key: zulip-n8n-bot
+        key: zulip-windmill-bot
     # PAPERLESS_TOKEN (field=mcp_token, prefixed to avoid colliding
     # with other items extracted above).
     - extract:

--- a/kubernetes/apps/home/windmill/workflows/README.md
+++ b/kubernetes/apps/home/windmill/workflows/README.md
@@ -26,9 +26,9 @@ or the inline curl in the README two levels up).
 | `LANGGRAPH_APPROVAL_SIGNING_KEY` | `langgraph-agents.LANGGRAPH_APPROVAL_SIGNING_KEY` |
 | `NTFY_URL` | literal template (`https://ntfy.${SECRET_DOMAIN}`) |
 | `NTFY_WRITE_TOKEN` | `ntfy.NTFY_WRITE_TOKEN` |
-| `ZULIP_BOT_EMAIL` | `zulip-n8n-bot.ZULIP_BOT_EMAIL` |
-| `ZULIP_BOT_API_KEY` | `zulip-n8n-bot.ZULIP_BOT_API_KEY` |
-| `ROB_ZULIP_USER_ID` | `zulip-n8n-bot.ROB_ZULIP_USER_ID` |
+| `ZULIP_BOT_EMAIL` | `zulip-windmill-bot.ZULIP_BOT_EMAIL` |
+| `ZULIP_BOT_API_KEY` | `zulip-windmill-bot.ZULIP_BOT_API_KEY` |
+| `ROB_ZULIP_USER_ID` | `zulip-windmill-bot.ROB_ZULIP_USER_ID` |
 | `PAPERLESS_TOKEN` | `paperless.mcp_token` (shared with paperless-mcp) |
 
 ## Approval-token signing (pre-sign at post-time)


### PR DESCRIPTION
## Summary

- Renamed 1Password item `zulip-n8n-bot` → `zulip-windmill-bot` (the Zulip bot account was created for n8n, which has been removed — Windmill is the actual consumer)
- Updated `externalsecret-workflows.yaml` to reference `zulip-windmill-bot`
- Updated workflows `README.md` to match
- Created the `#operations` Zulip stream (required by `langgraph-dlq-watcher` for DLQ alert posting)

## Test plan

- [ ] ExternalSecret re-syncs cleanly after reconcile (1P item and ES key now match)
- [ ] `windmill-workflows-secret` ZULIP fields still populated
- [ ] `langgraph-dlq-watcher` can post to `#operations` without "channel does not exist" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)