### PR TITLE
fix(media): bump immichkiosk-party fetch buffer 100->300

### DIFF
--- a/kubernetes/apps/media/immichkiosk-party/app/helmrelease.yaml
+++ b/kubernetes/apps/media/immichkiosk-party/app/helmrelease.yaml
@@ -89,11 +89,14 @@ spec:
               KIOSK_SHOW_MORE_INFO_IMAGE_LINK: true
               KIOSK_SHOW_MORE_INFO_QR_CODE: true
               KIOSK_SHOW_PERSON_AGE: true
-              # Kiosk settings — smaller fetch buffer + cache off so newly
-              # added Party Album photos enter the unplayed pool within
-              # one cycle, not eight hours later.
+              # Kiosk settings — cache off so newly added Party Album
+              # photos enter the unplayed pool within one cycle, not
+              # eight hours later. Buffer at 300 (not the main kiosk's
+              # 1000) keeps the pool fresh while giving prefetch enough
+              # margin to avoid htmx fetch-timeout reloads, which the
+              # ImmichFrame webview escapes into a bare browser.
               KIOSK_WATCH_CONFIG: false
-              KIOSK_FETCHED_ASSETS_SIZE: 100
+              KIOSK_FETCHED_ASSETS_SIZE: 300
               KIOSK_HTTP_TIMEOUT: 20
               KIOSK_PASSWORD: ""
               KIOSK_CACHE: false


### PR DESCRIPTION
## Summary
- Raises `KIOSK_FETCHED_ASSETS_SIZE` from `100` to `300` on the party kiosk while keeping `KIOSK_CACHE: false`.

## Why
The party kiosk fetched a tiny 100-asset buffer with cache disabled, forcing live Immich fetches that raced the htmx fetch timeout. Accumulated `htmx:sendError` events triggered `window.location.reload()`, which the ImmichFrame webview wrapper escaped into a bare standalone browser — surfacing as a visible address bar on the basement frame. A 300-asset buffer gives prefetch enough margin to avoid the timeout reloads; cache stays off so newly added Party Album photos still enter the unplayed pool within one cycle.

Device-side mitigation already applied separately (the two standalone browsers the reload escaped to are disabled on the basement frame), so this PR is the upstream softening, not the sole fix.

## Test plan
- [ ] Flux reconciles; `immichkiosk-party` pod rolls and comes Ready
- [ ] Party frame slideshow advances without error reloads
- [ ] Newly added Party Album photos still appear within one cycle