### PR TITLE
fix(mcp): memory-mcp uses spec.prefix not toolPrefix

### DIFF
--- a/kubernetes/apps/mcp-system/memory-mcp/mcp/mcpserverregistration.yaml
+++ b/kubernetes/apps/mcp-system/memory-mcp/mcp/mcpserverregistration.yaml
@@ -11,4 +11,4 @@ spec:
     group: gateway.networking.k8s.io
     kind: HTTPRoute
     name: memory-mcp
-  toolPrefix: memory_
+  prefix: memory_


### PR DESCRIPTION
## What

Change the memory-mcp `MCPServerRegistration` field from `toolPrefix` to `prefix`.

## Why

The Kuadrant `mcp.kuadrant.io/v1alpha1` `MCPServerRegistration` prefix field is `spec.prefix`. `toolPrefix` is not in the CRD schema, so the API server silently prunes it — the registration applies cleanly but the prefix never takes effect.

Result: memory-mcp's tools federate through the gateway **unprefixed** (`create_entity`, `add_observation`, `search`, `link`, `recent`, `graph_walk`, …). Those are generic names, exactly the kind that collide across backend servers in the broker-router — the same class of bug already fixed for `comfyui-mcp` (#12306) and `kubectl-mcp` (#12309).

After this change they federate as `memory_*`.

## Scope note

13 other registrations still use `toolPrefix`, but this is intentionally **not** a blanket fix:

- Natively-prefixed backends (`ha-mcp` → `ha_*`, `immich-mcp` → `immich_*`, `netbox-mcp` → `netbox_*`) must **not** take a `prefix:` or they double-prefix and break the operator allowlists.
- The rest (omada, grafana, paperless, time, cilium, etc.) are unprefixed and would benefit, but each needs the native-vs-generic check before flipping. Tracked separately.

## Verification

- `prefix:` matches the two known-good registrations (`comfyui-mcp`, `kubectl-mcp`).
- Local pre-submit hooks pass (yamllint, secrets, badges, CNP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)