### PR TITLE
chore(renovate): broaden digest + github-releases auto-merge

### DIFF
--- a/.github/renovate/autoMerge.json5
+++ b/.github/renovate/autoMerge.json5
@@ -9,17 +9,17 @@
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   packageRules: [
     {
-      description: "Auto merge container digests",
+      // Auto-merge all container digest re-tags (same version, rebuilt
+      // content). flux-local can't meaningfully validate a re-tag, so
+      // minimumReleaseAge is the real safety belt — a bad rebuild gets
+      // 3 days to be caught upstream before it can land. ignoreTests
+      // stays false so a red CI for any other reason still blocks.
+      description: "Auto-merge container digests",
       matchDatasources: ["docker"],
       automerge: true,
       automergeType: "pr",
       matchUpdateTypes: ["digest"],
-      matchPackageNames: [
-        "ghcr.io/home-operations/**",
-        "ghcr.io/onedr0p/**",
-        "ghcr.io/bjw-s/**",
-        "ghcr.io/bjw-s-labs/**",
-      ],
+      minimumReleaseAge: "3 days",
       ignoreTests: false,
     },
     {
@@ -63,13 +63,18 @@
       ignoreTests: true,
     },
     {
-      description: "Auto-merge GitHub Releases",
+      // Blanket non-major auto-merge for github-releases (CRD/version
+      // pins, etc). Semver-safe like the container+helm rule; majors
+      // are firewalled in packageRules.json5. Now CI-gated
+      // (ignoreTests=false, was true for the old trusted allowlist)
+      // plus a 3-day soak.
+      description: "Auto-merge github-releases minor + patch",
       matchDatasources: ["github-releases"],
       automerge: true,
       automergeType: "pr",
       matchUpdateTypes: ["minor", "patch"],
-      matchPackageNames: ["/external-dns/", "/gateway-api/", "/prometheus-operator/"],
-      ignoreTests: true,
+      minimumReleaseAge: "3 days",
+      ignoreTests: false,
     },
     {
       description: "Auto-merge rwlove personal container images",


### PR DESCRIPTION
## What

Follow-up to #12449. Removes the two remaining auto-merge allowlists so the rest of the routine dependency PRs merge themselves once green.

## Change (`.github/renovate/autoMerge.json5`)

- **Container digests** — dropped the 4-org trusted allowlist; all digest re-tags now auto-merge. flux-local can't meaningfully validate a re-tag, so `minimumReleaseAge: "3 days"` is the safety belt (a bad rebuild gets 3 days to be caught upstream). `ignoreTests` stays `false` so a red CI for any other reason still blocks.
- **github-releases** — dropped the 3-name allowlist (`external-dns`, `gateway-api`, `prometheus-operator`); all minor/patch now auto-merge, **CI-gated** (`ignoreTests` flipped `true`→`false`) + 3-day soak.

## Breaking-change firewall (unchanged)

Majors stay `automerge: false` → manual review (`packageRules.json5`).

## Impact

Bot-config only — effective on the next Renovate run, nothing reconciles in-cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)