### PR TITLE
fix(mcp-system): arr-mcp → v1.6.5 (stateless transport) + prefix

### DIFF
--- a/kubernetes/apps/mcp-system/arr-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/arr-mcp/app/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/arr-mcp
-              tag: v1.6.4@sha256:4b7f0e7f1637cdbf7e27820101bcf92c5b86b45638df8f6aae4d186f836d1142
+              tag: v1.6.5@sha256:d862cd5503459eaecebc8d928c18a6590699218c54600dc22f7d810bfe6a970a
             env:
               SONARR_URL: http://sonarr.media.svc.cluster.local:8989
               RADARR_URL: http://radarr.media.svc.cluster.local:7878

--- a/kubernetes/apps/mcp-system/arr-mcp/mcp/mcpserverregistration.yaml
+++ b/kubernetes/apps/mcp-system/arr-mcp/mcp/mcpserverregistration.yaml
@@ -11,4 +11,4 @@ spec:
     group: gateway.networking.k8s.io
     kind: HTTPRoute
     name: arr-mcp
-  toolPrefix: arr_
+  prefix: arr_


### PR DESCRIPTION
## Summary

`arr-tools` validated healthy at the broker but every tool call failed with `Server already initialized`.

**Root cause:** upstream `mcp-arr` ≤ v1.6.4 served a single shared *stateful* `StreamableHTTPServerTransport` (`sessionIdGenerator: randomUUID`). Behind the per-call mcp-gateway, each tool call opens a fresh MCP session → re-runs `initialize` → HTTP 400 `Server already initialized`. Validation initializes once (→ "healthy"), so the `.status` masked it.

**Fix:** upstream **v1.6.5 resolves this** — it creates a fresh transport per request with `sessionIdGenerator: undefined` (verified against the v1.6.5 source). Bump the image pin `v1.6.4 → v1.6.5`. No home-ops-side workaround needed; this is upstream-resolved, so no `# workaround:` annotation.

**Also:** `MCPServerRegistration` field `toolPrefix: arr_` → `prefix: arr_`. `toolPrefix` is not a CRD field (silently pruned), so arr tools federated unprefixed — including generic `search`/`fetch`, a broker collision risk. `prefix` namespaces them as `arr_*`. Verified accepted + retained via `kubectl apply --server-side --dry-run=server`.

## Notes

- Image `ghcr.io/rwlove/arr-mcp:v1.6.5` was built from the fixed upstream tag (containers repo, 2026-06-11). Pinned by digest.
- No README badge drift.
- Completes the github+arr half of the 2026-06-12 mcp-gateway backend sweep. windmill-mcp remains (Windmill token needs the `mcp` scope — a manual action, no manifest change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)