### PR TITLE
fix(mcp-system): comfyui MCP tools never reach the gateway (toolPrefix→prefix)

### DIFF
--- a/kubernetes/apps/mcp-system/comfyui-mcp/mcp/mcpserverregistration.yaml
+++ b/kubernetes/apps/mcp-system/comfyui-mcp/mcp/mcpserverregistration.yaml
@@ -7,8 +7,8 @@ metadata:
   labels:
     mcp.kuadrant.io/managed: "true"
 spec:
+  prefix: comfyui_
   targetRef:
     group: gateway.networking.k8s.io
     kind: HTTPRoute
     name: comfyui-mcp
-  toolPrefix: comfyui_


### PR DESCRIPTION
## What

The `comfyui-tools` `MCPServerRegistration` set `toolPrefix: comfyui_`, which is **not a field** on the CRD — the real field is `spec.prefix`. The API server silently pruned the unknown field, so comfyui's 46 tools federated **unprefixed**.

comfyui-mcp exposes a generic `health_check` tool, which then collided with `prometheus-mcp`'s `health_check` (already federated). On the collision the broker drops the **entire** comfyui server from the served set:

```
level=ERROR msg="tool conflict detected" upstream=mcp-system/comfyui-tools
  error="conflicting tools discovered. conflicting tool names [health_check]"
```

That's why comfyui never appeared at the gateway (lovenet-gateway / Open WebUI) despite the registration reporting `Ready / 46 tools`.

## Fix

`toolPrefix: comfyui_` → `prefix: comfyui_`. Namespaces all 46 tools as `comfyui_*` (e.g. `comfyui_health_check`), resolving the collision. Verified with `kubectl apply --server-side --dry-run=server`.

## Scope

Deliberately **comfyui-only**. The same `toolPrefix` typo is in all 16 registrations, but a blanket rename would double-prefix servers whose upstream tools are already namespaced (ha-mcp → `ha_ha_*`, immich-mcp → `immich_immich_*`), breaking live operator-agent and Open WebUI tool bindings. comfyui's tools are natively unprefixed, so the prefix is both correct and safe here.

## Follow-ups (not in this PR)
- `kubectl-tools` has the identical `health_check` collision (also `Ready=False` at the broker).
- The `toolPrefix` vs `prefix` field-name bug is latent across all 16 registrations — worth a tracked cleanup that accounts for native-prefix double-up.

## Verify after merge
`flux` reconciles → broker re-registers comfyui with the prefix → `comfyui_*` tools appear via the gateway's `discover_tools` / Open WebUI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)