### PR TITLE
fix(mcp-system): front github-mcp with token-injecting nginx + prefix

### DIFF
--- a/kubernetes/apps/mcp-system/github-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/github-mcp/app/helmrelease.yaml
@@ -12,9 +12,11 @@ spec:
   values:
     defaultPodOptions:
       securityContext:
-        runAsGroup: 1000
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 101
         runAsNonRoot: true
-        runAsUser: 1000
+        runAsUser: 101
     controllers:
       github-mcp:
         annotations:
@@ -23,16 +25,52 @@ spec:
           annotations:
             sidecar.istio.io/inject: "true"
         containers:
+          # nginx-unprivileged front: receives broker traffic on 8080,
+          # injects the Authorization: Bearer <PAT> header that the
+          # github-mcp-server http transport requires, and forwards to
+          # the sidecar on 127.0.0.1:8082. Runs as UID 101.
           app:
+            image:
+              repository: docker.io/nginxinc/nginx-unprivileged
+              tag: 1.31.1-alpine
+            env:
+              # envsubst replaces ${GITHUB_PERSONAL_ACCESS_TOKEN} in the
+              # template; the secret is materialized by the github-mcp
+              # ExternalSecret.
+              GITHUB_PERSONAL_ACCESS_TOKEN:
+                valueFrom:
+                  secretKeyRef:
+                    name: github-mcp-secret
+                    key: GITHUB_PERSONAL_ACCESS_TOKEN
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
+              limits:
+                memory: 128Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop: ["ALL"]
+              seccompProfile:
+                type: RuntimeDefault
+          # github-mcp-server in http mode, bound to 8082. The token is
+          # supplied per-request by the nginx front, not from env (the
+          # env PAT is only honored by the stdio transport), but envFrom
+          # is retained harmlessly. --trust-proxy-headers: we sit behind
+          # the nginx front.
+          github:
             image:
               repository: ghcr.io/github/github-mcp-server
               tag: v1.3.0
-            # github-mcp-server's HTTP transport was added in v0.31.0.
-            # --base-path /mcp matches the kuadrant gateway's default prefix.
             args:
               - http
+              - --port
+              - "8082"
               - --base-path
               - /mcp
+              - --trust-proxy-headers
             envFrom:
               - secretRef:
                   name: github-mcp-secret
@@ -44,10 +82,10 @@ spec:
                 memory: 256Mi
             securityContext:
               allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
               capabilities:
                 drop:
                   - ALL
-              readOnlyRootFilesystem: true
               seccompProfile:
                 type: RuntimeDefault
     service:
@@ -55,7 +93,7 @@ spec:
         controller: github-mcp
         ports:
           http:
-            port: 8082
+            port: 8080
     route:
       app:
         hostnames:
@@ -71,19 +109,59 @@ spec:
                   value: /mcp
             filters:
               # Strip inbound Authorization before forwarding to the
-              # backend MCP server. The Kuadrant mcp-gateway forwards
-              # all client headers; the broker-side Bearer (used to
-              # authentication can take
-              # precedence over the backend's own credential env in
-              # any upstream MCP client that honors `Authorization`,
-              # causing 401s against the real target service. Backend
-              # MCP servers each carry their own env-loaded creds —
-              # stripping the broker Bearer at this hop lets those
-              # take effect uniformly across the fleet.
+              # backend. The Kuadrant mcp-gateway forwards the broker
+              # Bearer (an Authelia JWT), which would shadow the GitHub
+              # PAT the nginx front injects. Removing it here lets the
+              # injected Bearer take effect.
               - type: RequestHeaderModifier
                 requestHeaderModifier:
                   remove:
                     - Authorization
             backendRefs:
               - identifier: app
-                port: 8082
+                port: 8080
+    persistence:
+      # Source nginx template — envsubst rewrites this into conf.d at
+      # container start. Mounted read-only.
+      nginx-templates:
+        type: configMap
+        name: github-mcp-nginx-config
+        advancedMounts:
+          github-mcp:
+            app:
+              - path: /etc/nginx/templates/default.conf.template
+                subPath: default.conf.template
+                readOnly: true
+      # nginx writes the rendered config + pid + cache here. With
+      # readOnlyRootFilesystem: true these must be emptyDirs.
+      nginx-conf-d:
+        type: emptyDir
+        advancedMounts:
+          github-mcp:
+            app:
+              - path: /etc/nginx/conf.d
+      nginx-cache:
+        type: emptyDir
+        advancedMounts:
+          github-mcp:
+            app:
+              - path: /var/cache/nginx
+      nginx-tmp:
+        type: emptyDir
+        advancedMounts:
+          github-mcp:
+            app:
+              - path: /tmp
+      nginx-run:
+        type: emptyDir
+        advancedMounts:
+          github-mcp:
+            app:
+              - path: /var/run
+      # github-mcp-server scratch under read-only rootfs.
+      github-tmp:
+        type: emptyDir
+        advancedMounts:
+          github-mcp:
+            github:
+              - path: /tmp

