### PR TITLE
fix(ai): chown comfyui-spark volumes via initContainer (1000:1000)

### DIFF
--- a/kubernetes/apps/ai/comfyui-spark/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/comfyui-spark/app/helmrelease.yaml
@@ -45,6 +45,24 @@ spec:
 
         type: statefulset
 
+        initContainers:
+          # mmartial refuses to chown a volume mount root and expects it
+          # pre-owned by WANTED_UID:WANTED_GID (the Docker model: mkdir the
+          # dirs as your user before run). Fresh ceph-block volumes mount as
+          # 0:0, and fsGroup only fixes the group — so chown both mounts to
+          # 1000:1000 here. Reuses the already-cached app image (no 2nd pull).
+          init-perms:
+            image:
+              repository: docker.io/mmartial/comfyui-nvidia-docker
+              tag: ubuntu24_cuda13.2-dgx-20260509@sha256:b1821811c57fab76a906e0eecbd7d66d96069d68e90579d06f001a9211c64468
+            command:
+              - sh
+              - -c
+              - chown -R 1000:1000 /comfy/mnt /basedir
+            securityContext:
+              runAsUser: 0
+              runAsNonRoot: false
+
         containers:
           app:
             image:
@@ -120,6 +138,8 @@ spec:
         existingClaim: comfyui-spark-basedir-pvc
         advancedMounts:
           comfyui-spark:
+            init-perms:
+              - path: /basedir
             app:
               - path: /basedir
       # ComfyUI source checkout + Python venv + pip/uv caches (regenerable).
@@ -127,5 +147,7 @@ spec:
         existingClaim: comfyui-spark-run-pvc
         advancedMounts:
           comfyui-spark:
+            init-perms:
+              - path: /comfy/mnt
             app:
               - path: /comfy/mnt


### PR DESCRIPTION
Follow-up to #12331. The Spark ComfyUI crashlooped on first run:

```
ERROR: Directory /comfy/mnt owned by unexpected user/group, expected 1000:1000, actual 0:0
  -- FORCE_CHOWN will not work for this folder, it is a PATH mounted at container startup
```

**Cause:** mmartial expects its `run`/`basedir` mounts pre-owned by `WANTED_UID:WANTED_GID` (Docker model: `mkdir` as your user before run) and explicitly refuses to chown a mount root. Fresh ceph-block volumes mount `0:0`; `fsGroup` only fixes the group (`0:1000`), still failing the exact `1000:1000` check.

**Fix:** an `init-perms` initContainer (reuses the already-cached app image, `runAsUser: 0`) that `chown -R 1000:1000 /comfy/mnt /basedir` before the main container starts. Both volumes mounted into it via `advancedMounts`.

The image/arch/GPU were already validated — first run detected CUDA 13.2 driver + GB10 before hitting the perms check. Verified `kubectl apply --server-side --dry-run=server` + yamllint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)