### PR TITLE
feat(ai): deploy langgraph-agents 0.2.70 (evidence salvage + reporter golden set)

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/cronjob-evals.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/cronjob-evals.yaml
@@ -33,7 +33,7 @@
 # initContainer pulls the harness tarball at the SAME tag the image is
 # built from, and the main container runs it on the image's pre-built
 # venv — so `agents` (venv, installed) and `evals` (fetched, cwd) are
-# the same commit (v0.2.69). No `uv sync` at runtime, no version skew.
+# the same commit (v0.2.70). No `uv sync` at runtime, no version skew.
 #
 # Pin the image digest + the fetch tag together on every fleet bump:
 # both must track the deployed langgraph-agents version (helmrelease.yaml).
@@ -78,13 +78,13 @@ spec:
             # emptyDir. Uses the image's own venv httpx (certifi CA bundle)
             # so TLS to github works without a ca-certificates package.
             - name: fetch-evals
-              image: ghcr.io/rwlove/langgraph-agents:0.2.69@sha256:0042df6d254c655f6134655735f934afd9c0beac382e0b2a8e5640d51c336d89
+              image: ghcr.io/rwlove/langgraph-agents:0.2.70@sha256:1dc3a99f05feb6d7afa0d9a7a5b2b285f43c0eb9224bc396ee35b6b0a452e4b5
               command:
                 - python
                 - -c
                 - |
                   import io, tarfile, httpx
-                  url = "https://github.com/rwlove/langgraph-agents/archive/refs/tags/v0.2.69.tar.gz"
+                  url = "https://github.com/rwlove/langgraph-agents/archive/refs/tags/v0.2.70.tar.gz"
                   data = httpx.get(url, follow_redirects=True, timeout=60).raise_for_status().content
                   tarfile.open(fileobj=io.BytesIO(data)).extractall("/workspace")
                   print(f"fetched evals harness ({len(data)} bytes) to /workspace")
@@ -98,8 +98,8 @@ spec:
                   drop: ["ALL"]
           containers:
             - name: evals
-              image: ghcr.io/rwlove/langgraph-agents:0.2.69@sha256:0042df6d254c655f6134655735f934afd9c0beac382e0b2a8e5640d51c336d89
-              workingDir: /workspace/langgraph-agents-0.2.69
+              image: ghcr.io/rwlove/langgraph-agents:0.2.70@sha256:1dc3a99f05feb6d7afa0d9a7a5b2b285f43c0eb9224bc396ee35b6b0a452e4b5
+              workingDir: /workspace/langgraph-agents-0.2.70
               command:
                 - /bin/sh
                 - -c

--- a/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/langgraph-agents
-              tag: 0.2.69@sha256:0042df6d254c655f6134655735f934afd9c0beac382e0b2a8e5640d51c336d89
+              tag: 0.2.70@sha256:1dc3a99f05feb6d7afa0d9a7a5b2b285f43c0eb9224bc396ee35b6b0a452e4b5
 
             env:
               # --- vault ---


### PR DESCRIPTION
## What

Bumps the langgraph-agents fleet pin **0.2.69 → 0.2.70** (digest `1dc3a99…`, resolved from the v0.2.70 tag-build).

0.2.70 ships:
- **Evidence-recursion salvage** (langgraph-agents #131, closes #130) — the operator evidence ReAct loop no longer discards gathered observations on a recursion-limit hit, and the limit now fits the 8-tool-call budget. This is the fix for the empty-evidence → local-fabrication confound the first eval sweep surfaced.
- **Traffic-shaped reporter golden set** (langgraph-agents #132) — 7 tasks matching reporter's real production flows (alert-remediation / PR-triage / daily-digest).

## Also in this PR

The `langgraph-evals` CronJob image digest + fetch tag bump to **v0.2.70 in lockstep** with the deployment pin. That keeps the eval running the exact code that's deployed — and means the next sweep picks up both fixes (which is what the re-sweep is meant to measure).

## Impact

Flux does a ~30–60s pod Recreate on the langgraph-agents Deployment (single-replica, Postgres-backed state; no GPU bounce). Routine internal change.

## Test

- `kubectl kustomize …/langgraph-agents/app/` renders clean.
- `pre-commit` on changed files: all hooks pass.
- No stale `0.2.69` refs remain in the app dir.

## After merge

Re-run the sweep to measure the de-confounded verdicts:
```sh
kubectl -n ai create job --from=cronjob/langgraph-evals eval-$(date +%Y%m%d-%H%M)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)