### PR TITLE
chore(kubectl-mcp): bump memory request 256→512Mi, limit 512→768Mi

### DIFF
--- a/kubernetes/apps/mcp-system/kubectl-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/kubectl-mcp/app/helmrelease.yaml
@@ -37,9 +37,9 @@ spec:
             resources:
               requests:
                 cpu: 50m
-                memory: 256Mi
-              limits:
                 memory: 512Mi
+              limits:
+                memory: 768Mi
     service:
       app:
         controller: kubectl-mcp


### PR DESCRIPTION
## What

Raise `kubectl-mcp` memory: request `256Mi → 512Mi`, limit `512Mi → 768Mi`.

## Why

`kubectl-mcp` is the heaviest pod in `mcp-system` — it sits at **~361Mi at idle** against the old **512Mi** limit (~70% of cap at rest). It OOM-killed (exit 137) on **2026-06-05** when a large kubectl response payload pushed working-set past the limit. The MCP server buffers full response bodies in memory, and the client-go cache keeps the baseline high, so it runs near the ceiling and a single large `get -o yaml` / `describe` / multi-hundred-row list tips it over.

This is a too-small-limit-for-a-bursty-workload, not a leak — only 2 restarts in 35 days. `768Mi` (midpoint of 512Mi–1Gi) gives real burst headroom without overcommitting the node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)