### PR TITLE
ci(image-registry-check): restrict Docker Hub only, allow all other registries

### DIFF
--- a/.github/image-registry-allowlist.txt
+++ b/.github/image-registry-allowlist.txt
@@ -1,33 +1,25 @@
 # Image registry allowlist
 #
-# Repo policy is "prefer ghcr.io for everything". This file lists the
-# exceptions — images whose ghcr.io publication does not exist (or is
-# strictly worse than the registry below). Entries are matched as
+# Repo policy is "any registry except Docker Hub". Docker Hub
+# (docker.io) rate-limits anonymous/free pulls, so it is the only
+# restricted registry — every other registry (ghcr.io, quay.io,
+# registry.k8s.io, nvcr.io, mcr.microsoft.com, lscr.io, ...) is fine
+# and needs no entry here.
+#
+# This file lists the docker.io exceptions — images whose only
+# acceptable home is Docker Hub (no non-docker publication exists, or
+# the alternatives are strictly worse). Entries are matched as
 # "starts with" against the image reference, *before* any `:tag` or
 # `@sha256:` suffix.
 #
-# Before adding an entry, check whether a ghcr.io path exists by
+# Before adding an entry, check whether a non-docker path exists by
 # running `skopeo list-tags docker://ghcr.io/<org>/<image>` against
 # the upstream org and against `home-operations` (the curated mirror
 # set this repo already uses).
 #
 # Format: one prefix per line; `#` for comments; trailing comments OK.
 
-# --- Official / canonical registries --------------------------------
-# These projects publish to a non-ghcr registry as their *primary*
-# home. Moving to ghcr would be a downgrade.
-quay.io/prometheus/                     # Prometheus project canonical
-quay.io/prometheus-operator/            # Prometheus Operator project canonical
-quay.io/oauth2-proxy/                   # oauth2-proxy project canonical; no ghcr.io publication
-quay.io/cilium/                         # Cilium project canonical
-nvcr.io/nvidia/                         # NVIDIA NGC catalog
-mirror.gcr.io/                          # Google pull-through mirror
-registry.k8s.io/                        # Kubernetes project canonical
-public.ecr.aws/emqx/                    # EMQX canonical (ghcr only has major.minor tags)
-registry.istio.io/release/              # Istio project canonical
-mcr.microsoft.com/                      # Microsoft Container Registry canonical
-
-# --- No suitable ghcr.io equivalent (verified 2026-05) --------------
+# --- No suitable non-docker equivalent (verified 2026-05) -----------
 docker.io/ollama/ollama
 docker.io/kanidm/server                 # ghcr is `devel`-only, no stable tags
 docker.io/glanceapp/glance
@@ -61,7 +53,6 @@ docker.io/qdrant/qdrant                 # ghcr.io/qdrant/qdrant ships only dev-*
 docker.io/robustadev/holmes             # no ghcr.io publication (ghcr.io/robusta-dev/holmes 403)
 docker.io/binwiederhier/ntfy            # no ghcr.io publication (verified 2026-05)
 docker.io/nginxinc/nginx-unprivileged   # nginx project canonical; no ghcr.io publication
-lscr.io/linuxserver/openssh-server      # linuxserver's canonical registry; ghcr mirror stops at 8.3_p1
 docker.io/hertzg/rtl_433               # no ghcr.io publication; Docker Hub is primary (verified 2026-05)
 docker.io/alpine/git                    # no ghcr.io publication; Docker Hub is primary (verified 2026-05)
 docker.io/rcooler/omada_exporter        # no ghcr.io publication; Docker Hub is primary (verified 2026-05)

--- a/tools/check-image-registry.sh
+++ b/tools/check-image-registry.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Check that container images use ghcr.io, or are explicitly allowlisted.
+# Check that container images do not pull from Docker Hub unless the
+# image is explicitly allowlisted.
 #
 # Usage:
 #   tools/check-image-registry.sh < images.txt           # one image per line
@@ -10,7 +11,12 @@
 # Pass --json if the input is a JSON array of image strings (e.g. the
 # output of `flux-local get cluster --only-images --output json`).
 #
-# Exits 0 if all images are ghcr.io or allowlisted; 1 otherwise.
+# Policy: Docker Hub (docker.io) is the only restricted registry — it
+# rate-limits anonymous/free pulls. Every other registry (ghcr.io,
+# quay.io, registry.k8s.io, nvcr.io, ...) is allowed. The allowlist
+# holds docker.io images that have no acceptable alternative.
+#
+# Exits 0 if no non-allowlisted docker.io images are present; 1 otherwise.
 # Prints offenders to stderr with the allowlist path so the fix is
 # obvious.
 
@@ -59,16 +65,12 @@ for image in "${images[@]}"; do
   bare="${image%@*}"
   bare="${bare%:*}"
 
