### PR TITLE
feat(network): Omada captive-portal LE cert sync via guest-portal hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ _Production-grade Kubernetes for a household._
 
 <br/>
 
-![apps](https://img.shields.io/badge/apps-187-blue?style=for-the-badge)
+![apps](https://img.shields.io/badge/apps-188-blue?style=for-the-badge)
 ![helmreleases](https://img.shields.io/badge/HelmReleases-199-326CE5?style=for-the-badge&logo=helm&logoColor=white)
 ![nodes](https://img.shields.io/badge/k8s_nodes-11-326CE5?style=for-the-badge&logo=kubernetes&logoColor=white)
 ![cnpg](https://img.shields.io/badge/Postgres_clusters-25-336791?style=for-the-badge&logo=postgresql&logoColor=white)

--- a/kubernetes/apps/network/external-dns/app/bind/helmrelease.yaml
+++ b/kubernetes/apps/network/external-dns/app/bind/helmrelease.yaml
@@ -55,6 +55,9 @@ spec:
               - --policy=sync
               - --provider=rfc2136
               - --registry=txt
+              - --source=crd
+              - --crd-source-apiversion=externaldns.k8s.io/v1alpha1
+              - --crd-source-kind=DNSEndpoint
               - --source=service
               - --source=gateway-httproute
               # - --source=gateway-tlsroute
@@ -105,7 +108,7 @@ spec:
               readOnlyRootFilesystem: true
 
     serviceAccount:
-      *app: {}
+      external-dns-bind: {}
 
     service:
       app:

--- a/kubernetes/apps/network/external-dns/app/bind/rbac.yaml
+++ b/kubernetes/apps/network/external-dns/app/bind/rbac.yaml
@@ -17,6 +17,12 @@ rules:
   - apiGroups: ["gateway.networking.k8s.io"]
     resources: ["httproutes", "gateways"]
     verbs: ["get", "watch", "list"]
+  - apiGroups: ["externaldns.k8s.io"]
+    resources: ["dnsendpoints"]
+    verbs: ["get", "watch", "list"]
+  - apiGroups: ["externaldns.k8s.io"]
+    resources: ["dnsendpoints/status"]
+    verbs: ["update"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/kubernetes/apps/network/kustomization.yaml
+++ b/kubernetes/apps/network/kustomization.yaml
@@ -22,5 +22,6 @@ resources:
   - ./envoy-gateway/ks.yaml
   - ./external-dns/ks.yaml
   - ./multus/ks.yaml
+  - ./omada-cert-sync/ks.yaml
   - ./wg-easy/ks.yaml
   - ./whoami/ks.yaml

--- a/kubernetes/apps/network/omada-cert-sync/app/dnsendpoint.yaml
+++ b/kubernetes/apps/network/omada-cert-sync/app/dnsendpoint.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/externaldns.k8s.io/dnsendpoint_v1alpha1.json
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: guest-portal
+spec:
+  endpoints:
+    # Captive-portal hostname for "Lovenet Guest". Points at brain's
+    # guest-VLAN gateway interface (enp6s0f0.30); the Omada controller
+    # binds *:8843 so it answers there directly — no cross-VLAN ACL.
+    # Resolved by brain's bind (named) on 10.10.30.1:53, written here
+    # via external-dns RFC2136. Matches the LE wildcard *.thesteamedcrab.com
+    # so the portal serves a publicly-trusted cert by name.
+    - dnsName: guest-portal.${SECRET_DOMAIN}
+      recordType: A
+      recordTTL: 300
+      targets:
+        - 10.10.30.1

--- a/kubernetes/apps/network/omada-cert-sync/app/kustomization.yaml
+++ b/kubernetes/apps/network/omada-cert-sync/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./dnsendpoint.yaml
+  - ./rbac.yaml

--- a/kubernetes/apps/network/omada-cert-sync/app/rbac.yaml
+++ b/kubernetes/apps/network/omada-cert-sync/app/rbac.yaml
@@ -1,0 +1,45 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/serviceaccount-v1.json
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: omada-cert-reader
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/role-rbac-v1.json
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: omada-cert-reader
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["thesteamedcrab-com-tls"]
+    verbs: ["get"]
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/rolebinding-rbac-v1.json
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: omada-cert-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: omada-cert-reader
+subjects:
+  - kind: ServiceAccount
+    name: omada-cert-reader
+    namespace: network
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/secret-v1.json
+# Long-lived token for an OFF-CLUSTER consumer (the Omada controller on
+# brain, which cannot use a TokenRequest-rotated projected token). The
+# token-controller populates .data.token + .data["ca.crt"] at runtime;
+# nothing secret is committed here. Rob copies these two values onto
+# brain at install time (see ./brain/README.md).
+apiVersion: v1
+kind: Secret
+metadata:
+  name: omada-cert-reader-token
+  annotations:
+    kubernetes.io/service-account.name: omada-cert-reader
+type: kubernetes.io/service-account-token

--- a/kubernetes/apps/network/omada-cert-sync/brain/README.md
+++ b/kubernetes/apps/network/omada-cert-sync/brain/README.md
@@ -1,0 +1,114 @@
+# omada-cert-sync (brain-side)
+
+Pulls the cluster's Let's Encrypt wildcard cert (`*.thesteamedcrab.com`,
+secret `thesteamedcrab-com-tls` in the `network` namespace) onto brain's
+Omada controller and restarts Omada **only when the cert changed**. This
+gives the guest captive portal a publicly-trusted cert by hostname, which
+modern iOS/Android captive clients require — they render a blank page on
+the old IP-based self-signed cert.
+
+These files are **not Flux-managed**. They live on brain, a piece of core
+network infrastructure (HOMELAB-SPEC Layer 2 #9 — human-installed, not
+agent-touched). They are checked in for review and history only.
+
+## How it stays automatic
+
+`cert-manager` renews the wildcard ~30 days before its 90-day expiry and
+rewrites the Secret. The systemd timer below fires daily; on the renewal
+day it sees a new fingerprint, rebuilds the keystore, and restarts Omada.
+Every other day it is a no-op. **No human action on rotation.** The only
+manual step is this one-time install.
+
+## One-time install (run on brain as root)
+
+The cluster side (ServiceAccount `omada-cert-reader`, its Role, and the
+long-lived token Secret `omada-cert-reader-token`) is applied by Flux from
+`../app`. Confirm it exists before installing here.
+
+1. Pull the token + CA from the cluster Secret (run from a machine with
+   cluster kubectl, e.g. your workstation):
+
+   ```bash
+   kubectl -n network get secret omada-cert-reader-token \
+     -o jsonpath='{.data.token}' | base64 -d > token
+   kubectl -n network get secret omada-cert-reader-token \
+     -o jsonpath='{.data.ca\.crt}' | base64 -d > ca.crt
+   ```
+
+2. Place config on brain (root-only):
+
+   ```bash
+   install -d -m 700 /etc/omada-cert-sync
+   install -m 600 token  /etc/omada-cert-sync/token
+   install -m 644 ca.crt /etc/omada-cert-sync/ca.crt
+   shred -u token ca.crt   # don't leave the token lying around
+   ```
+
+3. Install the script + units:
+
+   ```bash
+   install -m 755 omada-cert-sync.sh /usr/local/bin/omada-cert-sync.sh
+   install -m 644 omada-cert-sync.service /etc/systemd/system/
+   install -m 644 omada-cert-sync.timer   /etc/systemd/system/
+   systemctl daemon-reload
+   ```
+
+4. First run (manual, verifies the whole path end-to-end). This WILL
+   restart Omada if the cert differs from the current self-signed one —
+   expect a ~30-60s portal/controller blip:
+
+   ```bash
+   /usr/local/bin/omada-cert-sync.sh
+   ```
+
+5. Verify Omada now serves the LE cert on the portal port:
+
+   ```bash
+   echo | openssl s_client -connect 10.10.30.1:8843 -servername guest-portal.thesteamedcrab.com 2>/dev/null \
+     | openssl x509 -noout -issuer -subject
+   # issuer should be Let's Encrypt; subject CN *.thesteamedcrab.com
+   ```
+
+6. Enable the timer:
+
+   ```bash
+   systemctl enable --now omada-cert-sync.timer
+   systemctl list-timers omada-cert-sync.timer
+   ```
+
+## Safety properties
+
+- **Never restarts Omada without a valid new cert.** Any failure — cluster
+  unreachable, token expired, malformed cert/key — logs and exits 0,
+  leaving the existing keystore in place.
+- **Backup on every change.** The prior keystore is copied to
+  `eap.keystore.bak.<timestamp>` before the swap.
+- **Least privilege.** The SA token can `get` exactly one Secret
+  (`thesteamedcrab-com-tls`) in `network` — nothing else.
+
+## Do NOT enable the controller's native HTTPS Certificate feature
+
+Leave Omada's built-in **HTTPS Certificate** import (Settings → Controller)
+**disabled**. Verified on controller v6.2.0.17: with that feature off
+(`enable:false`), the controller serves directly from
+`eap.keystore` on disk — the live cert on the management port (8043) and
+the portal port (8843) both match the on-disk keystore fingerprint
+exactly. That is *why* this file-swap approach works.
+
+If someone toggles the native feature on, the controller starts managing
+the keystore itself and will fight this script's swap. The two
+mechanisms are mutually exclusive — keep the UI feature off and let the
+timer own the keystore.
+
+## Token note
+
+The SA token is long-lived (a `kubernetes.io/service-account-token`
+Secret), because brain is off-cluster and cannot use a rotated projected
+token without renewal tooling — which would defeat "nothing manual." If
+the token is ever revoked, re-run step 1–2.
+
+## Logs
+
+```bash
+journalctl -t omada-cert-sync --since "7 days ago"
+```

--- a/kubernetes/apps/network/omada-cert-sync/brain/omada-cert-sync.service
+++ b/kubernetes/apps/network/omada-cert-sync/brain/omada-cert-sync.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Sync cluster LE wildcard cert into Omada controller keystore
+Documentation=https://github.com/rwlove/home-ops/tree/main/kubernetes/apps/network/omada-cert-sync
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/omada-cert-sync.sh
+# Hardening: the script needs root (keystore + tpeap), but lock down the rest.
+ProtectSystem=full
+ProtectHome=true
+NoNewPrivileges=true
+PrivateTmp=true

--- a/kubernetes/apps/network/omada-cert-sync/brain/omada-cert-sync.sh
+++ b/kubernetes/apps/network/omada-cert-sync/brain/omada-cert-sync.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+#
+# omada-cert-sync.sh — pull the cluster's Let's Encrypt wildcard cert
+# onto brain's Omada controller keystore, restart Omada only when the
+# cert actually changed. Brain-initiated (Pull); the cluster is a passive
+# source. Designed to be a no-op on every tick except the ~quarterly
+# renewal day.
+#
+# INSTALL: this file is NOT Flux-managed. Rob installs it on brain once
+# (see README.md). It is checked into the repo for review + history only.
+#
+# Prime directive: never restart Omada with a missing/invalid cert. Any
+# fetch/parse failure => exit 0 and leave the keystore untouched.
+
+set -euo pipefail
+
+# --- config -----------------------------------------------------------
+API="https://192.168.6.1:6443"            # kube-vip controlplane VIP
+NS="network"
+SECRET="thesteamedcrab-com-tls"           # LE wildcard *.thesteamedcrab.com
+CONF_DIR="/etc/omada-cert-sync"
+TOKEN_FILE="${CONF_DIR}/token"            # SA token (Rob populates)
+CA_FILE="${CONF_DIR}/ca.crt"              # cluster CA (Rob populates)
+
+OMADA_DIR="/opt/tplink/EAPController"
+KEYSTORE="${OMADA_DIR}/data/keystore/eap.keystore"
+ALIAS="eap"
+STOREPASS="tplink"                        # Omada keystore default
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+log() { logger -t omada-cert-sync -- "$*"; echo "omada-cert-sync: $*"; }
+bail_clean() { log "$*"; exit 0; }   # non-fatal: leave keystore as-is
+
+# --- preconditions ----------------------------------------------------
+[[ -r "$TOKEN_FILE" ]] || bail_clean "token file $TOKEN_FILE missing/unreadable"
+[[ -r "$CA_FILE"    ]] || bail_clean "CA file $CA_FILE missing/unreadable"
+[[ -w "$KEYSTORE"   ]] || bail_clean "keystore $KEYSTORE missing/unwritable"
+
+TOKEN="$(< "$TOKEN_FILE")"
+
+# --- fetch ------------------------------------------------------------
+# On unreachable cluster (e.g. down at renewal) curl -f fails -> exit 0.
+if ! resp="$(curl -fsS --max-time 15 --cacert "$CA_FILE" \
+      -H "Authorization: Bearer ${TOKEN}" \
+      "${API}/api/v1/namespaces/${NS}/secrets/${SECRET}" 2>/dev/null)"; then
+  bail_clean "cluster API unreachable or secret fetch failed; keystore untouched"
+fi
+
+jq -r '.data["tls.crt"] // empty' <<<"$resp" | base64 -d > "$WORK/tls.crt" 2>/dev/null || true
+jq -r '.data["tls.key"] // empty' <<<"$resp" | base64 -d > "$WORK/tls.key" 2>/dev/null || true
+
+[[ -s "$WORK/tls.crt" && -s "$WORK/tls.key" ]] || bail_clean "secret missing tls.crt/tls.key; keystore untouched"
+openssl x509 -in "$WORK/tls.crt" -noout 2>/dev/null || bail_clean "fetched tls.crt not a valid cert; keystore untouched"
+openssl rsa  -in "$WORK/tls.key" -noout 2>/dev/null \
+  || openssl pkey -in "$WORK/tls.key" -noout 2>/dev/null \
+  || bail_clean "fetched tls.key not a valid key; keystore untouched"
+
+# --- diff -------------------------------------------------------------
+new_fp="$(openssl x509 -in "$WORK/tls.crt" -noout -fingerprint -sha256 | sed 's/.*=//')"
+cur_fp="$(keytool -list -keystore "$KEYSTORE" -storepass "$STOREPASS" -alias "$ALIAS" 2>/dev/null \
+            | grep -i 'SHA-256' | sed 's/.*: //' | tr -d ' ')"
+new_fp="$(tr -d ' ' <<<"$new_fp")"
+
+if [[ -n "$cur_fp" && "$new_fp" == "$cur_fp" ]]; then
+  bail_clean "cert unchanged (${new_fp}); no action"
+fi
+log "cert changed (old=${cur_fp:-none} new=${new_fp}); rebuilding keystore"
+
+# --- rebuild ----------------------------------------------------------
+openssl pkcs12 -export \
+  -in "$WORK/tls.crt" -inkey "$WORK/tls.key" \
+  -name "$ALIAS" -out "$WORK/eap.p12" -passout pass:"$STOREPASS"
+
+# Match the existing keystore type (JKS) so Omada reads it unchanged.
+keytool -importkeystore -noprompt \
+  -srckeystore "$WORK/eap.p12" -srcstoretype PKCS12 -srcstorepass "$STOREPASS" \
+  -destkeystore "$WORK/eap.keystore" -deststoretype JKS \
+  -deststorepass "$STOREPASS" -destkeypass "$STOREPASS" -alias "$ALIAS"
+
+# --- swap + restart ---------------------------------------------------
+cp -a "$KEYSTORE" "${KEYSTORE}.bak.$(date +%Y%m%d%H%M%S)"
+install -m 600 -o root -g root "$WORK/eap.keystore" "$KEYSTORE"
+
+log "restarting Omada controller (tpeap restart)"
+if tpeap restart >/dev/null 2>&1; then
+  log "Omada restarted; new cert active"
+else
+  log "WARNING: tpeap restart returned non-zero — check 'tpeap status'"
+  exit 1
+fi

--- a/kubernetes/apps/network/omada-cert-sync/brain/omada-cert-sync.timer
+++ b/kubernetes/apps/network/omada-cert-sync/brain/omada-cert-sync.timer
@@ -1,0 +1,13 @@
+[Unit]
+Description=Daily check for renewed cluster wildcard cert (Omada portal)
+
+[Timer]
+# Daily at 03:00 local — lands in the routine maintenance window so the
+# rare renewal-day Omada restart (~quarterly) is in-window. Every other
+# tick is a no-op fingerprint compare.
+OnCalendar=*-*-* 03:00:00
+RandomizedDelaySec=900
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/kubernetes/apps/network/omada-cert-sync/ks.yaml
+++ b/kubernetes/apps/network/omada-cert-sync/ks.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app omada-cert-sync
+  labels:
+    substitution.flux.home.arpa/enabled: "true"
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: network
+  path: ./kubernetes/apps/network/omada-cert-sync/app
+  interval: 30m
+  timeout: 5m
+  prune: true
+  wait: false
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system


### PR DESCRIPTION
## Summary
- Gives the guest captive portal a publicly-trusted cert **by hostname** (`guest-portal.${SECRET_DOMAIN}`) so modern iOS/Android captive clients stop rendering a blank page on the old IP-based self-signed cert.
- **Cluster side (Flux):** `omada-cert-reader` SA scoped to `get` the single wildcard Secret + long-lived token Secret for off-cluster brain; a `DNSEndpoint` (`guest-portal` → `10.10.30.1`) served by bind external-dns (adds `--source=crd` + `dnsendpoints` RBAC).
- **Brain side (NOT Flux-managed, install-once per HOMELAB-SPEC #9):** Pull sync script + systemd timer that rebuilds `eap.keystore` and restarts Omada **only when the cert fingerprint changes**. Any failure leaves the keystore untouched.
- Normalizes the `external-dns-bind` serviceAccount key from the `*app` alias to the literal name (identical render; was the sole repo file tripping `check-yaml`); bumps apps badge 187→188.

## Verified against the live controller (v6.2.0.17)
- keystore is JKS, alias `eap`, storepass `tplink` — matches the script.
- live cert on **8043 and 8843** matches the on-disk keystore fingerprint → controller serves from `eap.keystore` even with the native cert feature off; file-swap is the correct mechanism.
- brain → kube-vip `192.168.6.1:6443` returns 200 and the apiserver SAN includes the VIP → `--cacert` validates.
- wildcard cert SAN `*.${SECRET_DOMAIN}` covers `guest-portal`; LE R12, renews ~Jun 5.

## Test plan
- [ ] Flux reconciles the SA/token + DNSEndpoint (additive, no service impact).
- [ ] external-dns-bind logs show the `guest-portal` A record published to brain bind.
- [ ] One-time brain install (manual, per `brain/README.md`) — first run swaps keystore + restarts Omada (~30–60s blip).
- [ ] `openssl s_client -connect 10.10.30.1:8843 -servername guest-portal.${SECRET_DOMAIN}` shows LE issuer.
- [ ] Set Omada "Manage Portal URL" to `https://guest-portal.${SECRET_DOMAIN}:8843` (live guest-network change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)