### PR TITLE
chore(pump): bump image v0.0.95 → v0.0.96

### DIFF
--- a/kubernetes/apps/collab/pump/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump/app/helmrelease.yaml
@@ -32,7 +32,7 @@ spec:
           pump:
             image:
               repository: ghcr.io/rwlove/pump
-              tag: v0.0.95@sha256:859ddf9878e581ec974be62455d0bc4d174f280023b60fc89c4bcde302fd12f8
+              tag: v0.0.96@sha256:a982fe6efa75bb4fae4e19b1305fd2de483f4583e9aed00adce46bd1ed9c1903
 
             env:
               # Activates the /api/cv/* proxy in pump (see internal/web/exercise.go).


### PR DESCRIPTION
Rolls out PUMP **#33** (weight-log Older/Newer grey out only at the ends) and **#34** (clickable "Last 7 days" dots → jump to that day).

- `ghcr.io/rwlove/pump`: `v0.0.95` → `v0.0.96`, digest-pinned (`sha256:a982fe6e…`).
- v0.0.96 is built from `main`, a **superset** of v0.0.95 (the Overall Health dashboard, #32) plus #33/#34 — no regression.

Rolling update; no schema/PVC change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)