### PR TITLE
ci(renovate): hold flux-local at 8.1.x until upstream helm-4 OCI fix

### DIFF
--- a/.github/renovate/packageRules.json5
+++ b/.github/renovate/packageRules.json5
@@ -60,6 +60,17 @@
       matchPackageNames: ["ghcr.io/blakeblackshear/frigate"]
     },
     {
+      // Hold at 8.1.x: v8.2.0 bundles helm 4, which drops plain-HTTP
+      // OCI fallback and breaks `helm template` against our plain-HTTP
+      // zot pull-through cache (zot.kube-system.svc.cluster.local:5000),
+      // failing the Flux Local CI gate cluster-wide. Tracked upstream at
+      // allenporter/flux-local#1102. Re-allow when that lands.
+      description: "Hold flux-local at 8.1.x until allenporter/flux-local#1102 (helm 4 breaks plain-HTTP OCI against zot) is fixed upstream.",
+      matchDatasources: ["docker"],
+      matchPackageNames: ["ghcr.io/allenporter/flux-local"],
+      allowedVersions: "<8.2.0",
+    },
+    {
       // Suppresses the built-in flux manager's failing lookup for
       // OCIRepositories pointing at `oci://zot.kube-system...:5000/*`.
       // The companion customManager in customManagers.json5 captures


### PR DESCRIPTION
## What

Pins `ghcr.io/allenporter/flux-local` to `<8.2.0` in Renovate so it stops re-proposing the v8.2.0 bump.

## Why

v8.2.0 swaps the bundled helm 3.19.0 → **helm 4.1.1**. Helm 4 drops the plain-HTTP OCI fallback, so `helm template` fails against our plain-HTTP zot pull-through cache (`zot.kube-system.svc.cluster.local:5000`) with `http: server gave HTTP response to HTTPS client`. It also changed cache-dir handling, tripping `mkdir /.cache: permission denied` in the non-root container.

The Flux Local workflow runs **inside** the flux-local image (`container: image:`), so merging the bump (#12213) would point main's workflow at v8.2.0 and break the Flux Local CI gate on **every** subsequent PR — not just one app.

Tracked upstream: [allenporter/flux-local#1102](https://github.com/allenporter/flux-local/issues/1102) — open. Re-allow 8.2.x once that's fixed.

## Closes

- Supersedes / closes the stuck Renovate PR #12213.

🤖 Generated with [Claude Code](https://claude.com/claude-code)