### PR TITLE
feat(ai/langgraph-agents): deploy 0.2.59 — guardian approval queue

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/langgraph-agents
-              tag: 0.2.58@sha256:cf547d40a11a2d938916025394f3c811015e23342e47b5fcc7abfabdaa8bd83b
+              tag: 0.2.59@sha256:fe32c325233df830641c145d72841479326e858c8d086daa2bf136b2f65b89d9
 
             env:
               # --- vault ---


### PR DESCRIPTION
## Summary

Bumps `ghcr.io/rwlove/langgraph-agents` **0.2.58 → 0.2.59** (digest-pinned).

v0.2.59 releases everything merged to the agents repo since 0.2.58 (PRs #101–#105). Headline change is the **durable guardian approval queue** (HOMELAB-SPEC Layer 4 + Layer 5): approval-gated Class C/D tasks now park at `awaiting_approval` with a 24h TTL and lapse to the DLQ tagged `approval_ttl_expired` instead of auto-executing; defer re-pauses for a fresh verdict; depth/age gauges + a status-filtered `/admin/tasks` surface.

Also in this image: task-TTL enforcement (#103), trace_id propagation (#104), ml-operator gather_evidence pre-pass (#102), observability token-field fixes (#101).

## Deploy mechanics

- Single-replica Deployment, `strategy: Recreate` + Postgres-backed state → brief restart as the old pod terminates and the new one comes up.
- Startup runs `ensure_schema`, which applies **migration 004** (`approval_expires_at` column + `idx_task_queue_awaiting` partial index) idempotently — safe to re-run, safe to roll back (additive column, no data rewrite).
- Internal service (routine maintenance tier); no Renee-facing impact.

## Test plan

- [ ] Flux reconciles; pod rolls to 0.2.59 cleanly (no ImagePullBackOff / CrashLoop)
- [ ] Startup log shows migration 004 applied; `\d task_queue` has `approval_expires_at` + `idx_task_queue_awaiting`
- [ ] `GET /admin/tasks?status=awaiting_approval` returns 200
- [ ] Gauges `langgraph_awaiting_approval_tasks` / `_oldest_age_seconds` scrape in Prometheus

🤖 Generated with [Claude Code](https://claude.com/claude-code)