### PR TITLE
fix(ci): make the renovate dryRun dispatch input actually dry-run

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -7,7 +7,8 @@ on:
     inputs:
       dryRun:
         description: Dry Run
-        default: "false"
+        type: boolean
+        default: false
         required: false
       logLevel:
         description: Log Level
@@ -33,7 +34,11 @@ env:
   LOG_LEVEL: "${{ inputs.logLevel || 'debug' }}"
   RENOVATE_AUTODISCOVER: true
   RENOVATE_AUTODISCOVER_FILTER: "${{ github.repository }}"
-  RENOVATE_DRY_RUN: "${{ inputs.dryRun == true }}"
+  # `inputs.dryRun == true` compared a string-typed input to a boolean
+  # (always false), so dry-run never engaged. Type the input as boolean
+  # and emit Renovate's expected values ('full' / 'null'). Scheduled and
+  # push runs carry no inputs → 'null' (live), as intended.
+  RENOVATE_DRY_RUN: ${{ inputs.dryRun && 'full' || 'null' }}
   RENOVATE_PLATFORM: github
   RENOVATE_PLATFORM_COMMIT: enabled
   WORKFLOW_RENOVATE_VERSION: "${{ inputs.version || 'latest' }}"


### PR DESCRIPTION
`inputs.dryRun == true` compared a string-typed dispatch input to a
boolean, which is always false in GitHub expressions — so
RENOVATE_DRY_RUN was never set and a manual "dry run" ran live. Type
the input as boolean and emit Renovate's expected dryRun values
('full' / 'null'). Scheduled and push runs carry no inputs and fall
through to 'null' (live), as intended.

bulk-merge-prs.yaml is unaffected — it uses a bash string compare
(`[ "...dryRun" = "true" ]`), which already works correctly.

Found while standing up the same self-hosted Renovate workflow in
rwlove/containers (copied from here), where the broken dry-run opened
17 real PRs.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
