### PR TITLE
feat(ai): deploy langgraph-agents 0.2.68 (escalation temperature fix)

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/langgraph-agents
-              tag: 0.2.67@sha256:b1c321321ab461c34191fd48708f23061d75331729976ab302a834088a3a7e02
+              tag: 0.2.68@sha256:5720c94ebee4ae7463fad41b1073edb8e60560fe354e938531434c37250eee88
 
             env:
               # --- vault ---


### PR DESCRIPTION
Bumps the langgraph-agents image pin **0.2.67 → 0.2.68**.

v0.2.68 carries the escalate-to-Claude fix (rwlove/langgraph-agents#125): `_build_claude` no longer sends the deprecated `temperature` param that 400s on claude-opus-4.x — which had silently broken every escalation. (Also includes the eval-harness + hardware-routing doc commits, which don't change the running image.)

Tag-build digest resolved via `gh api` (differs from the main-build digest per the deploy chain). Pin bumped directly to skip the Renovate cadence. Deploy is a ~30–60s Recreate, no GPU bounce.