### PR TITLE
fix(media): lidarr-sab-autoimport reads album stats from the album API, not the queue embed

### DIFF
--- a/kubernetes/apps/media/lidarr-sab-autoimport/app/resources/scan.py
+++ b/kubernetes/apps/media/lidarr-sab-autoimport/app/resources/scan.py
@@ -97,10 +97,32 @@ def main():
         print("no stuck queue items")
         return
 
+    # The queue endpoint's embedded `album` object does NOT carry the
+    # `statistics` block (percentOfTracks / trackFileCount) — not even with
+    # includeAlbum=true. Reading stats off the queue row therefore always
+    # yielded an empty dict, so `already_imported` was always False and the
+    # drop-branch below never fired: completed rows whose tracks are already
+    # in /media got re-scanned every cycle ("Importing 0 tracks") and never
+    # dropped. Re-fetch each stuck row's album by id to get real statistics.
+    album_stats_cache = {}
+
+    def album_stats(album_id):
+        if album_id in album_stats_cache:
+            return album_stats_cache[album_id]
+        stats = {}
+        if album_id:
+            try:
+                album = call_api("GET", f"/api/v1/album/{album_id}") or {}
+                stats = album.get("statistics") or {}
+            except Exception as e:
+                print(f"  could not fetch album {album_id} statistics: {e}")
+        album_stats_cache[album_id] = stats
+        return stats
+
     scans = set()
     drops = []
     for r in stuck:
-        stats = (r.get("album") or {}).get("statistics") or {}
+        stats = album_stats(r.get("albumId"))
         already_imported = (
             (stats.get("percentOfTracks") or 0) >= 100
             and (stats.get("trackFileCount") or 0) > 0


### PR DESCRIPTION
## Problem

`lidarr-sab-autoimport` exists to clear SAB queue rows that Lidarr
3.1.2.4938 (develop) leaves wedged in `completed / importing` forever.
Its drop-branch is supposed to DELETE any row whose album is already
100% imported.

It decided that from the queue record's embedded `album.statistics`
block — but Lidarr's `/api/v1/queue` endpoint does **not** include
`statistics` on the embedded album, even with `includeAlbum=true`
(verified: the embedded `album` object has no `statistics` key). So the
stats dict was always empty, `already_imported` was always `False`, the
DELETE branch never ran, and completed rows whose tracks are already on
disk got re-scanned every 5 min (`Importing 0 tracks`) and never
dropped. The cleaner has been a no-op on its primary job.

Observed live: a queue of 11 wedged rows where 6 albums were already
100% imported into the library — pure stale tracker state the script
should have dropped.

## Fix

Re-fetch each stuck row's album via `/api/v1/album/{albumId}` (cached
per album id) to read the real `statistics` block, so the drop-branch
fires correctly.

## Test

- `python3 -m py_compile scan.py` — clean.
- Confirmed against live Lidarr that `/api/v1/album/{id}` returns
  `statistics.percentOfTracks` / `trackFileCount` where the queue embed
  does not.
- The 11 stuck rows were cleared out-of-band; with this change future
  imported-but-wedged rows drop on the next cycle instead of looping.

## Not covered (follow-up)

Rows whose download folder was deleted while the album is still
< 100% imported (genuine match-rejects that aged out) still can't be
auto-dropped — the cronjob is API-only and can't see the download
filesystem. Rare and typically unmonitored leftovers; left for a
separate change if it proves recurring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)