### PR TITLE
feat(pump): bump pump to v0.0.97

### DIFF
--- a/kubernetes/apps/collab/pump/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump/app/helmrelease.yaml
@@ -32,7 +32,7 @@ spec:
           pump:
             image:
               repository: ghcr.io/rwlove/pump
-              tag: v0.0.96@sha256:a982fe6efa75bb4fae4e19b1305fd2de483f4583e9aed00adce46bd1ed9c1903
+              tag: v0.0.97@sha256:f4d0e59d2724a86727065d06f6132edb8d9983b5938efa77655c7c66df9ce282
 
             env:
               # Activates the /api/cv/* proxy in pump (see internal/web/exercise.go).


### PR DESCRIPTION
Rolls out PUMP `v0.0.97` (image `ghcr.io/rwlove/pump@sha256:f4d0e59d…`, digest verified via skopeo).

Includes: HC numeric sleep-stage decode (deep sleep), resting-HR proxy, active-calories surfacing, **snapshot-correct steps/active-calories aggregation** (fixes ~9× step inflation), period-aware consistency heatmap, muscle-balance Sets/Volume toggle, and the wall service-worker un-pin that restores the AI-page navbar on the kiosk.

Statefulset rolling update; no schema migration. After deploy, hard-refresh the wall kiosk once to drop the stale `pump-wall-v3` shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)