### PR TITLE
feat(observability): Claude Code cost gates via Pushgateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ _Production-grade Kubernetes for a household._
 <br/>
 
 ![apps](https://img.shields.io/badge/apps-184-blue?style=for-the-badge)
-![helmreleases](https://img.shields.io/badge/HelmReleases-196-326CE5?style=for-the-badge&logo=helm&logoColor=white)
+![helmreleases](https://img.shields.io/badge/HelmReleases-197-326CE5?style=for-the-badge&logo=helm&logoColor=white)
 ![nodes](https://img.shields.io/badge/k8s_nodes-11-326CE5?style=for-the-badge&logo=kubernetes&logoColor=white)
 ![cnpg](https://img.shields.io/badge/Postgres_clusters-25-336791?style=for-the-badge&logo=postgresql&logoColor=white)
 ![secrets](https://img.shields.io/badge/secrets-117-0572EC?style=for-the-badge&logo=1password&logoColor=white)

--- a/kubernetes/apps/observability/exporters/kustomization.yaml
+++ b/kubernetes/apps/observability/exporters/kustomization.yaml
@@ -7,5 +7,6 @@ resources:
   - ./mqtt-exporter/ks.yaml
   - ./node-exporter/ks.yaml
   - ./omada-exporter/ks.yaml
+  - ./pushgateway/ks.yaml
   - ./smartctl-exporter/ks.yaml
   - ./snmp-exporter/ks.yaml

--- a/kubernetes/apps/observability/exporters/pushgateway/app/cnp-allow.yaml
+++ b/kubernetes/apps/observability/exporters/pushgateway/app/cnp-allow.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: pushgateway-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: pushgateway
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # Prometheus scrapes /metrics on port 9091
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: observability
+            app.kubernetes.io/name: prometheus
+      toPorts:
+        - ports:
+            - port: "9091"
+              protocol: TCP
+    # Internal gateway forwards PUT /metrics/job/… from the laptop exporter
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "9091"
+              protocol: TCP

--- a/kubernetes/apps/observability/exporters/pushgateway/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/exporters/pushgateway/app/helmrelease.yaml
@@ -1,0 +1,49 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app pushgateway
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: pushgateway
+  interval: 30m
+  values:
+    fullnameOverride: pushgateway
+
+    podAnnotations:
+      reloader.stakater.com/auto: "true"
+
+    podSecurityContext:
+      runAsNonRoot: true
+      runAsUser: 65534
+      runAsGroup: 65534
+
+    securityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop:
+          - ALL
+      seccompProfile:
+        type: RuntimeDefault
+
+    # No persistent storage — the laptop exporter re-pushes on restart.
+    # Pushgateway is purely a bridge from the laptop to Prometheus.
+    persistentVolume:
+      enabled: false
+
+    serviceMonitor:
+      enabled: true
+      namespace: observability
+      additionalLabels:
+        app: prometheus-operator
+        release: prometheus
+
+    resources:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        memory: 64Mi

--- a/kubernetes/apps/observability/exporters/pushgateway/app/httproute.yaml
+++ b/kubernetes/apps/observability/exporters/pushgateway/app/httproute.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: pushgateway
+spec:
+  hostnames: ["pushgateway.${SECRET_DOMAIN}"]
+  parentRefs:
+    - name: internal
+      namespace: network
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: pushgateway
+          namespace: observability
+          port: 9091

--- a/kubernetes/apps/observability/exporters/pushgateway/app/kustomization.yaml
+++ b/kubernetes/apps/observability/exporters/pushgateway/app/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./cnp-allow.yaml
+  - ./helmrelease.yaml
+  - ./httproute.yaml
+  - ./ocirepository.yaml
+  - ./prometheusrule.yaml

--- a/kubernetes/apps/observability/exporters/pushgateway/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/exporters/pushgateway/app/ocirepository.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/refs/heads/main/ocirepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: pushgateway
+spec:
+  interval: 10m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 2.14.0
+  insecure: true
+  url: oci://zot.kube-system.svc.cluster.local:5000/ghcr.io/prometheus-community/charts/prometheus-pushgateway

--- a/kubernetes/apps/observability/exporters/pushgateway/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/exporters/pushgateway/app/prometheusrule.yaml
@@ -1,0 +1,72 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: claude-code-cost-rules
+spec:
+  groups:
+    - name: claude-code-cost.rules
+      rules:
+        # ── Daily ───────────────────────────────────────────────────────
+        - alert: ClaudeCodeDailySoft
+          expr: claude_code_cost_usd{window="24h"} > 10
+          for: 0m
+          labels:
+            severity: warning
+            group: claude-cost
+          annotations:
+            summary: "Claude Code 24h spend at ${{ $value | printf \"%.2f\" }}"
+            description: >-
+              Claude Code cost over the last 24h is ${{ $value | printf "%.2f" }}
+              (soft limit $10). Consider switching to a lower-cost model tier.
+
+        - alert: ClaudeCodeDailyHard
+          expr: claude_code_cost_usd{window="24h"} > 20
+          for: 0m
+          labels:
+            severity: critical
+            group: claude-cost
+          annotations:
+            summary: "Claude Code daily gate: ${{ $value | printf \"%.2f\" }}"
+            description: >-
+              Claude Code cost over the last 24h is ${{ $value | printf "%.2f" }}
+              (hard limit $20). Run: claude-gate approve 2h
+
+        # ── Weekly ──────────────────────────────────────────────────────
+        - alert: ClaudeCodeWeeklySoft
+          expr: claude_code_cost_usd{window="7d"} > 20
+          for: 0m
+          labels:
+            severity: warning
+            group: claude-cost
+          annotations:
+            summary: "Claude Code 7d spend at ${{ $value | printf \"%.2f\" }}"
+            description: >-
+              Claude Code cost over the last 7 days is ${{ $value | printf "%.2f" }}
+              (soft limit $20).
+
+        - alert: ClaudeCodeWeeklyHard
+          expr: claude_code_cost_usd{window="7d"} > 30
+          for: 0m
+          labels:
+            severity: critical
+            group: claude-cost
+          annotations:
+            summary: "Claude Code weekly gate: ${{ $value | printf \"%.2f\" }}"
+            description: >-
+              Claude Code cost over the last 7 days is ${{ $value | printf "%.2f" }}
+              (hard limit $30). Run: claude-gate approve 4h
+
+        # ── Monthly ─────────────────────────────────────────────────────
+        - alert: ClaudeCodeMonthlyHard
+          expr: claude_code_cost_usd{window="30d"} > 60
+          for: 0m
+          labels:
+            severity: critical
+            group: claude-cost
+          annotations:
+            summary: "Claude Code monthly gate: ${{ $value | printf \"%.2f\" }}"
+            description: >-
+              Claude Code cost over the last 30 days is ${{ $value | printf "%.2f" }}
+              (hard limit $60). Run: claude-gate approve 24h

--- a/kubernetes/apps/observability/exporters/pushgateway/ks.yaml
+++ b/kubernetes/apps/observability/exporters/pushgateway/ks.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app pushgateway
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: observability
+  path: ./kubernetes/apps/observability/exporters/pushgateway/app
+  interval: 30m
+  timeout: 3m
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: kube-prometheus-stack
+      namespace: observability

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/alertmanagerconfig.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/alertmanagerconfig.yaml
@@ -16,12 +16,31 @@ spec:
         matchers:
           - name: alertname
             value: Watchdog
-            matchType: =
+            matchType: "="
       - receiver: "null"
         matchers:
           - name: alertname
             value: InfoInhibitor
-            matchType: =
+            matchType: "="
+      # Claude Code cost gates — bypass HolmesGPT (circular), split by severity
+      # so soft (warning) fires once/24h and hard (critical) repeats every 30m.
+      - receiver: "claude-cost-warn"
+        matchers:
+          - name: group
+            value: claude-cost
+            matchType: "="
+          - name: severity
+            value: warning
+            matchType: "="
+      - receiver: "claude-cost-hard"
+        repeatInterval: 30m
+        matchers:
+          - name: group
+            value: claude-cost
+            matchType: "="
+          - name: severity
+            value: critical
+            matchType: "="
       # Enrich critical alerts with HolmesGPT investigation via Windmill,
       # then `continue` to fall through to the existing pushover delivery
       # (immediate notification preserved; investigation arrives 1–3 min
@@ -32,22 +51,22 @@ spec:
         matchers:
           - name: severity
             value: critical
-            matchType: =
+            matchType: "="
       - receiver: pushover
         matchers:
           - name: severity
             value: critical
-            matchType: =
+            matchType: "="
   inhibitRules:
     - equal: ["alertname", "namespace"]
       sourceMatch:
         - name: severity
           value: critical
-          matchType: =
+          matchType: "="
       targetMatch:
         - name: severity
           value: warning
-          matchType: =
+          matchType: "="
   receivers:
     - name: "null"
     - name: "pushover"
@@ -80,6 +99,44 @@ spec:
           title: >-
             [{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}]
             {{ .CommonLabels.alertname }}
+          ttl: 86400s
+          token:
+            name: alertmanager-secret
+            key: pushover_api_token
+          userKey:
+            name: alertmanager-secret
+            key: pushover_api_userkey
+    - name: "claude-cost-warn"
+      pushoverConfigs:
+        - html: true
+          message: |-
+            {{- range .Alerts -}}
+              {{ .Annotations.description }}<br>
+            {{- end -}}
+          priority: "0"
+          sendResolved: true
+          sound: gamelan
+          title: >-
+            [{{ .Status | toUpper }}] {{ .CommonLabels.alertname }}
+          ttl: 86400s
+          token:
+            name: alertmanager-secret
+            key: pushover_api_token
+          userKey:
+            name: alertmanager-secret
+            key: pushover_api_userkey
+    - name: "claude-cost-hard"
+      pushoverConfigs:
+        - html: true
+          message: |-
+            {{- range .Alerts -}}
+              {{ .Annotations.description }}<br>
+            {{- end -}}
+          priority: "1"
+          sendResolved: true
+          sound: siren
+          title: >-
+            [{{ .Status | toUpper }}] {{ .CommonLabels.alertname }}
           ttl: 86400s
           token:
             name: alertmanager-secret


### PR DESCRIPTION
## Summary

- Deploys `prometheus-pushgateway` under `observability/exporters/` — bridges the laptop-side cost exporter to Prometheus
- Adds `PrometheusRule` with 5 alerts across daily/weekly/monthly windows
- Adds two new AlertManager receivers (`claude-cost-warn`, `claude-cost-hard`) that bypass HolmesGPT and use distinct Pushover sounds/priorities
- Routes claude-cost alerts before the existing critical→windmill path so cost alerts never trigger a HolmesGPT investigation

**Gates:**

| Window | Soft (warn) | Hard (critical, repeats 30m) |
|--------|-------------|------------------------------|
| Daily  | $10         | $20                          |
| Weekly | $20         | $30                          |
| Monthly | —          | $60                          |

**Laptop side (not in this PR — lives in `~/.claude-personal/scripts/`):**
- `claude-cost-exporter.py` — parses session JSONL files via SQLite cache, pushes 24h/7d/30d gauges every 15 min
- `claude-gate` — `approve [duration]` / `revoke` / `status` CLI that creates AlertManager silences
- Systemd user timer already enabled; first successful push requires Pushgateway to be deployed

## Test plan

- [ ] Flux reconciles `pushgateway` Kustomization cleanly
- [ ] `pushgateway` pod running in `observability` namespace
- [ ] `https://pushgateway.thesteamedcrab.com/metrics` reachable from laptop
- [ ] Run `systemctl --user start claude-cost-exporter.service` — confirm push succeeds
- [ ] Confirm `claude_code_cost_usd` metrics visible in Prometheus
- [ ] AlertManager config reloads without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)