### PR TITLE
feat(pump): wire /api/health ingest + bump to v0.0.93

### DIFF
--- a/kubernetes/apps/collab/pump/app/externalsecret.yaml
+++ b/kubernetes/apps/collab/pump/app/externalsecret.yaml
@@ -20,6 +20,11 @@ spec:
         # bt-scale ESPHome device reaching pump-ingest.${SECRET_DOMAIN}).
         # Add a "WEIGHT_INGEST_KEY" field to the 1Password "pump" item.
         WEIGHT_INGEST_KEY: "{{ .WEIGHT_INGEST_KEY }}"
+        # Required header value for off-cluster POST /api/health (the Android
+        # Health Connect "HC Webhook" bridge on Rob's S26 → pump-ingest).
+        # Add a "HEALTH_INGEST_KEY" field to the 1Password "pump" item; set
+        # the same value as the webhook app's X-Api-Key custom header.
+        HEALTH_INGEST_KEY: "{{ .HEALTH_INGEST_KEY }}"
 
         # Postgres Init
         INIT_POSTGRES_DBNAME: workoutdiary

--- a/kubernetes/apps/collab/pump/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump/app/helmrelease.yaml
@@ -32,7 +32,7 @@ spec:
           pump:
             image:
               repository: ghcr.io/rwlove/pump
-              tag: v0.0.92@sha256:15abc4a671ed2b96460261b92d90d8bf841ed94238c853e5444319b323a279e4
+              tag: v0.0.93@sha256:7e78489a840271d8ed0ff3ea02106970d65873a8c9cd6ee1c69f76d1411800a3
 
             env:
               # Activates the /api/cv/* proxy in pump (see internal/web/exercise.go).
@@ -88,11 +88,13 @@ spec:
                 port: 4180
 
       # Off-cluster ingest path. Bypasses oauth2-proxy and goes straight
-      # to pump-api:8851. Scoped to /api/weight only via the path match —
-      # all other /api/* endpoints on this hostname 404. App-side auth is
-      # WEIGHT_INGEST_KEY (env from pump-secret), enforced by the
-      # weightIngestAuth middleware on POST /api/weight in pump v0.0.91+.
-      # Only intended caller today is the bt-scale ESPHome device.
+      # to pump-api:8851. Scoped by path match to /api/weight and POST
+      # /api/health — all other /api/* endpoints on this hostname 404.
+      # App-side auth is WEIGHT_INGEST_KEY / HEALTH_INGEST_KEY (env from
+      # pump-secret), enforced by the weightIngestAuth / healthIngestAuth
+      # middleware on the respective POST routes (pump v0.0.91+ / v0.0.93+).
+      # Callers: the bt-scale ESPHome device (weight) and the Android
+      # Health Connect HC Webhook bridge on Rob's S26 (health).
       ingest:
         hostnames:
           - "pump-ingest.${SECRET_DOMAIN}"
@@ -117,6 +119,19 @@ spec:
               - path:
                   type: PathPrefix
                   value: /api/weight
+            backendRefs:
+              - kind: Service
+                name: pump-api
+                port: 8851
+          # Wearable metrics from Android Health Connect. Scoped to POST so
+          # GET /api/health (unauthenticated health-record read) is NOT
+          # reachable off-cluster — tighter than the weight rule above
+          # because health data is more sensitive.
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /api/health
+                method: POST
             backendRefs:
               - kind: Service
                 name: pump-api


### PR DESCRIPTION
## What

Cluster side of the **Xiaomi Smart Band 9 → Android Health Connect → PUMP** integration. Pairs with PUMP image **v0.0.93** (rwlove/PUMP#30, schema v8, `/api/health` endpoint).

- **helmrelease**: bump `ghcr.io/rwlove/pump` v0.0.92 → **v0.0.93**; add a `POST /api/health` rule to the off-cluster `ingest` Route on `pump-ingest.${SECRET_DOMAIN}`.
- **externalsecret**: add `HEALTH_INGEST_KEY` (the `X-Api-Key` for `POST /api/health`), templated from the 1Password **pump** item.

The `/api/health` rule is scoped to **POST** (the weight rule is path-only) so the unauthenticated `GET /api/health` read stays in-cluster — health records are more sensitive than weight.

## ⛔ Merge gate — do this first

**Add a `HEALTH_INGEST_KEY` field to the 1Password "pump" item** (Kubernetes vault) before merging. Without it the ExternalSecret renders an empty value, `healthIngestAuth` becomes a no-op, and merging would expose an **unauthenticated off-cluster ingest endpoint**.

Set the **same value** as the `X-Api-Key` custom header in the Android HC Webhook app.

## After merge

Flux rolls pump to v0.0.93 (migration v8 runs on startup), the ExternalSecret picks up the key, and `POST https://pump-ingest.${SECRET_DOMAIN}/api/health` accepts authenticated Health Connect payloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)