### PR TITLE
fix(longhorn): lower guaranteedInstanceManagerCpu 12→6 to unblock engine migration on master1/worker8

### DIFF
--- a/kubernetes/apps/longhorn-system/longhorn/app/helmrelease.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn/app/helmrelease.yaml
@@ -22,6 +22,13 @@ spec:
       createDefaultDiskLabeledNodes: true
       defaultDataLocality: best-effort
       defaultReplicaCount: 2
+      # Lowered from the 12% default so the new v1.12.0 instance-manager can
+      # schedule alongside the old v1.11.0-hotfix-1 IM on CPU-tight nodes
+      # (master1, worker8) during the engine migration — the doubled IM
+      # request wouldn't fit at 12%. Applies to new IM pods only (no restart
+      # of running IMs). 6% leaves ample headroom (actual IM load ~16% peak).
+      # Revisit once all volumes are on the v1.12.0 engine and old IMs drain.
+      guaranteedInstanceManagerCpu: 6
       kubernetesClusterAutoscalerEnabled: true
 
       replicaAutoBalance: best-effort


### PR DESCRIPTION
## Unblocks the Longhorn engine migration on CPU-tight nodes

During the v1.11.2 → v1.12.0 engine migration, the new v1.12.0 instance-manager must run **alongside** the old `v1.11.0-hotfix-1` IM. At the 12% default, the new IM's CPU request (960m on master1, 1200m on worker8) doesn't fit the free CPU on those two nodes — it sits `OutOfcpu` with no pod, so 12 volumes (including `seerr` + `medialyze` config) can't get a v1.12.0 IM there and currently fail to attach on worker8.

Lowering `guaranteedInstanceManagerCpu` to **6%** (480m master1 / 600m worker8) lets the new IM schedule.

## Why this is safe
- **Applies to new IM pods only** — Longhorn 1.12.0 does **not** restart running instance-managers when this setting changes (verified against Longhorn 1.12.0 settings docs). No existing volume is disrupted.
- 6% still leaves ample headroom — actual IM load peaks ~16% and these nodes are at 16–24% real CPU; this is a *reservation* floor, not a limit.
- Single additive `defaultSettings` value; rollback = revert the line.

## After merge
Flux reconciles → Longhorn places v1.12.0 IMs on master1 + worker8 → the previously-blocked volumes (incl. seerr/medialyze Longhorn config) can attach, clearing the 2 pods still `Init:0/1`.

The remaining engine-binary migration + the old-IM rolling drain are a **separate, deliberately-paused** step (the drain restarts pods and is Renee-facing) — not in this PR.

Refs #11828.

🤖 Generated with [Claude Code](https://claude.com/claude-code)