### PR TITLE
chore(longhorn,rook): retire longhorn 1.12.0 workaround + fix rook CSI annotation

### DIFF
--- a/kubernetes/apps/longhorn-system/longhorn/app/helmrelease.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn/app/helmrelease.yaml
@@ -15,20 +15,11 @@ spec:
       version: 1.12.0
   interval: 30m
   values:
-    # workaround: https://github.com/longhorn/longhorn/issues/12573 — image pins removed (1.12.0 ships the fixed manager/instanceManager images natively). preUpgradeChecker disables retained for now; re-enable as a follow-up once 1.12.0 is confirmed stable.
-    # Tracking: home-ops#11828
     defaultSettings:
       backupTarget: "nfs://beast:/mnt/mass_storage/longhorn-backups"
       createDefaultDiskLabeledNodes: true
       defaultDataLocality: best-effort
       defaultReplicaCount: 2
-      # Lowered from the 12% default so the new v1.12.0 instance-manager can
-      # schedule alongside the old v1.11.0-hotfix-1 IM on CPU-tight nodes
-      # (master1, worker8) during the engine migration — the doubled IM
-      # request wouldn't fit at 12%. Applies to new IM pods only (no restart
-      # of running IMs). 6% leaves ample headroom (actual IM load ~16% peak).
-      # Revisit once all volumes are on the v1.12.0 engine and old IMs drain.
-      guaranteedInstanceManagerCpu: 6
       kubernetesClusterAutoscalerEnabled: true
 
       replicaAutoBalance: best-effort
@@ -43,10 +34,6 @@ spec:
       defaultClass: false
       defaultClassReplicaCount: 1
       reclaimPolicy: Retain
-
-    preUpgradeChecker:
-      jobEnabled: false
-      upgradeVersionCheck: false
   # Scope the chart-shipped `longhorn-support-bundle` ClusterRoleBinding
   # from `cluster-admin` down to `view`. The chart hardcodes the binding
   # with no values knob to disable it (clusterrolebinding.yaml lines

--- a/kubernetes/apps/rook-ceph/rook-ceph/app/operator/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/app/operator/helmrelease.yaml
@@ -10,14 +10,15 @@ spec:
     name: rook-ceph
   interval: 1h
   values:
-    # workaround: https://github.com/rwlove/home-ops/issues/12266 — remove when rook
-    # ships a non-empty csiServiceAccountPrefix default for the bundled
-    # ceph-csi-operator subchart. rook 1.20.0's parent chart overrides the subchart
-    # default ("ceph-csi-operator-") to "", so the operator never creates the
-    # rbd/cephfs ctrlplugin+nodeplugin SAs and the ctrlplugin Deployments wedge at
-    # 0/2 (FailedCreate: serviceaccount not found), killing ceph-block + cephfs
-    # attach/detach cluster-wide. Restore the subchart's own default prefix.
-    # Renovate is pinned <1.20.0 alongside this until upstream is fixed.
+    # workaround: https://github.com/rook/rook/issues/17644 — remove when rook ships
+    # the ceph-csi driver ServiceAccounts/RBAC its bundled ceph-csi-operator
+    # references. rook 1.20.0 deploys the operator + Driver CRs but NOT the driver
+    # SAs/RBAC — the operator only references SAs by name (<prefix><driver>-<role>-sa)
+    # and never creates them, so ctrlplugin Deployments wedge at 0/2 (serviceaccount
+    # not found), killing ceph-block + cephfs attach/detach cluster-wide. We vendor
+    # the SAs+RBAC in ./csi-driver-rbac.yaml; this prefix aligns the operator's SA
+    # references to those vendored names. Renovate is pinned <1.20.0. Tracking:
+    # home-ops#12266.
     ceph-csi-operator:
       controllerManager:
         manager:


### PR DESCRIPTION
Post-incident cleanup from today's Longhorn 1.12.0 + rook 1.20.0 work.

## longhorn — fully retire the #12573 workaround (Closes #11828)
- **Re-enable `preUpgradeChecker` + `upgradeVersionCheck`** (remove the override → chart defaults). They were disabled "until 1.12.0 is confirmed stable"; that's now met — control plane, all engine binaries, and the Phase D old-IM drain are complete and healthy. The image-tag pins (the other half of the workaround) were already dropped in #12263.
- **Drop the inert `guaranteedInstanceManagerCpu: 6` line** — wrong casing vs the chart's `guaranteedInstanceManagerCPU`, so it was a confirmed no-op (Setting CR stayed at the 12% default). The actual CPU unblock used per-node `Node.spec.instanceManagerCPURequest` overrides on master1/worker8 (runtime Longhorn state, not GitOps).

## rook — fix the CSI-operator workaround comment (no functional change)
The comment described our first (wrong) theory ("restore the subchart's default prefix"). Corrected to the real mechanism: rook 1.20.0's ceph-csi-operator never creates the driver SAs (only references them), so we vendor them in `./csi-driver-rbac.yaml`; the prefix just aligns the operator's references to the vendored names. Now points at upstream **rook#17644**. Comment-only — `spec.values` unchanged, so no helm upgrade.

## Note
Re-enabling preUpgradeChecker triggers a longhorn helm upgrade that runs the pre-upgrade checker Job. On the current healthy cluster it should pass; I'll verify the HR stays Ready (and the data plane is untouched) after merge.

Closes #11828.

🤖 Generated with [Claude Code](https://claude.com/claude-code)