### PR TITLE
fix(observability): allow grafana-mcp ingress on grafana CNP

### DIFF
--- a/kubernetes/apps/observability/grafana/app/cnp-allow.yaml
+++ b/kubernetes/apps/observability/grafana/app/cnp-allow.yaml
@@ -26,6 +26,16 @@ spec:
         - ports:
             - port: "3000"
               protocol: TCP
+    # grafana-mcp in mcp-system queries Grafana for HolmesGPT alert
+    # root-cause analysis and operator evidence pre-pass.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: mcp-system
+            app.kubernetes.io/name: grafana-mcp
+      toPorts:
+        - ports:
+            - port: "3000"
+              protocol: TCP
   egress:
     # Postgres datasource: home_assistant DB via CNPG cluster
     # `postgres-home-assistant` in databases ns (Pattern B).


### PR DESCRIPTION
## Summary

- Adds an ingress rule to `grafana-allow` CiliumNetworkPolicy allowing `grafana-mcp` (in `mcp-system`) to reach Grafana on port 3000

## Why

`grafana-mcp` was silently blocked by the Grafana CNP — only the Envoy gateway ingress rule existed. This caused:
1. HolmesGPT alert root-cause analysis to fail (grafana-mcp queries Prometheus/Loki via Grafana for context)
2. Operator evidence pre-pass (`gather_evidence`) to timeout and crash operator nodes, sending tasks to DLQ

With this rule applied, `grafana-mcp` can reach Grafana and both paths recover.

## Test plan
- [ ] Flux reconciles `grafana-allow` CNP without error
- [ ] `kubectl exec -n mcp-system <grafana-mcp-pod> -- wget -O- http://grafana.observability:3000/api/health` returns 200
- [ ] HolmesGPT successfully queries Grafana during next alert triage
- [ ] Re-submit a smoke task to an operator and confirm `gather_evidence` returns actual data instead of empty string

🤖 Generated with [Claude Code](https://claude.com/claude-code)