### PR TITLE
feat(arc): dind runner set for off-quota containers image builds

### DIFF
--- a/.github/image-registry-allowlist.txt
+++ b/.github/image-registry-allowlist.txt
@@ -60,3 +60,4 @@ docker.io/rcooler/omada_exporter        # no ghcr.io publication; Docker Hub is 
 docker.io/squat/generic-device-plugin   # no ghcr.io publication; Docker Hub is primary (verified 2026-05)
 docker.io/tombursch/kitchenowl          # no ghcr.io publication; Docker Hub is primary (verified 2026-05)
 docker.io/giof71/squeezelite            # no ghcr.io publication; Docker Hub is primary (verified 2026-05)
+docker.io/library/docker                # ARC gha-runner-scale-set dind sidecar; chart hardcodes `docker:dind` (no values override)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ _Production-grade Kubernetes for a household._
 <br/>
 
 ![apps](https://img.shields.io/badge/apps-187-blue?style=for-the-badge)
-![helmreleases](https://img.shields.io/badge/HelmReleases-199-326CE5?style=for-the-badge&logo=helm&logoColor=white)
+![helmreleases](https://img.shields.io/badge/HelmReleases-200-326CE5?style=for-the-badge&logo=helm&logoColor=white)
 ![nodes](https://img.shields.io/badge/k8s_nodes-11-326CE5?style=for-the-badge&logo=kubernetes&logoColor=white)
 ![cnpg](https://img.shields.io/badge/Postgres_clusters-25-336791?style=for-the-badge&logo=postgresql&logoColor=white)
 ![secrets](https://img.shields.io/badge/secrets-115-0572EC?style=for-the-badge&logo=1password&logoColor=white)

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/cnp-containers.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/cnp-containers.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: arc-runner-set-containers-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: arc-runner-set-containers
+  # Additive — punches holes through the namespace default-deny. Mirrors
+  # arc-runner-set-home-ops-allow. The dind sidecar shares the runner
+  # pod's network namespace, so this single pod-level egress covers both
+  # the runner and the in-pod Docker daemon.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  egress:
+    # Wildcard 80/443 for the builder pods: image builds `docker pull`
+    # arbitrary base images, `git clone`, fetch build deps from any URL,
+    # and `docker push` to ghcr.io. Locking egress to an allow-list would
+    # break the moment a Dockerfile adds a new base image or apt/pip
+    # source, so — exactly as for arc-runner-set-home-ops — the trust
+    # boundary is the controller's GitHub-App scoping, not the network.
+    - toFQDNs:
+        - matchPattern: "*"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+            - port: "80"
+              protocol: TCP

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/containers.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/containers.yaml
@@ -1,0 +1,69 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: arc-containers
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: gha-runner-scale-set
+  driftDetection:
+    mode: enabled
+  values:
+    runnerScaleSetName: arc-runner-set-containers
+
+    # Dedicated builder runner set for the PRIVATE rwlove/containers repo.
+    # containers' image builds were the sole consumer of the rwlove
+    # account's 2,000-min Actions quota (home-ops is public → free). This
+    # set moves those builds off-quota onto local hardware.
+    githubConfigUrl: https://github.com/rwlove/containers
+
+    # Scale to zero when idle — unlike the home-ops set (which keeps a
+    # warm runner for fast PR feedback), image releases are infrequent and
+    # bursty, so paying for an idle privileged dind pod isn't worth it.
+    minRunners: 0
+    maxRunners: 4
+
+    # dind (docker-in-docker), NOT kubernetes mode: the containers
+    # workflows run `docker buildx` / build-push-action, which need a
+    # real Docker daemon. The chart injects a privileged dind sidecar
+    # that provides it. (The home-ops set uses kubernetes mode because
+    # its flux-local jobs only need `container:` job pods, not a daemon.)
+    # Privilege is inherent to dind image builds; the pod is scoped to
+    # building this repo's own Dockerfiles, isolated by namespace +
+    # CNP, and scheduled only on amd64 workers (never the Spark
+    # inference node).
+    containerMode:
+      type: dind
+
+    controllerServiceAccount:
+      name: actions-runner-controller
+      namespace: actions-runner-system
+
+    template:
+      spec:
+        # Native amd64 builds; av1corrector's arm64 image builds via QEMU
+        # in the dind daemon (still off-quota). Pinned to amd64 so a
+        # privileged builder never lands on the Spark (arm64) GPU node.
+        nodeSelector:
+          kubernetes.io/arch: amd64
+        containers:
+          - name: runner
+            image: ghcr.io/home-operations/actions-runner:2.335.1@sha256:3d544e5eed58722c0b6a97212a31eada0f9f2e99f189c41911a5573a23d7386a
+            command: ["/home/runner/run.sh"]
+
+  valuesFrom:
+    - kind: Secret
+      name: actions-runner-controller-auth
+      valuesKey: github_app_id
+      targetPath: githubConfigSecret.github_app_id
+    - kind: Secret
+      name: actions-runner-controller-auth
+      valuesKey: github_app_installation_id
+      targetPath: githubConfigSecret.github_app_installation_id
+    - kind: Secret
+      name: actions-runner-controller-auth
+      valuesKey: github_app_private_key
+      targetPath: githubConfigSecret.github_app_private_key

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/kustomization.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/kustomization.yaml
@@ -4,6 +4,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./cnp-allow.yaml
+  - ./cnp-containers.yaml
   - ./cnp-job-container.yaml
+  - ./containers.yaml
   - ./home-ops.yaml
   - ./ocirepository.yaml


### PR DESCRIPTION
## Why

The `rwlove` account is at **1,800 / 2,000** GitHub Actions minutes. `home-ops` is **public** (GitHub-hosted minutes are free), so 100% of that comes from the **private `rwlove/containers`** repo's image builds. This adds a self-hosted ARC runner set to move those builds **off-quota** onto local hardware.

## What

- **`arc-runner-set-containers`** — a dedicated runner set scoped to `rwlove/containers`, in **`containerMode: dind`** so `docker buildx` / `build-push-action` have a real Docker daemon (the existing `arc-runner-set-home-ops` uses kubernetes mode, which has no daemon, so it can't build images). `minRunners: 0` (scale to zero — releases are infrequent), `maxRunners: 4`, **pinned to amd64** so the privileged dind builder never schedules on the Spark arm64 **inference node**.
- **`arc-runner-set-containers-allow`** CNP — mirrors the home-ops runner's wildcard 80/443 egress through the namespace default-deny (image builds pull arbitrary base images + push to ghcr.io; the dind sidecar shares the pod network).

Native amd64 builds; `av1corrector`'s arm64 image builds via **QEMU in the dind daemon** — slower for that one image, but still off-quota and keeps Spark/inference untouched (per the design decision to avoid arm64-on-Spark).

## ⚠️ Prerequisite (needs your action — not GitOps)

The `actions-runner-controller` **GitHub App must have access to `rwlove/containers`** (GitHub → Settings → Applications → the App → repository access). The runner set will register but stay idle until the App can see the repo.

## Verification after merge

- `kubectl get autoscalingrunnerset -n actions-runner-system` shows `arc-runner-set-containers`.
- The dind runner pod starts (privileged sidecar) on an amd64 worker, not Spark.
- The companion `rwlove/containers` PR's first build lands on this runner and pushes to GHCR.

Companion PR: rwlove/containers (workflows → `runs-on: arc-runner-set-containers` + lint-gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)