### PR TITLE
feat(agents): claude-config-lint + data-classification-audit skills, worktree tools, GitOps prime directive

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -40,6 +40,7 @@ skills can discover them.
 | `add-cnpg-cluster.md` | Scaffold a CNPG postgres cluster with Garage-backed barman backups. |
 | `add-mcp-server.md` | Scaffold an MCP server under `mcp-system/` with the sidecar `MCPServerRegistration`. |
 | `claude-config-lint.md` | Audit Claude config health — @-import targets, symlinks, frontmatter, MEMORY.md budget. |
+| `data-classification-audit.md` | Grep a PR diff + description for restricted lexicon (arr stack, stash, credentials, internal hostnames). |
 | `dependency-mapper.md` | Build and validate the Flux Kustomization dependency graph. |
 | `expose-app.md` | Attach an HTTPRoute to a per-app Gateway listener with shim-managed TLS. |
 | `flux-suspend.md` | Document the suspend / unsuspend workflow and the `disable-<app>` commit pattern. |

--- a/.agents/README.md
+++ b/.agents/README.md
@@ -39,6 +39,7 @@ skills can discover them.
 | `add-app.md` | Scaffold a generic app-template HelmRelease application. |
 | `add-cnpg-cluster.md` | Scaffold a CNPG postgres cluster with Garage-backed barman backups. |
 | `add-mcp-server.md` | Scaffold an MCP server under `mcp-system/` with the sidecar `MCPServerRegistration`. |
+| `claude-config-lint.md` | Audit Claude config health — @-import targets, symlinks, frontmatter, MEMORY.md budget. |
 | `dependency-mapper.md` | Build and validate the Flux Kustomization dependency graph. |
 | `expose-app.md` | Attach an HTTPRoute to a per-app Gateway listener with shim-managed TLS. |
 | `flux-suspend.md` | Document the suspend / unsuspend workflow and the `disable-<app>` commit pattern. |

--- a/.agents/README.md
+++ b/.agents/README.md
@@ -40,7 +40,7 @@ skills can discover them.
 | `add-cnpg-cluster.md` | Scaffold a CNPG postgres cluster with Garage-backed barman backups. |
 | `add-mcp-server.md` | Scaffold an MCP server under `mcp-system/` with the sidecar `MCPServerRegistration`. |
 | `claude-config-lint.md` | Audit Claude config health — @-import targets, symlinks, frontmatter, MEMORY.md budget. |
-| `data-classification-audit.md` | Grep a PR diff + description for restricted lexicon (arr stack, stash, credentials, internal hostnames). |
+| `data-classification-audit.md` | Grep a PR diff + description for restricted-tier names, credentials, and internal hostnames per data-classification.md. |
 | `dependency-mapper.md` | Build and validate the Flux Kustomization dependency graph. |
 | `expose-app.md` | Attach an HTTPRoute to a per-app Gateway listener with shim-managed TLS. |
 | `flux-suspend.md` | Document the suspend / unsuspend workflow and the `disable-<app>` commit pattern. |

--- a/.agents/instructions/persona.md
+++ b/.agents/instructions/persona.md
@@ -52,7 +52,22 @@ Practical consequences:
   on the same point; don't refuse outright on judgment calls; don't
   silently comply when there's contrary evidence.
 
-## Tone / voice
+## Prime directive
+
+**You cannot break GitOps.**
+
+Concretely: no direct `kubectl apply` / `kubectl delete` that bypasses
+Flux reconciliation, no manual `flux resume` on a suspended app without
+explicit instruction, no merges that fail CI. This formalizes the
+stability bias below — GitOps is the source of truth, and changes that
+work around it create drift that is hard to trace and harder to roll
+back.
+
+This is not an outright refusal surface — it's a propose-then-execute
+gate. If a direct cluster write is genuinely necessary (emergency, no
+Git path), surface the gap and get explicit sign-off before acting.
+
+## Pushback discipline
 
 (Inherits global terse defaults from the system prompt — this section
 is the home-ops overlay.)

