### PR TITLE
fix(media): bump music-assistant memory limit 2Gi->3Gi to prevent OOMKill

### DIFF
--- a/kubernetes/apps/media/music-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/media/music-assistant/app/helmrelease.yaml
@@ -39,7 +39,7 @@ spec:
                 cpu: 15m
                 memory: 2Gi
               limits:
-                memory: 2Gi
+                memory: 3Gi
 
     service:
       app:


### PR DESCRIPTION
## Summary
- music-assistant-0 was OOMKilled (exit 137) at 2026-05-30 05:15 UTC during a Queue Flow stream colliding with the nightly MusicBrainz metadata scan, dropping the web UI websocket ("Connection Lost").
- Bumps `limits.memory` 2Gi -> 3Gi; `requests.memory` unchanged at 2Gi (Guaranteed -> Burstable, 1Gi spike headroom).

## Test plan
- [ ] Flux reconciles HelmRelease; pod restarts once with new 3Gi limit
- [ ] `kubectl get pod -n media music-assistant-0` shows Running, limit 3Gi
- [ ] Web UI reconnects and streams without OOM

🤖 Generated with [Claude Code](https://claude.com/claude-code)