### PR TITLE
fix(pump-cv): use FQDNs for gym cameras so the pod can resolve them

### DIFF
--- a/kubernetes/apps/collab/pump-cv/app/resources/default.yaml
+++ b/kubernetes/apps/collab/pump-cv/app/resources/default.yaml
@@ -7,11 +7,15 @@ cameras:
   # and any path is missing — the wall page wizard captures pairs and
   # writes the .npz files. Files persist on the cache PVC so a pod
   # restart skips the wizard.
+  # Use FQDNs, not bare hostnames: CoreDNS (forward . /etc/resolv.conf,
+  # autopath @kubernetes) only auto-expands cluster.local, so a bare
+  # `gym-front` is queried upstream verbatim and NXDOMAINs. The FQDN
+  # forwards to the LAN resolver and resolves to the camera's VLAN IP.
   - name: gym-front
-    rtsp_url: rtsp://${REOLINK_USER}:${REOLINK_PASSWORD}@gym-front:554/h264Preview_01_sub
+    rtsp_url: rtsp://${REOLINK_USER}:${REOLINK_PASSWORD}@gym-front.thesteamedcrab.com:554/h264Preview_01_sub
     calibration_path: /cache/calibration/gym-front.npz
   - name: gym-back
-    rtsp_url: rtsp://${REOLINK_USER}:${REOLINK_PASSWORD}@gym-back:554/h264Preview_01_sub
+    rtsp_url: rtsp://${REOLINK_USER}:${REOLINK_PASSWORD}@gym-back.thesteamedcrab.com:554/h264Preview_01_sub
     calibration_path: /cache/calibration/gym-back.npz
 
 pose:


### PR DESCRIPTION
## Problem
pump-cv loops `cannot open source rtsp://user:***@gym-front:554/...` (and `gym-back`) every retry, so no frames decode and the wall page shows broken camera previews.

## Root cause: DNS, not credentials
The failure is ~2ms (no network wait). CoreDNS here is `forward . /etc/resolv.conf` with `autopath @kubernetes`, which only auto-expands `cluster.local`. A **bare** `gym-front` from inside a pod is tried as `*.svc.cluster.local` (NXDOMAIN) then forwarded upstream verbatim as `gym-front.` → NXDOMAIN. The bare name only resolves on LAN hosts because their resolver has `search thesteamedcrab.com`, which pods don't inherit.

## Fix
Use FQDNs in the camera config: `gym-front.thesteamedcrab.com` / `gym-back.thesteamedcrab.com`. These forward to the LAN resolver and resolve to the cameras' VLAN IPs (10.10.40.26 / .27).

## Verification (out-of-band, from a LAN host)
- DNS: `gym-front.thesteamedcrab.com` → 10.10.40.26, `gym-back.thesteamedcrab.com` → 10.10.40.27
- TCP `:554` open on both
- `ffprobe -rtsp_transport tcp` pulls **h264 640x360 + aac** from both with the configured credentials

After deploy, Reloader restarts pump-cv; logs should stop emitting `cannot open source` and the wall previews should show live frames.

> Companion to #12488 (which set the correct gym-camera credentials on the `pump` 1Password item). That was necessary but insufficient — the bare hostname was the actual blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)