--- a/.agents/skills/claude-config-lint.md
+++ b/.agents/skills/claude-config-lint.md
@@ -1,0 +1,125 @@
+---
+name: claude-config-lint
+description: Audit Claude config health — verify @-import targets exist, symlinks are intact, skill frontmatter is complete, and MEMORY.md is within its load budget.
+last_verified: 2026-05-25
+---
+
+# Claude config lint
+
+One-shot audit of the Claude configuration surface. Run before making
+changes to CLAUDE.md, operators, or instructions files to establish a
+baseline, and again after to confirm nothing broke.
+
+## When to use
+
+- Before and after modifying any `.claude.md`, `.agents/instructions/`,
+  `.agents/skills/`, or `~/.claude-personal/agents/` files.
+- When a session seems to be missing context (instructions not firing,
+  operator behavior unexpected).
+- Weekly, as part of upstream-watcher hygiene.
+
+## Checks
+
+Run each check block in order. Failures are printed; silence = pass.
+
+### 1. Symlink integrity
+
+```bash
+# Global CLAUDE.md symlinks
+ls -la ~/.claude-personal/CLAUDE.md ~/.claude-personal/HOMELAB-SPEC.md ~/.claude-personal/memory
+
+# Vault backing exists
+test -f ~/vaults/claude/user/CLAUDE.md && echo "vault CLAUDE.md OK" || echo "FAIL: vault CLAUDE.md missing"
+test -f ~/vaults/claude/user/HOMELAB-SPEC.md && echo "vault HOMELAB-SPEC.md OK" || echo "FAIL: vault HOMELAB-SPEC.md missing"
+```
+
+### 2. `@`-import targets in CLAUDE.md files
+
+```bash
+# For each CLAUDE.md in the workspace, verify every @-import resolves
+for claude_md in \
+    ~/.claude-personal/CLAUDE.md \
+    ~/workspace/claude-workspace/home-ops/CLAUDE.md \
+    ~/workspace/claude-workspace/home-assistant-config/CLAUDE.md \
+    ~/workspace/claude-workspace/langgraph-agents/CLAUDE.md; do
+  [ -f "$claude_md" ] || continue
+  dir=$(dirname "$claude_md")
+  # Resolve symlinks for the dir
+  real_dir=$(readlink -f "$dir")
+  echo "=== $claude_md ==="
+  grep -E '^@' "$claude_md" | while read -r import_line; do
+    target="${import_line#@}"
+    # Expand relative path
+    full="$real_dir/$target"
+    [ -f "$full" ] || echo "  MISSING: $target"
+  done
+done
+```
+
+### 3. Skill frontmatter completeness
+
+```bash
+# Every skill in home-ops .agents/skills/ must have name: and description:
+for f in ~/workspace/claude-workspace/home-ops/.agents/skills/*.md; do
+  name=$(grep -m1 '^name:' "$f")
+  desc=$(grep -m1 '^description:' "$f")
+  [ -z "$name" ] && echo "MISSING name: in $f"
+  [ -z "$desc" ] && echo "MISSING description: in $f"
+done
+```
+
+### 4. Operator persona frontmatter
+
+```bash
+# Every operator must have name:, model:, description:, tools:
+for f in ~/.claude-personal/agents/*.md; do
+  [[ "$f" == */_shared/* ]] && continue
+  for field in name model description tools; do
+    grep -q "^$field:" "$f" || echo "MISSING $field: in $f"
+  done
+done
+```
+
+### 5. MEMORY.md load budget
+
+```bash
+MEM=~/.claude-personal/projects/-home-rwlove-workspace-claude-workspace-home-ops/memory/MEMORY.md
+lines=$(wc -l < "$MEM")
+maxlen=$(awk 'length > max {max=length} END {print max}' "$MEM")
+long=$(awk 'length > 150' "$MEM" | wc -l)
+echo "MEMORY.md: $lines lines (budget: 200) | max line: $maxlen chars | over-150: $long"
+[ "$lines" -gt 200 ] && echo "WARN: MEMORY.md exceeds 200-line load budget"
+[ "$long" -gt 10 ] && echo "WARN: $long entries exceed 150-char line length"
+```
+
+### 6. Shared MCP reference exists
+
+```bash
+test -f ~/.claude-personal/agents/_shared/mcp-tool-loading.md \
+  && echo "shared mcp-tool-loading.md OK" \
+  || echo "FAIL: ~/.claude-personal/agents/_shared/mcp-tool-loading.md missing"
+
+# Verify all operators reference it (not the old inline pattern)
+for f in ~/.claude-personal/agents/*.md; do
+  [[ "$f" == */_shared/* ]] && continue
+  grep -q "mcp-tool-loading.md\|reference_lovenet_gateway_mcp_tool_prefixes" "$f" \
+    || echo "WARN: $f has no MCP loading reference"
+done
+```
+
+## Interpreting results
+
+| Output | Meaning | Fix |
+|---|---|---|
+| `MISSING: <path>` | `@`-import target doesn't exist | Restore the file or remove the import |
+| `MISSING name: in <file>` | Frontmatter incomplete | Add the missing frontmatter field |
+| `WARN: MEMORY.md exceeds 200-line` | Index too long; older entries invisible | Archive overflow to `MEMORY-archive-*.md` |
+| `WARN: N entries exceed 150-char` | Entries too verbose for clean scanning | Trim descriptions to one-line hooks |
+| `WARN: <file> has no MCP loading reference` | Operator still has inline MCP prose | Replace with pointer to `_shared/mcp-tool-loading.md` |
+
+## What this is NOT
+
+- Not a runtime test — it doesn't invoke any tool or verify MCP
+  connectivity. It only checks the config files on disk.
+- Not a substitute for reading the files — it catches structural gaps,
+  not semantic ones (e.g. stale content in an operator).

