### PR TITLE
chore: strip leftover startpunkt.ullberg.us annotations

### DIFF
--- a/kubernetes/apps/home/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/home/frigate/app/helmrelease.yaml
@@ -139,11 +139,6 @@ spec:
     route:
       app:
         annotations:
-          startpunkt.ullberg.us/enable: "true"
-          startpunkt.ullberg.us/name: "Security Cameras"
-          startpunkt.ullberg.us/icon: mdi:cctv
-          startpunkt.ullberg.us/group: "security"
-          startpunkt.ullberg.us/instance: "user"
           glance/name: "Frigate"
           glance/show: "true"
           glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/frigate.png"

--- a/kubernetes/apps/home/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/home/home-assistant/app/helmrelease.yaml
@@ -101,11 +101,6 @@ spec:
           glance/show: "true"
           glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/home-assistant.png"
           glance/id: "Home Automation"
-          startpunkt.ullberg.us/enable: "true"
-          startpunkt.ullberg.us/icon: "home-automation"
-          startpunkt.ullberg.us/group: "home automation"
-          startpunkt.ullberg.us/name: "Home Assistant"
-          startpunkt.ullberg.us/instance: "user"
 
         hostnames:
           - "hass.${SECRET_DOMAIN}"

--- a/kubernetes/apps/media/music-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/media/music-assistant/app/helmrelease.yaml
@@ -65,11 +65,6 @@ spec:
     route:
       app:
         annotations:
-          startpunkt.ullberg.us/enable: "true"
-          startpunkt.ullberg.us/name: "Music Assistant"
-          startpunkt.ullberg.us/icon: "mdi:headphones"
-          startpunkt.ullberg.us/group: "media"
-          startpunkt.ullberg.us/instance: "user"
           glance/name: "Music Assistant"
           glance/show: "true"
           glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/music-assistant.png"

--- a/kubernetes/apps/media/seerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/seerr/app/helmrelease.yaml
@@ -69,11 +69,6 @@ spec:
           glance/show: "true"
           glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/seerr.png"
           glance/id: "Media"
-          startpunkt.ullberg.us/enable: "true"
-          startpunkt.ullberg.us/name: "Media"
-          startpunkt.ullberg.us/icon: simple-icons:seerr
-          startpunkt.ullberg.us/group: "media"
-          startpunkt.ullberg.us/instance: "user"
 
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"


### PR DESCRIPTION
Startpunkt was retired (oauth2-proxy removed in #12392; no Startpunkt workload runs in the cluster). These route-level dashboard annotations on **frigate**, **home-assistant**, **music-assistant**, and **seerr** were inert leftovers — nothing consumes them. Removing them so startpunkt is fully gone from the manifests. `glance/*` dashboard annotations are kept.

Route-annotation change only — does **not** restart the pods. All four `kubectl kustomize` builds clean.

The only remaining `startpunkt` string is the retirement comment in `collab/kustomization.yaml`, left intentionally as documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)