### PR TITLE
fix(windmill): lower ntfy push priority to default (simple buzz)

### DIFF
--- a/kubernetes/apps/home/windmill/workflows/alertmanager-holmesgpt-notify.ts
+++ b/kubernetes/apps/home/windmill/workflows/alertmanager-holmesgpt-notify.ts
@@ -112,8 +112,9 @@ export async function main(alerts?: AlertmanagerAlert[]) {
         message = ((m && m[0].length > 600) ? m[0] : cut).trimEnd() + "…";
     }
 
-    const sev = (a.labels.severity ?? "").toLowerCase();
-    const priority = sev === "critical" ? 5 : sev === "warning" ? 4 : 3;
+    // ntfy priority pinned to 3 (default/simple buzz) — Rob doesn't want
+    // the insistent max/urgent vibration pattern on alert relays.
+    const priority = 3;
 
     const notifyResp = await publishNtfy({
         topic: "alerts",

--- a/kubernetes/apps/home/windmill/workflows/langgraph-approval-post.ts
+++ b/kubernetes/apps/home/windmill/workflows/langgraph-approval-post.ts
@@ -58,7 +58,7 @@ export async function main(
             `Undo: ${r.undo_path ?? "(none)"}`,
             `Cost: $${r.cost_estimate_usd ?? 0}`,
         ].join("\n"),
-        priority: r.action_class === "D" ? 5 : 4,
+        priority: 3,
         tags: r.action_class === "D" ? ["warning", "rotating_light"] : ["warning"],
         actions: buildApprovalActions(task_id, approveTok, rejectTok, deferTok),
     });

--- a/kubernetes/apps/home/windmill/workflows/langgraph-awaiting-user-sweep.ts
+++ b/kubernetes/apps/home/windmill/workflows/langgraph-awaiting-user-sweep.ts
@@ -66,7 +66,7 @@ async function handle(t: Task, tier: "30min" | "4h" | "7d", age: number) {
             message: `Agent ${t.target_agent ?? "unknown"} is paused, age ${
                 Math.round(age / 60000)
             }m. Tap an action in the original approval push, or react in Zulip #approvals.`,
-            priority: 5,
+            priority: 3,
             tags: ["alarm_clock"],
         });
         return { action: "ntfy", ok: resp.ok };

--- a/kubernetes/apps/home/windmill/workflows/langgraph-inbox.ts
+++ b/kubernetes/apps/home/windmill/workflows/langgraph-inbox.ts
@@ -72,7 +72,7 @@ async function postApproval(task_id: string, r: ApprovalRequest) {
             `Undo: ${r.undo_path ?? "(none)"}`,
             `Cost: $${r.cost_estimate_usd ?? 0}`,
         ].join("\n"),
-        priority: 5,
+        priority: 3,
         tags: ["warning"],
         actions: buildApprovalActions(task_id, approveTok, rejectTok, deferTok),
         click: `https://chat.${Deno.env.get("SECRET_DOMAIN") ?? ""}/#narrow/stream/approvals/topic/${encodeURIComponent(topic)}`,

--- a/kubernetes/apps/home/windmill/workflows/windmill-failure-watcher.ts
+++ b/kubernetes/apps/home/windmill/workflows/windmill-failure-watcher.ts
@@ -177,7 +177,7 @@ async function notify(groups: Grouped[]) {
             topic: "alerts",
             title: `🚨 Windmill workflows failing: ${groups.length}`,
             message: lines.join("\n"),
-            priority: 4,
+            priority: 3,
             tags: ["warning", "windmill"],
         }),
         postZulipDM(lines.join("\n")),


### PR DESCRIPTION
## What

Lowers ntfy push priority to **3 (default)** across the notification workflows so the phone gets a single short buzz instead of the insistent max/urgent (5) vibration pattern (the "5-second buzz").

Spend-related alerting is **intentionally left elevated** — `langgraph-cost-cap-watcher.ts` stays at 5/4 per Rob's call ("everything can be reduced other than things that affect real \$\$ and spending").

| Workflow | Before | After |
|---|---|---|
| `alertmanager-holmesgpt-notify` | critical 5 / warning 4 | 3 |
| `langgraph-approval-post` | destructive 5 / else 4 | 3 |
| `langgraph-awaiting-user-sweep` | 5 | 3 |
| `langgraph-inbox` | 5 | 3 |
| `windmill-failure-watcher` | 4 | 3 |
| `langgraph-cost-cap-watcher` | 5 / 4 | **unchanged** |

## Note

Untouched fields: the `priority: "high"/"normal"` on the `/inbox` task body in `alertmanager-holmesgpt-notify.ts` is a langgraph **queue** priority, not the ntfy header — left alone. Pushover priorities in `alertmanagerconfig.yaml` are a different channel (not ntfy) — also untouched.

## Deploy

Windmill runs from its own DB with no Flux sync — after merge the scripts are pushed to live Windmill via the API (port-forward + `scripts/create` version-thread).

🤖 Generated with [Claude Code](https://claude.com/claude-code)