### PR TITLE
feat(langgraph-agents): bump image 0.2.59 -> 0.2.60

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/langgraph-agents
-              tag: 0.2.59@sha256:fe32c325233df830641c145d72841479326e858c8d086daa2bf136b2f65b89d9
+              tag: 0.2.60@sha256:7ddf45ddb14ccd466881a27928b598090905cf0d3a807d4c63ef66f4c5368847
 
             env:
               # --- vault ---


### PR DESCRIPTION
## Summary

Bumps langgraph-agents `0.2.59 → 0.2.60`, shipping the **two-person namespace-delete gate** (langgraph-agents #106).

Per HOMELAB-SPEC Layer 5 blast-radius: a namespace deletion needs Rob's approval PLUS an explicit second confirmation — never a single tap. This closes the one gap deliberately carved out of the 0.2.59 guardian queue. The gate fires on a `requires_two_person` flag or the executor's own fail-safe namespace-delete classifier; only a second grant proceeds.

errand-runner (the only MCP-write agent) has no kubectl-write target today, so this is forward-looking defense-in-depth — in place before the capability to propose a namespace delete exists.

Image digest verified via `skopeo` against the `0.2.60` registry tag.

## Test plan

- [x] langgraph-agents CI green on v0.2.60 (lint + mypy + 346 tests)
- [x] image build succeeded; digest pin matches registry
- [ ] Flux reconciles the HelmRelease; pod rolls to 0.2.60 (Recreate, single replica)