### PR TITLE
feat(media): snapclient-pool via generic-device-plugin

### DIFF
--- a/.github/image-registry-allowlist.txt
+++ b/.github/image-registry-allowlist.txt
@@ -64,4 +64,5 @@ lscr.io/linuxserver/openssh-server      # linuxserver's canonical registry; ghcr
 docker.io/hertzg/rtl_433               # no ghcr.io publication; Docker Hub is primary (verified 2026-05)
 docker.io/alpine/git                    # no ghcr.io publication; Docker Hub is primary (verified 2026-05)
 docker.io/rcooler/omada_exporter        # no ghcr.io publication; Docker Hub is primary (verified 2026-05)
+docker.io/squat/generic-device-plugin   # no ghcr.io publication; Docker Hub is primary (verified 2026-05)
 docker.io/tombursch/kitchenowl          # no ghcr.io publication; Docker Hub is primary (verified 2026-05)

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ _Production-grade Kubernetes for a household._
 
 <br/>
 
-![apps](https://img.shields.io/badge/apps-184-blue?style=for-the-badge)
-![helmreleases](https://img.shields.io/badge/HelmReleases-197-326CE5?style=for-the-badge&logo=helm&logoColor=white)
+![apps](https://img.shields.io/badge/apps-186-blue?style=for-the-badge)
+![helmreleases](https://img.shields.io/badge/HelmReleases-198-326CE5?style=for-the-badge&logo=helm&logoColor=white)
 ![nodes](https://img.shields.io/badge/k8s_nodes-11-326CE5?style=for-the-badge&logo=kubernetes&logoColor=white)
 ![cnpg](https://img.shields.io/badge/Postgres_clusters-25-336791?style=for-the-badge&logo=postgresql&logoColor=white)
 ![secrets](https://img.shields.io/badge/secrets-117-0572EC?style=for-the-badge&logo=1password&logoColor=white)

--- a/kubernetes/apps/kube-system/generic-device-plugin/app/daemonset.yaml
+++ b/kubernetes/apps/kube-system/generic-device-plugin/app/daemonset.yaml
@@ -1,0 +1,69 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/daemonset-apps-v1.json
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: generic-device-plugin
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: generic-device-plugin
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: generic-device-plugin
+    spec:
+      serviceAccountName: generic-device-plugin
+      priorityClassName: system-node-critical
+      tolerations:
+        - operator: Exists
+          effect: NoExecute
+        - operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: generic-device-plugin
+          # renovate: datasource=docker depName=docker.io/squat/generic-device-plugin
+          image: docker.io/squat/generic-device-plugin:0.2.0
+          args:
+            # Each group represents one allocation of squat.ai/snd; all
+            # paths in the group bind-mount together. The plugin requires
+            # every path in a group to exist on the node, so each card's
+            # specific minor enumeration gets its own group. Add a new
+            # group when a node has a different /dev/snd layout (e.g.
+            # worker2's audio card when snapclient-deck lands).
+            #
+            # master1 — Intel HDA ALC294 (onboard analog + HDMI):
+            - --device
+            - |
+              name: snd
+              groups:
+                - paths:
+                    - path: /dev/snd/controlC0
+                    - path: /dev/snd/hwC0D0
+                    - path: /dev/snd/hwC0D2
+                    - path: /dev/snd/pcmC0D0c
+                    - path: /dev/snd/pcmC0D0p
+                    - path: /dev/snd/pcmC0D3p
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              memory: 32Mi
+          securityContext:
+            # Required: device plugin writes to kubelet's plugin socket
+            # at /var/lib/kubelet/device-plugins and probes /dev. Workload
+            # pods consuming squat.ai/snd remain unprivileged.
+            privileged: true
+          volumeMounts:
+            - name: device-plugin
+              mountPath: /var/lib/kubelet/device-plugins
+            - name: dev
+              mountPath: /dev
+      volumes:
+        - name: device-plugin
+          hostPath:
+            path: /var/lib/kubelet/device-plugins
+        - name: dev
+          hostPath:
+            path: /dev

--- a/kubernetes/apps/kube-system/generic-device-plugin/app/kustomization.yaml
+++ b/kubernetes/apps/kube-system/generic-device-plugin/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./serviceaccount.yaml
+  - ./daemonset.yaml

--- a/kubernetes/apps/kube-system/generic-device-plugin/app/serviceaccount.yaml
+++ b/kubernetes/apps/kube-system/generic-device-plugin/app/serviceaccount.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/serviceaccount-v1.json
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: generic-device-plugin

--- a/kubernetes/apps/kube-system/generic-device-plugin/ks.yaml
+++ b/kubernetes/apps/kube-system/generic-device-plugin/ks.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app generic-device-plugin
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: kube-system
+  path: ./kubernetes/apps/kube-system/generic-device-plugin/app
+  interval: 30m
+  prune: true
+  wait: false
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system

--- a/kubernetes/apps/kube-system/kustomization.yaml
+++ b/kubernetes/apps/kube-system/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - ./coredns/ks.yaml
   - ./descheduler/ks.yaml
   - ./etcd-defrag
+  - ./generic-device-plugin/ks.yaml
   - ./gpu-operator/ks.yaml
   - ./intel-device-plugin/ks.yaml
   - ./k8tz/ks.yaml

--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -44,6 +44,7 @@ resources:
   - ./recyclarr/ks.yaml
   - ./romm/ks.yaml
   - ./seerr/ks.yaml
+  - ./snapclient-pool/ks.yaml
   - ./sonarr/ks.yaml
   - ./sonarr-oauth2-proxy/ks.yaml
   - ./soularr/ks.yaml

--- a/kubernetes/apps/media/snapclient-pool/app/helmrelease.yaml
+++ b/kubernetes/apps/media/snapclient-pool/app/helmrelease.yaml
@@ -1,0 +1,90 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app snapclient-pool
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 30m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+      strategy: rollback
+  values:
+    controllers:
+      snapclient-pool:
+        pod:
+          # Pin to master1 — the ALC294 line-out (Headphone jack) is the
+          # physical path to the Fosi V3 amp serving the pool speakers.
+          nodeSelector:
+            kubernetes.io/hostname: master1.thesteamedcrab.com
+          # WAF tier — pool audio dropouts are user-visible, so evict
+          # janitorr / recyclarr / metadata syncs before us. Stays well
+          # below system-cluster-critical so we never preempt infra.
+          priorityClassName: media-cluster-critical
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1114
+            runAsGroup: 1114
+            # GID 63 = `audio` on master1; /dev/snd/* is root:audio 660.
+            supplementalGroups:
+              - 63
+
+        annotations:
+          reloader.stakater.com/auto: "true"
+
+        strategy: Recreate
+        containers:
+          app:
+            image:
+              repository: ghcr.io/rwlove/snapclient
+              tag: 0.35.0
+
+            args:
+              - -h
+              - music-assistant.media.svc.cluster.local
+              - --hostID
+              - pool
+
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+              seccompProfile:
+                type: RuntimeDefault
+
+            # No liveness/readiness probes: snapclient is PID 1 with
+            # `exec`, so any crash already exits the container and the
+            # kubelet restarts it. A process-existence probe would add
+            # nothing; a hang-detection probe would need cooperation
+            # snapclient doesn't expose.
+
+            resources:
+              # squat.ai/snd is advertised by generic-device-plugin
+              # (kube-system DaemonSet). The kubelet handles bind-mount
+              # of /dev/snd and device-cgroup whitelisting; no
+              # privileged: true required on this pod.
+              requests:
+                cpu: 10m
+                memory: 32Mi
+                squat.ai/snd: 1
+              limits:
+                memory: 64Mi
+                squat.ai/snd: 1
+
+    persistence:
+      # readOnlyRootFilesystem: true means / is locked. Give snapclient
+      # and any ALSA libs scratch space they may expect to write.
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/media/snapclient-pool/app/kustomization.yaml
+++ b/kubernetes/apps/media/snapclient-pool/app/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../components/repos/app-template
+resources:
+  - ./helmrelease.yaml
+commonLabels:
+  app.kubernetes.io/instance: snapclient-pool
+  app.kubernetes.io/name: snapclient-pool

--- a/kubernetes/apps/media/snapclient-pool/ks.yaml
+++ b/kubernetes/apps/media/snapclient-pool/ks.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app snapclient-pool
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: media
+  path: ./kubernetes/apps/media/snapclient-pool/app
+  interval: 30m
+  prune: true
+  wait: false
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: generic-device-plugin
+      namespace: kube-system


### PR DESCRIPTION
## Summary
- New `generic-device-plugin` DaemonSet in `kube-system` (squat/generic-device-plugin v0.2.0) advertising `squat.ai/snd` for master1's ALC294 device files
- New `snapclient-pool` HelmRelease in `media` consuming the resource — replaces the legacy podman-managed snapclient on master1, plays snapserver → Fosi V3 amp → pool speakers
- Identity: `--hostID pool` (abstract, decoupled from master1's MAC, survives hardware refresh)
- Image registry allowlist: added `docker.io/squat/generic-device-plugin` (no ghcr.io publication)

## Why
The old podman snapclient on master1 ran `docker.io/saiyato/snapclient:amd64` (unmaintained since 2023) with no GitOps record. This brings the pool audio path into the cluster, pinned to a maintained image (`ghcr.io/rwlove/snapclient:0.35.0` from rwlove/containers#36), with a clean reset story when master1 is reinstalled.

The device-plugin route avoids `privileged: true` on the snapclient pod — only the plugin DaemonSet runs privileged (as all device plugins must).

## Dependency
Image must exist in GHCR before merging — blocks on rwlove/containers#36 building and tagging `snapclient-v0.35.0`, and the GHCR package being flipped to public.

## Cutover (post-merge)
1. Verify plugin advertises the resource: `kubectl get node master1.thesteamedcrab.com -o jsonpath='{.status.allocatable}' | jq '."squat.ai/snd"'`
2. On master1: `systemctl stop container-snapclient.service` (leave enabled as rollback)
3. Wait for `snapclient-pool` pod Running
4. In MA: re-pair the new "pool" client to the Pool group; delete the orphaned MAC-keyed client
5. In HA: verify `media_player.pool` entity still maps correctly
6. On master1: `systemctl disable container-snapclient.service` (leaves unit file in place as rollback)

## Rollback
- `flux suspend kustomization snapclient-pool -n media`
- `kubectl -n media scale deployment snapclient-pool --replicas=0`
- `ssh root@master1 'systemctl start container-snapclient.service'`

## Test plan
- [ ] DaemonSet pod Running on every node, no errors in logs
- [ ] master1 advertises `squat.ai/snd: 1`
- [ ] snapclient-pool pod schedules to master1, Running
- [ ] Audio plays through pool speakers
- [ ] MA shows new "pool" client; old MAC client offline
- [ ] HA `media_player.pool` reachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)