### PR TITLE
fix(observability): replace fictional claude-gate runbook with real guidance

### DIFF
--- a/kubernetes/apps/observability/exporters/pushgateway/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/exporters/pushgateway/app/prometheusrule.yaml
@@ -48,8 +48,11 @@ spec:
             summary: "Claude API daily gate: ${{ $value | printf \"%.2f\" }}"
             description: >-
               langgraph-agents Anthropic API cost over the last 24h is
-              ${{ $value | printf "%.2f" }} (hard limit $20).
-              Run: claude-gate approve 2h
+              ${{ $value | printf "%.2f" }} (hard limit $20). This alert
+              pages but does not block: in-process caps ($5/task,
+              $10/agent/day, $30/global/day) remain the live ceiling. To
+              hard-pin the fleet local, set ENABLE_CLAUDE_API=false in the
+              langgraph-agents HelmRelease env (or remove ANTHROPIC_API_KEY).
 
         # ── Weekly ────────────────────────────────────────────────────
         - alert: ClaudeApiWeeklySoft
@@ -74,8 +77,11 @@ spec:
             summary: "Claude API weekly gate: ${{ $value | printf \"%.2f\" }}"
             description: >-
               langgraph-agents Anthropic API cost over the last 7 days is
-              ${{ $value | printf "%.2f" }} (hard limit $30).
-              Run: claude-gate approve 4h
+              ${{ $value | printf "%.2f" }} (hard limit $30). This alert
+              pages but does not block: in-process caps ($5/task,
+              $10/agent/day, $30/global/day) remain the live ceiling. To
+              hard-pin the fleet local, set ENABLE_CLAUDE_API=false in the
+              langgraph-agents HelmRelease env (or remove ANTHROPIC_API_KEY).
 
         # ── Monthly ───────────────────────────────────────────────────
         - alert: ClaudeApiMonthlyHard
@@ -88,8 +94,12 @@ spec:
             summary: "Claude API monthly gate: ${{ $value | printf \"%.2f\" }}"
             description: >-
               langgraph-agents Anthropic API cost over the last 30 days is
-              ${{ $value | printf "%.2f" }} (hard limit $60).
-              Run: claude-gate approve 24h
+              ${{ $value | printf "%.2f" }} (hard limit $60). This alert
+              pages but does not block: in-process caps ($5/task,
+              $10/agent/day, $30/global/day) remain the live ceiling. To
+              hard-pin the fleet local, set ENABLE_CLAUDE_API=false in the
+              langgraph-agents HelmRelease env (or remove ANTHROPIC_API_KEY).
+              The Anthropic Console billing limit is the account-side backstop.
 
         # ── Metric dark alert ─────────────────────────────────────────
         # Fires if langgraph_cost_usd_total stops being scraped — ensures


### PR DESCRIPTION
## Summary

The `ClaudeApi*Hard` alert annotations told on-call to `Run: claude-gate approve Xh` — a command that exists nowhere (no binary, no cron, no code). On-call would be handed a dead string mid-incident.

Replaced with accurate guidance on all three hard alerts (daily/weekly/monthly):

- These alerts **page but do not block**.
- The in-process caps (`$5/task`, `$10/agent/day`, `$30/global/day`, enforced in `_build_claude`) are the live ceiling.
- The real hard-pin-local lever is `ENABLE_CLAUDE_API=false` on the langgraph-agents HelmRelease (or removing `ANTHROPIC_API_KEY`).
- The Anthropic Console billing limit is the account-side backstop.

Pairs with langgraph-agents PR #110, which makes `ENABLE_CLAUDE_API=false` an actual enforced kill switch.

## Test plan

- [x] `pre-commit` (check-yaml, yamllint, secret scans, badge/CNP checks) clean on the changed file