### PR TITLE
fix(paperless): bump memory limit 4Gi -> 5Gi

### DIFF
--- a/kubernetes/apps/collab/paperless/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/paperless/app/helmrelease.yaml
@@ -65,7 +65,10 @@ spec:
                 cpu: 15m
                 memory: 3Gi
               limits:
-                memory: 4Gi
+                # 4Gi -> 5Gi: a transient OCR/indexing spike OOMKilled the
+                # pod once (1 restart in 7d; steady-state ~1.5Gi). Slight
+                # headroom bump for the rare large-document burst.
+                memory: 5Gi
 
     service:
       app:


### PR DESCRIPTION
paperless-0 OOMKilled **once** (1 restart in 7d) on a transient OCR/indexing spike past its 4Gi limit; steady-state is ~1.5Gi (≈38% of limit).

Slight headroom bump on the **limit only** (4Gi → 5Gi); requests stay 3Gi so the scheduling footprint is unchanged. Absorbs the rare large-document burst without chasing the ceiling.

Actioned via GitOps rather than the parked HAI guardian approval (which proposed the same bump) — the HAI task is being denied so the agent doesn't patch the live resource out-of-band and get reverted by Flux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)