### PR TITLE
feat(collab/open-webui): cutover to external TEI reranker (PR-3 of Stream 2)

### DIFF
--- a/kubernetes/apps/collab/open-webui/app/cnp-allow.yaml
+++ b/kubernetes/apps/collab/open-webui/app/cnp-allow.yaml
@@ -48,6 +48,16 @@ spec:
         - ports:
             - port: "8765"
               protocol: TCP
+    # ai/tei-spark — external reranker (RAG_RERANKING_ENGINE=external,
+    # RAG_EXTERNAL_RERANKER_URL points at tei-spark:3000/rerank).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: ai
+            app.kubernetes.io/name: tei-spark
+      toPorts:
+        - ports:
+            - port: "3000"
+              protocol: TCP
     # databases/qdrant — vector store (VECTOR_DB=qdrant, QDRANT_URI).
     - toEndpoints:
         - matchLabels:

--- a/kubernetes/apps/collab/open-webui/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/open-webui/app/helmrelease.yaml
@@ -70,13 +70,12 @@ spec:
               # (Paperless) doesn't exist yet, so this PR has no
               # in-flight re-index cost.
               RAG_EMBEDDING_MODEL: bge-m3
-              # Cross-encoder reranker — runs in-process via sentence-transformers
-              # on CPU. Adds ~2.5GiB to the pod's resident set (model weights);
-              # latency is ~hundreds of ms per batch which is fine for homelab
-              # RAG volume. v0.9.5 also supports external rerank (TEI etc.) via
-              # RAG_RERANKING_ENGINE=external + RAG_EXTERNAL_RERANKER_URL — but
-              # the P40 is Pascal (sm_61) so no prebuilt TEI image fits without
-              # a custom Pascal build. Revisit if Spark lands.
+              # Cross-encoder reranker — external mode via TEI on Spark
+              # (PR-3 of Stream 2). RAG_RERANKING_MODEL is informational;
+              # TEI loads the model server-side. In-process sentence-transformers
+              # no longer runs in this pod — memory limit dropped 6Gi → 2Gi.
+              RAG_RERANKING_ENGINE: external
+              RAG_EXTERNAL_RERANKER_URL: http://tei-spark.ai.svc.cluster.local:3000/rerank
               RAG_RERANKING_MODEL: BAAI/bge-reranker-v2-m3
               RAG_TOP_K_RERANKER: "5"
               RAG_WEB_SEARCH_ENGINE: searxng
@@ -133,7 +132,7 @@ spec:
                 cpu: 15m
                 memory: 1Gi
               limits:
-                memory: 6Gi
+                memory: 2Gi
 
     service:
       app:


### PR DESCRIPTION
## Summary

PR-3 of Stream 2. TEI is live on Spark (PRs #11886, #11893, #11898, #11906, #11908). This PR routes Open WebUI to it.

- `RAG_RERANKING_ENGINE` flipped to `external`; `RAG_EXTERNAL_RERANKER_URL` set to `http://tei-spark.ai.svc.cluster.local:3000/rerank`
- `RAG_RERANKING_MODEL: BAAI/bge-reranker-v2-m3` retained (informational — TEI loads the model server-side)
- Memory limit lowered **6Gi → 2Gi**: reclaims headroom previously reserved for the in-process `sentence-transformers` reranker weights (~2.5 GiB)
- `cnp-allow.yaml`: new egress rule `ai/tei-spark:3000 TCP` so the CiliumNetworkPolicy allows the outbound rerank calls

Scheduled for the **Tuesday 02:00 ET maintenance window** per CLAUDE.md (Renee-facing cutover).

**Rollback:** single revert. open-webui falls back to in-process reranker; tei-spark stays running as dark capacity. Zero data loss — reranking is query-time only, no index changes.

> **Note:** `kubectl kustomize` render validation was skipped — neither `kubectl` nor `kustomize` is installed in this remote execution environment. Manual YAML review confirmed structure is correct. Rob: please run step 0 below to confirm the render before merging if desired.

---

## Verification (run Tuesday morning)

```bash
# 0. Optional: confirm kustomize renders cleanly
kubectl kustomize kubernetes/apps/collab/open-webui/app

# 1. Confirm Flux reconciled the new HelmRelease
flux -n collab get helmrelease open-webui

# 2. Confirm new pod is Ready with the new memory limit
kubectl -n collab get pod -l app.kubernetes.io/name=open-webui

# 3. Confirm resident set (was ~685 Mi pre-cutover; should stay similar
#    since the reranker was lazy-loaded and rarely fired — but the lower
#    limit matters for future scheduling decisions)
kubectl top pod -n collab -l app.kubernetes.io/name=open-webui

# 4. Trigger a RAG query in Open WebUI UI against a Knowledge Base
#    and watch tei-spark logs for the incoming POST /rerank
kubectl -n ai logs deploy/tei-spark --tail=50 -f

# 5. Confirm te_request_count is incrementing in Prometheus
#    (port-forward to prom + check sum(rate(te_request_count[5m])))
```

https://claude.ai/code/session_01L1HyXjehc5KJAPgZGeR7vD

---
_Generated by [Claude Code](https://claude.ai/code/session_01L1HyXjehc5KJAPgZGeR7vD)_