### PR TITLE
feat(ai): deploy langgraph-agents 0.2.69 (reasoning model → qwen3-next)

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/langgraph-agents
-              tag: 0.2.68@sha256:5720c94ebee4ae7463fad41b1073edb8e60560fe354e938531434c37250eee88
+              tag: 0.2.69@sha256:0042df6d254c655f6134655735f934afd9c0beac382e0b2a8e5640d51c336d89
 
             env:
               # --- vault ---


### PR DESCRIPTION
Bumps the langgraph-agents image pin **0.2.68 → 0.2.69**. v0.2.69 carries the GROUP_MODELS swap (#129): the 13 reasoning agents now run `qwen3-next:80b-a3b-instruct-q4_K_M` (MoE, **measured 62 tok/s** vs 10). qwen3-next is already pre-warmed + kept resident (MAX_LOADED=5), so the rollout won't trigger the ~8.6 min cold-load.