### PR TITLE
test(frigate): experiment — VAAPI driver iHD → i965 (memory leak)

### DIFF
--- a/kubernetes/apps/home/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/home/frigate/app/helmrelease.yaml
@@ -60,8 +60,14 @@ spec:
               tag: 0.17.1@sha256:1724960349dad0bd2ae8ec884171a6fd5755a4dc242a0e66cadbda9c0e85c99b
 
             env:
-              # LIBVA_DRIVER_NAME: i965
-              LIBVA_DRIVER_NAME: iHD
+              # Memory-leak experiment (issue #12327): testing the legacy
+              # i965 VAAPI driver in place of iHD. The upstream ffmpeg leak
+              # rides the HW-decode path; both drivers ship in the 0.17.1
+              # image and all cameras are H.264, which i965 decodes fine on
+              # this Kaby Lake (i7-7700) node. Revert to iHD if decode
+              # regresses or the 14d working-set trend is unchanged.
+              LIBVA_DRIVER_NAME: i965
+              # LIBVA_DRIVER_NAME: iHD
               # surpress error message documented here: https://github.com/blakeblackshear/frigate/discussions/15362
               OPENCV_LOG_LEVEL: FATAL
 


### PR DESCRIPTION
## Experiment 1 of N — reduce ffmpeg memory-leak frequency

Single-variable test toward the Frigate ffmpeg/recording memory leak (issue #12327, no upstream fix). The leak rides the hardware-decode path, so test whether the legacy **i965** VAAPI driver leaks less than **iHD**.

Verified before opening: `i965_drv_video.so` ships in the 0.17.1 image alongside `iHD`; `vainfo` loads `iHD` cleanly today; all cameras are H.264, which i965 decodes on this Kaby Lake (i7-7700) node. So worst case is "no change to the leak," not a decode outage. iHD line kept commented for a one-line revert.

## ⚠️ Merge in the maintenance window

This is an inline HelmRelease env change → Flux re-render rolls the frigate pod (~60–90s camera blip). Frigate is Renee-facing — **merge during Tuesday 02:00–04:00 ET** per the maintenance-window policy. Do not auto-merge.

## How to evaluate

After it rolls, confirm `vainfo` loads i965 and all cameras decode, then watch the 14-day working-set sawtooth:
```
max(container_memory_working_set_bytes{namespace="home",pod=~"frigate-.*",container="app"}) /1024/1024/1024
```
Compare peak/slope vs. the pre-change trend (bad episodes climbed ~0.4 GiB/hr to 9–14 GiB). If unchanged, revert and move to experiment 2 (decouple the record role from go2rtc restream).

🤖 Generated with [Claude Code](https://claude.com/claude-code)