### PR TITLE
feat(ai): retarget consumers qwen2.5:32b -> qwen3-next (HolmesGPT, routing-policy, docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Worker nodes attach to **iot** and **sec** VLANs via Multus for direct camera an
 | App | Purpose |
 |-----|---------|
 | **Ollama** (P40) | Local LLM serving on the Pascal P40 (≤8b-class models, embeddings) |
-| **Ollama Spark** | LLM serving on Spark/GB10 (qwen2.5:32b for the agent fleet + HolmesGPT + Open WebUI, bge-m3 embeddings) |
+| **Ollama Spark** | LLM serving on Spark/GB10 (qwen3-next:80b-a3b-instruct-q4_K_M for the agent fleet + HolmesGPT + Open WebUI, bge-m3 embeddings) |
 | **ComfyUI** | Image generation workflows |
 | **Khoj** + **khoj-oauth2-proxy** | Personal AI assistant over notes + docs (Authelia-gated) |
 | **LangGraph Agents** | Custom multi-agent runtime (`rwlove/langgraph-agents`, version pinned in `helmrelease.yaml`); Postgres-checkpointed with live `task_queue` + `task_dlq` substrate; MCP-gateway client. See **AI architecture** section below. |
@@ -332,13 +332,13 @@ flowchart TB
     end
 
     subgraph Agents[Agents]
-        Holmes[HolmesGPT<br/>✅ live · qwen2.5:32b]
+        Holmes[HolmesGPT<br/>✅ live · qwen3-next:80b-a3b-instruct-q4_K_M]
         LG[langgraph-agents<br/>🟡 plumbed, cold]
     end
 
     subgraph Inference[Inference]
         OllamaP40[(ollama / P40<br/>qwen2.5:7b · embeddings)]
-        OllamaSpark[(ollama-spark / GB10<br/>qwen2.5:32b · bge-m3)]
+        OllamaSpark[(ollama-spark / GB10<br/>qwen3-next:80b-a3b-instruct-q4_K_M · bge-m3)]
         Claude[(Claude API)]
     end
 
@@ -383,9 +383,9 @@ in 1Password.
 
 ### Surfaces, agents, and bridges
 
-- **Open WebUI** (`collab/`) — primary chat UI. Defaults to qwen2.5:32b on Ollama-Spark; users can switch to any langgraph agent via the OpenAI-compatible API. RAG runs over Qdrant with bge-m3 embeds + BGE reranker-v2-m3 in-process. Tool servers wired in: HolmesGPT + the MCP gateway.
+- **Open WebUI** (`collab/`) — primary chat UI. Defaults to qwen3-next:80b-a3b-instruct-q4_K_M on Ollama-Spark; users can switch to any langgraph agent via the OpenAI-compatible API. RAG runs over Qdrant with bge-m3 embeds + BGE reranker-v2-m3 in-process. Tool servers wired in: HolmesGPT + the MCP gateway.
 - **Khoj** (`ai/`) — parallel personal-AI surface for notes + docs. Self-contained: own embedding pipeline (default gte-small, optionally ollama nomic-embed-text), chat via Ollama-P40. Does **not** consume MCP gateway or langgraph-agents.
-- **HolmesGPT** (`observability/`) — live in production for alert triage. AlertManager firings reach it via Windmill's `alertmanager-holmesgpt-notify.ts`; it reasons over Prometheus + Loki + cluster state and posts a root-cause hypothesis to Zulip / ntfy. Open WebUI also surfaces it as a tool server. Prompt + context budget tuned for qwen2.5:32b on Spark (32K context, 6 tool-call budget per investigation).
+- **HolmesGPT** (`observability/`) — live in production for alert triage. AlertManager firings reach it via Windmill's `alertmanager-holmesgpt-notify.ts`; it reasons over Prometheus + Loki + cluster state and posts a root-cause hypothesis to Zulip / ntfy. Open WebUI also surfaces it as a tool server. Prompt + context budget tuned for qwen3-next:80b-a3b-instruct-q4_K_M on Spark (32K context, 6 tool-call budget per investigation).
 - **langgraph-agents** (`ai/`) — the FastAPI multi-agent runtime (`rwlove/langgraph-agents`, version pinned in `helmrelease.yaml`). Plumbed end-to-end (Postgres checkpoints + memory, live task-queue substrate in `postgres-langgraph-checkpoints`, vault PVCs, Windmill approval loop, cost caps in env). Trigger surface live: alertmanager → 6 namespace-mapped operators, daily 22:00 ET historian digest, weekly Saturday operator drift crons (ml / observability / network / reviewer / storage), errand-runner approval-flow smoke. `ENABLE_CLAUDE_API: false` so Claude API escalation is still gated. Public ingress splits CLI traffic (`hai.${SECRET_DOMAIN}`, Bearer-only) from browser traffic (`hai-web.${SECRET_DOMAIN}`, Authelia).
 - **Windmill** (`home/`) — 22 checked-in TypeScript flows under `kubernetes/apps/home/windmill/workflows/` are the bridges that knit the surfaces above together. Every alert webhook, Zulip-triggered DM, approval round-trip, daily digest, weekly vault-hygiene sweep, weekly operator drift sweeps (storage / network / ml / observability), DLQ retry, cost-cap pause, Paperless RAG ingest, and the errand-runner approval-flow smoke driver is a `.ts` file there.
 - **Langfuse** (`ai/`) — OTLP trace sink for langgraph-agents. Chart deploys ClickHouse + Valkey + MinIO bundled; Postgres comes from CNPG `postgres-langfuse`.
@@ -432,7 +432,7 @@ inference.
 | Tier | Backend                              | When used                                                  |
 |------|--------------------------------------|------------------------------------------------------------|
 | 1    | `qwen2.5:7b` on Ollama (P40)         | Fast / simple agents (`triager`, `note-maker` drafts)      |
-| 2    | `qwen2.5:32b` on Ollama-Spark (GB10) | Default chat + agent inference + HolmesGPT                 |
+| 2    | `qwen3-next:80b-a3b-instruct-q4_K_M` on Ollama-Spark (GB10) | Default chat + agent inference + HolmesGPT                 |
 | 3    | Claude API (langgraph escalation)    | Explicit uncertainty markers, repeated local-retry failure, novel/long-context, or `requires_cloud` tag. Cost caps `$5/task` · `$10/agent/day` · `$30/global/day` enforced inside the cluster |
 
 ### Voice-to-action: power button → HA Assist → agents → Obsidian
@@ -488,7 +488,7 @@ HolmesGPT is the one agent already running in production:
 
 ### Current state (2026-05-23)
 
-- **HolmesGPT** — live, handling cluster alerts daily on Ollama-Spark / qwen2.5:32b.
+- **HolmesGPT** — live, handling cluster alerts daily on Ollama-Spark / qwen3-next:80b-a3b-instruct-q4_K_M.
 - **LangGraph fleet** — 21 specialist agents plumbed end-to-end but cold (`ENABLE_CLAUDE_API: false`, no production triggers). Public ingress split into CLI (`hai.${SECRET_DOMAIN}`, Bearer) and browser (`hai-web.${SECRET_DOMAIN}`, Authelia). Gated on the Claude API key + a cluster-confidence sign-off; the Spark migration that was the prior gate completed 2026-05-20.
 - **claude-runner** — retired 2026-05-23. Superseded by the langgraph fleet; the two CronJobs (PR triage + cost-cap commentary) graduated into agent workflows inside langgraph-agents.
 - **KubeClaw** — retired (memo `project_open_issues_cleanup_2026_05_20`).
@@ -533,7 +533,7 @@ kube-prometheus-stack scrapes everything; Loki ingests pod logs (via Vector); Te
 Two GPUs split the workload:
 
 - **NVIDIA P40 on worker8** (Pascal, 24 GB VRAM) — Ollama for ≤8b-class models + embeddings, ComfyUI, Whisper STT, Immich CLIP face/pet recognition, and the immich-pet-tagger fork pinned to a P40-compatible PyTorch build.
-- **NVIDIA GB10 on Spark** (Grace-Blackwell, 128 GB unified) — the larger Ollama deployment serving qwen2.5:32b for the LangGraph agent fleet, HolmesGPT, and Open WebUI, plus bge-m3 embeddings for the cross-agent knowledge graph and Paperless RAG.
+- **NVIDIA GB10 on Spark** (Grace-Blackwell, 128 GB unified) — the larger Ollama deployment serving qwen3-next:80b-a3b-instruct-q4_K_M for the LangGraph agent fleet, HolmesGPT, and Open WebUI, plus bge-m3 embeddings for the cross-agent knowledge graph and Paperless RAG.
 
 Driver lifecycle is handled by the NVIDIA GPU Operator. Spark is the lone containerd node in an otherwise CRI-O cluster; a NodeFeatureRule auto-skips the GPU container-toolkit DaemonSet on CRI-O nodes.
 

--- a/docs/src/ai_architecture.md
+++ b/docs/src/ai_architecture.md
@@ -44,7 +44,7 @@ flowchart TB
 
     subgraph Inference[Inference]
         OllamaP40[(ollama / P40<br/>qwen2.5:7b · gte-small)]
-        OllamaSpark[(ollama-spark / GB10<br/>qwen2.5:32b · bge-m3)]
+        OllamaSpark[(ollama-spark / GB10<br/>qwen3-next:80b-a3b-instruct-q4_K_M · bge-m3)]
         Claude[(Claude API<br/>via langgraph-agents)]
         ClaudeCode[(Claude Code<br/>via claude-runner CronJobs)]
     end
@@ -119,7 +119,7 @@ migration.
 | Backend | Hardware | Service URL | Models | Notes |
 |---|---|---|---|---|
 | `ollama` | P40 (Pascal, 24 GB) on worker8 | `http://ollama.ai.svc.cluster.local:11434` | qwen2.5:7b, qwen3:8b (voice), bge-m3 (memory rebuild), gte-small/nomic-embed-text (khoj) | The pre-Spark generation. ≤8b chat, embeddings, voice STT/TTS pipeline support. |
-| `ollama-spark` | GB10 (Grace-Blackwell, 128 GB unified) | `http://ollama-spark.ai.svc.cluster.local:11434` | qwen2.5:32b (chat default), bge-m3 (1024-dim embeds) | The post-Spark workhorse. Open WebUI default; HolmesGPT model; langgraph-agents default for memory embeds. |
+| `ollama-spark` | GB10 (Grace-Blackwell, 128 GB unified) | `http://ollama-spark.ai.svc.cluster.local:11434` | qwen3-next:80b-a3b-instruct-q4_K_M (chat default), bge-m3 (1024-dim embeds) | The post-Spark workhorse. Open WebUI default; HolmesGPT model; langgraph-agents default for memory embeds. |
 | Claude API | Anthropic-hosted | langgraph-agents only, gated | per-task | Off by default — `ENABLE_CLAUDE_API: "false"` (`kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml:36`). Cost caps `$5/task`, `$10/agent/day`, `$30/global/day` (lines 54-56) enforced in code, not Anthropic's billing. |
 | Claude Code | Anthropic-hosted, CLI | `claude-runner` only | per-task | `claude` CLI baked into `ghcr.io/rwlove/claude-runner:0.1.1`; called from CronJobs with `--max-turns 20`. |
 
@@ -200,7 +200,7 @@ Cross-agent shared memory, not user-facing.
 
 | Agent | Surface | Status | Notes |
 |---|---|---|---|
-| HolmesGPT | `holmesgpt.observability` | ✅ live | qwen2.5:32b on ollama-spark; AlertManager-driven RCA; also a tool server for Open WebUI. Prompt + context budget tuned 2026-05-23 (32K context, 6 tool-call budget). |
+| HolmesGPT | `holmesgpt.observability` | ✅ live | qwen3-next:80b-a3b-instruct-q4_K_M on ollama-spark; AlertManager-driven RCA; also a tool server for Open WebUI. Prompt + context budget tuned 2026-05-23 (32K context, 6 tool-call budget). |
 | triager | langgraph-agents fleet | ✅ live | Default route for every untargeted `/inbox`. Voice ("inbox …") + Zulip-DM ingress. qwen2.5:7b on P40. |
 | supervisor | langgraph-agents fleet | ✅ live | In-graph fallback router when a specialist rejects work. |
 | reporter | langgraph-agents fleet | ✅ live | Universal in-graph terminus — every chain ends here, rendering raw state into user-facing markdown. |

--- a/docs/src/routing_policy.md
+++ b/docs/src/routing_policy.md
@@ -67,7 +67,7 @@ runtime wiring lands.
 
 Rules are evaluated in document order. The first rule whose `match`
 block matches all specified keys wins. If no rule matches, the `default`
-route applies (currently `local-spark`, i.e. qwen2.5:32b on Spark).
+route applies (currently `local-spark`, i.e. qwen3-next:80b-a3b-instruct-q4_K_M on Spark).
 
 **Match keys** (all optional; combined with AND):
 
@@ -86,7 +86,7 @@ route applies (currently `local-spark`, i.e. qwen2.5:32b on Spark).
 | Value | Hardware | Model |
 |---|---|---|
 | `local-p40` | P40 (Pascal, 24 GB) | `qwen2.5:7b` |
-| `local-spark` | DGX Spark (GB10) | `qwen2.5:32b` |
+| `local-spark` | DGX Spark (GB10) | `qwen3-next:80b-a3b-instruct-q4_K_M` |
 | `local-spark-coder` | DGX Spark (GB10) | `qwen2.5-coder:32b` |
 | `claude` | Anthropic API | `claude-sonnet-4-6` (default) |
 | `local-only` | whichever path is healthy | per rule; raises if both down |
@@ -135,7 +135,7 @@ capability):
 ### Context size threshold
 
 Requests exceeding 50,000 tokens escalate to Claude (`claude-sonnet-4-6`).
