### PR TITLE
fix(rtl-433): pin to 345MHz, drop 319.5MHz frequency hop

### DIFF
--- a/kubernetes/apps/home/rtl-433/app/helmrelease.yaml
+++ b/kubernetes/apps/home/rtl-433/app/helmrelease.yaml
@@ -44,7 +44,7 @@ spec:
             args:
               - |
                 MQTT_URL="mqtt://emqx.home.svc.cluster.local:1883,user=$${MQTT_USER},pass=$${MQTT_PASS},retain=1,events=rtl_433[/model][/id],states=rtl_433[/model][/id]/state,devices=rtl_433[/model][/id]"
-                exec rtl_433 -f 345M -f 319.5M -H 60 -M time:iso:tz -M protocol -M level -F "$$MQTT_URL" -F log
+                exec rtl_433 -f 345M -M time:iso:tz -M protocol -M level -F "$$MQTT_URL" -F log
 
             envFrom:
               - secretRef:


### PR DESCRIPTION
## What

Drop the `-f 319.5M -H 60` frequency hop from the rtl_433 receiver; pin to a single `-f 345M`.

## Why

Walk-testing the legacy security sensors into HA, every device in the live RF baseline (14 distinct sensors) transmits at ~344.9 MHz — nothing is on 319.5 MHz. The hop (`-H 60`) parked the receiver on the dead 319.5M band for ~50% of the time, silently dropping sensor state-change transmissions. Single deliberate triggers were missed ~half the time during the walk-test.

Pinning to continuous `-f 345M` dwell makes catches reliable. This is the intended end-state for the project anyway (post-walk-test cleanup).

## Impact

- Restarts `rtl-433-0` (single replica) → ~30–60s RF reception gap.
- No user-facing impact: these sensors are not yet wired into Home Assistant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)