### PR TITLE
fix(media): lidarr — heal /config uid 1000→1103 perms (restores file logging + cover-art writes)

### DIFF
--- a/kubernetes/apps/media/lidarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/lidarr/app/helmrelease.yaml
@@ -25,6 +25,31 @@ spec:
           reloader.stakater.com/auto: "true"
 
         type: statefulset
+
+        # The config PVC was populated when this controller ran as uid 1000;
+        # runAsUser is now 1103 and fsGroupChangePolicy:OnRootMismatch skips the
+        # recursive fsGroup chown (the PVC root already matches gid 1001), so the
+        # stale 0644 uid-1000 files (logs/lidarr.txt, MediaCover/**) aren't
+        # writable by 1103. NLog's file target then silently dies — no log file
+        # written since the uid switch — and cover-art writes throw
+        # "Permission denied". Reclaim /config ownership on startup; idempotent +
+        # self-heals. Scoped to /config only — the media/downloads NFS mounts are
+        # owned correctly and must not be touched.
+        initContainers:
+          init-perms:
+            image:
+              repository: ghcr.io/home-operations/lidarr
+              tag: 3.1.3@sha256:b1e206e02bcacf1b540a813be74afb4f788114bbb540830478e5eb0e469c2162
+            command:
+              - chown
+              - -R
+              - 1103:1001
+              - /config
+            securityContext:
+              runAsUser: 0
+              runAsGroup: 0
+              runAsNonRoot: false
+
         containers:
           app:
             image:


### PR DESCRIPTION
## Problem

Lidarr stopped writing its log file (`/config/logs/lidarr.txt`) at the
2026-06-03 restart — only stdout/console logging has survived — and its
stdout is a continuous stream of:

```
System.UnauthorizedAccessException: Access to the path
'/config/MediaCover/Albums/<id>/cover.jpg.part' is denied.
 ---> System.IO.IOException: Permission denied
```

### Root cause

The config PVC was populated when this controller ran as **uid 1000**.
The HelmRelease now pins **runAsUser: 1103** with
`fsGroupChangePolicy: OnRootMismatch`. Because the PVC root already
matches gid 1001, the kubelet **skips** the recursive fsGroup chown, so
the stale `0644` uid-1000 files were never made writable by 1103:

| File | Owner/mode | uid 1103 (gid 1001) can write? |
|---|---|---|
| `config.xml`, `lidarr.pid` | `1000:1001 0664` | ✅ group-writable → app works |
| `logs/lidarr.txt` | `1000:1001 0644` | ❌ group read-only → NLog file target silently dies |
| `MediaCover/**/cover.jpg` | `1000:1001 0644`, dirs `0755` | ❌ → cover-art writes denied |

This is the `OnRootMismatch`-on-a-large-volume trap the repo's
`storage-class.instructions.md` warns about.

Note: the missing `logs.db` is **not** a bug — `LIDARR__LOG__DBENABLED:
"False"` is set intentionally; observability is via stdout→Loki. Log
level is already effectively `info` (env `LIDARR__LOG__LEVEL: info`
overrides the stale `config.xml` value at runtime).

## Fix

Add a root `init-perms` initContainer that `chown -R 1103:1001 /config`
on startup — idempotent and self-healing, matching the existing
`gonic` init-perms pattern. Scoped to `/config` only; the media/downloads
NFS mounts are owned correctly and are not touched. `umask 0002` (already
set on the app command) keeps newly created files group-writable.

## Effect on merge

Flux recreates the pod; the initContainer heals `/config`, NLog's file
target re-initialises (log file resumes), and the cover-art
`Permission denied` flood stops. Lidarr is internal (non-Renee-facing);
the restart only briefly pauses queue processing, which resumes on its
own.

## Test

- `kubectl kustomize kubernetes/apps/media/lidarr/app` renders clean;
  initContainer present.
- Confirmed `chown` (GNU coreutils 9.8) exists in the lidarr image.
- pre-commit (yamllint, schema, README drift) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)