### PR TITLE
docs(rook-ceph): track ceph-csi-drivers null-resources workaround (#12302)

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/csi-drivers/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/csi-drivers/helmrelease.yaml
@@ -94,10 +94,12 @@ spec:
             plugin:
               requests: {memory: 512Mi}
               limits: {memory: 1Gi}
-            # The chart force-emits EVERY sidecar key under resources; any we
-            # don't size must be {} — the live Driver CRD rejects null on these
-            # object fields (server-side apply fails otherwise). These sidecars
-            # are unused/defaulted here (addons only runs with deployCsiAddons).
+            # workaround: https://github.com/ceph/ceph-csi-operator/issues/490 — remove when
+            # the ceph-csi-drivers chart guards unset sidecar resources keys instead of
+            # emitting `null`. The chart force-emits EVERY sidecar key under resources; the
+            # ones we don't size render as `null`, which the live Driver CRD rejects on
+            # server-side apply ("must be of type object"). Pad them with {} until fixed.
+            # Tracking: home-ops#12302. (addons only runs with deployCsiAddons.)
             liveness: {}
             addons: {}
             logRotator: {}


### PR DESCRIPTION
Converts the explanatory comment on the `{}` sidecar-resource padding (from the ceph-csi-drivers migration) into a `# workaround:` annotation pointing at upstream ceph/ceph-csi-operator#490, with a checkable remove-when so the `upstream-watcher` skill can retire it.

Tracking: #12302 (workaround label). **Comment-only** — YAML comments don't change parsed Helm values, so no reconcile/helm-upgrade effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)