### PR TITLE
fix(coredns): drop autopath @kubernetes — it breaks Cilium toFQDNs policies

### DIFF
--- a/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
@@ -35,8 +35,15 @@ spec:
               fallthrough in-addr.arpa ip6.arpa
             name: kubernetes
             parameters: cluster.local in-addr.arpa ip6.arpa
-          - name: autopath
-            parameters: "@kubernetes"
+          # NOTE: autopath @kubernetes intentionally NOT enabled. It collapses
+          # client search-path expansion server-side and returns external
+          # names (e.g. api.frigate.video) as a CNAME under the *queried*
+          # search-suffixed name. Cilium's toFQDNs DNS proxy matches on the
+          # queried name, so the real IPs get bound to
+          # `<host>.<ns>.svc.cluster.local` instead of the bare host —
+          # silently breaking every toFQDNs egress allow. Cilium docs
+          # recommend disabling autopath when using FQDN policies. See
+          # reference_cilium_tofqdns_ndots_searchdomain_bind / PR #12456.
           - name: forward
             parameters: . /etc/resolv.conf
           - configBlock: |-


### PR DESCRIPTION
## ⚠️ Cluster-wide DNS change — review before merge

This edits the **CoreDNS** Corefile (cluster DNS, a SPOF). Read the tradeoff before merging.

## What
Remove the `autopath @kubernetes` plugin from the CoreDNS server block.

## Why
Root cause behind #12456. `autopath` is a latency optimization that collapses the client's DNS search-path expansion **server-side**: when a pod queries `api.frigate.video.home.svc.cluster.local` (first search-domain candidate under `ndots:5`), autopath resolves the bare host upstream and returns it as a CNAME chain, so that *first, search-suffixed* query succeeds with the real IPs.

Cilium's `toFQDNs` DNS proxy keys policy on the **queried name**. So the real IPs get bound to `api.frigate.video.home.svc.cluster.local`, which matches no `toFQDNs` selector (`*.frigate.video` is single-label) → the egress the policy is meant to allow is **silently POLICY_DENIED**. This is latent for **every** toFQDNs egress app (immich / paperless rclone, etc.), not just frigate.

`ndots:2` (#12456) only patched frigate. Removing autopath restores standard client-side search expansion, so the proxy observes the **bare-name** lookup and toFQDNs works cluster-wide. [Cilium's docs](https://docs.cilium.io/en/stable/network/dns/) recommend disabling autopath when using FQDN policies; autopath also adds CoreDNS memory (it watches pods), so removal is a net simplification.

## Tradeoff / blast radius
- Pods resume client-side search expansion → a few extra DNS queries per **external** name lookup (the thing autopath optimized away). Mitigated by the `cache` + `prefetch 20` plugins already in the Corefile. 3 CoreDNS replicas.
- **Apply is low-disruption:** the `reload` plugin watches the Corefile and reloads **in-place** — no CoreDNS pod restart, no DNS outage. Flux updates the ConfigMap, CoreDNS reloads within ~30s.
- Rollback = revert this commit; `reload` reverts in-place too.
- After this lands, the per-app `ndots:2` on frigate becomes redundant (harmless; leaving it in place).

## Recommendation
Despite low disruption, this is cluster DNS — **I'm not suggesting auto-merge.** Merge it yourself, ideally during a **routine window (any night 02:00–05:00 EDT)** so you're watching when CoreDNS reloads. I can verify a toFQDNs binding flips to the bare name afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)