--- a/kubernetes/apps/mcp-system/github-mcp/app/kustomization.yaml
+++ b/kubernetes/apps/mcp-system/github-mcp/app/kustomization.yaml
@@ -8,3 +8,9 @@ resources:
   - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+configMapGenerator:
+  - name: github-mcp-nginx-config
+    files:
+      - default.conf.template=./resources/default.conf.template
+generatorOptions:
+  disableNameSuffixHash: true

--- a/kubernetes/apps/mcp-system/github-mcp/app/resources/default.conf.template
+++ b/kubernetes/apps/mcp-system/github-mcp/app/resources/default.conf.template
@@ -1,0 +1,49 @@
+# nginx reverse-proxy for github-mcp.
+#
+# github-mcp-server's `http` transport requires a per-request
+# Authorization: Bearer <PAT> header (it has no static-token env mode —
+# the GITHUB_PERSONAL_ACCESS_TOKEN env is only honored by the stdio
+# transport). The mcp-gateway broker strips Authorization at the route
+# hop (fleet convention) and forwards none, so the upstream rejects with
+# "authorization required". This proxy injects the Bearer from
+# $GITHUB_PERSONAL_ACCESS_TOKEN (set via env from the github-mcp-secret
+# ExternalSecret) before forwarding to the github-mcp-server sidecar on
+# 127.0.0.1:8082.
+#
+# Same token-injection pattern as windmill-mcp; the difference is the
+# upstream here is an in-pod sidecar (localhost) rather than a service
+# in another namespace.
+
+server {
+    listen 8080;
+    server_name _;
+
+    # /healthz — simple liveness/readiness target. No auth, no proxy.
+    location = /healthz {
+        access_log off;
+        return 200 "ok\n";
+        default_type text/plain;
+    }
+
+    # /mcp — broker entrypoint. Inject the Bearer token and forward to
+    # the github-mcp-server sidecar, which serves MCP at /mcp
+    # (--base-path /mcp).
+    location /mcp {
+        proxy_pass http://127.0.0.1:8082;
+
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+        # `$${GITHUB_PERSONAL_ACCESS_TOKEN}` (double-$) escapes Flux
+        # postBuild substitution — Flux renders it back to
+        # `${GITHUB_PERSONAL_ACCESS_TOKEN}`, which nginx's envsubst then
+        # expands from the env var at startup.
+        proxy_set_header Authorization "Bearer $${GITHUB_PERSONAL_ACCESS_TOKEN}";
+
+        # SSE / streamable-HTTP friendliness — the MCP transport streams.
+        proxy_buffering off;
+        proxy_request_buffering off;
+        proxy_read_timeout 1h;
+        proxy_send_timeout 1h;
+        chunked_transfer_encoding on;
+    }
+}

--- a/kubernetes/apps/mcp-system/github-mcp/mcp/mcpserverregistration.yaml
+++ b/kubernetes/apps/mcp-system/github-mcp/mcp/mcpserverregistration.yaml
@@ -11,4 +11,4 @@ spec:
     group: gateway.networking.k8s.io
     kind: HTTPRoute
     name: github-mcp
-  toolPrefix: github_
+  prefix: github_


### PR DESCRIPTION
## Summary

The `github-mcp` backend was unreachable to the mcp-gateway broker: `transport error: authorization required`.

**Root cause:** github-mcp-server's `http` transport requires a per-request `Authorization: Bearer <PAT>` header. The `GITHUB_PERSONAL_ACCESS_TOKEN` env is only honored by the *stdio* transport, and there is no static-token flag for http mode (confirmed against upstream v1.3.0). The broker strips `Authorization` at the route hop (fleet convention), so every connection was rejected.

**Fix:** front the server with an `nginx-unprivileged` proxy that injects the Bearer from the `github-mcp-secret` ExternalSecret, then forwards to the github-mcp-server sidecar on `127.0.0.1:8082`. Same token-injection pattern as `windmill-mcp`; here the upstream is an in-pod sidecar rather than a cross-namespace service.

Pod restructure:
- `app` container → `nginx-unprivileged` (port 8080, the service/route target), injects `Authorization`.
- `github` container → `github-mcp-server http --port 8082 --base-path /mcp --trust-proxy-headers`.
- Pod runs as UID 101 (nginx); emptyDirs for nginx conf.d/cache/tmp/run + github `/tmp` under read-only rootfs.

**Also:** `MCPServerRegistration` field `toolPrefix: github_` → `prefix: github_`. `toolPrefix` is not a CRD field (silently pruned); `prefix` namespaces the natively-unprefixed github tools as `github_*`. Verified accepted + retained via `kubectl apply --server-side --dry-run=server`.

## Notes

- No README badge drift (no app/secret count change).
- CNP unchanged — nginx→github is loopback; broker→nginx is intra-namespace (baseline allow).
- Part of the 2026-06-12 mcp-gateway backend health sweep. arr-mcp (image rebuild) and windmill-mcp (token scope) are tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)