### PR TITLE
chore(pump): bump image v0.0.91 → v0.0.92

### DIFF
--- a/kubernetes/apps/collab/pump/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump/app/helmrelease.yaml
@@ -32,7 +32,7 @@ spec:
           pump:
             image:
               repository: ghcr.io/rwlove/pump
-              tag: v0.0.91@sha256:b48005b9825286e3d2dec80e9c27ecfdcaf0605dac7057e0ca328ac42f9de9cf
+              tag: v0.0.92@sha256:15abc4a671ed2b96460261b92d90d8bf841ed94238c853e5444319b323a279e4
 
             env:
               # Activates the /api/cv/* proxy in pump (see internal/web/exercise.go).


### PR DESCRIPTION
Rolls out [PUMP #29](https://github.com/rwlove/PUMP/pull/29) — the body-weight **log** is now folded into **Stats → Body Weight** and the hidden `/weight/` page is removed.

- `ghcr.io/rwlove/pump`: `v0.0.91` → `v0.0.92`, digest-pinned (`sha256:15abc4a6…`).
- Image built + pushed by PUMP `container-publish` on tag `pump-v0.0.92` (green).

Rolling update; no schema/PVC change (CNPG `postgres-pump` untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)