-The 50k threshold reflects qwen2.5:32b's reliable quality window —
+The 50k threshold reflects qwen3-next:80b-a3b-instruct-q4_K_M's reliable quality window —
 the model's nominal context is 128k, but quality degrades significantly
 above ~64k. 50k is a conservative gate that avoids truncation or quality
 collapse on borderline cases.
@@ -159,7 +159,7 @@ greppable from the policy file without needing to read Python source.
 P40 (`qwen2.5:7b`) agents: `triager`, `note-maker`, `errand-runner`,
 `property-coordinator`, `doc-writer`, `health-tracker`.
 
-Spark general (`qwen2.5:32b`) agents: `historian`, `researcher`,
+Spark general (`qwen3-next:80b-a3b-instruct-q4_K_M`) agents: `historian`, `researcher`,
 `supervisor`, `reporter`, `homelab-engineer`, `network-operator`,
 `storage-operator`, `smart-home-operator`, `ml-operator`,
 `observability-operator`, `security`, `auditor`, `artist`.

--- a/docs/src/stage2_gap_analysis.md
+++ b/docs/src/stage2_gap_analysis.md
@@ -63,7 +63,7 @@ surface → bridge → langgraph-agents queue → triager → specialist → out
 | Specialist routing | Triager agent (LLM-driven) | Decides which specialist gets the task based on content |
 | Specialist execution | 13 named agents (supervisor, researcher, coder, reviewer, triager, reporter, note-maker, homelab-engineer, smart-home-operator, ml-operator, errand-runner, property-coordinator, health-tracker) | All run inside langgraph-agents pod; share the same graph |
 | Approval gate | `interrupt()` + Windmill `langgraph-approval-post.ts` + ntfy/Zulip | Class A/B/C/D taxonomy; ntfy tap → /approval endpoint |
