### PR TITLE
fix(ci): allowlist quay.io/prometheus-operator/ for image-registry check

### DIFF
--- a/.github/image-registry-allowlist.txt
+++ b/.github/image-registry-allowlist.txt
@@ -17,6 +17,7 @@
 # These projects publish to a non-ghcr registry as their *primary*
 # home. Moving to ghcr would be a downgrade.
 quay.io/prometheus/                     # Prometheus project canonical
+quay.io/prometheus-operator/            # Prometheus Operator project canonical
 quay.io/cilium/                         # Cilium project canonical
 nvcr.io/nvidia/                         # NVIDIA NGC catalog
 mirror.gcr.io/                          # Google pull-through mirror


### PR DESCRIPTION
## Summary

- Adds `quay.io/prometheus-operator/` to the image registry allowlist
- kube-prometheus-stack 86.0.0 (PR #12116) surfaces `prometheus-operator:v0.91.0` as a new image from this prefix
- The check-image-registry script was only allowlisted for `quay.io/prometheus/`; the operator project is a separate org on quay.io
- prometheus-operator publishes to quay.io as its canonical home (no ghcr.io equivalent)

## Test plan

- [ ] CI image-registry-check passes on this PR
- [ ] After merge, PR #12116 CI should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)