### PR TITLE
fix(downloads): correct upstream-link repo in CNP workaround annotations

### DIFF
--- a/kubernetes/apps/downloads/jdownloader2/app/cnp-allow.yaml
+++ b/kubernetes/apps/downloads/jdownloader2/app/cnp-allow.yaml
@@ -34,7 +34,7 @@ spec:
         - ports:
             - port: "4789"
               protocol: UDP
-    # workaround: https://github.com/angelnu/pod-gateway/issues/414 — drop this ICMP-echo allow when pod-gateway liveness mechanic changes or pod-gateway is replaced
+    # workaround: https://github.com/angelnu/helm-charts/issues/414 — drop this ICMP-echo allow when pod-gateway liveness mechanic changes or pod-gateway is replaced
     # Tracking: home-ops#11829
     # The gateway-sidecar init container (angelnu/pod-gateway
     # client_init.sh v7+) runs an ICMP liveness check against the

--- a/kubernetes/apps/downloads/kustomization.yaml
+++ b/kubernetes/apps/downloads/kustomization.yaml
@@ -5,7 +5,7 @@ kind: Kustomization
 namespace: downloads
 components:
   - ../../components/network-policy/baseline
-  # workaround: https://github.com/angelnu/pod-gateway/issues/414 — re-add default-deny when pod-gateway DHCP-over-VXLAN works under Cilium default-deny (or when pod-gateway is replaced with a static-IP wireguard pattern)
+  # workaround: https://github.com/angelnu/helm-charts/issues/414 — re-add default-deny when pod-gateway DHCP-over-VXLAN works under Cilium default-deny (or when pod-gateway is replaced with a static-IP wireguard pattern)
   # Tracking: home-ops#11829
   # Detail: the pod-gateway sidecar's init container brings up a VXLAN
   # tunnel to vpn/pod-gateway then runs `udhcpc` on vxlan0 to lease an

--- a/kubernetes/apps/downloads/prowlarr/app/cnp-allow.yaml
+++ b/kubernetes/apps/downloads/prowlarr/app/cnp-allow.yaml
@@ -54,7 +54,7 @@ spec:
         - ports:
             - port: "4789"
               protocol: UDP
-    # workaround: https://github.com/angelnu/pod-gateway/issues/414 — drop this ICMP-echo allow when pod-gateway liveness mechanic changes or pod-gateway is replaced
+    # workaround: https://github.com/angelnu/helm-charts/issues/414 — drop this ICMP-echo allow when pod-gateway liveness mechanic changes or pod-gateway is replaced
     # Tracking: home-ops#11829
     # The gateway-sidecar init container (angelnu/pod-gateway
     # client_init.sh v7+) runs an ICMP liveness check against the

--- a/kubernetes/apps/downloads/qbittorrent/app/cnp-allow.yaml
+++ b/kubernetes/apps/downloads/qbittorrent/app/cnp-allow.yaml
@@ -54,7 +54,7 @@ spec:
         - ports:
             - port: "4789"
               protocol: UDP
-    # workaround: https://github.com/angelnu/pod-gateway/issues/414 — drop this ICMP-echo allow when pod-gateway liveness mechanic changes or pod-gateway is replaced
+    # workaround: https://github.com/angelnu/helm-charts/issues/414 — drop this ICMP-echo allow when pod-gateway liveness mechanic changes or pod-gateway is replaced
     # Tracking: home-ops#11829
     # The gateway-sidecar init container (angelnu/pod-gateway
     # client_init.sh v7+) runs an ICMP liveness check against the

--- a/kubernetes/apps/downloads/sabnzbd/app/cnp-allow.yaml
+++ b/kubernetes/apps/downloads/sabnzbd/app/cnp-allow.yaml
@@ -48,7 +48,7 @@ spec:
         - ports:
             - port: "4789"
               protocol: UDP
-    # workaround: https://github.com/angelnu/pod-gateway/issues/414 — drop this ICMP-echo allow when pod-gateway liveness mechanic changes or pod-gateway is replaced
+    # workaround: https://github.com/angelnu/helm-charts/issues/414 — drop this ICMP-echo allow when pod-gateway liveness mechanic changes or pod-gateway is replaced
     # Tracking: home-ops#11829
     # The gateway-sidecar init container (angelnu/pod-gateway
     # client_init.sh v7+) runs an ICMP liveness check against the

--- a/kubernetes/apps/downloads/slskd/app/cnp-allow.yaml
+++ b/kubernetes/apps/downloads/slskd/app/cnp-allow.yaml
@@ -40,7 +40,7 @@ spec:
         - ports:
             - port: "4789"
               protocol: UDP
-    # workaround: https://github.com/angelnu/pod-gateway/issues/414 — drop this ICMP-echo allow when pod-gateway liveness mechanic changes or pod-gateway is replaced
+    # workaround: https://github.com/angelnu/helm-charts/issues/414 — drop this ICMP-echo allow when pod-gateway liveness mechanic changes or pod-gateway is replaced
     # Tracking: home-ops#11829
     # The gateway-sidecar init container (angelnu/pod-gateway
     # client_init.sh v7+) runs an ICMP liveness check against the


### PR DESCRIPTION
## What

Six `# workaround:` annotations in the downloads namespace pointed at `angelnu/pod-gateway/issues/414`, which does not exist — that repo's issues top out at #91. The tracked issues are filed against **`angelnu/helm-charts`** (the chart repo): #414 (ICMP INPUT DROP), #415 (VXLAN_PORT default), #416 (dig sanitization).

Re-anchors all six links `pod-gateway` → `helm-charts`. Issue numbers unchanged.

## Scope

Comment-only. No policy/behavior change — the CNP rules themselves are untouched (verified: 6 files, 6 lines, URL substring only).

## Status

Found during a 2026-06-09 upstream-watcher pass. All three upstream issues remain **open**, so the workaround stays in place; this just fixes the dead tracking link so the upstream-watcher can actually follow it.

Tracking: #11829 (body + comment already corrected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)