### PR TITLE
feat(beets): embed cover art and drop loose folder.jpg

### DIFF
--- a/kubernetes/apps/media/beets/app/resources/config.yaml
+++ b/kubernetes/apps/media/beets/app/resources/config.yaml
@@ -40,7 +40,7 @@ embedart:
   auto: yes
   ifempty: yes
   maxwidth: 500
-  remove_art_file: no
+  remove_art_file: yes # embed cover into files, then drop the loose folder.jpg
 
 replaygain:
   auto: no # heavy CPU per file; run `beet replaygain` manually when desired


### PR DESCRIPTION
Sets `embedart.remove_art_file: yes` in the beets config so beets embeds
fetched cover art into the audio files and removes the standalone
`folder.jpg` from album directories.

## Why

The music library accumulates a loose `folder.jpg` in every album dir
(beets `fetchart` + `embedart` previously kept the file). Embedding the
art and dropping the loose file keeps album folders to just the audio.

## Scope / behavior

- Applies to albums beets **(re-)imports going forward**. Import is
  `incremental`, so existing `folder.jpg` files are not stripped
  retroactively until those albums are reprocessed.
- To apply across the existing library, run `beet embedart` manually.
- Cosmetic-only; does not touch audio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)