### PR TITLE
feat(ai): alert when LangGraph Claude escalation is failing

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/prometheusrule.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/prometheusrule.yaml
@@ -36,3 +36,34 @@ spec:
           for: 5m
           labels:
             severity: warning
+    # Escalate-to-Claude (Path 1) health. When the fleet escalates a task to
+    # the Anthropic API and the call errors — dead API credit, a rejected/
+    # deprecated request param, an outage — the task silently degrades and no
+    # one notices. This guards two real silent failures we hit: a $0 credit
+    # balance, and a deprecated `temperature` 400. Fires only when escalations
+    # are *attempted and uniformly failing* (errors present AND zero successes
+    # over the hour), so it doesn't flap on a single transient hiccup nor stay
+    # green-but-meaningless when nothing escalates (the fleet routes ~100%
+    # local today, so claude-group volume is naturally low).
+    - name: langgraph-agents.escalation
+      rules:
+        - alert: LangGraphClaudeEscalationFailing
+          annotations:
+            summary: LangGraph Claude escalation failing (all attempts erroring)
+            description: |
+              Every escalate-to-Claude call in the last hour errored
+              ({{ $value }} failures, zero successes). The fleet's Path-1
+              escalation is broken — likely dead Anthropic API credit, a
+              rejected request parameter, or an API outage — so hard tasks
+              that route to Claude are silently degrading.
+
+              Check the ANTHROPIC_API_KEY balance (console.anthropic.com →
+              Billing) and recent pod logs:
+                kubectl -n ai logs deploy/langgraph-agents -c app | grep -i claude
+          expr: |-
+            (sum(increase(langgraph_calls_total{group="claude",outcome="error"}[1h])) > 0)
+            and
+            ((sum(increase(langgraph_calls_total{group="claude",outcome="success"}[1h])) or vector(0)) == 0)
+          for: 15m
+          labels:
+            severity: warning


### PR DESCRIPTION
Adds `LangGraphClaudeEscalationFailing` to the langgraph-agents PrometheusRule.

Guards two silent failures we actually hit: **$0 Anthropic API credit** and a **deprecated-`temperature` 400** — both broke every escalate-to-Claude call with zero signal.

Fires only when escalations are **attempted AND uniformly failing** — claude-group errors present, zero successes over 1h, `for: 15m` — so it won't flap on a transient hiccup nor stay meaninglessly green when nothing escalates (fleet routes ~100% local today). `severity: warning` (escalation is a fallback; failure degrades hard tasks but doesn't down the fleet).