-| Model selection | Per-agent default (qwen2.5:32b on Spark) + `requires_cloud` tag → Claude API escalation | Cost caps enforced in-cluster: `$5/task`, `$10/agent/day`, `$30/global/day` |
+| Model selection | Per-agent default (qwen3-next:80b-a3b-instruct-q4_K_M on Spark) + `requires_cloud` tag → Claude API escalation | Cost caps enforced in-cluster: `$5/task`, `$10/agent/day`, `$30/global/day` |
 | Inference backends | ollama-spark (GB10), ollama (P40), tei-spark (reranker), Claude API | Routing in `langgraph-agents/.agents/instructions/hardware-routing.md` |
 | Tool surface | MCP Gateway + 16 MCP servers via Istio | Same set as Claude Code, accessed differently (HTTP MCP not CLI MCP) |
 | Persistent outputs | Vault (`langgraph-vault` PVC + RO sync from laptop), Zulip threads, ntfy push, Langfuse traces | Outputs land in multiple sinks per task |

--- a/kubernetes/apps/ai/langgraph-agents/routing-policy.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/routing-policy.yaml
@@ -27,7 +27,7 @@ data:
     #
     # Supported route values:
     #   local-p40          — Ollama on P40, qwen2.5:7b
-    #   local-spark        — Ollama on Spark, qwen2.5:32b
+    #   local-spark        — Ollama on Spark, qwen3-next:80b-a3b-instruct-q4_K_M
     #   local-spark-coder  — Ollama on Spark, qwen2.5-coder:32b
     #   claude             — Anthropic API (model selected by `model` field)
     #   local-only         — never escalates; raises if both local paths down
