### PR TITLE
fix(mcp-system): kubectl MCP tools never reach the gateway (toolPrefix→prefix)

### DIFF
--- a/kubernetes/apps/mcp-system/kubectl-mcp/mcp/mcpserverregistration.yaml
+++ b/kubernetes/apps/mcp-system/kubectl-mcp/mcp/mcpserverregistration.yaml
@@ -7,8 +7,8 @@ metadata:
   labels:
     mcp.kuadrant.io/managed: "true"
 spec:
+  prefix: kubectl_
   targetRef:
     group: gateway.networking.k8s.io
     kind: HTTPRoute
     name: kubectl-mcp
-  toolPrefix: kubectl_


### PR DESCRIPTION
## What

Follow-up to #12306. Same root cause for `kubectl-tools`: the registration set `toolPrefix: kubectl_`, which is **not a CRD field** (the real field is `spec.prefix`). The API server pruned it, kubectl-mcp's tools federated **unprefixed**, its generic `health_check` collided with `prometheus-mcp`'s `health_check`, and the broker dropped the entire server (`Ready=False`):

```
level=ERROR msg="tool conflict detected" upstream=mcp-system/kubectl-tools
  error="conflicting tools discovered. conflicting tool names [health_check]"
```

## Fix

`toolPrefix: kubectl_` → `prefix: kubectl_`. Namespaces the tools as `kubectl_*` (e.g. `kubectl_health_check`, `kubectl_exec_in_pod`), resolving the collision. This also makes the `kubectl_*` tool names the operator agents already reference (`mcp__lovenet-gateway__kubectl_*`) actually resolve through the gateway. kubectl-mcp's upstream tools are natively unprefixed, so no double-prefixing. Verified with `kubectl apply --server-side --dry-run=server`.

## Verify after merge
`flux` reconciles → broker re-registers kubectl with the prefix → `kubectl_*` tools appear via the gateway's `discover_tools` / Open WebUI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)