### PR TITLE
chore(gonic): drop unused /playlist emptyDir volume

### DIFF
--- a/kubernetes/apps/media/gonic/app/helmrelease.yaml
+++ b/kubernetes/apps/media/gonic/app/helmrelease.yaml
@@ -109,8 +109,5 @@ spec:
       music:
         existingClaim: gonic-music-pvc
 
-      playlist:
-        type: emptyDir
-
       podcasts:
         existingClaim: gonic-podcasts-pvc


### PR DESCRIPTION
Removes the vestigial `playlist` `emptyDir` (mounted at `/playlist`) from the gonic HelmRelease. gonic stores playlists under `GONIC_PLAYLISTS_PATH=/data/playlists` (the data PVC); the `/playlist` emptyDir is a leftover from before playlists were made persistent and nothing references it.

Surfaced during the gonic playlist-permissions work. Purely cosmetic.

⚠️ **Renee-facing restart:** this is a pod-spec change, so Flux reconciling it will restart gonic (a few seconds; brief Music Assistant / Subsonic blip). No urgency — fine to hold for the Tuesday 02:00–04:00 window, or let it ride a future gonic change.

(Note: the `init-perms` initContainer image is already aligned to `v0.22.0`, so no tag change was needed there.)

`kubectl kustomize kubernetes/apps/media/gonic/app` builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)