### PR TITLE
fix(frigate): HF_HUB_OFFLINE=1 to stop redundant huggingface HEAD on startup

### DIFF
--- a/kubernetes/apps/home/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/home/frigate/app/helmrelease.yaml
@@ -75,6 +75,15 @@ spec:
               tag: 0.17.1@sha256:1724960349dad0bd2ae8ec884171a6fd5755a4dc242a0e66cadbda9c0e85c99b
 
             env:
+              # Semantic Search's jina-clip-v1 model is fully cached on the
+              # config PVC (/config/model_cache/jinaai/jina-clip-v1). Offline
+              # mode makes huggingface_hub skip the startup HEAD to
+              # huggingface.co — that egress is denied by the frigate CNP and
+              # was firing FrigateUnauthorizedEgressAttempt for ~4 min on every
+              # restart (5x retry then fall back to cache anyway). Search keeps
+              # working from cache. Flip to "0" if a model_size change or
+              # reindex needs to pull a new model.
+              HF_HUB_OFFLINE: "1"
               # Memory-leak experiment (issue #12327): testing the legacy
               # i965 VAAPI driver in place of iHD. The upstream ffmpeg leak
               # rides the HW-decode path; both drivers ship in the 0.17.1


### PR DESCRIPTION
## What
Add `HF_HUB_OFFLINE=1` to the frigate container env.

## Why
Follow-up to #12456. During that verification, the post-restart drops that kept `FrigateUnauthorizedEgressAttempt` firing turned out to have a **second** cause beyond `api.frigate.video`: Semantic Search's `huggingface_hub` does a startup HEAD to `huggingface.co` for the `jinaai/jina-clip-v1` model. That egress isn't in the frigate CNP → denied → 5× retry over ~4 min → falls back to the PVC cache anyway.

The model is **fully cached** (`/config/model_cache/jinaai/jina-clip-v1`: vision + text ONNX, tokenizer), so Search works regardless. `HF_HUB_OFFLINE=1` makes the library use the cache directly and skip the online check.

## Effect
- Eliminates the per-restart HuggingFace egress drops → the alert stops false-firing on frigate restarts.
- No policy hole, no functional change to Semantic Search.
- Flip to `"0"` for a one-off `model_size` change / reindex that needs a fresh model pull.

## Rollout
Restarts the frigate pod (brief recording gap) → Renee-facing, so apply in the **Tue 02:00–04:00 EDT** window or let it ride the daily OOM restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)