### PR TITLE
feat(pump): bump pump to v0.0.98

### DIFF
--- a/kubernetes/apps/collab/pump/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump/app/helmrelease.yaml
@@ -32,7 +32,7 @@ spec:
           pump:
             image:
               repository: ghcr.io/rwlove/pump
-              tag: v0.0.97@sha256:f4d0e59d2724a86727065d06f6132edb8d9983b5938efa77655c7c66df9ce282
+              tag: v0.0.98@sha256:d983be4ac889105eed5dc30ea5c6a02281b1050fddbbc55ff962a090a1c3220c
 
             env:
               # Activates the /api/cv/* proxy in pump (see internal/web/exercise.go).


### PR DESCRIPTION
Weight-log delete now removes the whole day's readings instead of a single duplicate row, so deleting a day that the bt-scale burst-posted (e.g. 2026-06-07's six identical rows) actually clears the value.