### PR TITLE
fix: correct broken in-cluster service references + normalize MBID case

### DIFF
--- a/kubernetes/apps/home/home-assistant/app/externalsecret.yaml
+++ b/kubernetes/apps/home/home-assistant/app/externalsecret.yaml
@@ -15,7 +15,7 @@ spec:
       data:
         # App
         HASS_TOKEN: "{{ .HASS_TOKEN }}"
-        HASS_POSTGRES_URL: "postgresql://{{ .POSTGRES_USER }}:{{ .POSTGRES_PASS }}@postgres-home-assistant-rw.database.svc.cluster.local/home_assistant"
+        HASS_POSTGRES_URL: "postgresql://{{ .POSTGRES_USER }}:{{ .POSTGRES_PASS }}@postgres-home-assistant-rw.databases.svc.cluster.local/home_assistant"
         # Postgres Init
         INIT_POSTGRES_DBNAME: home_assistant
         INIT_POSTGRES_HOST: postgres-home-assistant-rw.databases.svc.cluster.local

--- a/kubernetes/apps/media/beets/app/resources/mbid-scrub.py
+++ b/kubernetes/apps/media/beets/app/resources/mbid-scrub.py
@@ -8,10 +8,12 @@ validates every MBID as a UUID and aborts the ENTIRE track-sync pass on the
 first bad one, silently freezing MA's library. gonic passes the bad value
 straight through from the file tag.
 
