### PR TITLE
chore(pump): scrub stale workoutdiary refs post-rename

### DIFF
--- a/kubernetes/apps/collab/pump/app/externalsecret.yaml
+++ b/kubernetes/apps/collab/pump/app/externalsecret.yaml
@@ -14,10 +14,6 @@ spec:
       engineVersion: v2
       data:
         # App
-        # DB/role renamed workoutdiary -> pump (2026-06-08). The role name is
-        # POSTGRES_USER (1Password "pump" item) and must be set to "pump" with a
-        # matching password BEFORE this merges; merging is the cutover and must
-        # follow the manual pg_dump/restore of workoutdiary -> pump. See PR body.
         POSTGRES_DSN: postgres://{{ .POSTGRES_USER }}:{{ .POSTGRES_PASS }}@postgres-pump-rw.databases.svc.cluster.local:5432/pump
         API_KEY: "{{ .API_KEY }}"
         # Required header value for off-cluster POST /api/weight (e.g. the

--- a/tools/check-cnpg-soak.sh
+++ b/tools/check-cnpg-soak.sh
@@ -36,7 +36,7 @@ declare -A REQ=(
   [postgres-nametag]=512 [postgres-netbox]=512 [postgres-nextcloud]=512
   [postgres-paperless]=512 [postgres-romm]=1024
   [postgres-sparkyfitness]=1024
-  [postgres-workoutdiary]=1024
+  [postgres-pump]=1024
 )
 kubectl top pods -n "$ns" --no-headers 2>/dev/null \
   | awk '/^postgres-/ { print $1, $3 }' \


### PR DESCRIPTION
Follow-up cleanup after the `workoutdiary` → `pump` DB/role rename (#12395).

- **`tools/check-cnpg-soak.sh`** — the `REQ` map is keyed by **cluster** name (`${pod%-*}`), but carried the old **DB** name `postgres-workoutdiary`. The cluster is `postgres-pump`, which had no entry → fell back to the 512Mi default and mis-reported memory % (real request is 1Gi). Re-keyed to `postgres-pump=1024`. Pre-existing bug, surfaced by the rename sweep.
- **`externalsecret.yaml`** — removed the now-stale migration comment (the rename is complete and merged).

No functional change to the running secret (DSN/DBNAME already `pump`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)