### PR TITLE
feat(ai): in-cluster langgraph eval sweep runner (suspended CronJob)

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/cnp-evals.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/cnp-evals.yaml
@@ -1,0 +1,67 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+# Egress for the langgraph-evals sweep pod. Deliberately NOT reusing the
+# langgraph-agents-allow policy: the eval pod carries a distinct
+# `app.kubernetes.io/name: langgraph-evals` label so it can't match the
+# langgraph-agents Service selector and become a phantom backend endpoint.
+# This mirrors the egress subset the eval path actually exercises.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: langgraph-evals-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: langgraph-evals
+  # Additive — baseline default-deny is what locks the pod down; these
+  # punch the holes. Ingress stays open (nothing connects to the job).
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  egress:
+    # Ollama in the ai ns — local synthesis backend (ollama-spark for the
+    # reasoning operators; ollama/P40 for completeness). baseline
+    # allow-intra-namespace already covers ai->ai; explicit for grep.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: ai
+            app.kubernetes.io/name: ollama-spark
+        - matchLabels:
+            io.kubernetes.pod.namespace: ai
+            app.kubernetes.io/name: ollama
+      toPorts:
+        - ports:
+            - port: "11434"
+              protocol: TCP
+    # MCP gateway (mcp-system) — operator nodes pre-fetch evidence via the
+    # istio Service's internal :8080 (no JWT on that path; same tokenless
+    # route the deployed fleet uses).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: mcp-system
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+    # Both CNPG clusters in databases ns — checkpoints + memory, so the
+    # agents settings/memory store resolve identically to the deployment.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
+            cnpg.io/cluster: postgres-langgraph-checkpoints
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
+            cnpg.io/cluster: postgres-langgraph-memory
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+    # External :443 — api.anthropic.com (forced-Claude synthesis + Opus
+    # judge) and github.com/codeload (initContainer fetches the harness
+    # tarball). toEntities world+443 per the canonical-FQDN matchPattern
+    # limitation documented in cnp-allow.yaml.
+    - toEntities: [world]
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/ai/langgraph-agents/app/cronjob-evals.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/cronjob-evals.yaml
@@ -1,0 +1,173 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/cronjob-batch-v1.json
+# Manually-triggered Spark-vs-Claude eval sweep.
+#
+# Runs the `evals/` harness from rwlove/langgraph-agents against the
+# deployed fleet code, IN-CLUSTER so the operator nodes can reach the
+# MCP gateway (evidence pre-fetch) + ollama-spark (local synthesis). A
+# laptop run gets empty evidence — the gateway's internal :8080 path is
+# only reachable in-cluster and the local synthesis needs the Spark GPU.
+#
+# SUSPENDED: never fires on its own. Trigger a run with:
+#
+#   kubectl -n ai create job --from=cronjob/langgraph-evals \
+#     eval-$(date +%Y%m%d-%H%M)
+#
+# The score table + per-agent labels (offload-safe / route-to-api /
+# keep-local-fix) print to the pod log (queryable in Loki); the full
+# JSON report is catted at the end of the run.
+#
+# Why a suspended CronJob and not a bare Job:
+#   - $0 until explicitly triggered. The sweep spends metered tokens
+#     (~22 golden tasks x forced-Claude synthesis + Opus judge), so it
+#     must NOT auto-run on merge.
+#   - Repeatable without YAML churn — `create job --from=cronjob` gives
+#     a fresh run each time (a bare Job's spec is immutable; re-running
+#     means a delete-or-bump dance).
+#   Trigger inside the routine maintenance window (any night
+#   02:00-05:00 ET) — the sweep contends with the reasoning fleet for
+#   the shared Spark GPU.
+#
+# Why fetch-at-runtime: `evals/` is repo-root dev tooling, NOT in the
+# baked image (the Dockerfile COPYs only src/ + agents/). The
+# initContainer pulls the harness tarball at the SAME tag the image is
+# built from, and the main container runs it on the image's pre-built
+# venv — so `agents` (venv, installed) and `evals` (fetched, cwd) are
+# the same commit (v0.2.69). No `uv sync` at runtime, no version skew.
+#
+# Pin the image digest + the fetch tag together on every fleet bump:
+# both must track the deployed langgraph-agents version (helmrelease.yaml).
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: langgraph-evals
+  labels:
+    app.kubernetes.io/name: langgraph-evals
+spec:
+  # Feb 31 never occurs — belt to the `suspend` suspenders. This job is
+  # only ever started by hand via `create job --from=cronjob`.
+  schedule: "0 3 31 2 *"
+  suspend: true
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 0  # never silently retry an expensive metered sweep
+      activeDeadlineSeconds: 5400  # 90m ceiling (22 tasks x 3 sequential LLM calls)
+      ttlSecondsAfterFinished: 172800  # keep finished pods 2d for log review
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: langgraph-evals
+        spec:
+          restartPolicy: Never
+          # Same SA as the deployment for parity; token not mounted (the
+          # nodes reach the cluster via the MCP gateway, not the in-pod SA).
+          serviceAccountName: langgraph-agents
+          automountServiceAccountToken: false
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          initContainers:
+            # Fetch the evals/ harness at the deployed tag into the shared
+            # emptyDir. Uses the image's own venv httpx (certifi CA bundle)
+            # so TLS to github works without a ca-certificates package.
+            - name: fetch-evals
+              image: ghcr.io/rwlove/langgraph-agents:0.2.69@sha256:0042df6d254c655f6134655735f934afd9c0beac382e0b2a8e5640d51c336d89
+              command:
+                - python
+                - -c
+                - |
+                  import io, tarfile, httpx
+                  url = "https://github.com/rwlove/langgraph-agents/archive/refs/tags/v0.2.69.tar.gz"
+                  data = httpx.get(url, follow_redirects=True, timeout=60).raise_for_status().content
+                  tarfile.open(fileobj=io.BytesIO(data)).extractall("/workspace")
+                  print(f"fetched evals harness ({len(data)} bytes) to /workspace")
+              volumeMounts:
+                - name: workspace
+                  mountPath: /workspace
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: ["ALL"]
+          containers:
+            - name: evals
+              image: ghcr.io/rwlove/langgraph-agents:0.2.69@sha256:0042df6d254c655f6134655735f934afd9c0beac382e0b2a8e5640d51c336d89
+              workingDir: /workspace/langgraph-agents-0.2.69
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -e
+                  mkdir -p /tmp/vault
+                  echo "[evals] starting Spark-vs-Claude sweep (--all) on $(pwd)"
+                  python -m evals --all --out /workspace/results.json
+                  echo "[evals] ===== results.json ====="
+                  cat /workspace/results.json
+              env:
+                # Mirrors the deployment env that the agents settings +
+                # operator nodes read; only the bits the eval path touches.
+                - name: VAULT_ROOT
+                  value: /tmp/vault  # personas are baked into the image; this is just a writable scratch root
+                - name: ENABLE_CLAUDE_API
+                  value: "true"
+                - name: MCP_GATEWAY_URL
+                  value: http://mcp-gateway-istio.mcp-system.svc.cluster.local:8080
+                - name: MEMORY_EMBED_MODEL
+                  value: bge-m3
+                - name: MEMORY_OLLAMA_URL
+                  value: http://ollama-spark.ai.svc.cluster.local:11434
+                # Cost ceilings — same as the deployment. A 4-operator
+                # sweep stays well under these; they're the runaway guard.
+                - name: COST_CAP_PER_TASK_USD
+                  value: "5.0"
+                - name: COST_CAP_PER_AGENT_DAILY_USD
+                  value: "10.0"
+                - name: COST_CAP_GLOBAL_DAILY_USD
+                  value: "30.0"
+                - name: LOG_LEVEL
+                  value: INFO
+                - name: USER_TIMEZONE
+                  value: America/New_York
+                - name: POSTGRES_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: postgres-langgraph-checkpoints-app
+                      key: uri
+                - name: MEMORY_POSTGRES_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: postgres-langgraph-memory-app
+                      key: uri
+              envFrom:
+                # ANTHROPIC_API_KEY (the funded key) + the rest of the
+                # fleet secret surface.
+                - secretRef:
+                    name: langgraph-agents-secret
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 512Mi
+                limits:
+                  memory: 1Gi
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: ["ALL"]
+              volumeMounts:
+                - name: workspace
+                  mountPath: /workspace
+                - name: tmp
+                  mountPath: /tmp
+          volumes:
+            - name: workspace
+              emptyDir: {}
+            - name: tmp
+              emptyDir: {}

