### PR TITLE
fix(rook-ceph): ceph-csi-drivers resources {} not null (unblocks #12297 install)

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/csi-drivers/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/csi-drivers/helmrelease.yaml
@@ -94,6 +94,13 @@ spec:
             plugin:
               requests: {memory: 512Mi}
               limits: {memory: 1Gi}
+            # The chart force-emits EVERY sidecar key under resources; any we
+            # don't size must be {} — the live Driver CRD rejects null on these
+            # object fields (server-side apply fails otherwise). These sidecars
+            # are unused/defaulted here (addons only runs with deployCsiAddons).
+            liveness: {}
+            addons: {}
+            logRotator: {}
         nodePlugin:
           priorityClassName: "system-node-critical"
           kubeletDirPath: "/var/lib/kubelet"
@@ -116,6 +123,9 @@ spec:
             registrar:
               requests: {cpu: 50m, memory: 128Mi}
               limits: {memory: 256Mi}
+            liveness: {}
+            addons: {}
+            logRotator: {}
       cephfs:
         enabled: true
         name: "rook-ceph.cephfs.csi.ceph.com"
@@ -147,6 +157,10 @@ spec:
             plugin:
               requests: {cpu: 250m, memory: 512Mi}
               limits: {memory: 1Gi}
+            omapGenerator: {}
+            liveness: {}
+            addons: {}
+            logRotator: {}
         nodePlugin:
           priorityClassName: "system-node-critical"
           kubeletDirPath: "/var/lib/kubelet"
@@ -166,6 +180,9 @@ spec:
             registrar:
               requests: {cpu: 50m, memory: 128Mi}
               limits: {memory: 256Mi}
+            liveness: {}
+            addons: {}
+            logRotator: {}
       # Not used in this cluster — keep them off to match the current footprint
       # (the vendored RBAC only ever covered rbd + cephfs).
       nvmeof:


### PR DESCRIPTION
Hotfix for #12297, which merged but **failed Helm install** on server-side apply:

```
Driver.csi.ceph.io "rook-ceph.rbd.csi.ceph.com" is invalid:
  spec.controllerPlugin.resources.addons: Invalid value: "null": must be of type object
  ...liveness, logRotator, omapGenerator likewise
```

The `ceph-csi-drivers` chart force-emits **every** sidecar key under `resources:`; the ones we didn't size rendered as `null`, which the live Driver CRD rejects. `helm template` + flux-local diff don't validate against the live CRD's structural schema, so it only surfaced on the real apply.

**Fix:** set the unsized sidecars (`addons`, `liveness`, `logRotator`, + `omapGenerator` on cephfs) to `{}`. Verified with `kubectl apply --server-side --dry-run=server` against the live CRD — both Driver CRs pass.

**No disruption from the failed install:** `install.remediation.retries=0` meant Flux never uninstalled, the adopted Driver CRs were never mutated (SSA is atomic per object), and CSI stayed up on the vendored fallback throughout (`ctrlplugin` 2/2, `HEALTH_OK`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)