### PR TITLE
feat(media): cut pool zone over to squeezelite (canary)

### DIFF
--- a/.github/image-registry-allowlist.txt
+++ b/.github/image-registry-allowlist.txt
@@ -66,3 +66,4 @@ docker.io/alpine/git                    # no ghcr.io publication; Docker Hub is 
 docker.io/rcooler/omada_exporter        # no ghcr.io publication; Docker Hub is primary (verified 2026-05)
 docker.io/squat/generic-device-plugin   # no ghcr.io publication; Docker Hub is primary (verified 2026-05)
 docker.io/tombursch/kitchenowl          # no ghcr.io publication; Docker Hub is primary (verified 2026-05)
+docker.io/giof71/squeezelite            # no ghcr.io publication; Docker Hub is primary (verified 2026-05)

--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -45,11 +45,16 @@ resources:
   - ./romm/ks.yaml
   - ./seerr/ks.yaml
   - ./snapclient-deck/ks.yaml
-  - ./snapclient-pool/ks.yaml
   - ./sonarr/ks.yaml
   - ./sonarr-oauth2-proxy/ks.yaml
   - ./soularr/ks.yaml
   - ./soularr-oauth2-proxy/ks.yaml
+  # Pool multiroom: squeezelite (SlimProto) replaces snapclient as the
+  # canary zone. snapclient-pool unregistered here so Flux prunes it,
+  # freeing master1's single `devic.es/snd` allocation for the
+  # squeezelite-pool pod. snapclient-pool/ dir kept on disk for rollback
+  # until the migration is proven; deck stays on snapclient this round.
+  - ./squeezelite-pool/ks.yaml
   - ./stash/ks.yaml
   - ./suggestarr/ks.yaml
   - ./suggestarr-oauth2-proxy/ks.yaml


### PR DESCRIPTION
## Summary

**Phase 2 — disruptive cutover, pool zone only (canary).** Swaps the
pool speaker from snapclient (Snapcast) to squeezelite (SlimProto) by
editing `media/kustomization.yaml`:

- **Unregister** `snapclient-pool` → Flux prunes its deployment, freeing
  master1's single `devic.es/snd` allocation.
- **Register** `squeezelite-pool` → its pod binds the now-free ALSA
  device and connects to MA's SlimProto provider (`:3483`) over the
  ClusterIP.

Deck stays on snapclient this round — pool is the canary. The
`snapclient-pool/` directory is kept on disk for fast rollback.

## ⚠️ Do not merge until

1. **#12183 is merged** (this PR is stacked on it; `squeezelite-pool/`
   only exists on `main` after that lands — base auto-retargets to
   `main` on merge, then I'll rebase to a clean single-commit diff).
2. **You're ready for a brief pool-audio silence.** `devic.es/snd` is a
   single per-node allocation, so there's a short gap while
   snapclient-pool terminates and squeezelite-pool binds the device.
   The Renee-facing maintenance window was waived for this cutover, but
   it's still a live-audio interruption — merge when nobody's mid-song.

## Post-merge verification (pool canary)

- [ ] `squeezelite-pool` pod Running on master1, holding `devic.es/snd`.
- [ ] Player **Pool** appears in MA under the Squeezelite provider; test
      track plays.
- [ ] `kubectl delete pod` the player → same player returns (fixed MAC,
      no ghost / no "Pool 2").
- [ ] Group Pool + Deck, play one source → acceptable sync.
- [ ] Rollback path confirmed available (re-register snapclient-pool).

Once pool is proven, a follow-up PR repeats the swap for deck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)