### PR TITLE
feat(frigate): weekly restart CronJob to mitigate ffmpeg memory leak

### DIFF
--- a/kubernetes/apps/home/frigate/app/kustomization.yaml
+++ b/kubernetes/apps/home/frigate/app/kustomization.yaml
@@ -11,6 +11,8 @@ resources:
   - ./longhorn-pvc.yaml
   - ./nfs-pvc.yaml
   - ./prometheusrule.yaml
+  - ./restart-cronjob.yaml
+  - ./restart-rbac.yaml
   - ./snapshot-cnp.yaml
   - ./snapshot-cronjob.yaml
   - ./snapshot-externalsecret.yaml

--- a/kubernetes/apps/home/frigate/app/restart-cronjob.yaml
+++ b/kubernetes/apps/home/frigate/app/restart-cronjob.yaml
@@ -1,0 +1,69 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/cronjob-batch-v1.json
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: frigate-restart
+  # workaround: https://github.com/blakeblackshear/frigate/discussions/19925 — remove when upstream ships a recording/ffmpeg leak fix and our 14d frigate working-set trend stays flat
+spec:
+  # Weekly restart to clear the upstream ffmpeg/recording memory leak
+  # (frigate working-set sawtooths to ~14Gi and OOM-resets). Tuesday
+  # 02:00 is the Renee-facing maintenance window (CLAUDE.md). k8tz
+  # transparently injects timeZone: America/New_York on this cluster, so
+  # the schedule below is local ET — do NOT set an explicit timeZone
+  # (matches frigate-snapshot). NOTE: a weekly cadence does not prevent
+  # inter-Tuesday OOMs; the 14Gi limit remains the involuntary backstop.
+  schedule: "0 2 * * 2"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: frigate-restart
+        spec:
+          serviceAccountName: frigate-restart
+          restartPolicy: OnFailure
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+          containers:
+            - name: restart
+              image: docker.io/alpine/k8s:1.36.1
+              command:
+                - /bin/sh
+                - -ceu
+                # Delete the pod by name — the StatefulSet controller
+                # recreates frigate-0 with no spec mutation (GitOps-clean).
+                - |
+                  kubectl -n home delete pod frigate-0 --wait=false
+                  echo "Requested restart of frigate-0"
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 64Mi
+                limits:
+                  memory: 128Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop:
+                    - ALL
+                seccompProfile:
+                  type: RuntimeDefault
+              volumeMounts:
+                - name: tmp
+                  mountPath: /tmp
+                - name: kube
+                  mountPath: /.kube
+          volumes:
+            - name: tmp
+              emptyDir: {}
+            - name: kube
+              emptyDir: {}

--- a/kubernetes/apps/home/frigate/app/restart-rbac.yaml
+++ b/kubernetes/apps/home/frigate/app/restart-rbac.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: frigate-restart
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: frigate-restart
+rules:
+  # StatefulSet pod name is deterministic (frigate-0), so scope delete to
+  # that name — tighter than a label selector, which would need an
+  # unscopeable `list`. The StatefulSet controller recreates the pod, so
+  # no StatefulSet spec mutation (and thus no Flux drift) is involved.
+  - apiGroups: [""]
+    resources: ["pods"]
+    resourceNames: ["frigate-0"]
+    verbs: ["get", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: frigate-restart
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: frigate-restart
+subjects:
+  - kind: ServiceAccount
+    name: frigate-restart


### PR DESCRIPTION
## Problem

Frigate's container memory working-set sawtooths to the `14Gi` limit and OOM-resets. This is the upstream **recording/ffmpeg memory leak** ([#19925](https://github.com/blakeblackshear/frigate/discussions/19925), [#19646](https://github.com/blakeblackshear/frigate/discussions/19646), [#21222](https://github.com/blakeblackshear/frigate/discussions/21222)) — recording-dependent, in the ffmpeg/`frigate.capture` path, **no confirmed upstream fix**. We're on 0.17.1 (latest stable).

14-day working-set trend showed baseline ~4.5–5.5 GiB with leak episodes climbing to **9 GiB** (sustained ~2 days) and one run to **13.95 GiB** — an OOMKill reset against the limit.

## Change

Weekly `CronJob frigate-restart` (Tuesday 02:00 ET, the Renee-facing maintenance window) that deletes `frigate-0` so the StatefulSet recreates it on a clean schedule.

- **Delete-by-name** (`frigate-0` is deterministic for a StatefulSet) → no StatefulSet spec mutation, GitOps-clean, and tighter RBAC (`resourceNames`) than a label selector.
- **No CNP** — `network-policy/baseline/allow-apiserver` (`endpointSelector: {}`) already grants `kube-apiserver:6443` egress namespace-wide; the job only talks to the apiserver.
- Hardened pod (non-root, read-only rootfs, drop ALL, RuntimeDefault), mirroring `mcp-gateway-jwt-rotator`.

## Honest tradeoff

A *weekly* restart does **not** prevent inter-Tuesday OOMs (a bad episode reaches 14Gi within ~24h); the 14Gi limit stays the involuntary backstop. This is clean-slate hygiene within the maintenance-window policy. The real frequency reduction comes from follow-up single-variable config experiments (VAAPI driver, record-path decoupling).

Workaround tracked per `.agents/instructions/workarounds.md` (issue linked below).

🤖 Generated with [Claude Code](https://claude.com/claude-code)