### PR TITLE
fix(frigate): set ndots:2 so Frigate+ egress matches the toFQDNs allow

### DIFF
--- a/kubernetes/apps/home/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/home/frigate/app/helmrelease.yaml
@@ -17,6 +17,21 @@ spec:
           annotations:
             k8s.v1.cni.cncf.io/networks: frigate-security-static
 
+          # Lower ndots from the cluster default (5) to 2 so a 2-label
+          # external name like api.frigate.video is queried directly
+          # instead of being search-domain-expanded first. Under ndots:5
+          # the resolver tried api.frigate.video.home.svc.cluster.local
+          # first, which resolved to the real ELB IPs; Cilium's DNS proxy
+          # then bound those IPs to the search-suffixed name, which does
+          # NOT match the `*.frigate.video` toFQDNs selector in
+          # cnp-allow.yaml — so Frigate+ egress was POLICY_DENIED and
+          # FrigateUnauthorizedEgressAttempt false-fired. ndots:2 keeps
+          # 1-label in-cluster short names (e.g. emqx) expanding normally.
+          dnsConfig:
+            options:
+              - name: ndots
+                value: "2"
+
           nodeSelector:
             google.feature.node.kubernetes.io/coral-usb: "true"
             intel.feature.node.kubernetes.io/gpu: "true"


### PR DESCRIPTION
## What

Add a pod `dnsConfig` with `ndots:2` to the frigate controller so the resolver queries `api.frigate.video` directly instead of search-expanding it first.

## Why

`FrigateUnauthorizedEgressAttempt` has been false-firing in short bursts (Jun 9–11). Traced to Frigate+ cloud API calls being **POLICY_DENIED**:

- frigate-0 SYNs to `16.58.53.44` / `3.150.12.8` `:443` — both are `api.frigate.video` (Frigate+ REST API, AWS us-east-2 ELB).
- The CNP **already** allows `*.frigate.video:443` via `toFQDNs` (`cnp-allow.yaml`), but it wasn't matching.
- Root cause: frigate's `resolv.conf` has `ndots:5` + cluster search domains. `api.frigate.video` (2 labels) gets expanded to `api.frigate.video.home.svc.cluster.local` first, which resolves to the real ELB IPs. Cilium's DNS proxy binds those IPs to the **search-suffixed** name, which does not match the single-label `*.frigate.video` selector → IPs never authorized → denied.

`ndots:2` makes the 2-label name query directly, so the DNS proxy binds the bare name, the existing toFQDNs rule matches, Frigate+ works, and the forensic alert regains its signal. 1-label in-cluster short names (e.g. `emqx`) still expand normally. Same `dnsConfig` shape already used by `mqtt-exporter`.

## Effect

- Restores Frigate+ cloud egress (model sync / submission).
- `FrigateUnauthorizedEgressAttempt` self-clears — no alert-rule change needed.

## Rollout

Merging triggers a Flux reconcile → frigate pod restart → brief recording gap. Frigate is Renee-facing, so **apply in the Tue 02:00–04:00 EDT window**, or let it ride Frigate's ~daily 0.17.1 OOM restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)