### PR TITLE
fix(container): update ghcr.io/rwlove/langgraph-agents ( 0.2.64 → 0.2.65 )

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/langgraph-agents
-              tag: 0.2.64@sha256:b03efc06c32b45b1b04e463e89bf965d4865c6c3288294802acd37ec90d2f211
+              tag: 0.2.65@sha256:f07fe87dafa81e22b463c1f30d719acba57df302a85947d4edd7cfdaee03e906
 
             env:
               # --- vault ---


### PR DESCRIPTION
Deploys langgraph-agents #117 — the action-first approval listing.

## What's in 0.2.65
- Persists a curated `approval_request` subset (`payload_summary`, `action_class`, `proposed_by`, `undo_path`, `cost_estimate_usd`, `requires_two_person`) on the durable queue row at park time.
- Exposes it on the checkpointer-free `/admin/tasks?status=awaiting_approval` listing, so consumers get the decision context without a checkpointer scan.

## Why now
home-assistant-config #41 (merged) renders the phone notification + dashboard card **action-first** off these fields. Until this image deploys, those surfaces show the harmless `content` fallback. This bump lights up the real render.

Image digest resolved from the published multi-arch index for `0.2.65`.

## Test plan
- [x] pre-commit (yamllint, schema, secret scan) green locally
- [ ] CI green
- [ ] Flux reconciles langgraph-agents to 0.2.65; pod healthy
- [ ] Live: a real parked approval shows action-first on phone + dashboard