### PR TITLE
fix(media,longhorn): lidarr config-volume recovery + longhorn 1.12.0 pin removal

### DIFF
--- a/kubernetes/apps/longhorn-system/longhorn/app/helmrelease.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn/app/helmrelease.yaml
@@ -15,7 +15,7 @@ spec:
       version: 1.12.0
   interval: 30m
   values:
-    # workaround: https://github.com/longhorn/longhorn/issues/12573 — remove preUpgradeChecker disables + v1.11.0-hotfix-1 image pins when longhorn v1.11.1 lands as a chart release
+    # workaround: https://github.com/longhorn/longhorn/issues/12573 — image pins removed (1.12.0 ships the fixed manager/instanceManager images natively). preUpgradeChecker disables retained for now; re-enable as a follow-up once 1.12.0 is confirmed stable.
     # Tracking: home-ops#11828
     defaultSettings:
       backupTarget: "nfs://beast:/mnt/mass_storage/longhorn-backups"
@@ -28,13 +28,6 @@ spec:
       storageMinimalAvailablePercentage: 10
     global:
       imageRegistry: docker.io
-
-    image:
-      longhorn:
-        instanceManager:
-          tag: v1.11.0-hotfix-1
-        manager:
-          tag: v1.11.0-hotfix-1
 
     longhornManager:
       securityContext:

--- a/kubernetes/apps/media/lidarr/app/longhorn-pvc.yaml
+++ b/kubernetes/apps/media/lidarr/app/longhorn-pvc.yaml
@@ -39,4 +39,9 @@ spec:
     volumeAttributes:
       numberOfReplicas: "2"
       staleReplicaTimeout: "2880"
-    volumeHandle: lidarr-config-xfs
+    # 2026-06-02 XFS-corruption recovery: original volume lidarr-config-xfs
+    # suffered a bad-superblock crash (unclean detach 2026-05-31). Data
+    # restored from weekly backup backup-5f9fb53d2ec54d09 into a new Longhorn
+    # volume lidarr-config-recovery (xfs_repair -L log-replay, verified
+    # config.xml + asp/ keys intact). Old volume retained as fallback.
+    volumeHandle: lidarr-config-recovery


### PR DESCRIPTION
Two changes from the 2026-06-02 lidarr/longhorn incident response.

## 1. lidarr config PV → recovered Longhorn volume
`lidarr-0` was stuck Pending ~46h on an XFS `bad superblock` (unclean detach 2026-05-31). The config volume was recovered from the weekly backup into a new Longhorn volume `lidarr-config-recovery` (xfs_repair -L log-replay on a clone; `config.xml` + `asp/` data-protection keys verified intact). The corrupt original volume is retained as a fallback. This change points the PV's `volumeHandle` at the recovered volume so Git matches the cluster. The real lidarr DB lives in CNPG `postgres-lidarr` (untouched, healthy).

## 2. Drop longhorn `v1.11.0-hotfix-1` image pin
The 1.12.0 chart upgrade (Renovate #12241) was failing/rolling back. `longhorn#12573` (the v1.11.0 instance-manager high-memory bug) is fixed in 1.12.0, which ships the corrected manager/instanceManager images natively — so the hotfix pin must go (keeping it re-introduces the bug under the 1.12.0 chart). `preUpgradeChecker` disables are retained for now; `home-ops#11828` stays open for that follow-up.

Unblocks the longhorn 1.12.0 reconcile, which in turn unblocks the 34 `dependsOn: longhorn` apps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)