### PR TITLE
feat(pump-cv): bump image to v0.5.1 (FFmpeg-enabled OpenCV)

### DIFF
--- a/kubernetes/apps/collab/pump-cv/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump-cv/app/helmrelease.yaml
@@ -83,7 +83,7 @@ spec:
           pump-cv:
             image:
               repository: ghcr.io/rwlove/pump-cv
-              tag: v0.5.0@sha256:fed0360395bd65f86a7bde12183303a96fe2bbb6de0d388ce5d2ee21a6c03d38
+              tag: v0.5.1@sha256:5d71555e4f62dd131a337ee911aff1c97e301ec3ebc0ca510c60a90c2c511f22
 
             # Image's default ENTRYPOINT calls bare `python`, which doesn't
             # exist in PATH (only python3 is installed). Use the console-script


### PR DESCRIPTION
Bumps pump-cv to **v0.5.1**, the runtime image built on the rebuilt base (PUMP #42) where the FFmpeg-enabled `opencv-python` wheel replaces the nvcr base's headless OpenCV.

This is the change that actually fixes the broken camera feeds: `cv2.VideoCapture` now has an FFmpeg backend (verified at image build time by an assert), so the gym-front/gym-back RTSP streams can be opened. Reloader restarts pump-cv on the digest change.

Digest: `sha256:5d71555e4f62dd131a337ee911aff1c97e301ec3ebc0ca510c60a90c2c511f22` (multi-arch index, amd64+arm64).

🤖 Generated with [Claude Code](https://claude.com/claude-code)