@@ -58,7 +58,7 @@ data:
       - match:
           data_tier: restricted
         route: local-only
-        model: qwen2.5:32b
+        model: qwen3-next:80b-a3b-instruct-q4_K_M
         reason: "Restricted data tier — HOMELAB-SPEC Layer 2 #1 + Layer 5 classification"
 
       # -----------------------------------------------------------------------
@@ -89,7 +89,7 @@ data:
       - match:
           task_class: summarization
         route: local-spark
-        model: qwen2.5:32b
+        model: qwen3-next:80b-a3b-instruct-q4_K_M
         reason: "Summarization is well within 32b capability; no escalation needed"
 
       - match:
@@ -101,7 +101,7 @@ data:
       - match:
           task_class: log-triage
         route: local-spark
-        model: qwen2.5:32b
+        model: qwen3-next:80b-a3b-instruct-q4_K_M
         reason: "Log error-pattern extraction; local model handles well"
 
       - match:
@@ -119,7 +119,7 @@ data:
       - match:
           task_class: alert-triage
         route: local-spark
-        model: qwen2.5:32b
+        model: qwen3-next:80b-a3b-instruct-q4_K_M
         reason: "Alert analysis needs reasoning depth; Spark 32b preferred over 7b"
 
       # -----------------------------------------------------------------------
