### PR TITLE
fix(ai): allow comfyui-mcp → comfyui:8188 ingress (MCP tools fetch failed)

### DIFF
--- a/kubernetes/apps/ai/comfyui/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/comfyui/app/cnp-allow.yaml
@@ -14,11 +14,15 @@ spec:
     egress: false
     ingress: false
   ingress:
-    # HTTPRoute on internal gateway → comfyui:8188
+    # HTTPRoute on internal gateway → comfyui:8188, and the comfyui-mcp
+    # MCP server (mcp-system) that fronts ComfyUI for the lovenet-gateway.
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: network
             app.kubernetes.io/name: envoy
+        - matchLabels:
+            io.kubernetes.pod.namespace: mcp-system
+            app.kubernetes.io/name: comfyui-mcp
       toPorts:
         - ports:
             - port: "8188"


### PR DESCRIPTION
## What

Follow-up to #12306. The comfyui MCP tools federated to the gateway, but invoking any of them failed with `fetch failed` — the `comfyui-mcp` server (mcp-system) couldn't reach `comfyui.ai.svc.cluster.local:8188`.

## Diagnosis

Ruled out the obvious causes:
- **DNS** — resolves (`comfyui.ai.svc → 10.43.65.171`).
- **Listen address** — ComfyUI (ai-dock caddy) listens on `:::8188` and returns HTTP 200 on the pod IP *from inside the ai namespace*.
- **Endpoints** — Service has a healthy endpoint (`10.42.9.123:8188`), pod `1/1 Ready`.

The failure reproduces as a **connect timeout** (silent drop) from the comfyui-mcp pod — the signature of a CiliumNetworkPolicy denial. `comfyui-mcp-allow` egress already permits `ai/comfyui:8188`, but `comfyui-allow` ingress only admitted `network/envoy` (the internal-gateway HTTPRoute path). Cilium needs **both** the source's egress and the destination's ingress to allow a flow, so the destination dropped it.

## Fix

Add `mcp-system/comfyui-mcp` as a second allowed ingress source on 8188 in `comfyui-allow`. Validated with `kubectl apply --server-side --dry-run=server`.

## Verify after merge
Reconcile → re-test `fetch` from the comfyui-mcp pod (expect HTTP 200) and call a comfyui tool through the gateway (e.g. `comfyui_get_system_stats`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)