### PR TITLE
feat(zot): set resource requests/limits on registry cache

### DIFF
--- a/kubernetes/apps/kube-system/zot/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/zot/app/helmrelease.yaml
@@ -50,6 +50,12 @@ spec:
               readiness: *probe
               startup:
                 enabled: false
+            resources:
+              requests:
+                cpu: 50m
+                memory: 1Gi
+              limits:
+                memory: 5Gi
 
     service:
       app:


### PR DESCRIPTION
## What

Add resource requests/limits to the `zot` registry-cache HelmRelease.

```yaml
resources:
  requests:
    cpu: 50m
    memory: 1Gi
  limits:
    memory: 5Gi
```

## Why

`zot-0` was running as **BestEffort** QoS (no requests/limits), making it the **first pod evicted/OOM-killed under node memory pressure** on worker5. A pull-through cache that dies when the node is busy is the worst time for it to go — every cold image pull cluster-wide funnels through it.

This surfaced when a fleet-wide `app-template` 5.0.1 rollout caused a ~4-minute cold-pull stall: the proxy pods that landed on a node without the image cached couldn't get it served fast enough, and the gateway returned `upstream connect error` for the fronted services until the pull completed.

## Sizing

From 14-day observed usage of `zot-0`:

| | idle | 14d peak |
|---|---|---|
| memory (working set) | ~250Mi | **3.74 GiB** |
| cpu | 4m | **~1.19 cores** |

- **memory request 1Gi** — floor above idle; moves it out of BestEffort → Burstable so the kubelet won't evict it under pressure.
- **memory limit 5Gi** — above the 3.74Gi peak with headroom; a tighter limit would OOM the cache during exactly the pull storms it exists to absorb.
- **cpu request 50m** — scheduling priority during contention.
- **no cpu limit (intentional)** — avoid CFS-throttling a latency-sensitive cache mid-pull.

## Scope

Makes the single pod robust against eviction/OOM. Does **not** address the single-replica SPOF — that's a separate, larger change (RWX-shared registry storage or zot clustering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)