### PR TITLE
fix(ntfy): drop internal parentRef to stop external-dns CNAME flap

### DIFF
--- a/kubernetes/apps/home/ntfy/app/route.yaml
+++ b/kubernetes/apps/home/ntfy/app/route.yaml
@@ -16,13 +16,17 @@ spec:
     # Public via cloudflared so the Android app reaches the server
     # from cellular without requiring wg-easy 24/7. ntfy native auth
     # gates publish + subscribe; cloudflared is unauthenticated tunnel.
+    #
+    # External-only by design: the internal gateway was removed because
+    # attaching to both gateways made the bind external-dns instance
+    # (no gateway-label-filter) emit two CNAME targets for one name
+    # (external + gateway-int), flapping the record every 1m and
+    # churning brain's zone journal. LAN clients still resolve
+    # ntfy.${SECRET_DOMAIN} to a LAN LB IP via bind's
+    # external.${SECRET_DOMAIN} A record (no WAN hairpin) — same as
+    # every other public app. Windmill workflows hit the in-cluster
+    # Service directly and are unaffected.
     - name: external
-      namespace: network
-      sectionName: https
-    # LAN reachability for cluster-internal callers (Windmill workflows
-    # hit the in-cluster Service directly, but in-browser PWA users on
-    # LAN benefit from internal split-horizon resolution).
-    - name: internal
       namespace: network
       sectionName: https
   rules:


### PR DESCRIPTION
## Problem

The bind external-dns instance was rewriting `ntfy.<domain>` every 60s — deleting and re-adding the CNAME — which writes to brain's authoritative zone journal once a minute. That journal churn is the source of the recurring `.jnl` corruption that breaks NFS mounts cluster-wide.

## Root cause

`home/ntfy` was the only HTTPRoute attached to **both** the `external` and `internal` gateways. The bind external-dns instance has no `--gateway-label-filter` (unlike the cloudflare instance, which is scoped to `type=external`), so it derived a target from each gateway's annotation and emitted one endpoint with two CNAME targets:

```
ntfy.<domain> CNAME external.<domain>;gateway-int.<domain>
```

A name can't hold two CNAMEs, so under `--policy=sync --interval=1m` external-dns flapped the record indefinitely.

## Fix

Drop the redundant `internal` parentRef. ntfy becomes external-only like every other public app (`home-assistant`, `immich`, `authelia`, `gonic`, `zulip`…), all of which resolve on LAN via bind's `external.<domain>` A record — a LAN LB IP, no WAN hairpin. Result: a single CNAME target, no flap.

- Public reachability (cloudflared → external gateway) unchanged.
- LAN PWA users still resolve to a LAN IP (external gateway LB instead of gateway-int).
- Windmill workflows hit the in-cluster Service directly — unaffected.

## Verification

Confirmed live in `external-dns-bind` logs:
```
Endpoints generated from HTTPRoute home/ntfy: [ntfy.<domain> 0 IN CNAME external.<domain>;gateway-int.<domain> []]
Removing RR: ntfy.<domain> CNAME gateway-int.<domain>
Adding RR: ntfy.<domain> CNAME external.<domain>
Adding RR: ntfy.<domain> CNAME gateway-int.<domain>
```
ntfy was the only dual-homed route in the cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)