### PR TITLE
feat(langgraph-agents): bump to 0.2.66 (artist→comfyui-mcp rewire)

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/langgraph-agents
-              tag: 0.2.65@sha256:f07fe87dafa81e22b463c1f30d719acba57df302a85947d4edd7cfdaee03e906
+              tag: 0.2.66@sha256:d709b403b41a92b27054415fc586c301c4b246558539b84c5c3e4ea0aad7c2e5
 
             env:
               # --- vault ---


### PR DESCRIPTION
Deploys [langgraph-agents PR #119](https://github.com/rwlove/langgraph-agents/pull/119) into the cluster.

## What
Bumps the `langgraph-agents` image `0.2.65 → 0.2.66`. That release rewires the **artist** agent off the abandoned Pixelle-MCP backend onto the artokun comfyui-mcp running on the Spark (GB10):
- artist binds the **read-only** comfyui-mcp subset (system stats, model/workflow listing, queue/job status) so it can size proposals against shared GB10 VRAM
- the **write** tools (image generation, controlnet/ip-adapter, enqueue) go to **errand-runner** — sole-writer invariant preserved

## Why manual (not Renovate)
PR #119 was squash-merged without a semver tag, so Renovate had nothing to track. Pushed `v0.2.66` upstream to publish the semver image, then bumped here directly rather than wait on Renovate's scan cycle.

## Blast radius
Single-replica `Recreate` Deployment → ~30-60s pod bounce on Flux reconcile. State is Postgres-backed (at-least-once redelivery), no active task processing observed at assessment. **No GPU workloads restart** — `ollama-spark-0` / `comfyui-spark-0` (GB10) and the P40 comfyui/ollama are untouched. Inference path unaffected.

**Rollback:** revert the tag to `0.2.65@sha256:f07fe87…`; Flux reconciles back. No data at risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)