### PR TITLE
feat(media): scrub non-UUID MusicBrainz IDs after beets import

### DIFF
--- a/kubernetes/apps/media/beets/app/helmrelease.yaml
+++ b/kubernetes/apps/media/beets/app/helmrelease.yaml
@@ -63,6 +63,12 @@ spec:
                 while :; do
                   if beet -c /tmp/config.yaml import -q /media; then
                     echo "[$(date)] Beets import complete."
+                    # as-is imports preserve bad Discogs MBIDs in the file tags,
+                    # which break Music Assistant's OpenSubsonic track-sync.
+                    # Blank any non-UUID mb_* (DB + file). Non-fatal.
+                    echo "[$(date)] Scrubbing non-UUID MusicBrainz IDs..."
+                    python3 /scripts/mbid-scrub.py /media \
+                      || echo "[$(date)] WARN: mbid-scrub failed (non-fatal)"
                     exit 0
                   fi
                   attempts=$((attempts+1))
@@ -120,6 +126,14 @@ spec:
         globalMounts:
           - path: /tmptmp/config.yaml
             subPath: config.yaml
+            readOnly: true
+
+      scripts:
+        type: configMap
+        name: beets-scripts
+        globalMounts:
+          - path: /scripts/mbid-scrub.py
+            subPath: mbid-scrub.py
             readOnly: true
 
       media:

--- a/kubernetes/apps/media/beets/app/kustomization.yaml
+++ b/kubernetes/apps/media/beets/app/kustomization.yaml
@@ -16,6 +16,9 @@ configMapGenerator:
   - name: beets-config
     files:
       - config.yaml=./resources/config.yaml
