### PR TITLE
fix(istio): pin istiod chart back to 1.30.0 (1.30.1 unpublished, wedged mcp-system)

### DIFF
--- a/kubernetes/apps/istio-system/istio/app/istiod/helmrelease.yaml
+++ b/kubernetes/apps/istio-system/istio/app/istiod/helmrelease.yaml
@@ -11,7 +11,12 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: istio
-      version: 1.30.1
+      # 1.30.1 was never published to the istio chart repo
+      # (https://istio-release.storage.googleapis.com/charts has 1.30.0
+      # as latest stable); Renovate #12315 bumped to it and wedged the HR,
+      # cascading to block all mcp-system reconciliation. Held at 1.30.0
+      # (the running, healthy release) until a real >1.30.0 chart exists.
+      version: 1.30.0
   interval: 5m
   dependsOn:
     - name: istio-base


### PR DESCRIPTION
## Root cause
Renovate **#12315** bumped the istiod chart `1.30.0 → 1.30.1`, but **1.30.1 was never published** to the istio chart repo — `https://istio-release.storage.googleapis.com/charts` has `1.30.0` as latest stable. The HelmRelease wedged:

```
Ready: False — no 'istiod' chart with version matching '1.30.1' found
```

## Impact
The running release `istiod.v5 @ 1.30.0` is **healthy** (2/2 pods, 17d, 0 restarts) — istio data + control plane are fine. But the wedged HelmRelease never reports Ready, and because `mcp-gateway` (and below it every mcp-system app: comfyui-mcp, kubectl-mcp, the gateway broker, …) `dependsOn` istiod, **all of mcp-system's GitOps froze**. New mcp-system changes silently don't apply.

This was surfaced while trying to roll a comfyui-mcp env change — it wouldn't apply, and the dependency trace led here.

## Fix
Revert to `1.30.0` — the version **already running and healthy**. Git-matches-reality, **zero runtime change**, unwedges the HelmRelease and the whole mcp-system dependency chain.

## Follow-up
Renovate will re-propose 1.30.1. Recommend a packageRule to hold istiod at 1.30.0 until a real `>1.30.0` chart publishes (Renovate config is yours to own).

🤖 Generated with [Claude Code](https://claude.com/claude-code)