### PR TITLE
feat(observability): split frameo blackbox probe into familyroom + basement

### DIFF
--- a/kubernetes/apps/observability/exporters/blackbox-exporter/app/probes.yaml
+++ b/kubernetes/apps/observability/exporters/blackbox-exporter/app/probes.yaml
@@ -56,7 +56,8 @@ spec:
         - kodi-gym
         - kodi-bedroom
         # - birdcam
-        - frameo
+        - frameo-familyroom
+        - frameo-basement
 
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/probe_v1.json


### PR DESCRIPTION
## Summary
- Replaces the single `frameo` ICMP blackbox probe target with `frameo-familyroom` and `frameo-basement`.
- Both hostnames resolve via bind9 (`frameo-familyroom` → the original frame, `frameo-basement` → newly-provisioned ImmichFrame unit).

## Notes
- The rename drops the historical `frameo` probe series and starts two fresh series — expected for a target rename.

## Test plan
- [ ] Flux reconciles the `devices` Probe
- [ ] `probe_success{instance="frameo-familyroom"}` and `probe_success{instance="frameo-basement"}` appear in Prometheus