### PR TITLE
chore(vpa): bump recommender memory request 460M→512M, limit 460M→768M

### DIFF
--- a/kubernetes/apps/kube-system/vpa/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/vpa/app/helmrelease.yaml
@@ -30,10 +30,10 @@ spec:
         storage: prometheus
       resources:
         limits:
-          memory: 460M
+          memory: 768M
 
         requests:
           cpu: 20m
-          memory: 460M
+          memory: 512M
     updater:
       enabled: false


### PR DESCRIPTION
## What

Raise `vpa-recommender` memory: request `460M → 512M`, limit `460M → 768M`.

## Why

`vpa-recommender` ran with **request == limit == 460M** (Guaranteed QoS, zero burst headroom) and OOM-killed (exit 137) on **2026-06-07**. It idles at **~167Mi** but spikes during recommendation/history-load cycles when it pulls metrics from Prometheus, tipping past the 460M ceiling.

`768M` limit gives ~67% headroom over the level that OOMed; `512M` request keeps a sensible reserved floor. Mirrors the kubectl-mcp bump (#12386).

🤖 Generated with [Claude Code](https://claude.com/claude-code)