### PR TITLE
fix(media): bump kiosk-party-curator v0.1.1 → v0.2.0

### DIFF
--- a/kubernetes/apps/media/immichkiosk-party/app/helmrelease-curator.yaml
+++ b/kubernetes/apps/media/immichkiosk-party/app/helmrelease-curator.yaml
@@ -26,7 +26,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/kiosk-party-curator
-              tag: v0.1.1@sha256:f7dda1b62bffc38eba35b88be3f984cfd0b2ec03d23e25ca2394da95b7f3b6e7
+              tag: v0.2.0@sha256:637c4b0dc7458cd3def02dbe31bb629d17d5d8ee20415846b578ebcfe6f2cb00
 
             env:
               IMMICH_URL: "http://immich-server.media.svc.cluster.local:2283"


### PR DESCRIPTION
## Summary
- Bumps the Party Slideshow curator image to v0.2.0, fixing the wedge where the slideshow stopped showing photos once the album was fully cycled.
- v0.1.1 undercounted the played set (`_tagged_count` read a single `/api/search/metadata` page, capped at 250). The 251-asset album never registered as exhausted → the tag-reset never fired → the kiosk's `excluded_tags` filter found nothing to prefetch → empty-pool spinner.
- v0.2.0 paginates the count and adds a background reconcile loop that re-checks exhaustion on an interval independent of webhook traffic — durable against the "exhausted pool emits no webhooks, so a webhook-only reset never fires" failure mode.

Upstream image change: rwlove/containers#37 (released as `kiosk-party-curator-v0.2.0`).

## Test plan
- [ ] Flux reconciles the HelmRelease; curator pod rolls to v0.2.0
- [ ] Pod logs show `reconcile loop started (interval=600s)`
- [ ] After the pool next exhausts, logs show a `reset=true` cycle and frames keep rotating

🤖 Generated with [Claude Code](https://claude.com/claude-code)