### PR TITLE
feat(network): add omada.${SECRET_DOMAIN} for controller UI

### DIFF
--- a/kubernetes/apps/network/omada-cert-sync/app/dnsendpoint.yaml
+++ b/kubernetes/apps/network/omada-cert-sync/app/dnsendpoint.yaml
@@ -17,3 +17,15 @@ spec:
       recordTTL: 300
       targets:
         - 10.10.30.1
+    # Management-UI hostname for the Omada controller. Points at brain
+    # (192.168.1.1, what `brain` already resolves to); the controller
+    # binds *:8043 so it answers there. Matches the LE wildcard, so the
+    # admin UI loads at https://omada.${SECRET_DOMAIN}:8043/<controllerId>/
+    # with a publicly-trusted cert instead of the bare IP + self-signed
+    # warning. Independent of the controller `hostName` field — this only
+    # affects how a browser reaches the UI, not device inform/adoption.
+    - dnsName: omada.${SECRET_DOMAIN}
+      recordType: A
+      recordTTL: 300
+      targets:
+        - 192.168.1.1


### PR DESCRIPTION
## Summary
- Adds an internal A record `omada.${SECRET_DOMAIN}` → `192.168.1.1` (brain) alongside the existing `guest-portal` record in the omada-cert-sync DNSEndpoint.
- The controller binds `*:8043` and already serves the LE wildcard cert there (SAN `*.thesteamedcrab.com` covers `omada.${SECRET_DOMAIN}`), so the admin UI loads at `https://omada.${SECRET_DOMAIN}:8043/<controllerId>/` with a publicly-trusted cert instead of the bare-IP self-signed warning.

## Notes
- **Decoupled from the controller `hostName` field** — this only affects how a browser reaches the management UI. No device inform/adoption change, no re-inform blip.
- `:8043` and the `/<controllerId>/` path are Omada-intrinsic and unchanged; dropping the port would require a reverse proxy on brain (separate, optional follow-up).
- Written to brain's bind via external-dns RFC2136, same mechanism as the guest-portal record.

## Test plan
- [ ] Flux reconciles; `dig +short omada.${SECRET_DOMAIN}` returns `192.168.1.1`
- [ ] `https://omada.${SECRET_DOMAIN}:8043/<controllerId>/` loads with a trusted (green) cert, no warning