--- a/.agents/skills/data-classification-audit.md
+++ b/.agents/skills/data-classification-audit.md
@@ -1,0 +1,88 @@
+---
+name: data-classification-audit
+description: Audit a PR diff and description for data-classification violations — restricted lexicon (arr stack, stash, secrets, hostnames), and ensure no restricted content reaches external surfaces.
+last_verified: 2026-05-25
+---
+
+# Data classification audit
+
+One-shot check that a PR diff + description is safe to publish per
+`.agents/instructions/data-classification.md` and HOMELAB-SPEC Layer 5.
+Run as the final step in pre-submit (checklist item #7) before pushing.
+
+## When to use
+
+- Before opening any PR that touches `kubernetes/apps/media/`,
+  `kubernetes/apps/security/`, docs, READMEs, or memory entries.
+- Whenever the PR description mentions app names, hostnames, or
+  integration names that might fall under restricted patterns.
+- As a pre-push sanity check on any PR with an external-facing
+  artifact (docs site, README, mdBook chapter).
+
+## Check 1 — Restricted lexicon in diff
+
+```bash
+# Run from repo root against the PR diff vs main.
+# Fails if any restricted term appears in changed lines of docs/,
+# README files, or .agents/ (but not kubernetes/apps/ — app names in
+# manifests are fine; they're not external artifacts).
+git diff origin/main...HEAD -- 'docs/' 'README*' '.agents/' \
+  | grep '^+' \
+  | grep -iE '\b(radarr|sonarr|lidarr|readarr|prowlarr|bazarr|jackett|nzbget|stash)\b' \
+  && echo "FAIL: restricted app name in external artifact" \
+  || echo "OK: no restricted lexicon in external-artifact diff"
+```
+
+## Check 2 — Restricted lexicon in PR description
+
+If the PR description has been drafted, grep it:
+
+```bash
+# Paste the PR body into /tmp/pr-body.txt first.
+grep -iE '\b(radarr|sonarr|lidarr|readarr|prowlarr|bazarr|jackett|nzbget|stash)\b' \
+  /tmp/pr-body.txt \
+  && echo "FAIL: restricted app name in PR description" \
+  || echo "OK: PR description clean"
+```
+
+## Check 3 — Hostnames and internal IPs in external artifacts
+
+```bash
+git diff origin/main...HEAD -- 'docs/' 'README*' \
+  | grep '^+' \
+  | grep -E '([0-9]{1,3}\.){3}[0-9]{1,3}|\.local\b|\.internal\b|brain\b|beast\b|worker[0-9]' \
+  && echo "WARN: possible internal hostname/IP in external artifact — review manually" \
+  || echo "OK: no obvious internal hostnames in external artifact diff"
+```
+
+## Check 4 — Secrets in diff
+
+```bash
+# gitleaks covers this at commit time, but a belt-and-suspenders check
+# before push is worthwhile for ExternalSecret resolved values that
+# might have been accidentally inlined.
+git diff origin/main...HEAD \
+  | grep '^+' \
+  | grep -iE '(password|secret|token|apikey|api_key)\s*[:=]\s*["\047]?[A-Za-z0-9+/]{16,}' \
+  && echo "FAIL: possible credential in diff — review immediately" \
+  || echo "OK: no obvious credentials in diff"
+```
+
+## Interpreting results
+
+| Output | Action |
+|---|---|
+| `FAIL: restricted app name in external artifact` | Remove or replace with "the media stack" / "the download stack" |
+| `FAIL: restricted app name in PR description` | Rewrite using category names only |
+| `WARN: possible internal hostname` | Review — role descriptions (`the gateway`, `the storage node`) are fine; raw names and IPs are not |
+| `FAIL: possible credential in diff` | Stop. Do not push. Find and remove the credential. |
+
+## What this is NOT
+
+- Not a substitute for `gitleaks` / `detect-secrets` pre-commit hooks — those catch
+  credentials at commit time; this catches classification at publish time.
+- Not exhaustive — it checks the known restricted lexicon. New restricted
+  terms should be added to the grep patterns here and in
+  `.agents/instructions/data-classification.md`.
+- Not a code-content filter — app names inside `kubernetes/apps/` YAML
+  are intentionally excluded (they're not external artifacts).

--- a/.agents/skills/pre-submit.md
+++ b/.agents/skills/pre-submit.md
@@ -42,9 +42,11 @@ independent agent).
    `~/.claude-personal/projects/-home-rwlove-workspace-claude-workspace-home-ops/memory/`
    for any prior decisions that contradict the change. Cross-namespace
    grep too (per global `CLAUDE.md` "Cross-namespace memory").
-7. **Data classification** — review the diff and PR description per
-   `.agents/instructions/data-classification.md`. Refuse to emit
-   restricted content to external surfaces.
+7. **Data classification** — run the four grep checks in
+   `.agents/skills/data-classification-audit.md` against the diff and
+   PR description. Fail on any `FAIL:` output; review any `WARN:`
+   before proceeding. Refuse to emit restricted content to external
+   surfaces.
 
 ## Why
 

--- a/.github/workflows/data-classification-scrub.yaml
+++ b/.github/workflows/data-classification-scrub.yaml
@@ -11,6 +11,8 @@ name: "Docs: Data Classification Scrub"
 #  - `.agents/instructions/data-classification.md` — defines the
 #    convention by naming the categories.
 #  - `.agents/skills/historian.md` — cites the convention by name.
+#  - `.agents/skills/data-classification-audit.md` — implements the
+#    audit skill; contains the restricted names as grep patterns.
 #  - `docs/src/audit/**` — historical audit artifacts, frozen
 #    (replaced going forward by the convention).
 
@@ -51,6 +53,7 @@ jobs:
           if git grep -nEi "${PATTERN}" -- '*.md' \
               ':!.agents/instructions/data-classification.md' \
               ':!.agents/skills/historian.md' \
+              ':!.agents/skills/data-classification-audit.md' \
               ':!docs/src/audit/**'; then
             echo
             echo "❌ Restricted-tier names found in narrative artifacts."

--- a/docs/src/homeaiops_dod.md
+++ b/docs/src/homeaiops_dod.md
@@ -52,6 +52,66 @@ These closed in the same session before signoff:
 **Proceeding to Stage 2 capability gap analysis** per `goal.md`
 ("Show me the gap analysis before you start closing it.")
 
+### Stage 2 progress log
+
+#### 2026-05-25 — gap analysis + v0.2.57/0.2.58 bug fixes
+
+Gap analysis delivered in-session (not as a doc file per user
+clarification). Two P0 bugs identified and fixed:
+
+**P0-A — Langfuse trace ID crash (v0.2.57 → v0.2.58):**
+ULID task IDs (26-char Crockford base32) were passed raw as 32-char
+lowercase hex UUIDs to `CallbackHandler`, causing `ValueError` on
+every LLM call with Langfuse wired. Fix: convert via
+`UUID(int=int(ULID.from_str(str(task_id)))).hex` before passing to
+the handler. Smoke task `01KSJ9RPRDT76Y89C7FW5JHK0M` confirmed:
+Langfuse trace `019e649c5b0dd1cde425877f0b28cc14` created (19 chars
+shorter than ULID — correct UUID hex). lga PR #100 / home-ops PR #12097.
+
+**P0-B — Grafana datasource UID mismatch (v0.2.58):**
+`gather_evidence` called grafana-mcp with UID `'prometheus'` (display
+name). Correct UIDs: `PBFA97CFB590B2093` (Prometheus) and
+`P8E80F9AEF21F6940` (Loki). Fixed by injecting correct UIDs into the
+system prompt and adding `grafana_prometheus_datasource_uid` /
+`grafana_loki_datasource_uid` to `Settings` (env-overridable). lga
+PR #100.
+
+Post-fix smoke: observability-operator task
+`01KSK6PYEMSXS6J11WSKE39MAB` executed a live Prometheus query
+(`node_cpu_seconds_total`) with correct UID and returned real cluster
+metrics. No `ValueError` in logs.
+
+#### 2026-05-26 — todo migration + dogfooding task
+
+**Todo migration:** 13 TODO items from Claude Code memory files
+migrated to `hai todo` (durable queue-backed store). CLI surface
+confirmed: `hai todo ls`, `hai todo add`, `hai todo done` all
+functional.
+
+**Dogfooding task (Gate 2 pre-check):** Task submitted via
+`hai task add` — "summarize cluster state: namespaces, pods, Flux
+reconciliation status, write to vault." observability-operator claimed
+within seconds, completed in 46 s wall time, vault file written at
+`inbox/drafts/observability-01KSK92VB612Y5QW005ENVM53R.md`.
+
+`hai cost` (last 7 days): 117 completions — source breakdown:
+`cli: 71`, `holmesgpt: 25`, `test: 10`, `scheduled: 5`, `zulip: 3`.
+Non-CLI paths (Zulip bridge + scheduled crons) are confirmed working.
+
+**Stage 2 DoD remaining gaps (as of 2026-05-26):**
+
+| DoD item | Status |
+|---|---|
+| CLI result retrieval (`hai task show`) | ✅ working |
+| Non-CLI input smoke (Zulip + scheduled) | ✅ confirmed via `hai cost` |
+| Local vs escalated split in `hai cost` | ❌ TODO in code — provenance not landed |
+| One full week of CLI-first usage | ⏳ clock running — user must confirm |
+| Fallback runbook (local infra down) | ❌ not written |
+
+Gate 2 requires: dogfooding day log posted to vault + operator
+approval. Pre-check above satisfies the log requirement; pending
+operator sign-off.
+
 ### Stage 2 early progress (2026-05-25)
 
 **v0.2.50 — MCP transport fix + auditor ReAct smoke (lga PR-T, merged 2026-05-25):**

--- a/kubernetes/apps/collab/pump/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump/app/helmrelease.yaml
@@ -97,11 +97,14 @@ spec:
         hostnames:
           - "pump-ingest.${SECRET_DOMAIN}"
         # Attached to BOTH http:80 and https:443 on the internal Gateway.
-        # The bt-scale ESPHome device (M5 Atom, 320 KB RAM) can't reliably
-        # complete the MbedTLS handshake — the firmware crashes in the
-        # HTTPS path. HTTP works fine, and the IoT VLAN is internal-only,
-        # so cleartext is acceptable here. Auth is still enforced at the
-        # app layer via WEIGHT_INGEST_KEY.
+        # NOTE: the Gateway's http listener redirects to HTTPS (301), so in
+        # practice only HTTPS is served. The bt-scale ESPHome firmware was
+        # originally HTTP-only because MbedTLS crashed on the M5 Atom (320 KB
+        # RAM / ~4 KB BLE task stack). The firmware was fixed in 2026-05-26:
+        #   - sram1_as_iram: true (+40 KB IRAM headroom)
+        #   - deferred post_weight_to_pump script (handshake runs on main loop)
+        # The device now posts to https:// without crashing. Auth enforced at
+        # the app layer via WEIGHT_INGEST_KEY.
         parentRefs:
           - name: internal
             namespace: network

--- a/tools/claude-worktree-cleanup.sh
+++ b/tools/claude-worktree-cleanup.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+# Remove a Claude Code worktree created by tools/claude-worktree.sh.
+#
+# Usage:
+#   tools/claude-worktree-cleanup.sh <task-slug> [--force]
+#
+# Without --force, refuses if:
+#   - the working tree has uncommitted changes, OR
+#   - the branch has not been merged into origin/main.
+#
+# With --force, skips both checks (use after a PR is merged or when
+# discarding an abandoned task).
+set -eu
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+WT_BASE="$HOME/workspace/claude-workspace/home-ops.worktrees"
+
+usage() {
+  printf 'Usage: %s <task-slug> [--force]\n' "$0" >&2
+  exit 1
+}
+
+[ $# -ge 1 ] || usage
+
+slug="$1"
+force=0
+if [ "${2:-}" = "--force" ]; then
+  force=1
+fi
+
+WT="$WT_BASE/$slug"
+BRANCH="claude/$slug"
+
+if [ ! -d "$WT" ]; then
+  printf 'Worktree not found: %s\n' "$WT" >&2
+  exit 1
+fi
+
+if [ "$force" -eq 0 ]; then
+  # Refuse if the working tree is dirty.
+  if ! git -C "$WT" diff --quiet HEAD 2>/dev/null; then
+    printf 'ERROR: worktree has uncommitted changes. Commit, stash, or use --force.\n' >&2
+    exit 1
+  fi
+
+  # Refuse if the branch hasn't landed in origin/main.
+  git -C "$REPO_ROOT" fetch --quiet origin main
+  branch_sha=$(git -C "$REPO_ROOT" rev-parse "$BRANCH" 2>/dev/null || true)
+  if [ -z "$branch_sha" ]; then
+    printf 'ERROR: branch %s not found locally. Use --force to remove orphaned worktree.\n' "$BRANCH" >&2
+    exit 1
+  fi
+  if ! git -C "$REPO_ROOT" merge-base --is-ancestor "$branch_sha" origin/main; then
+    printf 'ERROR: branch %s has not been merged into origin/main.\n' "$BRANCH" >&2
+    printf '       Push your PR and merge it first, or use --force to discard.\n' >&2
+    exit 1
+  fi
+fi
+
+printf 'Removing worktree %s...\n' "$WT"
+git -C "$REPO_ROOT" worktree remove "$WT" ${force:+--force} 2>/dev/null || \
+  git -C "$REPO_ROOT" worktree remove --force "$WT" 2>/dev/null || true
+
+# Delete the local branch only if it still exists.
+if git -C "$REPO_ROOT" rev-parse --verify "$BRANCH" >/dev/null 2>&1; then
+  if [ "$force" -eq 1 ]; then
+    git -C "$REPO_ROOT" branch -D "$BRANCH"
+  else
+    git -C "$REPO_ROOT" branch -d "$BRANCH"
+  fi
+  printf 'Branch %s deleted.\n' "$BRANCH"
+fi
+
+printf 'Done.\n'

--- a/tools/claude-worktree.sh
+++ b/tools/claude-worktree.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+# Bootstrap a git worktree for a concurrent Claude Code session.
+#
+# Each Claude session working on this repo should run in its own worktree
+# so that file changes in one session don't appear in another's git status.
+#
+# Usage:
+#   tools/claude-worktree.sh <task-slug>
+#
+# Creates:
+#   ~/workspace/claude-workspace/home-ops.worktrees/<task-slug>/
+#   branch: claude/<task-slug>
+#
+# Idempotent: re-running with the same slug prints the existing path and exits 0.
+#
+# After creation, start your Claude session there:
+#   cd ~/workspace/claude-workspace/home-ops.worktrees/<task-slug>
+#   claude
+#
+# When done, clean up with:
+#   tools/claude-worktree-cleanup.sh <task-slug>
+set -eu
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+WT_BASE="$HOME/workspace/claude-workspace/home-ops.worktrees"
+
+usage() {
+  printf 'Usage: %s <task-slug>\n' "$0" >&2
+  printf '  task-slug: lowercase letters, digits, hyphens (e.g. fix-storage-weekly)\n' >&2
+  exit 1
+}
+
+[ $# -eq 1 ] || usage
+
+slug="$1"
+
+# Validate: lowercase letters, digits, hyphens; must start with letter or digit.
+case "$slug" in
+  *[!a-z0-9-]*) printf 'ERROR: slug must contain only lowercase letters, digits, and hyphens\n' >&2; exit 1 ;;
+  -*)           printf 'ERROR: slug must start with a letter or digit\n' >&2; exit 1 ;;
+esac
+
+WT="$WT_BASE/$slug"
+BRANCH="claude/$slug"
+
+if [ -d "$WT" ]; then
+  current_branch=$(git -C "$WT" symbolic-ref --short HEAD 2>/dev/null || echo "(detached)")
+  printf 'Worktree already exists:\n'
+  printf '  path:   %s\n' "$WT"
+  printf '  branch: %s\n' "$current_branch"
+  exit 0
+fi
+
+mkdir -p "$WT_BASE"
+
+printf 'Fetching origin/main...\n'
+git -C "$REPO_ROOT" fetch --quiet origin main
+
+printf 'Creating worktree %s on branch %s...\n' "$WT" "$BRANCH"
+git -C "$REPO_ROOT" worktree add -b "$BRANCH" "$WT" origin/main
+
+# Symlink both hooks into the new worktree.  git worktree stores its
+# per-worktree git dir under .git/worktrees/<slug>/ in the main repo;
+# the hooks subdir lives there.
+WT_GIT="$REPO_ROOT/.git/worktrees/$slug"
+if [ -d "$WT_GIT" ]; then
+  mkdir -p "$WT_GIT/hooks"
+  ln -sf "$REPO_ROOT/tools/git-hooks/pre-commit" "$WT_GIT/hooks/pre-commit"
+  ln -sf "$REPO_ROOT/tools/git-hooks/pre-push"   "$WT_GIT/hooks/pre-push"
+  printf 'Hooks linked into worktree git dir.\n'
+else
+  printf 'NOTE: could not locate worktree git dir at %s — link hooks manually:\n' "$WT_GIT" >&2
+  printf '  ln -sf %s/tools/git-hooks/pre-commit <worktree-git-dir>/hooks/pre-commit\n' "$REPO_ROOT" >&2
+  printf '  ln -sf %s/tools/git-hooks/pre-push   <worktree-git-dir>/hooks/pre-push\n'   "$REPO_ROOT" >&2
+fi
+
+printf '\nWorktree ready:\n'
+printf '  cd %s\n' "$WT"
+printf '  branch: %s\n' "$BRANCH"

--- a/tools/git-hooks/README.md
+++ b/tools/git-hooks/README.md
@@ -1,0 +1,20 @@
+# git hooks
+
+Hooks in this directory enforce repo-level invariants at commit and push time.
+
+## Install (primary checkout)
+
+```sh
+ln -sf ../../tools/git-hooks/pre-commit .git/hooks/pre-commit
+ln -sf ../../tools/git-hooks/pre-push   .git/hooks/pre-push
+```
+
+For worktrees created by `tools/claude-worktree.sh`, both hooks are linked
+automatically.
+
+## Hooks
+
+| Hook | What it checks |
+|------|----------------|
+| `pre-commit` | Blocks commits that introduce literal credentials into staged YAML files. |
+| `pre-push` | Blocks pushes from branches behind `origin/main`; run `git rebase origin/main` to fix. |

--- a/tools/git-hooks/pre-push
+++ b/tools/git-hooks/pre-push
@@ -1,0 +1,46 @@
+#!/bin/sh
+# Block pushes from branches that are not rebased on origin/main.
+#
+# Stale branches cause CI failures on the merge commit even when the branch
+# itself passes lint locally. This hook catches that before the push lands.
+#
+# Install with:
+#   ln -sf ../../tools/git-hooks/pre-push .git/hooks/pre-push
+#
+# tools/claude-worktree.sh installs this automatically in new worktrees.
+#
+# Bypass for a single push (rare, e.g., initial branch setup):
+#   git push --no-verify
+set -eu
+
+remote="$1"
+# $2 is the remote URL — unused.
+
+# Read refs from stdin: <local-ref> <local-sha> <remote-ref> <remote-sha>
+while read -r local_ref local_sha remote_ref remote_sha; do
+  # Deletes: local_sha is all zeros — nothing to check.
+  case "$local_sha" in
+    0000000000000000000000000000000000000000) continue ;;
+  esac
+
+  # Tags: skip.
+  case "$local_ref" in
+    refs/tags/*) continue ;;
+  esac
+
+  # Pushing main itself: skip (we're not rebasing main on itself).
+  case "$local_ref" in
+    refs/heads/main) continue ;;
+  esac
+
+  # Fetch current origin/main so the check is against the live remote state.
+  git fetch --quiet "$remote" main 2>/dev/null || git fetch --quiet origin main 2>/dev/null || true
+
+  if ! git merge-base --is-ancestor origin/main "$local_sha" 2>/dev/null; then
+    printf '\n%s\n' "ERROR: branch $(git symbolic-ref --short HEAD 2>/dev/null || echo "$local_ref") is behind origin/main." >&2
+    printf '%s\n'   "       Run: git rebase origin/main" >&2
+    printf '%s\n'   "       Then retry the push." >&2
+    printf '%s\n'   "       Bypass (rare): git push --no-verify" >&2
+    exit 1
+  fi
+done


### PR DESCRIPTION
## Summary

- `.agents/skills/claude-config-lint.md` — one-shot skill that audits the full Claude config surface: `@`-import targets, symlink integrity, skill/operator frontmatter, MEMORY.md load budget, shared MCP reference presence
- `.agents/skills/data-classification-audit.md` — four grep checks (restricted lexicon, PR description, internal hostnames, credentials in diff); wired into `pre-submit.md` checklist item #7
- `tools/claude-worktree.sh` + `tools/claude-worktree-cleanup.sh` — create/destroy isolated git worktrees for concurrent Claude sessions; prevents cross-session `git status` bleed
- `tools/git-hooks/pre-push` + `tools/git-hooks/README.md` — hook that blocks pushes from branches behind `origin/main`
- `.agents/instructions/persona.md` — "You cannot break GitOps" prime directive formalizing the existing stability bias as an inviolable rule; "Pushback discipline" section rename
- `kubernetes/apps/collab/pump/app/helmrelease.yaml` — update stale comment: bt-scale ESPHome firmware now handles MbedTLS (sram1_as_iram + deferred post), HTTPS works

These were committed on `fix/zulip-2.0-memcached-auth` 2026-05-25 but that branch was never PRed for this content (the branch name was reused for an unrelated fix). Cherry-picked onto a clean branch off current main.

## Test plan

- [ ] Pre-commit passes on all 4 commits (confirmed locally)
- [ ] `tools/claude-worktree.sh` is executable (mode 755 in tree)
- [ ] `tools/git-hooks/pre-push` is executable (mode 755 in tree)
- [ ] `.agents/README.md` skills table updated with both new skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)