### PR TITLE
feat(container): update ghcr.io/rwlove/langgraph-agents ( 0.2.66 → 0.2.67 )

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/langgraph-agents
-              tag: 0.2.66@sha256:d709b403b41a92b27054415fc586c301c4b246558539b84c5c3e4ea0aad7c2e5
+              tag: 0.2.67@sha256:b1c321321ab461c34191fd48708f23061d75331729976ab302a834088a3a7e02
 
             env:
               # --- vault ---


### PR DESCRIPTION
Bumps the langgraph-agents image pin `0.2.66 → 0.2.67` (manifest-list digest `sha256:b1c321…`).

**Primary:** ships the dedicated task-queue Postgres pool fix ([langgraph-agents#124](https://github.com/rwlove/langgraph-agents/pull/124)) — the guardian status poll (`/admin/tasks?status=awaiting_approval`, polled once a minute by HA with a 15s timeout) no longer shares the checkpointer pool, so it stops queue-waiting behind 35–123s graph runs and timing out.

**Also bundled** (already on `main` since the 0.2.66 release, shipping on this tag regardless):
- #123 feat(evals): golden sets for storage / smart-home / ml operators
- #122 feat(cli): hai offload — Path-2 entrypoint to the fleet
- #121 feat(router): never escalate Claude-Code-offloaded tasks to the API
- #120 feat(evals): Spark-vs-Claude per-agent eval harness

Image `v0.2.67` built + pushed by the langgraph-agents `build` workflow (green). This is the manual equivalent of the Renovate bump (matches prior #12344/#12172 pattern); a Renovate PR for the same version can be closed as superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)