### PR TITLE
fix(kube-system): include snd/seq + snd/timer + HDMI PCMs in plugin group

### DIFF
--- a/kubernetes/apps/kube-system/generic-device-plugin/app/daemonset.yaml
+++ b/kubernetes/apps/kube-system/generic-device-plugin/app/daemonset.yaml
@@ -32,7 +32,9 @@ spec:
             # group when a node has a different /dev/snd layout (e.g.
             # worker2's audio card when snapclient-deck lands).
             #
-            # master1 — Intel HDA ALC294 (onboard analog + HDMI):
+            # master1 — Intel HDA ALC294 (onboard analog + HDMI).
+            # seq + timer are required by ALSA's dmix plugin (the default
+            # PCM target snapclient resolves to), not optional.
             - --device
             - |
               name: snd
@@ -44,6 +46,10 @@ spec:
                     - path: /dev/snd/pcmC0D0c
                     - path: /dev/snd/pcmC0D0p
                     - path: /dev/snd/pcmC0D3p
+                    - path: /dev/snd/pcmC0D7p
+                    - path: /dev/snd/pcmC0D8p
+                    - path: /dev/snd/seq
+                    - path: /dev/snd/timer
           resources:
             requests:
               cpu: 10m


### PR DESCRIPTION
## Summary
- Add `/dev/snd/seq`, `/dev/snd/timer`, `/dev/snd/pcmC0D7p`, `/dev/snd/pcmC0D8p` to the generic-device-plugin group on top of #12155

## Why
snapclient's ALSA dmix plugin (default PCM target on debian-slim) fails without `timer`:
```
ALSA lib pcm_direct.c: unable to open timer 'hw:CLASS=3,...'
Can't open default:CARD=PCH, error: No such file or directory
```
My initial `ls /dev/snd | head` on master1 truncated and I missed `seq`, `timer`, and the HDMI PCMs. The plugin requires every path in a group to exist, so a single corrected group is the only working shape (a separate group would split the allocation count).

## Test plan
- [ ] DaemonSet rolls fresh on every node
- [ ] master1 still advertises `devic.es/snd: 1`
- [ ] snapclient-pool pod logs go quiet (no more `Can't open default:CARD=PCH`)
- [ ] Audio plays through pool speakers

🤖 Generated with [Claude Code](https://claude.com/claude-code)