### PR TITLE
fix(rook-ceph): bump operator and mon memory limits to prevent OOMKill

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/app/operator/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/app/operator/helmrelease.yaml
@@ -30,8 +30,8 @@ spec:
 
     resources:
       limits:
-        memory: 588M
+        memory: 768Mi
       requests:
         cpu: 70m
-        memory: 588M
+        memory: 768Mi
   timeout: 15m

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -96,10 +96,10 @@ spec:
             memory: 256Mi
         mon:
           limits:
-            memory: 840Mi
+            memory: 1Gi
           requests:
             cpu: 50m
-            memory: 840Mi
+            memory: 1Gi
         osd:
           limits:
             memory: 4Gi


### PR DESCRIPTION
## Summary

- Operator: 588M → 768Mi (OOMed in 24s during 2026-05-27 NodeNotReady cluster recovery)
- Mon: 840Mi → 1Gi (OOMed after 3 weeks under incident stress)

Both are currently running at ~50% of old limits in steady state; the headroom is needed for reconciliation spikes under cluster load.

## Test plan
- [ ] Flux rolls new limits to operator and mon pods
- [ ] OOMKilled alerts clear after pods restart cleanly with new limits

🤖 Generated with [Claude Code](https://claude.com/claude-code)