### PR TITLE
fix(observability/grafana): raise Helm upgrade timeout + pin image-renderer off :latest

### DIFF
--- a/.github/image-registry-allowlist.txt
+++ b/.github/image-registry-allowlist.txt
@@ -40,6 +40,7 @@ docker.io/library/python                # Python language image, no ghcr publica
 docker.io/rhasspy/wyoming-openwakeword
 docker.io/rhasspy/wyoming-piper
 docker.io/rhasspy/wyoming-whisper
+docker.io/grafana/grafana-image-renderer  # Grafana project canonical; no ghcr publication
 docker.io/grafana/mcp-grafana
 docker.io/grafana/tempo                # Grafana project canonical; ghcr publication missing
 docker.io/jmtvms/tplink-omada-mcp

--- a/kubernetes/apps/observability/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/grafana/app/helmrelease.yaml
@@ -14,6 +14,12 @@ spec:
 
       version: 10.5.15
   interval: 30m
+  # A values-only upgrade (e.g. #11989) blocks on re-resolving the 12
+  # unsigned plugins + pulling the image-renderer image, which can
+  # exceed Flux's default 5m Helm action timeout and trip an
+  # auto-rollback even though the running pod stays healthy. 10m gives
+  # the upgrade room to complete.
+  timeout: 10m
   values:
     affinity:
       podAntiAffinity:
@@ -339,6 +345,12 @@ spec:
       enabled: true
       env:
         RENDERING_MODE: clustered
+      image:
+        # Pinned off the chart-default `:latest` so each Helm upgrade
+        # pulls a deterministic digest instead of whatever `latest`
+        # drifted to. Bump deliberately; no Renovate manager tracks
+        # helm-values image tags in this repo yet.
+        tag: "5.8.8"
     persistence:
       enabled: false
 


### PR DESCRIPTION
## Summary

The grafana HelmRelease stalls on values-only upgrades (most recently #11989). The Helm upgrade blocks on re-resolving the 12 unsigned plugins + pulling the `grafana-image-renderer` image, which exceeds Flux's default **5m** Helm action timeout and trips an auto-rollback — even though the running pod stays healthy on the prior revision (HR observed rolled back to `grafana.v47`, `deployed/failed/failed/superseded` history).

Two changes:

- **`spec.timeout: 10m`** — gives the upgrade room to finish the plugin resolution + image pull instead of timing out at 5m.
- **`imageRenderer.image.tag: "5.8.8"`** — pins off the chart-default `:latest`. `:latest` currently resolves to `5.8.8` (digest `a30a…`, released 2026-05-28), so this is deterministic, not a version jump beyond what `:latest` would pull anyway. No Renovate manager tracks helm-values image tags in this repo, so future bumps are manual (noted inline).

## Test plan

- [x] pre-commit hooks pass (yamllint green)
- [ ] CI flux-local + lint pass
- [ ] Post-merge: HR reconciles `Ready=True / UpgradeSucceeded`, image-renderer rolls to 5.8.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)