### PR TITLE
feat(media): add snapclient-deck for worker2 pool audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ _Production-grade Kubernetes for a household._
 
 <br/>
 
-![apps](https://img.shields.io/badge/apps-186-blue?style=for-the-badge)
-![helmreleases](https://img.shields.io/badge/HelmReleases-198-326CE5?style=for-the-badge&logo=helm&logoColor=white)
+![apps](https://img.shields.io/badge/apps-187-blue?style=for-the-badge)
+![helmreleases](https://img.shields.io/badge/HelmReleases-199-326CE5?style=for-the-badge&logo=helm&logoColor=white)
 ![nodes](https://img.shields.io/badge/k8s_nodes-11-326CE5?style=for-the-badge&logo=kubernetes&logoColor=white)
 ![cnpg](https://img.shields.io/badge/Postgres_clusters-25-336791?style=for-the-badge&logo=postgresql&logoColor=white)
 ![secrets](https://img.shields.io/badge/secrets-117-0572EC?style=for-the-badge&logo=1password&logoColor=white)

--- a/kubernetes/apps/kube-system/generic-device-plugin/app/daemonset.yaml
+++ b/kubernetes/apps/kube-system/generic-device-plugin/app/daemonset.yaml
@@ -25,16 +25,18 @@ spec:
           # renovate: datasource=docker depName=docker.io/squat/generic-device-plugin
           image: docker.io/squat/generic-device-plugin:0.2.0
           args:
-            # Each group represents one allocation of squat.ai/snd; all
+            # Each group represents one allocation of devic.es/snd; all
             # paths in the group bind-mount together. The plugin requires
-            # every path in a group to exist on the node, so each card's
-            # specific minor enumeration gets its own group. Add a new
-            # group when a node has a different /dev/snd layout (e.g.
-            # worker2's audio card when snapclient-deck lands).
+            # every path in a group to exist on the node, so a node only
+            # advertises the resource if its /dev/snd matches. Add a new
+            # group only when a node has a *different* /dev/snd layout.
             #
-            # master1 — Intel HDA ALC294 (onboard analog + HDMI).
-            # seq + timer are required by ALSA's dmix plugin (the default
-            # PCM target snapclient resolves to), not optional.
+            # master1 AND worker2 — Intel HDA ALC294 (onboard analog +
+            # HDMI), identical minor layout, so they share this one
+            # group: master1 serves snapclient-pool, worker2 serves
+            # snapclient-deck. seq + timer are required by ALSA's dmix
+            # plugin (the default PCM target snapclient resolves to),
+            # not optional.
             - --device
             - |
               name: snd

--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -44,6 +44,7 @@ resources:
   - ./recyclarr/ks.yaml
   - ./romm/ks.yaml
   - ./seerr/ks.yaml
+  - ./snapclient-deck/ks.yaml
   - ./snapclient-pool/ks.yaml
   - ./sonarr/ks.yaml
   - ./sonarr-oauth2-proxy/ks.yaml

--- a/kubernetes/apps/media/snapclient-deck/app/helmrelease.yaml
+++ b/kubernetes/apps/media/snapclient-deck/app/helmrelease.yaml
@@ -1,0 +1,93 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app snapclient-deck
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 30m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+      strategy: rollback
+  values:
+    controllers:
+      snapclient-deck:
+        pod:
+          # Pin to worker2 — the ALC294 Headphone jack is the physical
+          # path to the amp serving the Deck speakers. worker2's audio
+          # card is an identical ALC294 with the same /dev/snd minor
+          # layout as master1, so it shares the generic-device-plugin
+          # `snd` group rather than needing its own.
+          nodeSelector:
+            kubernetes.io/hostname: worker2.thesteamedcrab.com
+          # WAF tier — deck audio dropouts are user-visible, so evict
+          # janitorr / recyclarr / metadata syncs before us. Stays well
+          # below system-cluster-critical so we never preempt infra.
+          priorityClassName: media-cluster-critical
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1114
+            runAsGroup: 1114
+            # GID 63 = `audio` on worker2; /dev/snd/* is root:audio 660.
+            supplementalGroups:
+              - 63
+
+        annotations:
+          reloader.stakater.com/auto: "true"
+
+        strategy: Recreate
+        containers:
+          app:
+            image:
+              repository: ghcr.io/rwlove/snapclient
+              tag: 0.35.0
+
+            args:
+              - -h
+              - music-assistant.media.svc.cluster.local
+              - --hostID
+              - deck
+
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+              seccompProfile:
+                type: RuntimeDefault
+
+            # No liveness/readiness probes: snapclient is PID 1 with
+            # `exec`, so any crash already exits the container and the
+            # kubelet restarts it. A process-existence probe would add
+            # nothing; a hang-detection probe would need cooperation
+            # snapclient doesn't expose.
+
+            resources:
+              # devic.es/snd is advertised by generic-device-plugin
+              # (kube-system DaemonSet). The kubelet handles bind-mount
+              # of /dev/snd and device-cgroup whitelisting; no
+              # privileged: true required on this pod.
+              requests:
+                cpu: 10m
+                memory: 32Mi
+                devic.es/snd: 1
+              limits:
+                memory: 64Mi
+                devic.es/snd: 1
+
+    persistence:
+      # readOnlyRootFilesystem: true means / is locked. Give snapclient
+      # and any ALSA libs scratch space they may expect to write.
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/media/snapclient-deck/app/kustomization.yaml
+++ b/kubernetes/apps/media/snapclient-deck/app/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../components/repos/app-template
+resources:
+  - ./helmrelease.yaml
+commonLabels:
+  app.kubernetes.io/instance: snapclient-deck
+  app.kubernetes.io/name: snapclient-deck

--- a/kubernetes/apps/media/snapclient-deck/ks.yaml
+++ b/kubernetes/apps/media/snapclient-deck/ks.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app snapclient-deck
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: media
+  path: ./kubernetes/apps/media/snapclient-deck/app
+  interval: 30m
+  prune: true
+  wait: false
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: generic-device-plugin
+      namespace: kube-system


### PR DESCRIPTION
## Summary
- Replicates the `snapclient-pool` GitOps pattern as `snapclient-deck` on worker2, retiring the podman-managed snapclient there.
- worker2's ALC294 has an **identical `/dev/snd` minor layout** to master1, so it shares the existing `generic-device-plugin` `snd` group — no daemonset device-group change needed (comment updated to reflect this).
- Same self-built `ghcr.io/rwlove/snapclient:0.35.0` image, `--hostID deck`, nodeSelector worker2, audio GID 63, `media-cluster-critical` priority.

## Cutover (post-merge, manual)
1. Stop podman snapclient on worker2 (`systemctl stop container-snapclient.service`) — brief Deck audio interruption.
2. `kubectl -n media rollout restart deployment snapclient-deck` to claim a fresh device allocation.
3. Verify pod connects to snapserver as `deck`.
4. Disable podman unit (retain file for rollback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)