### PR TITLE
fix(network): scope internal-only DNSEndpoints away from Cloudflare

### DIFF
--- a/kubernetes/apps/network/external-dns/app/cloudflare/helmrelease.yaml
+++ b/kubernetes/apps/network/external-dns/app/cloudflare/helmrelease.yaml
@@ -65,6 +65,12 @@ spec:
       - --events
       - --ignore-ingress-tls-spec
       - --gateway-label-filter=type=external
+      # Exclude internal-only DNSEndpoints (dns-provider=bind) from the
+      # Cloudflare instance. Set-based "!=" also matches objects without
+      # the label, so all public records are still published; only
+      # bind-scoped private-IP records are skipped. Ref: guest-portal
+      # DNSEndpoint pushing 10.10.30.1/192.168.1.1 → Cloudflare err 9003.
+      - --label-filter=dns-provider!=bind
       # - --annotation-filter=external-dns.alpha.kubernetes.io/target
       # - --gateway-name=external
       # - --gateway-name=tcp

--- a/kubernetes/apps/network/omada-cert-sync/app/dnsendpoint.yaml
+++ b/kubernetes/apps/network/omada-cert-sync/app/dnsendpoint.yaml
@@ -4,6 +4,12 @@ apiVersion: externaldns.k8s.io/v1alpha1
 kind: DNSEndpoint
 metadata:
   name: guest-portal
+  labels:
+    # Internal-only records (private-IP A records served by brain's bind
+    # via RFC2136). The cloudflare external-dns instance excludes this
+    # label (--label-filter=dns-provider!=bind) so it doesn't try to
+    # publish private IPs as proxied records to Cloudflare (error 9003).
+    dns-provider: bind
 spec:
   endpoints:
     # Captive-portal hostname for "Lovenet Guest". Points at brain's


### PR DESCRIPTION
## What

- Label the `guest-portal` DNSEndpoint `dns-provider: bind`.
- Add `--label-filter=dns-provider!=bind` to the **cloudflare** external-dns instance.

## Why

The `guest-portal` DNSEndpoint declares two private-IP A records (`guest-portal` → `10.10.30.1`, `omada` → `192.168.1.1`) that are only meant for brain's bind via RFC2136 (split-horizon internal). Both external-dns instances consume `--crd-source-kind=DNSEndpoint` with no discriminator, so the **cloudflare** instance also tried to publish them — as **proxied** records. Cloudflare rejects proxied records pointing at private IPs:

```
code 9003: Target 10.10.30.1 is not allowed for a proxied record
```

This wedged the cloudflare sync in a retry loop (**700+ consecutive soft errors**). Last successful Cloudflare sync was ~11.6h ago — **no public DNS record changes applied** during the stall, tripping the `ExternalDNSStale` critical alert.

## How the filter is safe

`--label-filter=dns-provider!=bind` uses set-based selector semantics: `!=` **also matches objects that don't have the label**. So every existing DNSEndpoint / gateway source (none of which carry `dns-provider`) is still published to Cloudflare unchanged; only objects explicitly labeled `dns-provider=bind` (just this one) are excluded. The bind instance keeps consuming everything, so internal resolution is unchanged.

Side benefit: keeps internal/private IPs out of public DNS (data-classification).

## Blast radius

Two files in `network`. Cloudflare external-dns pod restarts on reconcile and resumes a clean sync; bind instance untouched.

## Verification after merge

- `external_dns_controller_last_sync_timestamp_seconds` for the cloudflare instance becomes recent (soft-error loop stops).
- `guest-portal` / `omada` still resolve internally via bind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)