### PR TITLE
feat(rook-ceph): adopt ceph-csi-drivers chart for CSI driver SAs/RBAC (PR 1/2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ _Production-grade Kubernetes for a household._
 <br/>
 
 ![apps](https://img.shields.io/badge/apps-188-blue?style=for-the-badge)
-![helmreleases](https://img.shields.io/badge/HelmReleases-199-326CE5?style=for-the-badge&logo=helm&logoColor=white)
+![helmreleases](https://img.shields.io/badge/HelmReleases-200-326CE5?style=for-the-badge&logo=helm&logoColor=white)
 ![nodes](https://img.shields.io/badge/k8s_nodes-11-326CE5?style=for-the-badge&logo=kubernetes&logoColor=white)
 ![cnpg](https://img.shields.io/badge/Postgres_clusters-25-336791?style=for-the-badge&logo=postgresql&logoColor=white)
 ![secrets](https://img.shields.io/badge/secrets-117-0572EC?style=for-the-badge&logo=1password&logoColor=white)

--- a/kubernetes/apps/rook-ceph/rook-ceph/csi-drivers/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/csi-drivers/helmrelease.yaml
@@ -1,0 +1,174 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: ceph-csi-drivers
+spec:
+  # Release name MUST be `ceph-csi-drivers` in namespace `rook-ceph` so Helm
+  # adopts the existing, orphaned `Driver` CRs (rook-ceph.{rbd,cephfs}.csi.ceph.com)
+  # — they already carry meta.helm.sh/release-name=ceph-csi-drivers,
+  # release-namespace=rook-ceph + app.kubernetes.io/managed-by=Helm. rook 1.20
+  # relinquished CSI Driver/OperatorConfig CR management (release notes:
+  # "CSI settings are removed from the Rook operator configmap and the rook-ceph
+  # Helm chart … for helm users, configured by the ceph-csi-drivers chart"), so
+  # nothing in the rook-ceph chart fights this release for those CRs anymore.
+  #
+  # This release supplies the driver ServiceAccounts + RBAC that rook 1.20 stopped
+  # shipping (the gap behind rook/rook#17644). PR 1 of 2: additive — keep the
+  # vendored ../operator/csi-driver-rbac.yaml + the operator's
+  # csiServiceAccountPrefix override in place as a fallback until this release is
+  # verified adopting the CRs and the new SAs are in use. PR 2 removes the vendored
+  # RBAC, the now-inert csi.pluginTolerations, the prefix override, and the
+  # renovate <1.20.0 pin. Tracking: home-ops#12266.
+  releaseName: ceph-csi-drivers
+  chart:
+    spec:
+      chart: ceph-csi-drivers
+      sourceRef:
+        kind: HelmRepository
+        name: ceph-csi-operator
+      version: 1.0.1
+  interval: 1h
+  install:
+    # retries: 0 on purpose. This release ADOPTS the existing, live Driver CRs.
+    # Flux remediation uninstalls before retrying a failed install — which would
+    # delete the now-Helm-owned Driver CRs and hard-break ceph-block + cephfs
+    # attach/detach cluster-wide. On a failed first install, leave it failed and
+    # fix forward by hand; do not let Flux nuke the CSI control plane.
+    remediation:
+      retries: 0
+  upgrade:
+    # Don't delete partially-applied resources (e.g. the driver SAs) on a failed
+    # upgrade of the critical CSI path; prefer rollback to the prior good revision.
+    cleanupOnFail: false
+    remediation:
+      retries: 3
+      strategy: rollback
+  values:
+    # The OperatorConfig (ceph-csi-operator-config) is left to the rook operator,
+    # which still writes its imageSet (rook-csi-operator-image-set-configmap) and
+    # clusterName. Managing it here would clobber those rook-owned values.
+    operatorConfig:
+      create: false
+    # Driver specs are mirrored field-for-field from the live (rook-1.19-written,
+    # now-frozen) Driver CRs so adoption changes only `serviceAccountName`. Verified
+    # via `helm template` diff against the live `.spec`: the only functional delta is
+    # the SA name; all other deltas are explicit forms of inherited operator defaults
+    # (hostNetwork, attachRequired, grpcTimeout, snapshotPolicy) or empty/null
+    # equivalences. Re-run that diff before merge if the chart version changes.
+    drivers:
+      rbd:
+        enabled: true
+        # Keep the existing CSI driver/provisioner name (namespace-prefixed) — it is
+        # the provisioner referenced by every ceph-block PV/StorageClass. Changing it
+        # would orphan all RBD volumes.
+        name: "rook-ceph.rbd.csi.ceph.com"
+        log: null
+        clusterName: "rook-ceph"
+        enableMetadata: false
+        fsGroupPolicy: "File"
+        imageSet:
+          name: "rook-csi-operator-image-set-configmap"
+        controllerPlugin:
+          hostNetwork: true
+          replicas: 2
+          priorityClassName: "system-cluster-critical"
+          imagePullPolicy: ""
+          resources:
+            attacher:
+              requests: {cpu: 100m, memory: 128Mi}
+              limits: {memory: 256Mi}
+            provisioner:
+              requests: {cpu: 100m, memory: 128Mi}
+              limits: {memory: 256Mi}
+            resizer:
+              requests: {cpu: 100m, memory: 128Mi}
+              limits: {memory: 256Mi}
+            snapshotter:
+              requests: {cpu: 100m, memory: 128Mi}
+              limits: {memory: 256Mi}
+            omapGenerator:
+              requests: {cpu: 250m, memory: 512Mi}
+              limits: {memory: 1Gi}
+            plugin:
+              requests: {memory: 512Mi}
+              limits: {memory: 1Gi}
+        nodePlugin:
+          priorityClassName: "system-node-critical"
+          kubeletDirPath: "/var/lib/kubelet"
+          enableSeLinuxHostMount: false
+          imagePullPolicy: ""
+          updateStrategy:
+            type: RollingUpdate
+          # ollama-spark-0 uses ceph-block PVCs, so the RBD nodeplugin must run on
+          # Spark's arm64 dedication taint. Under rook 1.20 the operator's
+          # csi.pluginTolerations value is dead — this is now the live home for it.
+          tolerations:
+            - key: kubernetes.io/arch
+              operator: Equal
+              value: arm64
+              effect: NoSchedule
+          resources:
+            plugin:
+              requests: {cpu: 250m, memory: 512Mi}
+              limits: {memory: 1Gi}
+            registrar:
+              requests: {cpu: 50m, memory: 128Mi}
+              limits: {memory: 256Mi}
+      cephfs:
+        enabled: true
+        name: "rook-ceph.cephfs.csi.ceph.com"
+        log: null
+        clusterName: "rook-ceph"
+        enableMetadata: false
+        # Live cephfs runs fsGroupPolicy File (the chart's cephfs default is None).
+        fsGroupPolicy: "File"
+        imageSet:
+          name: "rook-csi-operator-image-set-configmap"
+        controllerPlugin:
+          hostNetwork: true
+          replicas: 2
+          priorityClassName: "system-cluster-critical"
+          imagePullPolicy: ""
+          resources:
+            attacher:
+              requests: {cpu: 100m, memory: 128Mi}
+              limits: {memory: 256Mi}
+            provisioner:
+              requests: {cpu: 100m, memory: 128Mi}
+              limits: {memory: 256Mi}
+            resizer:
+              requests: {cpu: 100m, memory: 128Mi}
+              limits: {memory: 256Mi}
+            snapshotter:
+              requests: {cpu: 100m, memory: 128Mi}
+              limits: {memory: 256Mi}
+            plugin:
+              requests: {cpu: 250m, memory: 512Mi}
+              limits: {memory: 1Gi}
+        nodePlugin:
+          priorityClassName: "system-node-critical"
+          kubeletDirPath: "/var/lib/kubelet"
+          enableSeLinuxHostMount: false
+          imagePullPolicy: ""
+          updateStrategy:
+            type: RollingUpdate
+          tolerations:
+            - key: kubernetes.io/arch
+              operator: Equal
+              value: arm64
+              effect: NoSchedule
+          resources:
+            plugin:
+              requests: {cpu: 250m, memory: 512Mi}
+              limits: {memory: 1Gi}
+            registrar:
+              requests: {cpu: 50m, memory: 128Mi}
+              limits: {memory: 256Mi}
+      # Not used in this cluster — keep them off to match the current footprint
+      # (the vendored RBAC only ever covered rbd + cephfs).
+      nvmeof:
+        enabled: false
+      nfs:
+        enabled: false

--- a/kubernetes/apps/rook-ceph/rook-ceph/csi-drivers/helmrepository.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/csi-drivers/helmrepository.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: ceph-csi-operator
+spec:
+  interval: 2h
+  url: https://ceph.github.io/ceph-csi-operator

--- a/kubernetes/apps/rook-ceph/rook-ceph/csi-drivers/kustomization.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/csi-drivers/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/rook-ceph/rook-ceph/ks.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/ks.yaml
@@ -23,6 +23,29 @@ spec:
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
+  name: &app rook-ceph-csi-drivers
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: rook-ceph
+  path: ./kubernetes/apps/rook-ceph/rook-ceph/csi-drivers
+  interval: 30m
+  timeout: 5m
+  prune: true
+  wait: true
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: rook-ceph
+      namespace: rook-ceph
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
   name: &app rook-ceph-cluster
 spec:
   commonMetadata:


### PR DESCRIPTION
## Draft — do not merge outside a maintenance window

Replaces the emergency vendored CSI RBAC workaround (rook/rook#17644) with the upstream-sanctioned mechanism. **PR 1 of 2**, additive and staged. Applying it rolls the CSI plugin pods → land in a **routine window (any night 02:00–05:00 ET)**, not a casual reconcile.

## Why

rook 1.20.0 deliberately **relinquished** Ceph-CSI `Driver`/`OperatorConfig` CR management to the standalone `ceph-csi-drivers` chart. From the [v1.20 release notes](https://github.com/rook/rook/releases/tag/v1.20.0):

> CSI settings are removed from the Rook operator configmap and the `rook-ceph` Helm chart … For helm users, the Ceph CSI operator settings are configured by the `ceph-csi-drivers` chart.

On our in-place 1.19.6 → 1.20.0 upgrade the driver ServiceAccounts/RBAC stopped being created → ctrlplugin Deployments wedged 0/2 → ceph-block + cephfs attach/detach broke cluster-wide. The stopgap (`../operator/csi-driver-rbac.yaml`) vendored the SAs by hand.

## What this does

A `ceph-csi-drivers` HelmRelease (release name `ceph-csi-drivers` / ns `rook-ceph`) that **adopts** the existing, orphaned `Driver` CRs — they already carry `meta.helm.sh/release-name=ceph-csi-drivers` + `managed-by=Helm` — and creates the driver SAs + RBAC the chart owns. rook 1.20 no longer writes those CRs (confirmed: `managedFields` manager=`rook` frozen at the 1.19-era write, untouched across the June-3 operator restart onto v1.20.0), so nothing fights this release for them.

## Verification (the gate)

`helm template` of this chart with these values, deep-diffed against the **live** `Driver.spec`:

- **The only functional delta is `serviceAccountName`** (→ the new chart SAs). That is the entire point.
- Every other delta is an explicit form of an inherited operator default (`hostNetwork: true`, `attachRequired`, `grpcTimeout`, `snapshotPolicy`) or an empty/null equivalence (`log: {}`, `affinity`, `imagePullPolicy`). No resource requests/limits change.
- **Driver names unchanged** (`rook-ceph.{rbd,cephfs}.csi.ceph.com`) → PVs untouched; the `ceph-csi-allow` CNP (selects on the `app` label derived from the driver name) still matches.

## Safety choices

- `operatorConfig.create=false` — leave the rook-operator-written `OperatorConfig` (imageSet/clusterName) alone.
- `install.remediation.retries=0` + `upgrade.cleanupOnFail=false` — never let Flux uninstall-on-failure delete the **adopted** Driver CRs and hard-break CSI. Fix forward by hand if install fails.
- `nvmeof`/`nfs` disabled to match the current rbd+cephfs footprint.
- Spark arm64 nodePlugin toleration carried in the chart values (its old home, `csi.pluginTolerations`, is **dead** under 1.20 — see PR 2).

## Cutover checklist (window)

1. Merge → Flux reconciles `rook-ceph-csi-drivers` (dependsOn `rook-ceph`).
2. Confirm Helm **adopts** both Driver CRs (no "exists and cannot be imported").
3. New SAs `rook-ceph-{rbd,cephfs}-csi-ceph-com-{ctrl,node}plugin-sa` created; ctrlplugin 2/2, nodeplugin rolled; a test PVC attaches; `ollama-spark-0` RBD still mounts (arm64 toleration).
4. Then **PR 2**: remove vendored `csi-driver-rbac.yaml`, the now-inert `csi.pluginTolerations`, the `csiServiceAccountPrefix` override, unpin renovate `<1.20.0`, `Closes #12266`.

## Files
- `kubernetes/apps/rook-ceph/rook-ceph/csi-drivers/{helmrelease,helmrepository,kustomization}.yaml`
- `kubernetes/apps/rook-ceph/rook-ceph/ks.yaml` — new `rook-ceph-csi-drivers` Kustomization
- `README.md` — HelmRelease badge 199→200

🤖 Generated with [Claude Code](https://claude.com/claude-code)