### PR TITLE
feat(ai): ollama-spark OLLAMA_KEEP_ALIVE=-1 (keep qwen3-next warm)

### DIFF
--- a/kubernetes/apps/ai/ollama-spark/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/ollama-spark/app/helmrelease.yaml
@@ -64,6 +64,12 @@ spec:
               OLLAMA_FLASH_ATTENTION: 1
               OLLAMA_CONTEXT_LENGTH: 16384
               OLLAMA_NUM_PARALLEL: 4
+              # Never idle-unload. MAX_LOADED lets the working set co-reside,
+              # but the default 5m keep-alive would unload qwen3-next between
+              # bursts on this low-traffic fleet — and its cold-load is ~8.6m.
+              # -1 pins the loaded set (qwen3-next + coder + embedders) warm so
+              # cold-loads happen only on an actual pod restart, not every idle.
+              OLLAMA_KEEP_ALIVE: "-1"
               # Working set after the qwen2.5:32b -> qwen3-next swap:
               #   qwen3-next:80b-a3b-instruct  -- fleet reasoning + HolmesGPT
               #                                   + Open WebUI (one shared model)


### PR DESCRIPTION
Final keep-warm piece for the qwen3-next swap. `MAX_LOADED=5` lets the working set co-reside, but ollama's default 5m keep-alive still idle-unloads qwen3-next between bursts on this low-traffic fleet — and its cold-load is ~8.6 min, so every first-request-after-idle would stall the reasoning tier. `-1` pins the loaded set resident; cold-loads now only on an actual pod restart.