### PR TITLE
fix(pump-cv): source gym camera RTSP creds from the pump 1Password item

### DIFF
--- a/kubernetes/apps/collab/pump-cv/app/externalsecret.yaml
+++ b/kubernetes/apps/collab/pump-cv/app/externalsecret.yaml
@@ -14,14 +14,14 @@ spec:
       engineVersion: v2
       data:
         PUMP_API_KEY: "{{ .API_KEY }}"
-        # Reolink RTSP creds shared with frigate (same camera fleet, same
-        # account). The init container envsubsts these into the configmap
-        # before pump-cv starts; pump-cv config.py does not natively
-        # interpolate env vars in YAML.
+        # RTSP creds for the gym-front / gym-back Reolinks. These two units
+        # were provisioned with their own credentials (distinct from the
+        # frigate camera fleet), so they live on the `pump` 1Password item
+        # rather than being borrowed from `frigate`. The init container
+        # envsubsts these into the configmap before pump-cv starts; pump-cv
+        # config.py does not natively interpolate env vars in YAML.
         REOLINK_USER: "{{ .reolink_user }}"
         REOLINK_PASSWORD: "{{ .reolink_password }}"
   dataFrom:
     - extract:
         key: pump
-    - extract:
-        key: frigate


### PR DESCRIPTION
## What
pump-cv could not open either RTSP stream — its log loops `cannot open source rtsp://user:***@gym-front:554/...` (and `gym-back`) every 30s, so `latest_frame()` stays `None` and the wall page's camera previews render as broken images.

Root cause: the `gym-front` / `gym-back` Reolinks were authenticating with the **frigate camera-fleet** password (borrowed via the `frigate` extract), but those two units were provisioned with their **own** credentials.

## Change
- pump-cv's ExternalSecret now sources `reolink_user` / `reolink_password` from the **`pump`** 1Password item (where the gym cameras' own creds now live), and drops the `frigate` extract so there's a single, unambiguous source.
- Template references (`{{ .reolink_user }}` / `{{ .reolink_password }}`) unchanged.

No secret values appear in this diff. Reloader (`reloader.stakater.com/auto`) restarts pump-cv when `pump-cv-secret` updates, re-rendering `/config/default.yaml` with the correct creds.

## Verification after deploy
pump-cv log should stop emitting `cannot open source` and the wall previews should show live frames (replacing the new "waiting for camera…" placeholder).

🤖 Generated with [Claude Code](https://claude.com/claude-code)