### PR TITLE
feat(pump): bump pump to v0.0.99

### DIFF
--- a/kubernetes/apps/collab/pump/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump/app/helmrelease.yaml
@@ -32,7 +32,7 @@ spec:
           pump:
             image:
               repository: ghcr.io/rwlove/pump
-              tag: v0.0.98@sha256:d983be4ac889105eed5dc30ea5c6a02281b1050fddbbc55ff962a090a1c3220c
+              tag: v0.0.99@sha256:93365c9343a5c205cee25e0a67f62288a664ce24be1cb5db5459cb04c7455e93
 
             env:
               # Activates the /api/cv/* proxy in pump (see internal/web/exercise.go).


### PR DESCRIPTION
Rolls out PUMP v0.0.99 (digest 93365c93, skopeo-verified). Weight ingest now dedups identical same-day readings so the bt-scale stops creating duplicate rows. Backend-only; no schema/UI change.