### PR TITLE
feat(media): cut deck zone over to squeezelite

### DIFF
--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -44,16 +44,17 @@ resources:
   - ./recyclarr/ks.yaml
   - ./romm/ks.yaml
   - ./seerr/ks.yaml
-  - ./snapclient-deck/ks.yaml
   - ./sonarr/ks.yaml
   - ./sonarr-oauth2-proxy/ks.yaml
   - ./soularr/ks.yaml
   - ./soularr-oauth2-proxy/ks.yaml
-  # Pool multiroom: squeezelite (SlimProto) replaces snapclient as the
-  # canary zone. snapclient-pool unregistered here so Flux prunes it,
-  # freeing master1's single `devic.es/snd` allocation for the
-  # squeezelite-pool pod. snapclient-pool/ dir kept on disk for rollback
-  # until the migration is proven; deck stays on snapclient this round.
+  # Multiroom audio on squeezelite (SlimProto) replacing snapclient.
+  # Each snapclient ks unregistered so Flux prunes it, freeing the node's
+  # single `devic.es/snd` allocation for the squeezelite pod (deck=worker2,
+  # pool=master1). Pool proved out as the canary 2026-05-31; deck follows.
+  # snapclient-deck/ + snapclient-pool/ dirs kept on disk for rollback
+  # until the full migration is decommissioned (Phase 3).
+  - ./squeezelite-deck/ks.yaml
   - ./squeezelite-pool/ks.yaml
   - ./stash/ks.yaml
   - ./suggestarr/ks.yaml


### PR DESCRIPTION
## Summary

Second and final zone of the snapclient → **squeezelite (SlimProto)** multiroom migration. Mirrors the pool cutover (#12185), on **worker2** this time.

- Unregisters `./snapclient-deck/ks.yaml` so Flux prunes it, freeing worker2's single `devic.es/snd` allocation.
- Registers `./squeezelite-deck/ks.yaml` (already on disk via #12183) — fixed MAC `aa:bb:cc:00:00:02`, name `Deck`, `docker.io/giof71/squeezelite` (already allowlisted via #12185).
- `snapclient-deck/` dir kept on disk for rollback until Phase 3 decommission.

## Why disruptive

The device-plugin advertises **one** `devic.es/snd` per node. snapclient-deck and squeezelite-deck cannot co-run on worker2, so the swap is a hard per-zone cutover with a brief deck-audio silence while the snd device transfers. Music-only zone — not a voice/TTS target.

## Canary precedent

Pool proved out 2026-05-31: identity persists across pod restart via the fixed MAC (same `upa…` universal player returns, no ghost); MA auto-cleaned the old snapcast player from the group.

## Test plan

- [ ] CI green (flux-local diff/build; image already in rendered set, no new image)
- [ ] On merge: `squeezelite-deck` pod Running on worker2 holding `devic.es/snd`; `snapclient-deck` pruned
- [ ] **Deck** registers under MA's Squeezelite provider; survives a pod delete with no ghost
- [ ] Pool + Deck group and play in sync (both now SlimProto)
- [ ] Audio confirmed by ear

🤖 Generated with [Claude Code](https://claude.com/claude-code)