-  # ghcr.io — always OK
-  if [[ "$bare" == ghcr.io/* ]]; then
-    continue
-  fi
-
-  # Normalize bare docker.io paths to their fully-qualified
+  # Normalize bare/implicit paths to their fully-qualified
   # `docker.io/<namespace>/<image>` form. Docker Hub treats unspecified
   # namespace as `library/`, so all four of these are equivalent:
   #   busybox / library/busybox / docker.io/busybox / docker.io/library/busybox
-  # The allowlist uses the `docker.io/library/...` form for clarity.
+  # This resolves short Docker Hub refs so they're caught by the gate
+  # below. The allowlist uses the `docker.io/library/...` form for clarity.
   case "$bare" in
     docker.io/*/* ) ;;                            # `docker.io/org/img` — canonical
     docker.io/* )
@@ -78,6 +80,14 @@ for image in "${images[@]}"; do
     * )     bare="docker.io/library/$bare" ;;     # `img`
   esac
 
+  # Only Docker Hub is restricted (it rate-limits free pulls). Every
+  # other registry — ghcr.io, quay.io, registry.k8s.io, nvcr.io, ... —
+  # passes without an allowlist entry.
+  if [[ "$bare" != docker.io/* ]]; then
+    continue
+  fi
+
+  # docker.io image — must be explicitly allowlisted.
   matched=false
   for p in "${prefixes[@]}"; do
     if [[ "$bare" == "$p"* ]]; then
@@ -90,18 +100,20 @@ for image in "${images[@]}"; do
 done
 
 if (( ${#violations[@]} == 0 )); then
-  echo "OK: all $(printf '%s\n' "${images[@]}" | wc -l) images use ghcr.io or are allowlisted."
+  echo "OK: none of the $(printf '%s\n' "${images[@]}" | wc -l) images pull from Docker Hub (or they are allowlisted)."
   exit 0
 fi
 
 {
-  echo "Non-ghcr.io images found that are not allowlisted:"
+  echo "Docker Hub (docker.io) images found that are not allowlisted:"
   printf '  - %s\n' "${violations[@]}"
   echo
-  echo "Repo policy is to prefer ghcr.io. For each offender, either:"
-  echo "  1. Switch to the upstream ghcr.io publication if one exists, or"
+  echo "Docker Hub rate-limits anonymous/free pulls, so it is restricted."
+  echo "For each offender, either:"
+  echo "  1. Switch to a non-docker.io publication (ghcr.io, quay.io,"
+  echo "     registry.k8s.io, ... — any of these is fine), or"
   echo "  2. Add the image's prefix to ${ALLOWLIST#"$PWD/"} with a one-line"
-  echo "     reason (e.g. 'no ghcr publication', 'official canonical home')."
+  echo "     reason (e.g. 'no non-docker publication')."
   echo
   echo "Check for a ghcr.io equivalent with:"
   echo "  skopeo list-tags docker://ghcr.io/<org>/<image>"


### PR DESCRIPTION
## What

The Image Registry Check was built as *"ghcr.io is the only free pass, everything else must be allowlisted."* Actual repo policy is the inverse: **Docker Hub (`docker.io`) is the only restricted registry** because it rate-limits anonymous/free pulls — every other registry (`ghcr.io`, `quay.io`, `registry.k8s.io`, `nvcr.io`, `mcr.microsoft.com`, `lscr.io`, …) is acceptable.

This flips the gate to a docker.io-only blocklist.

## Changes

- **`tools/check-image-registry.sh`** — passes any non-`docker.io` image without an allowlist entry; only `docker.io` images must be allowlisted. Short/implicit Docker Hub refs (`nginx`, `org/img`) are still normalized and caught. Header + error text rewritten for the new policy.
- **`.github/image-registry-allowlist.txt`** — dropped the 11 now-redundant non-docker entries (`quay.io/*`, `nvcr.io/*`, `registry.k8s.io/`, `lscr.io/*`, `mcr.microsoft.com/`, `public.ecr.aws/*`, `registry.istio.io/*`, `mirror.gcr.io/`). The remaining `docker.io/*` entries are the real exception list. Header rewritten.

## Why

The rook-ceph v1.20.0 bump (#12247) pulls in `quay.io/ceph/ceph:v20.2.1` and `quay.io/cephcsi/ceph-csi-operator:v1.0.1`. Both were flagged by the old gate despite `quay.io` being a perfectly fine registry. After this change they pass, as does any future quay/k8s/nvcr bump.

## Verification

Tested locally:
- ✅ `quay.io/ceph/ceph`, `quay.io/cephcsi/ceph-csi-operator`, `quay.io/prometheus/*` (a dropped entry), `registry.k8s.io/*`, `ghcr.io/*` all pass.
- ✅ Non-allowlisted `docker.io/*` and short forms (`nginx`, `org/img`) still fail.