### PR TITLE
chore(frigate): align recordings/clips PV capacity with new XFS quotas

### DIFF
--- a/kubernetes/apps/home/frigate/app/nfs-pvc.yaml
+++ b/kubernetes/apps/home/frigate/app/nfs-pvc.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   storageClassName: frigate-recordings-storage-class
   capacity:
-    storage: 2000G
+    storage: 2200G
   accessModes:
     - ReadWriteOnce
   nfs:
@@ -41,7 +41,7 @@ metadata:
 spec:
   storageClassName: frigate-clips-storage-class
   capacity:
-    storage: 400G
+    storage: 300G
   accessModes:
     - ReadWriteOnce
   nfs:


### PR DESCRIPTION
## What

Updates the Frigate NFS PV `capacity` labels to match the live XFS project quotas on security-storage:

- `frigate-recordings-pv`: `2000G` → `2200G`
- `frigate-clips-pv`: `400G` → `300G`

PVC `requests` left unchanged (immutable on bound static NFS PVs; `kubelet_volume_stats_*` already reports the XFS-quota truth).

## Why

The recordings project quota sat at **98%** (2.0 TB used of a 2.0 TB hard limit), which kept Frigate's storage maintainer running near-continuously. Tonight that constant churn cascaded into a Python API thread-pool deadlock (Explore view hung, snapshots returned black). Root cause: the backing mirror LV is **2.5 TB**, but the recordings XFS quota capped usage at 2.0 TB — the quota was the constraint, not the disk.

The 500 GB gap between the quota and the LV is genuinely free, on-mirror space. Rebalanced the two project quotas live to reclaim it while preserving the clips↔recordings isolation the quotas exist to enforce:

| Project | Before | After |
|---|---|---|
| recordings | 2.0 TB | 2.2 TB (2200 GiB) |
| clips | 400 GB | 300 GB |

Sum = 2500 GiB vs. the 2560 GiB filesystem → ~60 GiB slack retained (never run XFS to 100%). Clips uses ~17 GB today, so a 300 GB cap is ~18× headroom.

Live quota change already applied on security-storage; this PR keeps Git in lockstep per the documented quota-management procedure. Continuous retention unchanged at 21 days (Rob's call).

## Verification

- `xfs_quota -x -c "report -pbh"` on security-storage confirms recordings `2.1T` hard / clips `300G` hard post-change.
- Recordings now off the cap with ~150 GiB immediate headroom; write-blocked condition relieved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)