--- a/kubernetes/apps/ai/langgraph-agents/app/kustomization.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/kustomization.yaml
@@ -7,6 +7,8 @@ components:
 resources:
   - ./backendtrafficpolicy.yaml
   - ./cnp-allow.yaml
+  - ./cnp-evals.yaml
+  - ./cronjob-evals.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./prometheusrule.yaml


### PR DESCRIPTION
## What

Adds a **manually-triggered** Spark-vs-Claude eval-runner for the langgraph-agents per-agent routing eval (`rwlove/langgraph-agents` `evals/`). Two new manifests in the existing `ai/langgraph-agents/app/`:

- `cronjob-evals.yaml` — a **suspended** CronJob `langgraph-evals`.
- `cnp-evals.yaml` — a dedicated CiliumNetworkPolicy for the sweep pod.

## Why this shape

This is the last blocker on the routing eval: there was **no way to run the sweep**. The `evals/` harness invokes each agent's *real node in-process*, so it needs cluster network — the MCP gateway for evidence pre-fetch and ollama-spark for local synthesis. A laptop run reaches neither (Istio/JWT on the external path; no GPU) and produces **empty evidence**.

Design decisions (deviations from the literal "bare Job + `uv run`" sketch, called out for review):

| Decision | Rationale |
|---|---|
| **Suspended CronJob**, not a bare Job | Spends `$0` until explicitly triggered (the sweep burns metered Claude synthesis + Opus-judge tokens, so it must **not** auto-run on merge), and is repeatable with no YAML churn — a bare Job's spec is immutable. |
| **Reuse the baked image + fetch only `evals/`**, not clone + full `uv sync` | `evals/` is repo-root dev tooling and is **not** in the image (`Dockerfile` COPYs only `src/` + `agents/` — confirmed). The initContainer pulls the harness tarball at the deployed tag and the main container runs it on the image's pre-built venv, so `agents` (venv) and `evals` (fetched) are the **same commit** (`v0.2.69`, digest-matched to the live deployment). No runtime dep resolution, no version skew, fewer moving parts. |
| **Dedicated CNP + distinct label** (`app.kubernetes.io/name: langgraph-evals`) | Keeps the pod from matching the `langgraph-agents` Service selector (which keys on `instance=langgraph-agents`) and becoming a phantom backend endpoint. Allows only the egress the eval path uses: ollama-spark, mcp-gateway `:8080`, both CNPG clusters, `world:443` (Anthropic + github). |