@@ -141,7 +141,7 @@ data:
       - match:
           task_class: image-generation
         route: local-spark
-        model: qwen2.5:32b
+        model: qwen3-next:80b-a3b-instruct-q4_K_M
         reason: "Prompt composition for ComfyUI; stays local"
 
       # -----------------------------------------------------------------------
@@ -244,79 +244,79 @@ data:
       - match:
           agent_id: historian
         route: local-spark
-        model: qwen2.5:32b
+        model: qwen3-next:80b-a3b-instruct-q4_K_M
         reason: "Historian produces vault summaries; 32b for quality prose"
 
       - match:
           agent_id: researcher
         route: local-spark
-        model: qwen2.5:32b
+        model: qwen3-next:80b-a3b-instruct-q4_K_M
         reason: "Researcher needs structured-output reasoning depth"
 
       - match:
           agent_id: supervisor
         route: local-spark
-        model: qwen2.5:32b
+        model: qwen3-next:80b-a3b-instruct-q4_K_M
         reason: "Supervisor orchestrates sub-agents; needs 32b reasoning"
 
       - match:
           agent_id: reporter
         route: local-spark
-        model: qwen2.5:32b
+        model: qwen3-next:80b-a3b-instruct-q4_K_M
         reason: "Reporter formats rich-text DMs; 32b for link-formatting precision"
 
       - match:
           agent_id: homelab-engineer
         route: local-spark
-        model: qwen2.5:32b
+        model: qwen3-next:80b-a3b-instruct-q4_K_M
         reason: "Homelab-engineer handles complex cluster analysis"
 
       - match:
           agent_id: network-operator
         route: local-spark
-        model: qwen2.5:32b
+        model: qwen3-next:80b-a3b-instruct-q4_K_M
         reason: "Network analysis needs structured reasoning depth"
 
       - match:
           agent_id: storage-operator
         route: local-spark
-        model: qwen2.5:32b
+        model: qwen3-next:80b-a3b-instruct-q4_K_M
         reason: "Storage analysis needs structured reasoning depth"
 
       - match:
           agent_id: smart-home-operator
         route: local-spark
