### PR TITLE
fix(network): harden omada-cert-sync restart — stop/start + portal-port verify

### DIFF
--- a/kubernetes/apps/network/omada-cert-sync/brain/omada-cert-sync.sh
+++ b/kubernetes/apps/network/omada-cert-sync/brain/omada-cert-sync.sh
@@ -83,10 +83,33 @@ keytool -importkeystore -noprompt \
 cp -a "$KEYSTORE" "${KEYSTORE}.bak.$(date +%Y%m%d%H%M%S)"
 install -m 600 -o root -g root "$WORK/eap.keystore" "$KEYSTORE"
 
-log "restarting Omada controller (tpeap restart)"
-if tpeap restart >/dev/null 2>&1; then
-  log "Omada restarted; new cert active"
-else
-  log "WARNING: tpeap restart returned non-zero — check 'tpeap status'"
-  exit 1
-fi
+# `tpeap restart` is unreliable on this controller (v6.2.0.17): it can
+# return success while leaving the embedded mongod down, so the
+# controller times out connecting to :27217 and self-shuts. Do an
+# explicit stop -> start and verify the portal port actually comes
+# back, so an unattended renewal that fails to restart is loud in the
+# journal (unit exits non-zero) instead of silently leaving guest auth
+# down on the router host.
+PORTAL_PORT=8843
+
+log "stopping Omada controller (tpeap stop)"
+tpeap stop >/dev/null 2>&1 || true
+for _ in $(seq 1 30); do                 # wait for full shutdown (~60s max)
+  tpeap status 2>/dev/null | grep -qi 'is running' || break
+  sleep 2
+done
+
+log "starting Omada controller (tpeap start)"
+tpeap start >/dev/null 2>&1 || true
+
+for _ in $(seq 1 30); do                 # poll portal port, ~150s max
+  if (exec 3<>"/dev/tcp/127.0.0.1/${PORTAL_PORT}") 2>/dev/null; then
+    exec 3>&- 3<&-
+    log "Omada restarted; new cert active (portal :${PORTAL_PORT} up)"
+    exit 0
+  fi
+  sleep 5
+done
+
+log "ERROR: Omada did not come back on :${PORTAL_PORT} after restart — cert WAS swapped; run 'tpeap start' and check 'tpeap status'"
+exit 1


### PR DESCRIPTION
## Summary
- `tpeap restart` on the Omada controller (v6.2.0.17) can return success while leaving the embedded mongod down, so the controller times out connecting to `:27217` and self-shuts. Hit this during first install: the cert swap succeeded, but the controller stayed down until a manual `tpeap start`.
- The systemd timer runs this script **unattended at 03:00**, so the next cert rotation (~Jun 5; cert expires Jul 5) would have left guest auth down on the router host with no signal.
- Replaces the bare `tpeap restart` with explicit **stop → wait-for-down → start → poll portal port 8843** (timeout). On failure the unit exits non-zero so a failed renewal is loud in the journal instead of silently down. Keystore swap logic is unchanged (already proven correct in prod).

## Test plan
- [x] First-install run confirmed `tpeap restart` left the controller down; `tpeap start` recovered it and the LE wildcard is now served on 8843 (issuer Let's Encrypt R12, notAfter Jul 5 2026).
- [ ] Next unattended renewal (~Jun 5) exercises the new path; verify `journalctl -t omada-cert-sync` shows portal-port-up on success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)