### PR TITLE
feat(ai): bump langgraph-agents 0.2.71 (per-dimension eval breakout)

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/cronjob-evals.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/cronjob-evals.yaml
@@ -33,7 +33,7 @@
 # initContainer pulls the harness tarball at the SAME tag the image is
 # built from, and the main container runs it on the image's pre-built
 # venv — so `agents` (venv, installed) and `evals` (fetched, cwd) are
-# the same commit (v0.2.70). No `uv sync` at runtime, no version skew.
+# the same commit (v0.2.71). No `uv sync` at runtime, no version skew.
 #
 # Pin the image digest + the fetch tag together on every fleet bump:
 # both must track the deployed langgraph-agents version (helmrelease.yaml).
@@ -78,13 +78,13 @@ spec:
             # emptyDir. Uses the image's own venv httpx (certifi CA bundle)
             # so TLS to github works without a ca-certificates package.
             - name: fetch-evals
-              image: ghcr.io/rwlove/langgraph-agents:0.2.70@sha256:1dc3a99f05feb6d7afa0d9a7a5b2b285f43c0eb9224bc396ee35b6b0a452e4b5
+              image: ghcr.io/rwlove/langgraph-agents:0.2.71@sha256:ef1d30450e9ca93bc48ad81faa9da970e111be49280ab9bf2853027f54a02cfe
               command:
                 - python
                 - -c
                 - |
                   import io, tarfile, httpx
-                  url = "https://github.com/rwlove/langgraph-agents/archive/refs/tags/v0.2.70.tar.gz"
+                  url = "https://github.com/rwlove/langgraph-agents/archive/refs/tags/v0.2.71.tar.gz"
                   data = httpx.get(url, follow_redirects=True, timeout=60).raise_for_status().content
                   tarfile.open(fileobj=io.BytesIO(data)).extractall("/workspace")
                   print(f"fetched evals harness ({len(data)} bytes) to /workspace")
@@ -98,8 +98,8 @@ spec:
                   drop: ["ALL"]
           containers:
             - name: evals
-              image: ghcr.io/rwlove/langgraph-agents:0.2.70@sha256:1dc3a99f05feb6d7afa0d9a7a5b2b285f43c0eb9224bc396ee35b6b0a452e4b5
-              workingDir: /workspace/langgraph-agents-0.2.70
+              image: ghcr.io/rwlove/langgraph-agents:0.2.71@sha256:ef1d30450e9ca93bc48ad81faa9da970e111be49280ab9bf2853027f54a02cfe
+              workingDir: /workspace/langgraph-agents-0.2.71
               command:
                 - /bin/sh
                 - -c

--- a/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/langgraph-agents
-              tag: 0.2.70@sha256:1dc3a99f05feb6d7afa0d9a7a5b2b285f43c0eb9224bc396ee35b6b0a452e4b5
+              tag: 0.2.71@sha256:ef1d30450e9ca93bc48ad81faa9da970e111be49280ab9bf2853027f54a02cfe
 
             env:
               # --- vault ---


### PR DESCRIPTION
## What

Bumps the langgraph-agents pin **0.2.70 → 0.2.71** (digest `ef1d3045…`).

0.2.71 carries **only** langgraph-agents #133 — the `evals/` harness now prints a per-dimension `local→claude` breakout (correctness / completeness / safety_gate / actionability) under each agent, plus a legend flagging `correctness`+`safety_gate` as the dealbreaker dims. It makes "is this Δ acceptable?" readable at a glance. The per-dimension means also land in the `--out` JSON.

## Why bump the fleet for an evals-only change

No `src/agents` change between 0.2.70 and 0.2.71, so the Deployment pod Recreate is a **functional no-op**. It's bumped purely to hold the version invariant the CronJob documents — **deployment pin == eval image == fetch tag, all the same commit** — rather than leaving a split-version state that would bite on the next real bump. The `langgraph-evals` CronJob image + fetch tag move to v0.2.71 in lockstep so the next sweep prints the new breakout.

## Impact

~30–60s single-replica Recreate on langgraph-agents (no GPU bounce). Routine.

## Test

- `kubectl kustomize` renders clean; no stale `0.2.70` refs remain.
- `pre-commit` on changed files passes.

## After merge

Next sweep shows the breakout:
```sh
kubectl -n ai create job --from=cronjob/langgraph-evals eval-$(date +%Y%m%d-%H%M)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)