### PR TITLE
feat(frigate): enable genai Ollama connectivity via CNP

### DIFF
--- a/kubernetes/apps/ai/ollama/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/ollama/app/cnp-allow.yaml
@@ -61,6 +61,11 @@ spec:
         - matchLabels:
             io.kubernetes.pod.namespace: observability
             app.kubernetes.io/name: holmesgpt
+        # Frigate genai integration — LLM description generation for
+        # detection events (genai.provider=ollama in Frigate config).
+        - matchLabels:
+            io.kubernetes.pod.namespace: home
+            app.kubernetes.io/name: frigate
       toPorts:
         - ports:
             - port: "11434"

--- a/kubernetes/apps/home/frigate/app/cnp-allow.yaml
+++ b/kubernetes/apps/home/frigate/app/cnp-allow.yaml
@@ -34,14 +34,14 @@ spec:
               protocol: TCP
             - port: "8971"
               protocol: TCP
-    # NOTE: most cameras live on the SECURITY VLAN and are reached via
-    # the multus-attached secondary NIC (frigate-security-static).
-    # Those pulls bypass Cilium entirely.
-    #
-    # birdcam is the exception — it sits on the main LAN at
-    # 192.168.1.31, so its RTSP + HTTP pulls go via eth0 and ARE
-    # governed by Cilium. Explicit toCIDR egress required after the
-    # home-namespace default-deny rollout (PR #11592, 2026-05-18).
+  # NOTE: most cameras live on the SECURITY VLAN and are reached via
+  # the multus-attached secondary NIC (frigate-security-static).
+  # Those pulls bypass Cilium entirely.
+  #
+  # birdcam is the exception — it sits on the main LAN at
+  # 192.168.1.31, so its RTSP + HTTP pulls go via eth0 and ARE
+  # governed by Cilium. Explicit toCIDR egress required after the
+  # home-namespace default-deny rollout (PR #11592, 2026-05-18).
   egress:
     - toCIDR:
         - 192.168.1.31/32
@@ -85,4 +85,14 @@ spec:
       toPorts:
         - ports:
             - port: "1935"
+              protocol: TCP
+    # Frigate genai integration — Ollama LLM descriptions for detection
+    # events (genai.provider=ollama, base_url=ollama.ai.svc.cluster.local).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: ai
+            app.kubernetes.io/name: ollama
+      toPorts:
+        - ports:
+            - port: "11434"
               protocol: TCP


### PR DESCRIPTION
## What

Adds the CiliumNetworkPolicy rules that let Frigate reach the cluster Ollama service for genai detection descriptions:

- `frigate-allow` — egress rule `frigate` → `ai/ollama:11434`
- `ollama-allow` — `home/frigate` added as a permitted ingress source

## Why

Frigate's genai integration (`provider=ollama`, model `qwen2.5:7b`) was silently failing. Root cause was three-part, found while diagnosing a hung Explore view:

1. `genai.base_url` pointed at `http://ollama.ai:11434` — which resolves to the **public** ollama.ai (Cloudflare), not the in-cluster service. Fixed in-PVC to `http://ollama.ai.svc.cluster.local:11434` (PVC config is authoritative).
2. `amcrest_garage` genai `required_zones` referenced a phantom `walkway` zone → never fired. Fixed in-PVC to `[driveway]`.
3. **This PR:** even with the correct FQDN, egress was denied — `ollama-allow` only permitted `home-assistant`/`holmesgpt`, and `frigate-allow` had no Ollama egress rule.

The hung Explore view (separate issue — API thread-pool deadlock after storage maintenance + a false_positive write) was resolved by a pod restart; not part of this PR.

## Verification

- `kubectl apply --dry-run` / flux-local CI validates the CNP manifests.
- After merge + Cilium reconcile (~30s), Frigate genai calls to Ollama should succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)