### PR TITLE
fix(container): update langgraph-agents ( 0.2.55 → 0.2.58 )

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/langgraph-agents
-              tag: 0.2.57@sha256:4de2338c8856989678e6d89f27ba0b8a305df429638d269865c4a1a096d4f552
+              tag: 0.2.58@sha256:cf547d40a11a2d938916025394f3c811015e23342e47b5fcc7abfabdaa8bd83b
 
             env:
               # --- vault ---


### PR DESCRIPTION
## Summary

- Fixes Langfuse trace ID regression: ULID task IDs were passed raw as 32-char hex trace IDs, causing `ValueError` on every LLM call and dropping all traces since v0.2.57
- Fixes Grafana datasource UID mismatch: `gather_evidence` was guessing UID `prometheus` (display name); now injects the correct opaque UIDs (`PBFA97CFB590B2093` for Prometheus, `P8E80F9AEF21F6940` for Loki) into the system prompt via `settings.py` env-overridable fields

lga PR: rwlove/langgraph-agents#100

## Test plan

- [ ] Flux reconciles langgraph-agents to v0.2.58
- [ ] Submit a task; confirm Langfuse trace appears in the UI
- [ ] Submit an observability task; confirm `gather_evidence` does not log `evidence_gather_failed` with "datasource not found"

🤖 Generated with [Claude Code](https://claude.com/claude-code)