### PR TITLE
fix(media): snapclient-pool requests devic.es/snd (not squat.ai/snd)

### DIFF
--- a/kubernetes/apps/media/snapclient-pool/app/helmrelease.yaml
+++ b/kubernetes/apps/media/snapclient-pool/app/helmrelease.yaml
@@ -69,17 +69,17 @@ spec:
             # snapclient doesn't expose.
 
             resources:
-              # squat.ai/snd is advertised by generic-device-plugin
+              # devic.es/snd is advertised by generic-device-plugin
               # (kube-system DaemonSet). The kubelet handles bind-mount
               # of /dev/snd and device-cgroup whitelisting; no
               # privileged: true required on this pod.
               requests:
                 cpu: 10m
                 memory: 32Mi
-                squat.ai/snd: 1
+                devic.es/snd: 1
               limits:
                 memory: 64Mi
-                squat.ai/snd: 1
+                devic.es/snd: 1
 
     persistence:
       # readOnlyRootFilesystem: true means / is locked. Give snapclient


### PR DESCRIPTION
## Summary
- One-character fix: the resource name is `devic.es/snd`, not `squat.ai/snd`

## Why
`squat/generic-device-plugin`'s default `--domain` is `devic.es` (squat's vanity domain). I assumed `squat.ai` during plan review without verifying. Result post-#12155 merge:

- `master1` Node.status.allocatable: `devic.es/snd: 1` ✓
- `snapclient-pool` pod requests: `squat.ai/snd: 1` ✗
- Scheduler: `FailedScheduling: 1 Insufficient squat.ai/snd, 3 untolerated taints, 7 nodeaffinity mismatch`

## Test plan
- [ ] snapclient-pool pod schedules to master1
- [ ] Pod Running once master1's `/dev/snd` is released by `systemctl stop container-snapclient.service`

🤖 Generated with [Claude Code](https://claude.com/claude-code)