### PR TITLE
feat(network): allow HA → langgraph-agents /inbox for voice ingress

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/cnp-allow.yaml
@@ -20,6 +20,9 @@ spec:
     # cost-cap-watcher / daily-digest flows.
     # collab/open-webui hits the in-cluster Service directly via
     # OPENAI_API_BASE_URLS (each agent id registered as a model).
+    # home/home-assistant POSTs the /inbox task contract directly via a
+    # rest_command when Rob speaks a "create a task" intent to Assist
+    # (HOMELAB-SPEC Layer 0 phone/voice ingress).
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: network
@@ -27,6 +30,9 @@ spec:
         - matchLabels:
             io.kubernetes.pod.namespace: collab
             app.kubernetes.io/name: open-webui
+        - matchLabels:
+            io.kubernetes.pod.namespace: home
+            app.kubernetes.io/name: home-assistant
         - matchExpressions:
             - key: io.kubernetes.pod.namespace
               operator: In

--- a/kubernetes/apps/home/home-assistant/app/cnp-allow.yaml
+++ b/kubernetes/apps/home/home-assistant/app/cnp-allow.yaml
@@ -195,6 +195,20 @@ spec:
         - ports:
             - port: "11434"
               protocol: TCP
+    # In-cluster langgraph-agents (ai/langgraph-agents:8765). HA POSTs the
+    # /inbox task contract here via a rest_command when Rob speaks a
+    # "create a task" intent to Assist (HOMELAB-SPEC Layer 0 phone/voice
+    # ingress). The matching ingress half lives in langgraph-agents' CNP.
+    # HA's toEntities:world (443/80) does NOT cover the in-cluster
+    # ClusterIP on 8765, so this explicit toEndpoints rule is required.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: ai
+            app.kubernetes.io/name: langgraph-agents
+      toPorts:
+        - ports:
+            - port: "8765"
+              protocol: TCP
     # LAN discovery multicast/broadcast from HA's eth0 interface. HA's
     # `zeroconf` and `ssdp` integrations bind to all interfaces by
     # default and emit periodic discovery on the cilium-governed pod


### PR DESCRIPTION
## Summary
First slice of the phone/voice ingress path (HOMELAB-SPEC Layer 0 — "tasks enter through Home Assistant voice"). Two additive CiliumNetworkPolicy holes so Home Assistant can reach `langgraph-agents:8765` to POST the `/inbox` task contract when Rob speaks a "create a task" intent to Assist.

- **langgraph-agents ingress** — add `home/home-assistant` to the existing `:8765` `fromEndpoints` allowlist (alongside envoy, open-webui, windmill).
- **home-assistant egress** — add a sibling `toEndpoints` block to `ai/langgraph-agents:8765`, patterned on the existing `ai/ollama:11434` block. HA's `toEntities: world` (443/80) does **not** cover the in-cluster ClusterIP, so the explicit `toEndpoints` is required.

Both rules are additive (`enableDefaultDeny` unchanged); they only punch holes through the existing default-deny.

## Scope
Network-only. The HA-side consumer wiring (`rest_command`, custom sentences, `intent_script`, mobile-app confirmation notify) and the `HAI_CLI_TOKEN` secret land in a separate follow-up PR (in `home-assistant-config` + an ExternalSecret edit here), gated on confirming the live Assist pipeline config.

## Test plan
- [ ] CI green (kustomize build, schema, yamllint)
- [ ] After merge + Flux reconcile: HA POST to `http://langgraph-agents.ai.svc.cluster.local:8765/inbox` returns **401** (reachable, auth-gated) rather than a connection timeout — proves the CNP hole is open both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)