### PR TITLE
chore(sonarr): bump memory limit 1G→1.25G (keep request 1G)

### DIFF
--- a/kubernetes/apps/media/sonarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sonarr/app/helmrelease.yaml
@@ -49,7 +49,7 @@ spec:
                 cpu: 15m
                 memory: 1G
               limits:
-                memory: 1G
+                memory: 1.25G
 
             securityContext:
               allowPrivilegeEscalation: false


### PR DESCRIPTION
## What

Nudge `sonarr-0` memory limit `1G → 1.25G`, keeping request at `1G`.

## Why

`sonarr-0` ran with **request == limit == 1G** (Guaranteed QoS, no burst headroom) and OOM-killed (exit 137) on **2026-06-08** during an import/scan spike. It idles at **~220Mi**, so this is bursty, not a leak (1 restart in ~3 days).

Small, conservative limit bump to `1.25G` gives burst room while keeping the `1G` reserved floor. Intentionally modest — revisit if it OOMs again. Follows the same pattern as the kubectl-mcp (#12386) and vpa (#12389) bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)