### PR TITLE
feat(pump): rename DB/role workoutdiary → pump

### DIFF
--- a/kubernetes/apps/collab/pump/app/externalsecret.yaml
+++ b/kubernetes/apps/collab/pump/app/externalsecret.yaml
@@ -14,7 +14,11 @@ spec:
       engineVersion: v2
       data:
         # App
-        POSTGRES_DSN: postgres://{{ .POSTGRES_USER }}:{{ .POSTGRES_PASS }}@postgres-pump-rw.databases.svc.cluster.local:5432/workoutdiary
+        # DB/role renamed workoutdiary -> pump (2026-06-08). The role name is
+        # POSTGRES_USER (1Password "pump" item) and must be set to "pump" with a
+        # matching password BEFORE this merges; merging is the cutover and must
+        # follow the manual pg_dump/restore of workoutdiary -> pump. See PR body.
+        POSTGRES_DSN: postgres://{{ .POSTGRES_USER }}:{{ .POSTGRES_PASS }}@postgres-pump-rw.databases.svc.cluster.local:5432/pump
         API_KEY: "{{ .API_KEY }}"
         # Required header value for off-cluster POST /api/weight (e.g. the
         # bt-scale ESPHome device reaching pump-ingest.${SECRET_DOMAIN}).
@@ -27,7 +31,7 @@ spec:
         HEALTH_INGEST_KEY: "{{ .HEALTH_INGEST_KEY }}"
 
         # Postgres Init
-        INIT_POSTGRES_DBNAME: workoutdiary
+        INIT_POSTGRES_DBNAME: pump
         INIT_POSTGRES_HOST: postgres-pump-rw.databases.svc.cluster.local
         INIT_POSTGRES_USER: "{{ .POSTGRES_USER }}"
         INIT_POSTGRES_PASS: "{{ .POSTGRES_PASS }}"


### PR DESCRIPTION
Renames the PUMP database and role from the legacy `workoutdiary` to `pump`.

## ⚠️ Draft / DO-NOT-AUTO-MERGE — merging IS the cutover

The `postgres-pump` CNPG cluster has **no `bootstrap.initdb`** — the DB/role are created by the `init-db` init container from `pump-secret`. So this rename is a data copy + config repoint, not an `ALTER`. Merging this PR makes Flux reconcile `pump-secret` to point at db `pump`; if the data has not been migrated first, `init-db` creates an **empty `pump` DB** and PUMP comes up with no history.

**Merge only after Phases 0–3 below are done and verified.**

## Runbook (requires kubeconfig + 1Password — not automatable from CI)

```bash
# Phase 0 — safety net
kubectl get cluster postgres-pump -n databases -o jsonpath="{.status.lastSuccessfulBackup}{\"\n\"}"
PRI=$(kubectl get pods -n databases -l cnpg.io/cluster=postgres-pump,cnpg.io/instanceRole=primary -o name | head -1)

# Phase 1 — quiesce PUMP
flux suspend hr pump -n collab
kubectl scale sts pump -n collab --replicas=0 && kubectl rollout status sts pump -n collab

# Phase 2 — copy data (pick NEWPASS, reuse it in Phase 3)
kubectl exec -n databases "${PRI#pod/}" -c postgres -- bash -c '
  pg_dump -U postgres -Fc --no-owner --no-acl workoutdiary > /tmp/wd.dump &&
  psql -U postgres -v ON_ERROR_STOP=1 -c "CREATE ROLE pump LOGIN PASSWORD '"'"'NEWPASS'"'"';" &&
  psql -U postgres -v ON_ERROR_STOP=1 -c "CREATE DATABASE pump OWNER pump;" &&
  pg_restore -U postgres --no-owner --no-acl -d pump /tmp/wd.dump &&
  psql -U postgres -d pump -c "REASSIGN OWNED BY postgres TO pump;" &&
  psql -U postgres -d pump -c "GRANT ALL ON SCHEMA public TO pump;"
'
# verify row parity:
kubectl exec -n databases "${PRI#pod/}" -c postgres -- psql -U postgres -d pump -c "select metric_type,count(*) from health_record group by 1 order by 2 desc;"

# Phase 3 — 1Password "pump" item: POSTGRES_USER=pump, POSTGRES_PASS=NEWPASS

# Phase 3b — MERGE THIS PR (the GitOps cutover)

# Phase 4 — resume
flux resume hr pump -n collab
kubectl scale sts pump -n collab --replicas=1

# Phase 5 — verify
kubectl logs -n collab pump-0 | tail -20   # connection established, schema v8, PUMP ready

# Phase 6 — cleanup (separate, after a few days)
# DROP DATABASE workoutdiary; DROP ROLE workoutdiary;  (optionally DROP DATABASE app;)
```

## Rollback (any time before Phase 6)
Revert this PR + restore 1Password `POSTGRES_USER`/`PASS` to `workoutdiary`, `flux resume`. `workoutdiary` is untouched until Phase 6, so rollback is instant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)