### PR TITLE
feat(ai): comfyui-spark — ComfyUI on the DGX Spark (GB10), parallel to P40

### DIFF
--- a/.github/image-registry-allowlist.txt
+++ b/.github/image-registry-allowlist.txt
@@ -34,6 +34,7 @@ docker.io/rhasspy/wyoming-piper
 docker.io/rhasspy/wyoming-whisper
 docker.io/grafana/grafana-image-renderer  # Grafana project canonical; no ghcr publication
 docker.io/grafana/mcp-grafana
+docker.io/mmartial/comfyui-nvidia-docker  # DGX Spark arm64+GB10 ComfyUI; Docker Hub only, no ghcr
 docker.io/grafana/tempo                # Grafana project canonical; ghcr publication missing
 docker.io/jmtvms/tplink-omada-mcp
 docker.io/isokoliuk/mcp-searxng

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ _Production-grade Kubernetes for a household._
 
 <br/>
 
-![apps](https://img.shields.io/badge/apps-188-blue?style=for-the-badge)
-![helmreleases](https://img.shields.io/badge/HelmReleases-200-326CE5?style=for-the-badge&logo=helm&logoColor=white)
+![apps](https://img.shields.io/badge/apps-189-blue?style=for-the-badge)
+![helmreleases](https://img.shields.io/badge/HelmReleases-201-326CE5?style=for-the-badge&logo=helm&logoColor=white)
 ![nodes](https://img.shields.io/badge/k8s_nodes-11-326CE5?style=for-the-badge&logo=kubernetes&logoColor=white)
 ![cnpg](https://img.shields.io/badge/Postgres_clusters-25-336791?style=for-the-badge&logo=postgresql&logoColor=white)
 ![secrets](https://img.shields.io/badge/secrets-117-0572EC?style=for-the-badge&logo=1password&logoColor=white)

--- a/kubernetes/apps/ai/comfyui-spark/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/comfyui-spark/app/cnp-allow.yaml
@@ -1,0 +1,38 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: comfyui-spark-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: comfyui-spark
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal gateway → comfyui-spark:8188 (validation UI).
+    # comfyui-mcp ingress is NOT added yet — the MCP server still fronts
+    # the P40 comfyui until cutover.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "8188"
+              protocol: TCP
+  egress:
+    # First run pulls ComfyUI (git), the Python venv (pypi), ComfyUI
+    # Manager, and re-downloads models (HuggingFace / civitai / github).
+    # The pypi family forces toEntities:[world]+443 (matchPattern FQDN
+    # gaps, see project_cilium_matchpattern_fqdn_limits.md), so the rule
+    # collapses to world:443 — matches the comfyui-allow precedent.
+    - toEntities: [world]
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/ai/comfyui-spark/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/comfyui-spark/app/helmrelease.yaml
@@ -1,0 +1,131 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app comfyui-spark
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 30m
+  # First run git-clones ComfyUI and builds a Python venv (minutes);
+  # don't let Flux block the Kustomization waiting on readiness.
+  install:
+    disableWait: true
+  upgrade:
+    disableWait: true
+  values:
+    controllers:
+      comfyui-spark:
+        pod:
+          nodeSelector:
+            node-role.kubernetes.io/gpu: blackwell
+
+          tolerations:
+            # Spark is tainted kubernetes.io/arch=arm64:NoSchedule to keep
+            # amd64-only workloads off it, plus nvidia.com/gpu=true:NoSchedule.
+            # This image is arm64-native (mmartial DGX build), so tolerate both.
+            - key: kubernetes.io/arch
+              operator: Equal
+              value: arm64
+              effect: NoSchedule
+            - key: nvidia.com/gpu
+              operator: Equal
+              value: "true"
+              effect: NoSchedule
+
+        # Deliberately no priorityClassName: comfyui-spark runs at the
+        # global default (0), far below ollama-spark's ai-gpu-critical
+        # (100040). On the shared time-sliced GB10 the kubelet evicts
+        # this pod first under node memory pressure — the inference path
+        # (ollama-spark) is never starved by image generation.
+        annotations:
+          reloader.stakater.com/auto: "true"
+
+        type: statefulset
+
+        containers:
+          app:
+            image:
+              # Docker Hub is mmartial's only registry (no ghcr); allowlisted.
+              # arm64 + CUDA 13.2 + PyTorch built native for sm_121 (GB10).
+              repository: docker.io/mmartial/comfyui-nvidia-docker
+              tag: ubuntu24_cuda13.2-dgx-20260509@sha256:b1821811c57fab76a906e0eecbd7d66d96069d68e90579d06f001a9211c64468
+
+            env:
+              BASE_DIRECTORY: /basedir
+              SECURITY_LEVEL: normal
+              USE_UV: "true"
+              # Re-map the in-image `comfy` user to 1000/1000 and chown the
+              # fresh ceph-block volumes on first start.
+              WANTED_UID: "1000"
+              WANTED_GID: "1000"
+              FORCE_CHOWN: "yes"
+              # Shared GB10: --lowvram makes ComfyUI release VRAM between
+              # ops so it can't camp on the unified pool ollama-spark needs.
+              # Raise to --normalvram once contention headroom is measured.
+              COMFY_CMDLINE_EXTRA: --lowvram
+
+            resources:
+              requests:
+                cpu: 500m
+                memory: 2Gi
+                nvidia.com/gpu: 1
+              limits:
+                # NOTE: on GB10 unified memory, CUDA-mapped model weights do
+                # NOT bill against the kubelet cgroup (see ollama-spark), so
+                # this limit bounds container RSS, not VRAM. The real VRAM
+                # lever is COMFY_CMDLINE_EXTRA above.
+                memory: 24Gi
+                nvidia.com/gpu: 1
+
+            securityContext:
+              # mmartial's init starts as the in-image user and uses sudo to
+              # usermod/chown to WANTED_UID/GID; matches ollama-spark + the
+              # existing comfyui (both privileged). Deviates from
+              # helmrelease.security.md by design — documented here.
+              privileged: true
+
+    service:
+      app:
+        controller: comfyui-spark
+        ports:
+          http:
+            port: &httpPort 8188
+
+    route:
+      main:
+        annotations:
+          glance/name: "Comfy UI (Spark)"
+          glance/show: "true"
+          glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/comfy-ui.png"
+          glance/id: "AI"
+        hostnames:
+          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: *httpPort
+
+    persistence:
+      # Regenerable model data (re-downloaded fresh) + outputs/custom_nodes.
+      # ceph-block: RWO, attaches on the Spark (rook RBD nodeplugin present),
+      # rule-2 tier for reconstructable data.
+      basedir:
+        existingClaim: comfyui-spark-basedir-pvc
+        advancedMounts:
+          comfyui-spark:
+            app:
+              - path: /basedir
+      # ComfyUI source checkout + Python venv + pip/uv caches (regenerable).
+      run:
+        existingClaim: comfyui-spark-run-pvc
+        advancedMounts:
+          comfyui-spark:
+            app:
+              - path: /comfy/mnt

--- a/kubernetes/apps/ai/comfyui-spark/app/kustomization.yaml
+++ b/kubernetes/apps/ai/comfyui-spark/app/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../components/repos/app-template
+resources:
+  - ./cnp-allow.yaml
+  - ./helmrelease.yaml
+  - ./pvc.yaml

--- a/kubernetes/apps/ai/comfyui-spark/app/pvc.yaml
+++ b/kubernetes/apps/ai/comfyui-spark/app/pvc.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: comfyui-spark-basedir-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: ceph-block
+  resources:
+    requests:
+      storage: 150Gi
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: comfyui-spark-run-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: ceph-block
+  resources:
+    requests:
+      storage: 30Gi

--- a/kubernetes/apps/ai/comfyui-spark/ks.yaml
+++ b/kubernetes/apps/ai/comfyui-spark/ks.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app comfyui-spark
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: ai
+  path: ./kubernetes/apps/ai/comfyui-spark/app
+  interval: 30m
+  prune: true
+  wait: false
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: gpu-operator
+      namespace: kube-system
+    - name: rook-ceph-cluster
+      namespace: rook-ceph

--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
   - ./namespace.yaml
   - ./priority-class.yaml
   - ./comfyui/ks.yaml
+  - ./comfyui-spark/ks.yaml
   - ./langfuse/ks.yaml
   - ./langgraph-agents/ks.yaml
   - ./ollama/ks.yaml


### PR DESCRIPTION
## What

Stands up a **second** ComfyUI on the DGX Spark (GB10/arm64) as a new app `ai/comfyui-spark`, **parallel** to the existing P40 `comfyui` — which is left completely untouched as the fallback. Cutting `comfyui-mcp` + the HTTPRoute over to the Spark instance is a **deliberate later step**, after GB10 performance is validated.

## Image
`docker.io/mmartial/comfyui-nvidia-docker:ubuntu24_cuda13.2-dgx-20260509` pinned by digest `sha256:b1821811…4468`:
- `linux/arm64`, **CUDA 13.2 + PyTorch compiled native for sm_121** (GB10 — not PTX-forward), non-root, listens on 8188.
- mmartial: 393★, MIT, maintained, date-stamped tags. Docker Hub is its only registry (no ghcr) → added to `.github/image-registry-allowlist.txt`.

## Placement
- `nodeSelector: node-role.kubernetes.io/gpu=blackwell` + the `arm64` / `nvidia.com/gpu` **NoSchedule tolerations** the Spark taints require (copied from the proven `ollama-spark`).

## Inference-path guardrails (HOMELAB-SPEC: *cannot crash the inference path*)
The Spark's GB10 is **one physical GPU time-sliced**, sharing the 127 GB unified pool with `ollama-spark` (the LLM inference path). So:
- **No `priorityClassName`** → global default `0`, far below `ollama-spark`'s `ai-gpu-critical` (100040). Under node memory pressure the kubelet evicts ComfyUI first; ollama is never starved.
- **`COMFY_CMDLINE_EXTRA=--lowvram`** → ComfyUI releases VRAM between ops instead of camping on the unified pool. Tunable up to `--normalvram` once headroom is measured.

## Storage (fresh — no migration)
Per your call: models re-download fresh. Two **ceph-block** PVCs (`basedir` 150Gi, `run` 30Gi) — ceph RBD attaches on the Spark; Longhorn does not. The old 94 GB Longhorn workspace PVC stays with the P40 instance. `output` is *not* repointed yet (parallel phase).

## Deviation
`securityContext.privileged: true` — mmartial's init usermods/chowns to `WANTED_UID/GID` via sudo. Matches `ollama-spark` and the existing `comfyui`. Documented in-line vs `helmrelease.security.md`.

## Post-merge validation plan
1. Flux reconciles; pod schedules on the Spark, first run git-clones ComfyUI + builds venv (minutes; `disableWait` set so Flux doesn't block).
2. Hit `comfyui-spark.${SECRET_DOMAIN}`, confirm GB10 in system stats, run a Flux workflow, watch `ollama-spark` power/latency for contention.
3. If good → follow-up PR cuts `comfyui-mcp` + the internal route to the Spark and retires the P40 instance. If not → delete this app, zero impact on the P40 ComfyUI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)