### PR TITLE
fix(container): update ghcr.io/rwlove/langgraph-agents ( 0.2.60 → 0.2.61 )

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/langgraph-agents
-              tag: 0.2.60@sha256:7ddf45ddb14ccd466881a27928b598090905cf0d3a807d4c63ef66f4c5368847
+              tag: 0.2.61@sha256:02febfc101650f3cb3b5ee7f0611a768c3680c439712b95f22fad5f1d9bf0e58
 
             env:
               # --- vault ---


### PR DESCRIPTION
## Summary

Deploys langgraph-agents **v0.2.61** — the task-contract envelope
validator at `/inbox` ingress (langgraph-agents PR #107).

- Lenient / minimal-mandatory gate: 422s only the semantic checks
  Pydantic can't express (blank `task_id`/`content`, non-positive
  `ttl_seconds`, blank `idempotency_key`, unknown `target_agent`).
- Zero blast radius on current traffic — no live caller populates the
  full envelope; optional fields ride on defaults.
- Adds `langgraph_inbox_envelope_rejected_total{reason}` for ground
  truth on what (if anything) trips the gate.

Image `0.2.61@sha256:02febfc1…` built from merge commit `2d586ae`
(tag `sha-2d586ae` on the same digest confirms provenance).

## Test plan

- [x] langgraph-agents CI green on #107 (357 passed / 2 postgres-skip)
- [x] Image published by build.yaml on tag v0.2.61
- [ ] Flux reconciles HelmRelease; pod rolls to 0.2.61 Running 1/1

🤖 Generated with [Claude Code](https://claude.com/claude-code)