### PR TITLE
fix(media): bump kiosk-party-curator to v0.2.1 (untag endpoint fix)

### DIFF
--- a/kubernetes/apps/media/immichkiosk-party/app/helmrelease-curator.yaml
+++ b/kubernetes/apps/media/immichkiosk-party/app/helmrelease-curator.yaml
@@ -26,7 +26,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/kiosk-party-curator
-              tag: v0.2.0@sha256:637c4b0dc7458cd3def02dbe31bb629d17d5d8ee20415846b578ebcfe6f2cb00
+              tag: v0.2.1@sha256:0aa7984dd66a6d95cd31841538686b5dd47da86456322b2f48b227c93046761f
 
             env:
               IMMICH_URL: "http://immich-server.media.svc.cluster.local:2283"


### PR DESCRIPTION
## Summary
- The party slideshow (basement frame + family-room display) went blank because the curator's pool-recycle crashed.
- curator v0.2.0's `_untag_assets` called `DELETE /api/tags/assets` — an endpoint that does not exist in Immich (returns HTTP 400). Once every album asset was tagged "shown", the kiosk's excluded-tag filter found nothing eligible, the recycle that should clear the tag crashed, and the slideshow wedged on an empty pool.
- v0.2.1 uses the correct bulk removal endpoint `DELETE /api/tags/{tagId}/assets` with body `{ids:[...]}` (verified against Immich 2.6.3).

## Test plan
- [ ] Flux reconciles the new image (`v0.2.1@sha256:0aa7984…`).
- [ ] Curator reconcile loop detects the exhausted pool and clears the played tag without a 400.
- [ ] Kiosk resumes serving assets; slideshow displays on both the frame and the family-room display.