-This scrub runs after each import. For every item it blanks any mb_* field
-whose value is present but is NOT a valid UUID — both in the beets DB and in
-the file's tags (what gonic actually reads). A valid UUID is never touched,
-so this is safe to run across the whole library; it only removes garbage.
+This scrub runs after each import. For every item it (a) blanks any mb_* field
+whose value is present but is NOT a valid UUID and (b) lowercases any valid
+UUID that carries uppercase hex — MA rejects non-lowercase MBIDs and aborts the
+sync exactly the same way (e.g. `…-A3fb…`). Both the beets DB and the file's
+tags (what gonic actually reads) are corrected. Already-lowercase UUIDs are
+never touched, so this is safe to run across the whole library.
 
 Idempotent. Non-fatal by contract: it must never fail the import job.
 """
@@ -40,11 +42,23 @@ FILE_FIELDS = [
 ]
 
 
-def is_bad(value) -> bool:
+def fix(value):
+    """Return the corrected MBID for a field, or None if no change is needed.
+
+    ''            -> blank it (value present but not a valid UUID)
+    lowercased    -> valid UUID that contained uppercase hex (MA rejects it)
+    None          -> empty, or already a valid lowercase UUID; leave as-is
+    """
     if not value:
-        return False
-    raw = value if isinstance(value, bytes) else str(value).encode()
-    return UUID.match(raw.strip()) is None
+        return None
+    s = value.decode() if isinstance(value, (bytes, bytearray)) else str(value)
+    st = s.strip()
+    if not st:
+        return None
+    if UUID.match(st.encode()) is None:
+        return ""
+    low = st.lower()
+    return low if low != s else None
 
 
 def main() -> int:
@@ -66,16 +80,21 @@ def main() -> int:
     fixed_db = fixed_files = miss = noperm = err = 0
     for row in rows:
         item_id, path = row[0], row[1]
-        bad_db = [f for f, v in zip(db_fields, row[2:]) if is_bad(v)]
-        if not bad_db:
+        # field -> corrected value ('' blanks a non-UUID, or a lowercased UUID)
+        db_changes = {
+            f: nv for f, nv in
+            ((f, fix(v)) for f, v in zip(db_fields, row[2:]))
+            if nv is not None
+        }
+        if not db_changes:
             continue
 
-        # 1) beets DB — blank the bad columns so they are not re-stamped.
+        # 1) beets DB — blank bad / lowercase upper so values aren't re-stamped.
         try:
             db.execute(
                 "UPDATE items SET %s WHERE id=?"
-                % ",".join("%s=''" % f for f in bad_db),
-                (item_id,),
+                % ",".join("%s=?" % f for f in db_changes),
+                list(db_changes.values()) + [item_id],
             )
             db.commit()
             fixed_db += 1
@@ -98,8 +117,9 @@ def main() -> int:
             mf = mediafile.MediaFile(ap)
             changed = False
             for f in FILE_FIELDS:
-                if is_bad(getattr(mf, f, None)):
-                    setattr(mf, f, None)
+                nv = fix(getattr(mf, f, None))
+                if nv is not None:
+                    setattr(mf, f, nv or None)  # '' -> None blanks the tag
                     changed = True
             if changed:
                 mf.save()

--- a/kubernetes/apps/media/immich/app/helmrelease.yaml
+++ b/kubernetes/apps/media/immich/app/helmrelease.yaml
@@ -47,7 +47,7 @@ spec:
               EXTERNAL_PATH: "/external"
               IMMICH_MACHINE_LEARNING_URL: http://immich-machine-learning.media:3003
               # IMMICH_WEB_URL: http://immich-web.media.svc.cluster.local:3000
-              IMMICH_SERVER_URL: http://immich-server.media.svc.cluster.local:3001
+              IMMICH_SERVER_URL: http://immich-server.media.svc.cluster.local:2283
               LOG_LEVEL: verbose
               IMMICH_CONFIG_FILE: /config/system.json
               PUBLIC_IMMICH_SERVER_URL: https://photos.${SECRET_DOMAIN}

--- a/kubernetes/apps/observability/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/grafana/app/helmrelease.yaml
@@ -269,7 +269,7 @@ spec:
               maxLines: 1000
             name: Loki
             type: loki
-            url: http://loki-gateway.observability.svc.cluster.local:80
+            url: http://loki.observability.svc.cluster.local:3100
           - access: proxy
             jsonData:
               implementation: prometheus


### PR DESCRIPTION
## What

Follow-up from a codebase audit that cross-referenced all **516** in-cluster `*.svc` FQDN references in `kubernetes/` against the **321** live Services (name + namespace + port). Four real defects:

| Reference | File | Problem | Fix |
|---|---|---|---|
| `loki-gateway.observability.svc:80` | grafana HR | Service doesn't exist — Loki runs SingleBinary (`gateway.enabled: false`); `loki` svc serves queries on `:3100`. Broke all Grafana Loki panels + HolmesGPT log lookups (proxy 502) | `loki.observability.svc:3100` |
| `…rw.`**`database`**`.svc` | home-assistant externalsecret (`HASS_POSTGRES_URL`) | Namespace `database` (singular) doesn't exist; CNPG svc is in `databases`. Vestigial today (HA connects via the correct `POSTGRES_HOST` env) but a latent landmine | `databases` |
| `immich-server.media.svc:`**`3001`** | immich HR (`IMMICH_SERVER_URL`) | Pre-unified-port leftover; `immich-server` exposes `:2283` | `:2283` |
| MBID case guard | beets `mbid-scrub.py` | UUID regex is case-insensitive, so a valid-but-uppercase MBID (`…-A3fb…`) passed as "valid" and survived — but MA rejects non-lowercase hex and aborts the whole OpenSubsonic track-sync on it | also lowercase uppercase UUIDs (DB + file tag) |

## Why the scrub change matters

A single library track carried an MBID with one uppercase letter. The existing scrub only blanks *non*-UUID values (Discogs IDs); this value is UUID-shaped, so it slipped through and froze MA's nightly track sync. The patched `fix()` lowercases valid-but-uppercase UUIDs in addition to blanking garbage.

## Verification

- `python3 -m py_compile mbid-scrub.py` ✓; `fix()` unit-tested (uppercase→lowercased, Discogs→blank, lowercase→untouched, empty→untouched).
- `kubectl kustomize` clean for grafana / home-assistant / immich / beets.
- Confirmed HA recorder is unaffected (5 live Postgres connections via the correct `POSTGRES_HOST`).

Loki datasource + Immich activate on Grafana/Immich reconcile; the HA secret refreshes via ESO (no behavior change — `HASS_POSTGRES_URL` is unused). The live tag fix for the affected track + gonic rescan is handled out-of-band.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
