### PR TITLE
fix(observability): silence chronic cry-wolf node/storage alerts

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/addons/alerts/node-exporter.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/addons/alerts/node-exporter.yaml
@@ -12,7 +12,11 @@ spec:
     - name: node-exporter.rules
       rules:
         - alert: HostOutOfMemory
-          expr: node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes * 100 < 10
+          # security-storage excluded: it's a RAM-starved Core 2 box (7.4 GiB)
+          # whose steady state is <10% MemAvailable because the Frigate write
+          # path keeps page cache pegged. Expected, not an incident — the real
+          # fix is the NAS rebuild (project_todo_security_storage_new_build).
+          expr: node_memory_MemAvailable_bytes{instance!~"security-storage.*"} / node_memory_MemTotal_bytes{instance!~"security-storage.*"} * 100 < 10
           for: 2m
           labels:
             severity: warning

--- a/kubernetes/apps/observability/kube-prometheus-stack/addons/alerts/node-exporter.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/addons/alerts/node-exporter.yaml
@@ -175,13 +175,20 @@ spec:
         #     description: "Context switching is growing on node (> 8000 / s)\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
 
         - alert: HostSwapIsFillingUp
-          expr: (1 - (node_memory_SwapFree_bytes / node_memory_SwapTotal_bytes)) * 100 > 80
-          for: 2m
+          # beast is the only swap-enabled host (4 GiB swap / 188 GiB RAM) and
+          # parks flat at ~86% — a static >80% threshold cries wolf forever.
+          # Require swap to be both high AND trending toward exhaustion so the
+          # rule only fires on a real fill event, not steady-state parked swap.
+          expr: |
+            (1 - (node_memory_SwapFree_bytes / node_memory_SwapTotal_bytes)) * 100 > 80
+            and
+            predict_linear(node_memory_SwapFree_bytes[1h], 3600) < 0
+          for: 10m
           labels:
             severity: warning
           annotations:
             summary: Host swap is filling up (instance {{ $labels.instance }})
-            description: "Swap is filling up (>80%)\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+            description: "Swap is filling up (>80%) and still growing\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
 
         - alert: HostSystemdServiceCrashed
           expr: node_systemd_unit_state{state="failed"} == 1

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/prometheusrule-pv.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/prometheusrule-pv.yaml
@@ -133,6 +133,15 @@ spec:
             severity: warning
     - name: kubernetes-storage-nfs-export
       rules:
+        # security-storage is excluded from this blunt <3%-free critical: the
+        # Frigate recording export is *designed* to run pegged near-full
+        # (Frigate fills to its retention cap, then GCs the oldest segments —
+        # a sawtooth that lives at the top), so <3% free is its healthy steady
+        # state, not an incident. A genuine "GC actually broke and it's heading
+        # to true zero" event is still caught by the predict_linear variant
+        # below, whose 6h trend stays flat during a healthy sawtooth and goes
+        # negative only on a real monotonic decline. Permanent capacity fix is
+        # the NAS rebuild (project_todo_security_storage_new_build).
         - alert: KubeNFSExportFillingUp
           annotations:
             description: NFS export on {{ $labels.nfs_server }} is only {{ $value | humanizePercentage }} free. One or more PVCs backed by this server share the same underlying filesystem; check `df` on the server and identify the largest consumer.
@@ -147,7 +156,7 @@ spec:
                 * on (namespace, persistentvolumeclaim) group_left(persistentvolume)
               label_replace(kube_persistentvolumeclaim_info, "persistentvolume", "$1", "volumename", "(.+)")
                 * on (persistentvolume) group_left(nfs_server)
-              kube_persistentvolume_info{nfs_server!=""}
+              kube_persistentvolume_info{nfs_server!="", nfs_server!~"security-storage\\..*"}
             ) < 0.03
           for: 1m
           labels:

--- a/kubernetes/apps/observability/silence-operator/silences/kustomization.yaml
+++ b/kubernetes/apps/observability/silence-operator/silences/kustomization.yaml
@@ -7,4 +7,5 @@ resources:
   - ./ceph.yaml
   - ./frigate-media-pvc.yaml
   - ./prometheus.yaml
+  - ./security-storage-memory.yaml
   - ./zot-data-pvc.yaml

--- a/kubernetes/apps/observability/silence-operator/silences/security-storage-memory.yaml
+++ b/kubernetes/apps/observability/silence-operator/silences/security-storage-memory.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/observability.giantswarm.io/silence_v1alpha2.json
+#
+# security-storage is a RAM-starved Core 2 box (7.4 GiB) whose steady state is
+# >90% memory used: the Frigate recording write path keeps page cache pegged.
+# This is expected, not an incident. NodeMemoryHighUtilization is a
+# kube-prometheus-stack chart built-in (can't take a per-instance exclusion
+# inline like our own rules can), so it's silenced here scoped to this one
+# instance only — every other host still alerts normally.
+#
+# Companion change: PR #12324 excluded security-storage from our own
+# HostOutOfMemory and from the blunt KubeNFSExportFillingUp critical. The
+# permanent fix for all of these is the NAS rebuild
+# (project_todo_security_storage_new_build). Remove this silence when that box
+# is replaced.
+apiVersion: observability.giantswarm.io/v1alpha2
+kind: Silence
+metadata:
+  name: nodememoryhighutilization-security-storage
+spec:
+  matchers:
+    - name: alertname
+      value: NodeMemoryHighUtilization
+    - matchType: "=~"
+      name: instance
+      value: security-storage.*


### PR DESCRIPTION
Three alert rules that fired continuously on healthy steady state, burying real signal. Per the observability prime directive (don't bury a real alert under flap), the fixes *narrow* rather than blanket-silence — a genuine failure still pages.

## 1. `HostSwapIsFillingUp` (the swap node)

The only swap-enabled host (4 GiB swap / 188 GiB RAM) parks flat at ~86% swap — ~1.8% of RAM, because it runs ~160 GiB of KVM guest RAM (the cluster-node VMs) as anonymous pages and the kernel swaps the coldest. The static `>80%` rule fired forever. Now gated on `predict_linear(SwapFree[1h], 1h) < 0` so it fires only when swap is high **and** actually draining toward exhaustion. `for` 2m → 10m. A real swap-exhaustion spiral still pages; the parked-flat false positive is gone.

## 2. The Frigate recording NAS — expected-state alerts (our own rules)

The recording export is *designed* to run pegged near-full (fills to retention cap, then GCs oldest segments — a sawtooth living at the top) on a RAM-starved box. Two of our rules fired on its healthy steady state:

- **`KubeNFSExportFillingUp`** (critical, `<3%` free) — excluded from the blunt-threshold variant. The `predict_linear`-to-fill-in-4-days variant still catches a real GC-broke / heading-to-true-zero event: its 6h trend stays flat during a healthy sawtooth and goes negative only on a monotonic decline.
- **`HostOutOfMemory`** (warning, `<10%` MemAvailable) — excluded; the write path keeps page cache pegged as expected.

## 3. The same NAS — `NodeMemoryHighUtilization` (chart built-in → Silence CR)

`NodeMemoryHighUtilization` is a kube-prometheus-stack built-in, so it can't take the inline per-instance exclusion used in §2. Handled via a scoped `Silence` CR through the existing silence-operator convention, matching `alertname` + `instance=security-storage.*` only — every other host still alerts.

Permanent fix for all of §2/§3 is the NAS rebuild.

## Validation
Both edited expressions validated against live Prometheus: each returns empty with the exclusion applied (the excluded host was the sole match), no other host affected. Silences kustomization renders cleanly (`kubectl kustomize`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)