+  - name: beets-scripts
+    files:
+      - mbid-scrub.py=./resources/mbid-scrub.py
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/kubernetes/apps/media/beets/app/resources/mbid-scrub.py
+++ b/kubernetes/apps/media/beets/app/resources/mbid-scrub.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Blank non-UUID MusicBrainz IDs left in the library by as-is imports.
+
+`import.quiet_fallback: asis` preserves whatever MUSICBRAINZ_* tags a source
+file shipped with. Bootleg / Discogs-tagged rips arrive with Discogs IDs
+(e.g. ``16327311-1``) in those fields. Music Assistant's OpenSubsonic sync
+validates every MBID as a UUID and aborts the ENTIRE track-sync pass on the
+first bad one, silently freezing MA's library. gonic passes the bad value
+straight through from the file tag.
+
+This scrub runs after each import. For every item it blanks any mb_* field
+whose value is present but is NOT a valid UUID — both in the beets DB and in
+the file's tags (what gonic actually reads). A valid UUID is never touched,
+so this is safe to run across the whole library; it only removes garbage.
+
+Idempotent. Non-fatal by contract: it must never fail the import job.
+"""
+import os
+import re
+import sqlite3
+import sys
+
+LIBRARY = os.environ.get("BEETS_LIBRARY", "/config/library.db")
+MUSIC_ROOT = (sys.argv[1] if len(sys.argv) > 1 else "/media").encode()
+
+UUID = re.compile(
+    rb"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.I
+)
+
+# beets `items` columns that hold MusicBrainz identifiers.
+DB_FIELDS = [
+    "mb_workid", "mb_trackid", "mb_albumid", "mb_artistid", "mb_artistids",
+    "mb_albumartistid", "mb_albumartistids", "mb_releasetrackid",
+    "mb_releasegroupid",
+]
+# Subset that maps to real on-disk tags (mediafile attributes).
+FILE_FIELDS = [
+    "mb_trackid", "mb_releasetrackid", "mb_albumid", "mb_artistid",
+    "mb_albumartistid", "mb_releasegroupid", "mb_workid",
+]
+
+
+def is_bad(value) -> bool:
+    if not value:
+        return False
+    raw = value if isinstance(value, bytes) else str(value).encode()
+    return UUID.match(raw.strip()) is None
+
+
+def main() -> int:
+    try:
+        import mediafile
+    except Exception as exc:  # pragma: no cover - import guard
+        print(f"mbid-scrub: mediafile unavailable, skipping: {exc}")
+        return 0
+
+    db = sqlite3.connect(LIBRARY, timeout=60)
+    db.execute("PRAGMA busy_timeout=60000")
+    cols = {r[1] for r in db.execute("PRAGMA table_info(items)")}
+    db_fields = [f for f in DB_FIELDS if f in cols]
+
+    rows = db.execute(
+        "SELECT id, path, %s FROM items" % ",".join(db_fields)
+    ).fetchall()
+
+    fixed_db = fixed_files = miss = noperm = err = 0
+    for row in rows:
+        item_id, path = row[0], row[1]
+        bad_db = [f for f, v in zip(db_fields, row[2:]) if is_bad(v)]
+        if not bad_db:
+            continue
+
+        # 1) beets DB — blank the bad columns so they are not re-stamped.
+        try:
+            db.execute(
+                "UPDATE items SET %s WHERE id=?"
+                % ",".join("%s=''" % f for f in bad_db),
+                (item_id,),
+            )
+            db.commit()
+            fixed_db += 1
+        except Exception as exc:
+            print(f"mbid-scrub: DB update failed id={item_id}: {exc}")
+            err += 1
+            continue
+
+        # 2) File tags — what gonic / Music Assistant actually read.
+        ap = path if os.path.isabs(path) and os.path.exists(path) \
+            else os.path.join(MUSIC_ROOT, path)
+        if not os.path.exists(ap):
+            miss += 1
+            continue
+        if not os.access(ap, os.W_OK):
+            noperm += 1
+            print(f"mbid-scrub: no write perm: {ap!r}")
+            continue
+        try:
+            mf = mediafile.MediaFile(ap)
+            changed = False
+            for f in FILE_FIELDS:
+                if is_bad(getattr(mf, f, None)):
+                    setattr(mf, f, None)
+                    changed = True
+            if changed:
+                mf.save()
+                fixed_files += 1
+        except Exception as exc:
+            print(f"mbid-scrub: tag write failed {ap!r}: {exc}")
+            err += 1
+
+    print(
+        "mbid-scrub: cleaned db=%d files=%d (missing=%d noperm=%d err=%d) "
+        "over %d items"
+        % (fixed_db, fixed_files, miss, noperm, err, len(rows))
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as exc:  # never fail the import job
+        print(f"mbid-scrub: unexpected error, ignoring: {exc}")
+        sys.exit(0)


### PR DESCRIPTION
## Problem

Music Assistant's library has been frozen for days — no new tracks since ~2026-06-05. Root cause is **not** a permission or MA-config issue:

- beets imports unmatched files **as-is** (`quiet_fallback: asis`), preserving whatever `MUSICBRAINZ_*` tags the source files shipped with.
- Discogs-tagged rips arrive with **Discogs IDs** (e.g. `16327311-1`) sitting in the MusicBrainz tag fields — not valid UUIDs.
- gonic passes the value straight through from the file tag.
- Music Assistant's OpenSubsonic sync validates every MBID as a UUID and **aborts the entire track-sync pass on the first bad one** (`Invalid MusicBrainz identifier: 16327311-1`), so nothing new lands in MA's library.

34 tracks in the library currently carry such IDs (one This Heat bootleg + many DJ Screw chapter rips + a couple others). They were already hand-cleaned live (beets DB + file tags) to unblock MA; this PR prevents recurrence on future as-is imports.

## Change

Add `mbid-scrub.py`, run after each successful `beet import`:

- For every item, blank any `mb_*` field whose value is present but **not a valid UUID** — in both the beets DB and the file tags (what gonic actually reads).
- A valid UUID is **never** touched, so it is safe to run library-wide — it only removes garbage. This is the key safety property vs. the beets `zero` plugin (whose misconfiguration could strip *all* MBIDs).
- Non-fatal by contract: wrapped so it can never fail the import job.

## Files

- `resources/mbid-scrub.py` — the scrub (follows the `lidarr-bridge/bridge.py` script-as-resource pattern)
- `kustomization.yaml` — `beets-scripts` configMapGenerator
- `helmrelease.yaml` — mount at `/scripts/`, invoke after import

## Notes

- Runs only inside the beets import job (post-import, same container) — no concurrency with the live MA/gonic services.
- Idempotent; on a clean library it reports `cleaned db=0 files=0` and exits 0.
- Does not address the upstream behaviour that MA aborts a whole sync on one bad MBID — that's worth a separate upstream report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)