-        model: qwen2.5:32b
+        model: qwen3-next:80b-a3b-instruct-q4_K_M
         reason: "HA/Frigate operations need reasoning depth"
 
       - match:
           agent_id: ml-operator
         route: local-spark
-        model: qwen2.5:32b
+        model: qwen3-next:80b-a3b-instruct-q4_K_M
         reason: "ML tuning decisions need 32b reasoning"
 
       - match:
           agent_id: observability-operator
         route: local-spark
-        model: qwen2.5:32b
+        model: qwen3-next:80b-a3b-instruct-q4_K_M
         reason: "Observability analysis needs structured reasoning"
 
       - match:
           agent_id: security
         route: local-spark
-        model: qwen2.5:32b
+        model: qwen3-next:80b-a3b-instruct-q4_K_M
         reason: "Security analysis needs nuance in observation vs inference"
 
       - match:
           agent_id: auditor
         route: local-spark
-        model: qwen2.5:32b
+        model: qwen3-next:80b-a3b-instruct-q4_K_M
         reason: "Auditor needs precision citing CVEs and scoring exposure"
 
       - match:
           agent_id: artist
         route: local-spark
-        model: qwen2.5:32b
+        model: qwen3-next:80b-a3b-instruct-q4_K_M
         reason: "Prompt composition benefits from Spark's prompt-engineering perf"
 
       - match:

--- a/kubernetes/apps/ai/ollama-spark/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/ollama-spark/app/cnp-allow.yaml
@@ -49,7 +49,7 @@ spec:
             io.kubernetes.pod.namespace: observability
             app.kubernetes.io/name: prometheus-blackbox-exporter
         # HolmesGPT chat-mode investigation LLM calls. MODEL is
-        # `ollama/qwen2.5:32b` served here per the Spark-Unblocks-RAG
+        # `ollama/qwen3-next:80b-a3b-instruct-q4_K_M` served here per the Spark-Unblocks-RAG
         # cutover (PR #11752); the holmesgpt egress side allows :11434
         # to the cluster.
         - matchLabels:

--- a/kubernetes/apps/collab/open-webui/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/open-webui/app/helmrelease.yaml
@@ -32,7 +32,7 @@ spec:
               tag: v0.9.6
 
             env:
-              # Multi-endpoint: Spark (qwen2.5:32b) is the new default,
+              # Multi-endpoint: Spark (qwen3-next:80b-a3b-instruct-q4_K_M) is the new default,
               # P40 (qwen2.5:7b) remains user-selectable per
               # conversation. Open WebUI parses this as `;`-separated
               # endpoints and exposes each model under its own provider

--- a/kubernetes/apps/observability/holmesgpt/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/holmesgpt/app/helmrelease.yaml
@@ -57,7 +57,7 @@ spec:
               # prompt surgery (context trimming + tool-call budget)
               # before a >32b model is viable. Until then, 32b is the
               # right ceiling. Investigation transcript in #11961 body.
-              MODEL: ollama/qwen2.5:32b
+              MODEL: ollama/qwen3-next:80b-a3b-instruct-q4_K_M
               OLLAMA_API_BASE: http://ollama-spark.ai.svc.cluster.local:11434
               # Raised 16384 → 32768 on 2026-05-23 to give Holmes' tool-loop
               # room. The prior 16K cap meant a kubectl_logs payload could


### PR DESCRIPTION
Companion to the langgraph GROUP_MODELS swap (rwlove/langgraph-agents#129). Points every **current** consumer of the Spark reasoning model at `qwen3-next:80b-a3b-instruct-q4_K_M`:

- **langgraph-routing-policy** ConfigMap — all 18 `model:` rules.
- **HolmesGPT** — `MODEL` → qwen3-next (alert triage now on the shared model).
- Open WebUI default-chat comment, ollama-spark cnp comment.
- Docs: README + docs/src/{ai_architecture, routing_policy, stage2_gap_analysis}.

**Intentionally left as accurate history** (not falsified): the dated audit doc, the dated behavioral comments in the Windmill workflows / Grafana panel description / HolmesGPT tuning history, and the ollama-spark comments that correctly reference qwen2.5:32b as the *old* model in the transition. The blackbox spark probe targets `/api/embed` (bge-m3), not the reasoning model — no change needed.