### PR TITLE
fix(ci): allowlist docker.io/dpage/pgadmin4 for image-registry check

### DIFF
--- a/.github/image-registry-allowlist.txt
+++ b/.github/image-registry-allowlist.txt
@@ -46,6 +46,7 @@ docker.io/mekayelanik/time-mcp               # wraps yokingma stdio time-mcp; gh
 docker.io/ciuse99/suggestarr
 docker.io/cloudflare/cloudflared        # tracked by cloudflare/cloudflared#1533
 docker.io/favonia/cloudflare-ddns
+docker.io/dpage/pgadmin4                # no ghcr.io publication (verified 2026-05)
 docker.io/dxflrs/garage
 docker.io/khairul169/garage-webui
 docker.io/hjacobs/kube-ops-view         # upstream archived 2020


### PR DESCRIPTION
## Summary

- Adds `docker.io/dpage/pgadmin4` to the image registry allowlist
- pgadmin4 1.64.0 (PR #12122) surfaces this image; no ghcr.io publication exists
- Unblocks auto-merge on #12122 once this lands on main

## Test plan

- [ ] CI image-registry-check passes on this PR
- [ ] After merge, re-trigger #12122 CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)