### PR TITLE
fix(mcp-system): arr-mcp → patched v1.6.5-deadlockfix1 (workaround mcp-arr#22)

### DIFF
--- a/.github/renovate/packageRules.json5
+++ b/.github/renovate/packageRules.json5
@@ -2,6 +2,18 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "packageRules": [
     {
+      // workaround: https://github.com/aplaceforallmystuff/mcp-arr/pull/22
+      // arr-mcp is pinned to a v1.6.5-deadlockfix build (PR #22 patch applied at
+      // build time) because stock v1.6.5 deadlocks behind the mcp-gateway. Keep
+      // Renovate off it so it can't downgrade to the broken stock tag (a
+      // `-deadlockfix1` prerelease sorts below v1.6.5). REMOVE this rule when the
+      // upstream PR merges + a fixed mcp-arr is released and pinned.
+      "description": "WORKAROUND: pin arr-mcp during the mcp-arr#22 deadlock patch",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["ghcr.io/rwlove/arr-mcp"],
+      "enabled": false
+    },
+    {
       "description": "Major updates: always open a PR, never auto-merge — manual review",
       "matchUpdateTypes": ["major"],
       "dependencyDashboardApproval": false,

--- a/kubernetes/apps/mcp-system/arr-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/arr-mcp/app/helmrelease.yaml
@@ -26,7 +26,15 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/arr-mcp
-              tag: v1.6.5@sha256:d862cd5503459eaecebc8d928c18a6590699218c54600dc22f7d810bfe6a970a
+              # workaround: https://github.com/aplaceforallmystuff/mcp-arr/pull/22 — remove when merged + a fixed mcp-arr (> v1.6.5) is released and pinned
+              # Stock v1.6.5 deadlocks its http transport behind the mcp-gateway
+              # (serialized queue blocked by the broker's long-lived GET stream),
+              # so arr never federates. This `-deadlockfix1` image is v1.6.5 with
+              # the PR #22 patch applied at build time (see rwlove/containers
+              # arr-mcp/patches). Renovate is pinned off this image in
+              # .github/renovate/packageRules.json5 so it can't downgrade back to
+              # the broken stock tag.
+              tag: v1.6.5-deadlockfix1@sha256:841c0fd73c89ccb37573db9d376aed95e2f8bf90c338309e12d70e3334c7b43e
             env:
               SONARR_URL: http://sonarr.media.svc.cluster.local:8989
               RADARR_URL: http://radarr.media.svc.cluster.local:7878


### PR DESCRIPTION
## Summary

Stock `mcp-arr` v1.6.5 deadlocks its http transport behind the mcp-gateway — it serializes every request through one shared MCP `Server`, and the broker's long-lived GET (SSE) stream blocks that queue permanently. arr never federates (`Ready=False`, 0 tools).

Pin to **`v1.6.5-deadlockfix1`** — v1.6.5 with the upstream fix applied at build time (fresh `Server` per request, [rwlove/containers#96](https://github.com/rwlove/containers/pull/96), patch tracked at upstream [mcp-arr#22](https://github.com/aplaceforallmystuff/mcp-arr/pull/22)).

Renovate is disabled for this image (`packageRules.json5`) so it can't downgrade off the `-deadlockfix1` tag (which sorts below stock v1.6.5) back to the broken build.

## Verification

Built the image, held a GET SSE stream open, POST returns 200 in ~6ms (stock v1.6.5 timed out with no response).

## Removal

When mcp-arr#22 merges and a fixed release is cut: drop the build-time patch in containers, remove this image pin's `-deadlockfix1`, and remove the Renovate pin rule. Tracked by a `workaround`-labeled issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)