### PR TITLE
fix(media): chown gonic playlist tree so MA can edit playlists

### DIFF
--- a/kubernetes/apps/media/gonic/app/helmrelease.yaml
+++ b/kubernetes/apps/media/gonic/app/helmrelease.yaml
@@ -33,6 +33,29 @@ spec:
           reloader.stakater.com/auto: "true"
         type: statefulset
 
+        initContainers:
+          # gonic writes playlists as m3u files under GONIC_PLAYLISTS_PATH and
+          # touches them via os.Chtimes() with an explicit mtime, which the
+          # kernel only permits to the file owner. The pre-existing playlist
+          # tree was created root-owned (uid 0) before this controller pinned
+          # runAsUser 1112, so the non-root gonic process gets EPERM on every
+          # playlist edit ("touch m3u: ... operation not permitted") and clients
+          # like Music Assistant fail to add tracks. fsGroup fixes the GID but
+          # never the UID. Reclaim ownership on startup; idempotent + self-heals.
+          init-perms:
+            image:
+              repository: ghcr.io/sentriz/gonic
+              tag: v0.21.0@sha256:a6b7abf599cdfdf079a18df16ec2b8067cf85d60d056b439e3096b6a157e4dd9
+            command:
+              - chown
+              - -R
+              - 1112:1112
+              - /data/playlists
+            securityContext:
+              runAsUser: 0
+              runAsGroup: 0
+              runAsNonRoot: false
+
         containers:
           app:
             image:


### PR DESCRIPTION
## Problem

Music Assistant can't add songs to gonic (Subsonic) playlists. The error surfaced to the client is the misleading *"check your permissions"*, but gonic actually returns HTTP 200 and fails internally:

```
subsonic error code 0: save playlist: touch m3u:
  chtimes /data/playlists/2/...m3u: operation not permitted
```

## Root cause

`playlist.Write()` in gonic calls `os.Chtimes(absPath, …, playlist.UpdatedAt)` with an **explicit** mtime. `utimensat` with explicit times is permitted only to the file owner (or CAP_FOWNER). The `/data/playlists` tree is owned by **uid 0**, but the gonic container runs as **uid 1112** → EPERM on every playlist edit. `fsGroup: 1112` fixes the GID but never the UID, so it can't help here.

The tree was created root-owned before this controller pinned `runAsUser: 1112`; new playlists created by gonic-as-1112 are fine, but the pre-existing ones are stranded.

## Fix

Root `initContainer` that runs `chown -R 1112:1112 /data/playlists` on startup. Idempotent, self-healing, reuses the gonic image (no new image pull). `media` namespace PSA is `audit: baseline` (not enforced), so the root init container is permitted.

## Verification

- `kubectl kustomize kubernetes/apps/media/gonic/app` renders clean.
- Confirmed gonic image ships `chown`; confirmed runtime uid 1112 vs file uid 0.
- Confirmed playlist edits are owner-scoped in gonic (no admin override) — co-editing is out of scope here; MA owns the playlist and is the sole editor.

Activates on the next gonic pod restart (Renee-facing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)