### PR TITLE
chore(pump): bump image v0.0.93 → v0.0.94

### DIFF
--- a/kubernetes/apps/collab/pump/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump/app/helmrelease.yaml
@@ -32,7 +32,7 @@ spec:
           pump:
             image:
               repository: ghcr.io/rwlove/pump
-              tag: v0.0.93@sha256:7e78489a840271d8ed0ff3ea02106970d65873a8c9cd6ee1c69f76d1411800a3
+              tag: v0.0.94@sha256:6c2160fba270b0ef75290db894186a1e0f3dace99d288ba7639df05a0c341c04
 
             env:
               # Activates the /api/cv/* proxy in pump (see internal/web/exercise.go).


### PR DESCRIPTION
Rolls out [PUMP #31](https://github.com/rwlove/PUMP/pull/31) — the **Body Weight log** on Stats now honors the selected time period (weekly/monthly/all-time), matching the chart.

- `ghcr.io/rwlove/pump`: `v0.0.93` → `v0.0.94`, digest-pinned (`sha256:6c2160fb…`).
- Image built + pushed by PUMP `container-publish` on tag `pump-v0.0.94` (green).

Rolling update; no schema/PVC change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)