### PR TITLE
feat(ai): ollama-spark LOAD_TIMEOUT 20m + MAX_LOADED 5 (qwen3-next prep)

### DIFF
--- a/kubernetes/apps/ai/ollama-spark/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/ollama-spark/app/helmrelease.yaml
@@ -53,30 +53,31 @@ spec:
               OLLAMA_ORIGINS: "*"
               OLLAMA_LOG_LEVEL: info
               OLLAMA_MODELS: &pvc /models
-              OLLAMA_LOAD_TIMEOUT: 10m
+              # qwen3-next:80b-a3b-instruct is a ~50 GB model whose cold-load
+              # off the ceph PVC + novel-arch init exceeds the old 10m bound
+              # (it hit OLLAMA_LOAD_TIMEOUT and aborted mid-load). 20m gives
+              # it room. KNOWN DOWNSIDE: a cold-load (pod restart / eviction)
+              # stalls the reasoning tier for >10m — the MAX_LOADED keep-warm
+              # below makes cold-loads rare, but can't make them fast.
+              OLLAMA_LOAD_TIMEOUT: 20m
               OLLAMA_KV_CACHE_TYPE: q8_0
               OLLAMA_FLASH_ATTENTION: 1
               OLLAMA_CONTEXT_LENGTH: 16384
               OLLAMA_NUM_PARALLEL: 4
-              # Spark's 128 GB unified memory comfortably runs 30b-class
-              # models concurrently. P40-era cap of 1 lifted.
-              # 2026-05-22: held at 3 through HolmesGPT 32b→72b upgrade.
-              # Working set is bge-m3 (always-warm, RAG + wedge probe)
-              # + qwen2.5:72b (HolmesGPT) + qwen2.5:32b (Open WebUI
-              # default chat). max=3 forces ollama to evict the
-              # rarely-used coder:32b under pressure rather than evict
-              # bge-m3 — which would wedge RAG and the wedge probe.
-              # Worst-case unified-memory residence reported by
-              # /api/ps: ~66 GB (72b) + ~22 GB (32b) + 1.3 GB (bge-m3)
-              # ≈ 89 GB of the 128 GB node. The pod cgroup RSS stays
-              # much lower (~14 GB observed with 72b loaded) because
-              # CUDA-mapped model weights on Grace-Blackwell unified
-              # memory don't bill against the kubelet's pod accounting.
-              # Pod limit bumped 64Gi → 80Gi as defensive headroom for
-              # ollama runtime + 16K context KV cache (q8) across
-              # NUM_PARALLEL=4 slots — not strictly required by the
-              # measured RSS but cheap on a 128 GB node.
-              OLLAMA_MAX_LOADED_MODELS: 3
+              # Working set after the qwen2.5:32b -> qwen3-next swap:
+              #   qwen3-next:80b-a3b-instruct  -- fleet reasoning + HolmesGPT
+              #                                   + Open WebUI (one shared model)
+              #   qwen2.5-coder:32b            -- coder / reviewer agents
+              #   bge-m3 + nomic-embed-text    -- RAG + wedge probe (always-warm)
+              # = 4 distinct models steady-state; 5 lets the old qwen2.5:32b
+              # stay resident through the swap transition without eviction
+              # churn. q8 KV + qwen3-next's hybrid attention keep KV modest;
+              # worst-case unified-memory residence ~qwen3-next(50) + coder(20)
+              # + embedders(1.3) + KV ~ 90-105 GB of 128 GB. CUDA-mapped
+              # weights on Grace-Blackwell unified memory don't bill against
+              # the kubelet's pod RSS (~14 GB observed), so the 80Gi pod limit
+              # (runtime + KV headroom) still holds.
+              OLLAMA_MAX_LOADED_MODELS: 5
 
             resources:
               requests:


### PR DESCRIPTION
Prep for the qwen2.5:32b → qwen3-next:80b-a3b-instruct reasoning-model swap. Raises `OLLAMA_LOAD_TIMEOUT` 10m→20m (qwen3-next's ~50 GB cold-load exceeds 10m and was aborting mid-load) and `OLLAMA_MAX_LOADED_MODELS` 3→5 (holds qwen3-next + coder + 2 embedders steady-state, +1 for the swap transition). No model change yet — only makes the new model loadable + keep-warm-able. Restarts the spark pod (brief inference blip as models reload).