### PR TITLE
fix(pump-cv): address gym cameras by reserved IP, not DNS name

### DIFF
--- a/kubernetes/apps/collab/pump-cv/app/resources/default.yaml
+++ b/kubernetes/apps/collab/pump-cv/app/resources/default.yaml
@@ -7,15 +7,19 @@ cameras:
   # and any path is missing — the wall page wizard captures pairs and
   # writes the .npz files. Files persist on the cache PVC so a pod
   # restart skips the wizard.
-  # Use FQDNs, not bare hostnames: CoreDNS (forward . /etc/resolv.conf,
-  # autopath @kubernetes) only auto-expands cluster.local, so a bare
-  # `gym-front` is queried upstream verbatim and NXDOMAINs. The FQDN
-  # forwards to the LAN resolver and resolves to the camera's VLAN IP.
+  # Address the cameras by their reserved VLAN IPs rather than DNS names.
+  # Neither the bare hostname nor the FQDN resolves from inside this pod —
+  # the cluster's resolver doesn't return the gym-front/gym-back records,
+  # so RTSP open failed instantly with "cannot open source". The IPs are
+  # DHCP-reserved (gym-front 10.10.40.26, gym-back 10.10.40.27) and the
+  # CiliumNetworkPolicy already allows egress to 10.10.40.0/24:554, so this
+  # removes the DNS dependency entirely. Verified reachable + streaming via
+  # ffprobe from a LAN host.
   - name: gym-front
-    rtsp_url: rtsp://${REOLINK_USER}:${REOLINK_PASSWORD}@gym-front.thesteamedcrab.com:554/h264Preview_01_sub
+    rtsp_url: rtsp://${REOLINK_USER}:${REOLINK_PASSWORD}@10.10.40.26:554/h264Preview_01_sub
     calibration_path: /cache/calibration/gym-front.npz
   - name: gym-back
-    rtsp_url: rtsp://${REOLINK_USER}:${REOLINK_PASSWORD}@gym-back.thesteamedcrab.com:554/h264Preview_01_sub
+    rtsp_url: rtsp://${REOLINK_USER}:${REOLINK_PASSWORD}@10.10.40.27:554/h264Preview_01_sub
     calibration_path: /cache/calibration/gym-back.npz
 
 pose:


### PR DESCRIPTION
## Problem
After fixing creds (#12488) and switching to FQDNs (#12489), pump-cv **still** fails instantly: `cannot open source rtsp://user:***@gym-front.thesteamedcrab.com:554/...`. The ~2ms failure means name resolution, not auth or a connect timeout.

## Evidence
- **Cameras + creds + path are good:** `ffprobe -rtsp_transport tcp` from a LAN host pulls h264 640x360 + aac from both cameras with the configured credentials.
- **Routing to the VLAN works:** Frigate is actively pulling its Reolinks on the same `10.10.40.0/24` right now (live frames).
- **So the gap is DNS:** the cluster's resolver doesn't return the `gym-front`/`gym-back` records to the pod (bare and FQDN both fail instantly), even though they resolve fine from LAN hosts.

## Fix
Address the cameras by their DHCP-reserved IPs (`10.10.40.26` / `10.10.40.27`). The `CiliumNetworkPolicy` already allows egress to `10.10.40.0/24:554`, so this removes the DNS dependency entirely.

After deploy, Reloader restarts pump-cv; the `cannot open source` loop should stop and frames should flow (calibration wizard previews go live).

> Follow-up worth tracking separately: *why* internal `thesteamedcrab.com` records resolve from LAN hosts but not from this pod's resolver path, while Frigate's bare Reolink names do resolve. Not needed for pump-cv now that it uses IPs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)