### PR TITLE
feat(immich): enable on-demand video transcode (required policy, CPU)

### DIFF
--- a/kubernetes/apps/media/immich/app/externalsecret.yaml
+++ b/kubernetes/apps/media/immich/app/externalsecret.yaml
@@ -22,7 +22,8 @@ spec:
           {
             "ffmpeg": {
               "targetResolution": "1080",
-              "transcode": "disabled"
+              "transcode": "required",
+              "accel": "disabled"
             },
             "library": {
               "watch": {

--- a/kubernetes/apps/media/immich/app/externalsecret.yaml
+++ b/kubernetes/apps/media/immich/app/externalsecret.yaml
@@ -23,7 +23,8 @@ spec:
             "ffmpeg": {
               "targetResolution": "1080",
               "transcode": "required",
-              "accel": "disabled"
+              "accel": "disabled",
+              "preset": "medium"
             },
             "library": {
               "watch": {


### PR DESCRIPTION
## Why

Browser video playback in Immich (`photos.thesteamedcrab.com`) has a long start delay. Root cause is `ffmpeg.transcode: "disabled"` — Immich serves camera-originals verbatim, and phone clips are a worst case for direct browser playback:

- **Codec: HEVC Main 10** (10-bit H.265) — no decode path in Chromium/Brave on Linux.
- **Non-faststart** — the `moov` index sits at end-of-file, so the browser must download the entire clip (~62 MB over NFS→Immich) before it can render frame 1.

Verified by ffprobe on a sample asset (`mdat` at byte 40, `moov` at byte 64,784,792).

## Change

Flip `ffmpeg.transcode` `disabled` → `required` in the locked `system.json`. `accel` pinned explicitly to `disabled` (CPU x264).

- `required` transcodes **only** sources the browser can't play (non-H.264). Existing H.264 clips pass through untouched.
- Transcodes are **one-time, cached** in `encoded-video/`; playback start is then instant.

## Why CPU, not NVENC

The single GPU is reserved for Immich ML/CLIP inference (`ai-gpu-critical`, and the chart notes GPU inference can briefly block the HTTP server). NVENC would:
- add GPU contention against ML for no benefit — playback-start latency is identical for CPU- vs GPU-produced output, since the job is one-time/cached;
- give worse quality-per-bitrate for a permanent library (cuts against quality-over-speed for infrequent ops).

NVENC only becomes correct if Immich-server gets its own GPU **and** transcode volume outpaces CPU — neither is true today.

## Heads-up / rollout

- Flipping to `required` queues a **backfill** of all existing non-H.264 videos → a sustained CPU burst on `immich-server` until the queue drains. Worth landing into a maintenance window rather than mid-day.
- No GitOps/storage risk; reverts cleanly by flipping back to `disabled`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)