### PR TITLE
fix(rook-ceph): repair 1.20.0 CSI ServiceAccount prefix (restore ceph-block attach/detach)

### DIFF
--- a/.github/renovate/groups.json5
+++ b/.github/renovate/groups.json5
@@ -59,6 +59,12 @@
       groupName: "Rook-Ceph",
       matchDatasources: ["docker"],
       matchPackageNames: ["/rook-ceph/", "/rook-ceph-cluster/"],
+      // workaround: pin <1.20.0 — rook 1.20.0 blanks the bundled
+      // ceph-csi-operator csiServiceAccountPrefix, breaking CSI attach.
+      // See rwlove/home-ops#12266. Lift once upstream ships a non-empty
+      // default (we stay on 1.20.0 with a values override meanwhile;
+      // rook does not support minor-version downgrades).
+      allowedVersions: "<1.20.0",
       group: {
         commitMessageTopic: "{{{groupName}}} group",
       },

--- a/kubernetes/apps/rook-ceph/rook-ceph/app/operator/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/app/operator/helmrelease.yaml
@@ -10,6 +10,19 @@ spec:
     name: rook-ceph
   interval: 1h
   values:
+    # workaround: https://github.com/rwlove/home-ops/issues/12266 — remove when rook
+    # ships a non-empty csiServiceAccountPrefix default for the bundled
+    # ceph-csi-operator subchart. rook 1.20.0's parent chart overrides the subchart
+    # default ("ceph-csi-operator-") to "", so the operator never creates the
+    # rbd/cephfs ctrlplugin+nodeplugin SAs and the ctrlplugin Deployments wedge at
+    # 0/2 (FailedCreate: serviceaccount not found), killing ceph-block + cephfs
+    # attach/detach cluster-wide. Restore the subchart's own default prefix.
+    # Renovate is pinned <1.20.0 alongside this until upstream is fixed.
+    ceph-csi-operator:
+      controllerManager:
+        manager:
+          env:
+            csiServiceAccountPrefix: "ceph-csi-operator-"
     csi:
       # Tolerate Spark's arm64 dedication taint. ollama-spark-0 uses
       # ceph-block PVCs (ollama-spark-data-pvc + ollama-spark-models-


### PR DESCRIPTION
## Outage fix — ceph-block + cephfs attach/detach broken cluster-wide

Rook-Ceph 1.20.0 (bump #12247) makes the bundled **ceph-csi-operator** subchart mandatory, but the parent chart overrides its `csiServiceAccountPrefix` default (`ceph-csi-operator-`) to **`""`**. With the prefix blanked, the operator renders the RBD/CephFS ctrlplugin Deployments referencing ServiceAccounts it never creates:

```
FailedCreate ... serviceaccount "rbd-ctrlplugin-sa" not found
```

→ both ctrlplugin Deployments stuck `0/2` → no external-attacher → **no ceph-block/cephfs volume can attach or detach.** Running pods were unaffected, but any pod reschedule or CNPG Postgres failover hangs. Surfaced live 2026-06-03 07:52 EDT when Flux rolled the 1.20.0 operator.

## Fix

Restore the subchart's own default prefix via a values override (additive; does **not** change CSIDriver names, so the existing 187 RBD + 4 CephFS VolumeAttachments are untouched):

```yaml
ceph-csi-operator:
  controllerManager:
    manager:
      env:
        csiServiceAccountPrefix: "ceph-csi-operator-"
```

Plus a Renovate `<1.20.0` pin so the group bump doesn't re-break it (we stay on 1.20.0 — rook doesn't support minor-version downgrades).

## Verification after merge
- ctrlplugin Deployments → `2/2`, the four plugin SAs created
- stuck VolumeAttachments drain; `esphome-0`, `medialyze`, `seerr` attach and reach Running
- CNPG failover no longer hangs

Tracking: #12266

🤖 Generated with [Claude Code](https://claude.com/claude-code)