### PR TITLE
fix(media): expose MA streamserver :8097 on Service for in-cluster players

### DIFF
--- a/kubernetes/apps/media/music-assistant/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/music-assistant/app/cnp-allow.yaml
@@ -21,8 +21,9 @@ spec:
     # These arrive from `reserved:world`. :3483 here is for LAN SlimProto
     # clients — notably the future LAN-based BOOM Pi bridge. The in-cluster
     # squeezelite pool/deck pods do NOT use this rule: they reach MA via the
-    # ClusterIP (music-assistant.media.svc:3483 / :1780), covered by the
-    # baseline allow-intra-namespace policy.
+    # ClusterIP for SlimProto control (:3483) and fetch the audio flow from
+    # the streamserver (:8097, publish_ip=ClusterIP) — both intra-namespace,
+    # covered by the baseline allow-intra-namespace policy.
     - fromEntities:
         - world
       toPorts:

--- a/kubernetes/apps/media/music-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/media/music-assistant/app/helmrelease.yaml
@@ -57,6 +57,12 @@ spec:
             port: 3483
           snapserver:
             port: 1704
+          # Streamserver — serves the audio flow to SlimProto/squeezelite
+          # players. Exposed on the ClusterIP so in-cluster players can fetch
+          # the stream URL (publish_ip=ClusterIP:8097); intra-namespace only,
+          # not in the world ingress allow-list.
+          streamserver:
+            port: 8097
 
     route:
       app:


### PR DESCRIPTION
## Summary

In-cluster squeezelite players (pool/deck) register over SlimProto control (:3483) but never play audio. MA hands each player a stream URL at `publish_ip:8097`, and the player makes a separate HTTP fetch for the audio flow. Two problems blocked that fetch:

1. **Port 8097 was never on the MA Service** — the streamserver listens inside the pod but had no Service port forwarding it.
2. `publish_ip` was set to the LoadBalancer IP, which is `world`-classified from a regular pod (socket-LB is host-netns-only here) and dropped by media's default-deny egress.

This PR fixes (1): adds `streamserver: 8097` to the MA Service so its stable ClusterIP forwards the stream port. Pod→ClusterIP:8097 is intra-namespace, covered by baseline allow-intra-namespace — **no new world exposure** (8097 is deliberately NOT in the world ingress allow-list).

The matching runtime change — repointing `publish_ip` to the ClusterIP — is applied out-of-band in MA's `settings.json` (not GitOps-managed).

Also corrects a stale comment in `cnp-allow.yaml` that claimed in-cluster players stream over :1780.

## Symptom signature

Exactly 10.0s between MA log "Setting active output protocol ... to Squeezelite" and "Player unavailable", with zero "Start Queue Flow stream" lines = MA's wait-for-stream-start timeout, player can't reach the stream URL.

## Test plan

- [ ] Flux reconciles; `kubectl get svc -n media music-assistant` shows port 8097
- [ ] Set `publish_ip` to ClusterIP in settings.json, bounce MA
- [ ] Play on Pool — audio out + "Start Queue Flow stream" log line instead of 10s timeout