In-cluster auth is verified: the gateway's JWT `SecurityPolicy` targets only `HTTPRoute mcp-gateway-internal` (the external hostname), **not** the in-cluster `:8080` Service path — so the Job authenticates tokenless exactly as the deployed fleet does. Vault PVCs are `ReadWriteMany`, so no multi-attach concern (and personas are baked into the image — the eval path doesn't need them mounted; `VAULT_ROOT` is just scratch).

## How to run it

Inside the routine maintenance window (any night 02:00–05:00 ET — it contends with the reasoning fleet for the shared Spark GPU):

```sh
kubectl -n ai create job --from=cronjob/langgraph-evals eval-$(date +%Y%m%d-%H%M)
kubectl -n ai logs -f job/eval-<stamp>
```

The score table + per-agent labels (`offload-safe` / `route-to-api` / `keep-local-fix`) print to the pod log (Loki-queryable); the full JSON report is catted at the end.

## Scope today

`--all` runs the **4 operator golden sets on disk** (ml / network / smart-home / storage — 22 tasks). The 4 high-traffic agents (`reporter`, `observability-operator`, `researcher`, `homelab-engineer`) are still un-seeded (blocked on Langfuse), so they're not in this sweep.

## Maintenance / version coupling

On every fleet version bump, the image digest **and** the fetch tag in `cronjob-evals.yaml` must both track the deployed `langgraph-agents` version in `helmrelease.yaml` (currently `0.2.69@sha256:0042df6…`).

## Test

- `kubectl kustomize …/langgraph-agents/app/` renders clean (CronJob + CNP).
- `pre-commit run` on changed files: all hooks pass (yamllint, README-drift, CNP-has-rules, secret detection).
- README badge counts unaffected (CronJob/CNP aren't counted kinds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)