### PR TITLE
feat(ai): expand ollama-spark models PVC 100Gi -> 256Gi

### DIFF
--- a/kubernetes/apps/ai/ollama-spark/app/pvc.yaml
+++ b/kubernetes/apps/ai/ollama-spark/app/pvc.yaml
@@ -24,4 +24,4 @@ spec:
   storageClassName: ceph-block
   resources:
     requests:
-      storage: 100Gi
+      storage: 256Gi


### PR DESCRIPTION
## What

Expands `ollama-spark-models-pvc` (ceph-block) **100Gi → 256Gi**.

## Why

The Spark model store was 100Gi and ~85% full with `qwen2.5:{32b,72b,coder}` + embedders (~83G). Evaluating a larger local model (`gpt-oss:120b`, ~65G) needs ~148G alongside the existing set — the pull filled the volume to 100% and failed with `no space left on device`. 256Gi fits gpt-oss:120b + the current models + headroom for further MoE/local candidates (qwen3, etc.).

## Safety

- `ceph-block` has `allowVolumeExpansion=true` (rook RBD) → **online expansion, no pod restart, no downtime**.
- Grow-only — no data risk.
- Single-file change; no behavioral change beyond capacity.

After merge: Flux reconciles → rook CSI resizes the RBD + filesystem live.