### PR TITLE
chore(renovate): blanket non-major auto-merge for containers + helm

### DIFF
--- a/.github/renovate/autoMerge.json5
+++ b/.github/renovate/autoMerge.json5
@@ -23,15 +23,19 @@
       ignoreTests: false,
     },
     {
-      description: "Auto merge minors and patches",
-      matchDatasources: ["docker"],
+      // Blanket non-major auto-merge for containers + helm charts.
+      // patch/minor are non-breaking by the semver contract; majors
+      // are firewalled to manual review in packageRules.json5. The
+      // flux-local CI gate (ignoreTests=false) still must pass, and
+      // minimumReleaseAge gives a bad release 3 days to get yanked
+      // upstream before it can land. Digests stay on the trusted-org
+      // allowlist above — CI can't meaningfully validate a re-tag.
+      description: "Auto-merge all non-major container + helm updates once CI passes",
+      matchDatasources: ["docker", "helm"],
       automerge: true,
       automergeType: "pr",
       matchUpdateTypes: ["minor", "patch"],
-      matchPackageNames: [
-        "/kube-prometheus-stack/",
-        "/mogenius\\/helm-charts\\/renovate-operator/",
-      ],
+      minimumReleaseAge: "3 days",
       ignoreTests: false,
     },
     {
@@ -42,17 +46,6 @@
       matchUpdateTypes: ["minor", "patch", "digest"],
       minimumReleaseAge: "3 days",
       ignoreTests: true,
-    },
-    {
-      description: "Auto-merge high-cadence packages weekly",
-      matchDatasources: ["docker"],
-      automerge: true,
-      automergeType: "pr",
-      matchUpdateTypes: ["minor", "patch"],
-      matchPackageNames: [
-        "ghcr.io/renovatebot/renovate",
-      ],
-      ignoreTests: false,
     },
     {
       description: "Auto-merge trusted GitHub Actions",


### PR DESCRIPTION
## What

Broaden Renovate auto-merge from a named allowlist to **all container + helm patch/minor updates**, so the largest class of routine dependency PRs merges itself once CI is green — cutting manual merge load without auto-merging breaking changes.

## Change (`.github/renovate/autoMerge.json5`)

- Replaced the `kube-prometheus-stack` / `renovate-operator` named-allowlist minor/patch rule with a blanket rule matching `docker` + `helm`, `["minor","patch"]`.
- Added `minimumReleaseAge: "3 days"` — a bad release has time to get yanked upstream before it can land.
- Kept `ignoreTests: false` — flux-local CI must pass first.
- Removed the now-redundant standalone `renovatebot/renovate` rule (subsumed by the blanket rule).

## Breaking-change firewalls (unchanged)

- **Majors** stay `automerge: false` → manual review (`packageRules.json5`).
- **Digests** stay limited to the 4 trusted orgs — CI can't meaningfully validate a re-tag, so broadening there would be unbacked trust.
- **CI gate** preserved on the new rule (`ignoreTests: false`).

## Impact

Bot-config only — takes effect on the next Renovate run, nothing reconciles in-cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)