### PR TITLE
feat(home-assistant): add HAI_CLI_TOKEN for voice task ingress

### DIFF
--- a/kubernetes/apps/home/home-assistant/app/externalsecret.yaml
+++ b/kubernetes/apps/home/home-assistant/app/externalsecret.yaml
@@ -25,9 +25,14 @@ spec:
         # Voice ingress — Bearer token HA presents on langgraph-agents
         # /inbox when Rob speaks a "create a task" intent to Assist
         # (HOMELAB-SPEC Layer 0). Same `hai-cli` 1P item + `TOKEN` field
-        # the langgraph-agents fleet validates against (agents/api/auth.py);
-        # HA references it as `!env_var HAI_CLI_TOKEN` in its rest_command.
+        # the langgraph-agents fleet validates against (agents/api/auth.py).
+        # HA's Jinja sandbox can't read env vars, so we also emit the
+        # ready-made `Authorization` header value — HA references it as
+        # `!env_var HAI_CLI_AUTH_HEADER` in its rest_command. Raw token
+        # kept too for grep parity with the agents side and any future
+        # direct use.
         HAI_CLI_TOKEN: "{{ .HAI_CLI_TOKEN }}"
+        HAI_CLI_AUTH_HEADER: "Bearer {{ .HAI_CLI_TOKEN }}"
   data:
     - secretKey: HAI_CLI_TOKEN
       remoteRef:

--- a/kubernetes/apps/home/home-assistant/app/externalsecret.yaml
+++ b/kubernetes/apps/home/home-assistant/app/externalsecret.yaml
@@ -22,6 +22,17 @@ spec:
         INIT_POSTGRES_USER: "{{ .POSTGRES_USER }}"
         INIT_POSTGRES_PASS: "{{ .POSTGRES_PASS }}"
         INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
+        # Voice ingress — Bearer token HA presents on langgraph-agents
+        # /inbox when Rob speaks a "create a task" intent to Assist
+        # (HOMELAB-SPEC Layer 0). Same `hai-cli` 1P item + `TOKEN` field
+        # the langgraph-agents fleet validates against (agents/api/auth.py);
+        # HA references it as `!env_var HAI_CLI_TOKEN` in its rest_command.
+        HAI_CLI_TOKEN: "{{ .HAI_CLI_TOKEN }}"
+  data:
+    - secretKey: HAI_CLI_TOKEN
+      remoteRef:
+        key: hai-cli
+        property: TOKEN
   dataFrom:
     - extract:
         key: home-assistant


### PR DESCRIPTION
## Summary
Second slice of the phone/voice ingress path. Adds the Bearer token Home Assistant presents on `langgraph-agents:8765/inbox` so a spoken "create a task" intent can enqueue a task (HOMELAB-SPEC Layer 0).

- Sources `HAI_CLI_TOKEN` from the **same `hai-cli` 1Password item, field `TOKEN`** that the langgraph-agents fleet validates against (`agents/api/auth.py`) — single rotation surface, no new secret to provision.
- Surfaces it on the existing `home-assistant` Secret (consumed via the HelmRelease's `envFrom`), so HA reads it as `!env_var HAI_CLI_TOKEN`.

## Sequencing
Depends on **#12198** (the CNP network path) for the POST to actually reach the agents. The matching HA-side wiring (`rest_command` + custom sentences + `intent_script`) lands in the `home-assistant-config` repo and references `!env_var HAI_CLI_TOKEN` — so **this PR must merge before that one** (HA config validation fails if the env var is absent).

## Test plan
- [ ] CI green
- [ ] After merge + ESO refresh: `kubectl get secret home-assistant -n home -o jsonpath='{.data.HAI_CLI_TOKEN}'` is populated (reloader restarts HA to pick it up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)