### PR TITLE
feat(media): enable MA SlimProto + scaffold squeezelite pool/deck

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ _Production-grade Kubernetes for a household._
 
 <br/>
 
-![apps](https://img.shields.io/badge/apps-188-blue?style=for-the-badge)
-![helmreleases](https://img.shields.io/badge/HelmReleases-199-326CE5?style=for-the-badge&logo=helm&logoColor=white)
+![apps](https://img.shields.io/badge/apps-190-blue?style=for-the-badge)
+![helmreleases](https://img.shields.io/badge/HelmReleases-201-326CE5?style=for-the-badge&logo=helm&logoColor=white)
 ![nodes](https://img.shields.io/badge/k8s_nodes-11-326CE5?style=for-the-badge&logo=kubernetes&logoColor=white)
 ![cnpg](https://img.shields.io/badge/Postgres_clusters-25-336791?style=for-the-badge&logo=postgresql&logoColor=white)
 ![secrets](https://img.shields.io/badge/secrets-117-0572EC?style=for-the-badge&logo=1password&logoColor=white)

--- a/kubernetes/apps/media/music-assistant/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/music-assistant/app/cnp-allow.yaml
@@ -15,9 +15,14 @@ spec:
     egress: false
     ingress: false
   ingress:
-    # LoadBalancer Service at 10.45.0.20 exposes :1780 (HTTP2 streaming)
-    # and :1704 (Snapserver) directly to LAN clients (sonos, snapcast,
-    # HA media_player, etc.). These arrive from `reserved:world`.
+    # LoadBalancer Service at 10.45.0.20 exposes :1780 (HTTP2 streaming),
+    # :1704 (Snapserver), and :3483 (SlimProto) directly to LAN clients
+    # (sonos, snapcast, HA media_player, the phone app on :8095, etc.).
+    # These arrive from `reserved:world`. :3483 here is for LAN SlimProto
+    # clients — notably the future LAN-based BOOM Pi bridge. The in-cluster
+    # squeezelite pool/deck pods do NOT use this rule: they reach MA via the
+    # ClusterIP (music-assistant.media.svc:3483 / :1780), covered by the
+    # baseline allow-intra-namespace policy.
     - fromEntities:
         - world
       toPorts:
@@ -25,6 +30,8 @@ spec:
             - port: "1780"
               protocol: TCP
             - port: "1704"
+              protocol: TCP
+            - port: "3483"
               protocol: TCP
             - port: "8095"
               protocol: TCP

--- a/kubernetes/apps/media/music-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/media/music-assistant/app/helmrelease.yaml
@@ -53,6 +53,8 @@ spec:
             port: &httpPort 8095
           http2:
             port: 1780
+          slimproto:
+            port: 3483
           snapserver:
             port: 1704
 

--- a/kubernetes/apps/media/squeezelite-deck/app/helmrelease.yaml
+++ b/kubernetes/apps/media/squeezelite-deck/app/helmrelease.yaml
@@ -1,0 +1,109 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app squeezelite-deck
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 30m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+      strategy: rollback
+  values:
+    controllers:
+      squeezelite-deck:
+        pod:
+          # Pin to worker2 — the ALC294 Headphone jack is the physical
+          # path to the amp serving the Deck speakers. worker2's audio
+          # card is an identical ALC294 with the same /dev/snd minor
+          # layout as master1, so it shares the generic-device-plugin
+          # `snd` group rather than needing its own.
+          nodeSelector:
+            kubernetes.io/hostname: worker2.thesteamedcrab.com
+          # WAF tier — deck audio dropouts are user-visible, so evict
+          # janitorr / recyclarr / metadata syncs before us. Stays well
+          # below system-cluster-critical so we never preempt infra.
+          priorityClassName: media-cluster-critical
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1114
+            runAsGroup: 1114
+            # GID 63 = `audio` on worker2; /dev/snd/* is root:audio 660.
+            supplementalGroups:
+              - 63
+
+        annotations:
+          reloader.stakater.com/auto: "true"
+
+        strategy: Recreate
+        containers:
+          app:
+            image:
+              repository: docker.io/giof71/squeezelite
+              tag: debian-alsa-squeezelite-1.8.4-r2
+
+            env:
+              # SlimProto server = Music Assistant's built-in provider.
+              SQUEEZELITE_SERVER_PORT: music-assistant.media.svc.cluster.local:3483
+              # Friendly name in the MA player list (squeezelite -n).
+              SQUEEZELITE_NAME: Deck
+              # SlimProto identity is the 6-byte MAC sent in the HELO. The
+              # container NIC MAC is ephemeral, so pin a stable, unique,
+              # locally-administered address — this is what stops MA from
+              # spawning a ghost player on every pod restart.
+              SQUEEZELITE_MAC_ADDRESS: "aa:bb:cc:00:00:02"
+              # With a fixed MAC the entrypoint never writes /config; this
+              # makes that explicit so nothing touches the read-only rootfs.
+              DISABLE_MAC_ADDRESS_GENERATION: "Y"
+              # ALSA "default" PCM on card 0 (ALC294). USER_MODE is left
+              # unset, so the entrypoint execs squeezelite directly as the
+              # pod's non-root user instead of the root-dropping path —
+              # which is what lets us keep runAsNonRoot + read-only rootfs.
+              SQUEEZELITE_AUDIO_DEVICE: default
+
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+              seccompProfile:
+                type: RuntimeDefault
+
+            # No liveness/readiness probes: squeezelite is the exec'd PID 1,
+            # so any crash exits the container and the kubelet restarts it.
+            # SlimProto reconnect is handled client-side on restart.
+
+            resources:
+              # devic.es/snd is advertised by generic-device-plugin
+              # (kube-system DaemonSet). The kubelet handles bind-mount
+              # of /dev/snd and device-cgroup whitelisting; no
+              # privileged: true required on this pod.
+              requests:
+                cpu: 25m
+                memory: 64Mi
+                devic.es/snd: 1
+              limits:
+                memory: 128Mi
+                devic.es/snd: 1
+
+    persistence:
+      # readOnlyRootFilesystem: true locks /. giof71's bash entrypoint
+      # sources helper scripts and lists ALSA devices at startup; give it
+      # /tmp and /config (a Dockerfile VOLUME) as emptyDir scratch.
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp
+      config:
+        type: emptyDir
+        globalMounts:
+          - path: /config

--- a/kubernetes/apps/media/squeezelite-deck/app/kustomization.yaml
+++ b/kubernetes/apps/media/squeezelite-deck/app/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../components/repos/app-template
+resources:
+  - ./helmrelease.yaml
+commonLabels:
+  app.kubernetes.io/instance: squeezelite-deck
+  app.kubernetes.io/name: squeezelite-deck

--- a/kubernetes/apps/media/squeezelite-deck/ks.yaml
+++ b/kubernetes/apps/media/squeezelite-deck/ks.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app squeezelite-deck
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: media
+  path: ./kubernetes/apps/media/squeezelite-deck/app
+  interval: 30m
+  prune: true
+  wait: false
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: generic-device-plugin
+      namespace: kube-system

--- a/kubernetes/apps/media/squeezelite-pool/app/helmrelease.yaml
+++ b/kubernetes/apps/media/squeezelite-pool/app/helmrelease.yaml
@@ -1,0 +1,106 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app squeezelite-pool
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 30m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+      strategy: rollback
+  values:
+    controllers:
+      squeezelite-pool:
+        pod:
+          # Pin to master1 — the ALC294 line-out (Headphone jack) is the
+          # physical path to the Fosi V3 amp serving the pool speakers.
+          nodeSelector:
+            kubernetes.io/hostname: master1.thesteamedcrab.com
+          # WAF tier — pool audio dropouts are user-visible, so evict
+          # janitorr / recyclarr / metadata syncs before us. Stays well
+          # below system-cluster-critical so we never preempt infra.
+          priorityClassName: media-cluster-critical
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1114
+            runAsGroup: 1114
+            # GID 63 = `audio` on master1; /dev/snd/* is root:audio 660.
+            supplementalGroups:
+              - 63
+
+        annotations:
+          reloader.stakater.com/auto: "true"
+
+        strategy: Recreate
+        containers:
+          app:
+            image:
+              repository: docker.io/giof71/squeezelite
+              tag: debian-alsa-squeezelite-1.8.4-r2
+
+            env:
+              # SlimProto server = Music Assistant's built-in provider.
+              SQUEEZELITE_SERVER_PORT: music-assistant.media.svc.cluster.local:3483
+              # Friendly name in the MA player list (squeezelite -n).
+              SQUEEZELITE_NAME: Pool
+              # SlimProto identity is the 6-byte MAC sent in the HELO. The
+              # container NIC MAC is ephemeral, so pin a stable, unique,
+              # locally-administered address — this is what stops MA from
+              # spawning a ghost player on every pod restart.
+              SQUEEZELITE_MAC_ADDRESS: "aa:bb:cc:00:00:01"
+              # With a fixed MAC the entrypoint never writes /config; this
+              # makes that explicit so nothing touches the read-only rootfs.
+              DISABLE_MAC_ADDRESS_GENERATION: "Y"
+              # ALSA "default" PCM on card 0 (ALC294). USER_MODE is left
+              # unset, so the entrypoint execs squeezelite directly as the
+              # pod's non-root user instead of the root-dropping path —
+              # which is what lets us keep runAsNonRoot + read-only rootfs.
+              SQUEEZELITE_AUDIO_DEVICE: default
+
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+              seccompProfile:
+                type: RuntimeDefault
+
+            # No liveness/readiness probes: squeezelite is the exec'd PID 1,
+            # so any crash exits the container and the kubelet restarts it.
+            # SlimProto reconnect is handled client-side on restart.
+
+            resources:
+              # devic.es/snd is advertised by generic-device-plugin
+              # (kube-system DaemonSet). The kubelet handles bind-mount
+              # of /dev/snd and device-cgroup whitelisting; no
+              # privileged: true required on this pod.
+              requests:
+                cpu: 25m
+                memory: 64Mi
+                devic.es/snd: 1
+              limits:
+                memory: 128Mi
+                devic.es/snd: 1
+
+    persistence:
+      # readOnlyRootFilesystem: true locks /. giof71's bash entrypoint
+      # sources helper scripts and lists ALSA devices at startup; give it
+      # /tmp and /config (a Dockerfile VOLUME) as emptyDir scratch.
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp
+      config:
+        type: emptyDir
+        globalMounts:
+          - path: /config

--- a/kubernetes/apps/media/squeezelite-pool/app/kustomization.yaml
+++ b/kubernetes/apps/media/squeezelite-pool/app/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../components/repos/app-template
+resources:
+  - ./helmrelease.yaml
+commonLabels:
+  app.kubernetes.io/instance: squeezelite-pool
+  app.kubernetes.io/name: squeezelite-pool

--- a/kubernetes/apps/media/squeezelite-pool/ks.yaml
+++ b/kubernetes/apps/media/squeezelite-pool/ks.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app squeezelite-pool
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: media
+  path: ./kubernetes/apps/media/squeezelite-pool/app
+  interval: 30m
+  prune: true
+  wait: false
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: generic-device-plugin
+      namespace: kube-system


### PR DESCRIPTION
## Summary

Phase 0 + Phase 1 of the pool/deck multiroom migration from Snapcast to
Squeezelite (SlimProto), served by Music Assistant's built-in SlimProto
provider on TCP 3483. **Additive and non-disruptive** — current Snapcast
playback is unaffected.

The end goal is to put every player in one SlimProto sync domain so a
future LAN Bluetooth-sink bridge can join the same synced zone (a thing
Snapcast structurally cannot do). The BT bridge itself is a later
follow-on, not part of this PR.

## What's in this PR

- **MA Service**: add `slimproto: 3483` port to the LoadBalancer Service.
- **MA CiliumNetworkPolicy**: allow ingress `world:3483` and re-scope the
  comment — `:3483` from `world` is for **LAN** SlimProto clients (the
  future BT bridge). The in-cluster pool/deck pods reach MA over the
  ClusterIP, already covered by the baseline `allow-intra-namespace`
  policy.
- **squeezelite-pool / squeezelite-deck**: app-template HelmReleases +
  ks/kustomization, mirroring the existing snapclient apps (master1 /
  worker2 node pins, `devic.es/snd: 1`, hardened non-root + read-only
  rootfs, `media-cluster-critical` priority). Upstream
  `docker.io/giof71/squeezelite` image; fixed per-player SlimProto MAC so
  no PVC is needed.
- README app/HelmRelease badge counts bumped for the two new apps.

## Deliberately NOT in this PR

- The squeezelite apps are **not** registered in `media/kustomization.yaml`.
  Per-node `devic.es/snd` is a single allocation, so snapclient must free
  the device before squeezelite can bind it. That swap is a brief
  per-zone silence and lands in a **separate cutover PR** (pool canary
  first, then deck).
- Snapcast decommission (`snapserver:1704`) is a later phase.

## Runtime state

MA's SlimProto provider has already been enabled in the UI; MA logged
`Loaded player provider Squeezelite` and is listening on 3483.

## Test plan

- [ ] CI green (lint, schema, kustomize build).
- [ ] After merge: `flux get ks -n flux-system` reconciles cleanly; MA
      Service shows the new `slimproto` port; CNP applies without drops.
- [ ] Squeezelite apps remain inert (not registered) until the cutover PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)