### PR TITLE
fix(media): make lidarr-sab-autoimport tolerate transient DNS blips

### DIFF
--- a/kubernetes/apps/media/lidarr-sab-autoimport/app/helmrelease.yaml
+++ b/kubernetes/apps/media/lidarr-sab-autoimport/app/helmrelease.yaml
@@ -29,7 +29,10 @@ spec:
           concurrencyPolicy: Forbid
           successfulJobsHistory: 1
           failedJobsHistory: 3
-          backoffLimit: 0
+          # Retry transient failures (e.g. musl EAI_AGAIN DNS blips) on a
+          # fresh pod instead of failing the run on the first hiccup. The
+          # script also retries internally; this is the outer net.
+          backoffLimit: 2
           activeDeadlineSeconds: 300
           ttlSecondsAfterFinished: 86400
         type: cronjob

--- a/kubernetes/apps/media/lidarr-sab-autoimport/app/resources/scan.py
+++ b/kubernetes/apps/media/lidarr-sab-autoimport/app/resources/scan.py
@@ -32,11 +32,22 @@ within ~1 min of the next `Refresh Monitored Downloads` cycle.
 """
 import json
 import os
+import time
+import urllib.error
 import urllib.parse
 import urllib.request
 
 LIDARR_URL = os.environ.get("LIDARR_URL", "http://lidarr.media.svc.cluster.local:8686")
 LIDARR_API_KEY = os.environ["LIDARR__API_KEY"]
+
+# The python:*-alpine base uses musl libc, which returns EAI_AGAIN
+# ([Errno -3] Try again) on brief CoreDNS hiccups where glibc would
+# retry internally. Every call here targets an in-cluster Service, and
+# the operations are idempotent (DownloadedAlbumsScan / DELETE queue
+# row), so retry connection-level failures and transient 5xx instead of
+# failing the whole run on one DNS blip.
+MAX_ATTEMPTS = 4
+RETRY_BACKOFF_S = 2
 
 
 def call_api(method, path, params=None, body=None):
@@ -49,9 +60,26 @@ def call_api(method, path, params=None, body=None):
         data = json.dumps(body).encode("utf-8")
         headers["Content-Type"] = "application/json"
     req = urllib.request.Request(url, data=data, headers=headers, method=method)
-    with urllib.request.urlopen(req, timeout=30) as resp:
-        raw = resp.read()
-        return json.loads(raw) if raw else {}
+    for attempt in range(1, MAX_ATTEMPTS + 1):
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                raw = resp.read()
+                return json.loads(raw) if raw else {}
+        except urllib.error.HTTPError as e:
+            # Server answered — only 5xx is worth retrying; 4xx is fatal.
+            if e.code < 500 or attempt == MAX_ATTEMPTS:
+                raise
+            err = e
+        except urllib.error.URLError as e:
+            # Connection-level failure: transient DNS (EAI_AGAIN),
+            # refused, timeout. Retry until attempts exhausted.
+            if attempt == MAX_ATTEMPTS:
+                raise
+            err = e
+        sleep_s = RETRY_BACKOFF_S * attempt
+        print(f"  call_api {method} {path} attempt {attempt}/{MAX_ATTEMPTS} "
+              f"failed ({err}); retrying in {sleep_s}s")
+        time.sleep(sleep_s)
 
 
 def main():


### PR DESCRIPTION
## What

- `scan.py`: retry `call_api()` on connection-level `URLError` (transient DNS `EAI_AGAIN`, refused, timeout) and transient 5xx — 4 attempts, linear backoff. 4xx still fails fast.
- `helmrelease.yaml`: `backoffLimit: 0 → 2` as an outer net (fresh pod on job retry).

## Why

The `*/5` cronjob intermittently failed with:

```
urllib.error.URLError: <urlopen error [Errno -3] Try again>
```

`[Errno -3] Try again` is `EAI_AGAIN` — a **transient CoreDNS resolution failure** for the in-cluster `lidarr` Service, not a Lidarr/SABnzbd problem. The `python:*-alpine` base uses **musl libc**, which surfaces `EAI_AGAIN` on brief resolver hiccups where glibc retries internally.

It wasn't actually failing much — ~2 of ~288 daily runs (~0.7%), and the most recent run completed. But two config choices amplified it into a persistent `KubeJobFailed`:

| Setting | Was | Effect |
|---|---|---|
| `backoffLimit` | 0 | One DNS blip = instant job failure, no retry |
| `failedJobsHistory` + `ttl` | 3 / 24h | Failed jobs linger 24h → alert keeps firing after the blip clears |

## Safety

Both API operations are idempotent — `DownloadedAlbumsScan` (re-scanning a path is harmless) and `DELETE` of a queue row (already-gone row returns 4xx → fail-fast, no loop). So retrying connection-level failures is safe. Worst-case retry time stays well under `activeDeadlineSeconds: 300`.

## Note

This is **internal cluster DNS (CoreDNS)**, unrelated to the external-dns/Cloudflare `ExternalDNSStale` fix (#12202). Two blips/day is normal transient territory — the job just needs to tolerate them rather than alert on them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)