### PR TITLE
chore(workarounds): repoint stale upstream links, add tei-spark tracking issue

### DIFF
--- a/kubernetes/apps/ai/tei-spark/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/tei-spark/app/helmrelease.yaml
@@ -49,10 +49,12 @@ spec:
         containers:
           app:
             image:
-              # workaround: https://github.com/huggingface/text-embeddings-inference/issues/870
-              #   — remove when TEI cuts a release tag containing PRs
-              #   #840 (sm_121 arm64) + #852 (12.1 arm64-restricted),
-              #   currently only on main post-v1.9.3.
+              # workaround: https://github.com/huggingface/text-embeddings-inference/pull/852
+              #   — remove when TEI cuts a release tag > v1.9.3 containing
+              #   PRs #840 (sm_121 arm64) + #852 (12.1 arm64-restricted),
+              #   both merged 2026-03-31 but still main-only (latest
+              #   release v1.9.3 predates them).
+              # Tracking: home-ops#12477
               # Pinned to the multi-arch index digest; arm64 is the only
               # platform inside this index (TEI #852 restricted 12.1
               # builds to linux/arm64).

--- a/kubernetes/apps/external-secrets/external-secrets/app/cnp-allow-controller.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/app/cnp-allow-controller.yaml
@@ -15,7 +15,7 @@ spec:
     egress: false
     ingress: false
   egress:
-    # workaround: https://github.com/cilium/cilium/issues/26477 — remove when canonical-FQDN matchPattern matches reliably through K8s DNS search-domain augmentation
+    # workaround: https://github.com/cilium/cilium/issues/20191 — remove when canonical-FQDN matchPattern matches reliably through K8s DNS search-domain augmentation
     # Tracking: home-ops#11851
     # GithubAccessToken generator (renovate/github-auth-token ES) runs
     # IN the controller process and POSTs to api.github.com for App

--- a/kubernetes/apps/kube-system/node-feature-discovery/rules/gpu-operator-runtime-override.yaml
+++ b/kubernetes/apps/kube-system/node-feature-discovery/rules/gpu-operator-runtime-override.yaml
@@ -5,7 +5,7 @@ kind: NodeFeatureRule
 metadata:
   name: gpu-operator-runtime-override
 spec:
-  # workaround: https://github.com/NVIDIA/gpu-operator/issues/591 — remove when the container-toolkit DS handles non-containerd runtimes OR when all GPU nodes migrate to containerd
+  # workaround: https://github.com/NVIDIA/gpu-operator/issues/1528 — remove when the container-toolkit DS handles non-containerd runtimes OR when all GPU nodes migrate to containerd
   # Tracking: home-ops#11852
   # The cluster runs CRI-O on every node except Spark (Ubuntu 24.04 +
   # containerd). gpu-operator's `nvidia-container-toolkit-daemonset`


### PR DESCRIPTION
Three `# workaround:` annotations cited closed or unrelated upstream
issues, which would false-positive the weekly upstream-watcher (it flags
closed upstreams as retire candidates). Repointed to the real, open gaps;
also added a tracking issue for a pin that had none.

| File | Was | Now |
|---|---|---|
| `ai/tei-spark/.../helmrelease.yaml` | TEI `issues/870` (open, unrelated driver-6xx bug) | `pull/852` — the merged-but-unreleased sm_121/arm64 gate; + tracking `#12477` (pin had no issue) |
| `kube-system/node-feature-discovery/.../gpu-operator-runtime-override.yaml` | gpu-operator `#591` (closed 2025-11-14, vGPU MDEV — unrelated) | `#1528` — open, mixed containerd/CRI-O support |
| `external-secrets/.../cnp-allow-controller.yaml` | cilium `#26477` (closed 2023 backport — unrelated) | `#20191` — open, toFQDNs broken under DNS search-domain augmentation |

Issue bodies #11851 and #11852 already updated upstream with the repoint
rationale. No behavior change — comments only.

Filed during a workaround/issue cross-reference audit.
