### PR TITLE
fix(media): bump immichkiosk-party memory limit 1Gi -> 2Gi

### DIFF
--- a/kubernetes/apps/media/immichkiosk-party/app/helmrelease.yaml
+++ b/kubernetes/apps/media/immichkiosk-party/app/helmrelease.yaml
@@ -111,7 +111,7 @@ spec:
                 cpu: 15m
                 memory: 1Gi
               limits:
-                memory: 1Gi
+                memory: 2Gi
 
     service:
       app:


### PR DESCRIPTION
## What

Raise the `immichkiosk-party` container memory limit from 1Gi to 2Gi. Request stays at 1Gi (Burstable).

## Why

`immichkiosk-party-0` was OOMKilled (exit 137) on 2026-05-30, firing a critical `OOMKilled` alert. The pod restarted and has run healthy since, but the ceiling is too tight: the party kiosk runs with `KIOSK_USE_ORIGINAL_IMAGE=true` + `KIOSK_PREFETCH=true` + `KIOSK_FETCHED_ASSETS_SIZE=100`, so it prefetches 100 original-resolution assets — a memory spike that exceeds 1Gi. Same pattern as the earlier music-assistant 2Gi→3Gi bump.

## Blast radius

Single HelmRelease, one pod restart on reconcile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)