### PR TITLE
fix(observability/grafana): correct image-renderer tag to v5.8.8

### DIFF
--- a/kubernetes/apps/observability/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/grafana/app/helmrelease.yaml
@@ -350,7 +350,7 @@ spec:
         # pulls a deterministic digest instead of whatever `latest`
         # drifted to. Bump deliberately; no Renovate manager tracks
         # helm-values image tags in this repo yet.
-        tag: "5.8.8"
+        tag: "v5.8.8"
     persistence:
       enabled: false
 


### PR DESCRIPTION
## Summary
One-character fix for the renderer image tag I shipped in #12192. The pin
landed as `5.8.8` (no `v`); Docker Hub publishes `v5.8.8`. The bare `5.8.8`
returns 404, so the `grafana-image-renderer` Deployment can't pull, never
reaches Ready, and Helm `--wait` times out on every upgrade — driving an
auto-rollback loop (helm revs v51–v55 today, HR now `Stalled/RetriesExceeded`).

`v5.8.8` is the exact build `:latest` resolves to right now (both pushed
2026-05-28), so this is a no-op on the running digest while restoring
deterministic, pullable upgrades. Merging bumps the HR generation, which
clears the Stalled state and lets Flux re-attempt the upgrade cleanly.

The image-registry allowlist entry (`docker.io/grafana/grafana-image-renderer`)
is prefix-match/tag-stripped, so it already covers `v5.8.8` — no allowlist change.

## Test plan
- [ ] image-registry-check green (allowlist already covers the prefix)
- [ ] After merge: HR leaves Stalled, renderer Deployment pulls `v5.8.8` and goes Ready, no rollback