### PR TITLE
fix(observability/grafana): add missing mcp dashboardProvider

### DIFF
--- a/kubernetes/apps/observability/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/grafana/app/helmrelease.yaml
@@ -124,6 +124,14 @@ spec:
               path: /var/lib/grafana/dashboards/ai
             orgId: 1
             type: file
+          - disableDeletion: false
+            editable: true
+            folder: mcp
+            name: mcp
+            options:
+              path: /var/lib/grafana/dashboards/mcp
+            orgId: 1
+            type: file
     dashboards:
       ai:
         aihomeops-state:


### PR DESCRIPTION
## Summary
Second, independent blocker in the grafana upgrade-rollback loop, exposed
once the renderer tag fix (#12193) let the upgrade get past the image pull.

`dashboards.mcp.mcp-system` was added to the values **without** a matching
`dashboardProviders` entry. The chart builds the init-container
`mkdir -p /var/lib/grafana/dashboards/<folder>` lines from
`dashboardProviders`, but the download loop from `dashboards`. With no `mcp`
provider, the `mcp/` directory is never created, so the init container's
`> /var/lib/grafana/dashboards/mcp/mcp-system.json` redirect fails with
`nonexistent directory` — crash-looping the `download-dashboards` init on
**every** new grafana pod since the MCP dashboard landed. The currently
running pod predates that change, which is why it survived while all newer
rollouts crash-looped and rolled back.

This adds the `mcp` provider (folder `mcp`, path
`/var/lib/grafana/dashboards/mcp`), matching the other 11 providers, so the
init `mkdir`s the dir and the dashboard loads into an "mcp" folder in Grafana.

## Test plan
- [ ] CI green
- [ ] After merge: `download-dashboards` init completes, new grafana pod reaches 3/3 Ready, HR goes Ready, upgrade no longer rolls back