### PR TITLE
revert(immich): restore transcode "disabled"

### DIFF
--- a/kubernetes/apps/media/immich/app/externalsecret.yaml
+++ b/kubernetes/apps/media/immich/app/externalsecret.yaml
@@ -22,9 +22,7 @@ spec:
           {
             "ffmpeg": {
               "targetResolution": "1080",
-              "transcode": "required",
-              "accel": "disabled",
-              "preset": "medium"
+              "transcode": "disabled"
             },
             "library": {
               "watch": {


### PR DESCRIPTION
Reverts #12285.

## Why revert

Enabling `transcode: required` surfaced two blockers that make the migration not worth it for this library:

1. **Broken, not slow.** `required` returns **HTTP 500** for any video lacking an encoded version — no graceful fallback to the original. Every untranscoded HEVC clip is broken-on-play during the backfill.
2. **Days-long backfill.** ~3,550 of 4,005 videos need processing, at concurrency 1, CPU-bound (one `medium` 1080p encode saturates ~6 cores). That's many hours to multiple days — won't fit a maintenance window — with breakage #1 live the whole time.

The original symptom (slow HEVC playback *start* in the desktop browser) is browser-only; the **native mobile app decodes HEVC fine**. Not worth a multi-day breaking migration for desktop-browser convenience.

## State after merge

`transcode: disabled` — slow-but-working HEVC in browser, everywhere else unaffected. The paused backfill queue has already been emptied out-of-band; immich-server will be restarted to load the reverted config (subPath mount doesn't hot-reload).

🤖 Generated with [Claude Code](https://claude.com/claude-code)