### PR TITLE
chore(pump): bump image v0.0.94 → v0.0.95

### DIFF
--- a/kubernetes/apps/collab/pump/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump/app/helmrelease.yaml
@@ -32,7 +32,7 @@ spec:
           pump:
             image:
               repository: ghcr.io/rwlove/pump
-              tag: v0.0.94@sha256:6c2160fba270b0ef75290db894186a1e0f3dace99d288ba7639df05a0c341c04
+              tag: v0.0.95@sha256:859ddf9878e581ec974be62455d0bc4d174f280023b60fc89c4bcde302fd12f8
 
             env:
               # Activates the /api/cv/* proxy in pump (see internal/web/exercise.go).


### PR DESCRIPTION
Rolls out the PUMP **Overall Health dashboard + wearable Stats tabs** (Steps / Heart Rate / Sleep / Cardio) for the Android Health Connect metrics.

- UI-only; **no schema change** (reads the v8 `health_record` table from v0.0.93).
- See rwlove/PUMP#32.

Flux rolls pump to v0.0.95; `/health/` appears in the nav and the new tabs under `/stats/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)