### PR TITLE
fix(mcp): use spec.prefix not toolPrefix across MCP registrations

### DIFF
--- a/kubernetes/apps/mcp-system/chrome-mcp/mcp/mcpserverregistration.yaml
+++ b/kubernetes/apps/mcp-system/chrome-mcp/mcp/mcpserverregistration.yaml
@@ -11,4 +11,4 @@ spec:
     group: gateway.networking.k8s.io
     kind: HTTPRoute
     name: chrome-mcp
-  toolPrefix: chrome_
+  prefix: chrome_

--- a/kubernetes/apps/mcp-system/cilium-mcp/mcp/mcpserverregistration.yaml
+++ b/kubernetes/apps/mcp-system/cilium-mcp/mcp/mcpserverregistration.yaml
@@ -11,4 +11,4 @@ spec:
     group: gateway.networking.k8s.io
     kind: HTTPRoute
     name: cilium-mcp
-  toolPrefix: cilium_
+  prefix: cilium_

--- a/kubernetes/apps/mcp-system/grafana-mcp/mcp/mcpserverregistration.yaml
+++ b/kubernetes/apps/mcp-system/grafana-mcp/mcp/mcpserverregistration.yaml
@@ -11,4 +11,4 @@ spec:
     group: gateway.networking.k8s.io
     kind: HTTPRoute
     name: grafana-mcp
-  toolPrefix: grafana_
+  prefix: grafana_

--- a/kubernetes/apps/mcp-system/ha-mcp/mcp/mcpserverregistration.yaml
+++ b/kubernetes/apps/mcp-system/ha-mcp/mcp/mcpserverregistration.yaml
@@ -11,4 +11,3 @@ spec:
     group: gateway.networking.k8s.io
     kind: HTTPRoute
     name: ha-mcp
-  toolPrefix: ha_

--- a/kubernetes/apps/mcp-system/immich-mcp/mcp/mcpserverregistration.yaml
+++ b/kubernetes/apps/mcp-system/immich-mcp/mcp/mcpserverregistration.yaml
@@ -11,4 +11,3 @@ spec:
     group: gateway.networking.k8s.io
     kind: HTTPRoute
     name: immich-mcp
-  toolPrefix: immich_

--- a/kubernetes/apps/mcp-system/netbox-mcp/mcp/mcpserverregistration.yaml
+++ b/kubernetes/apps/mcp-system/netbox-mcp/mcp/mcpserverregistration.yaml
@@ -11,4 +11,4 @@ spec:
     group: gateway.networking.k8s.io
     kind: HTTPRoute
     name: netbox-mcp
-  toolPrefix: netbox_
+  prefix: netbox_

--- a/kubernetes/apps/mcp-system/omada-mcp/mcp/mcpserverregistration.yaml
+++ b/kubernetes/apps/mcp-system/omada-mcp/mcp/mcpserverregistration.yaml
@@ -11,4 +11,4 @@ spec:
     group: gateway.networking.k8s.io
     kind: HTTPRoute
     name: omada-mcp
-  toolPrefix: omada_
+  prefix: omada_

--- a/kubernetes/apps/mcp-system/paperless-mcp/mcp/mcpserverregistration.yaml
+++ b/kubernetes/apps/mcp-system/paperless-mcp/mcp/mcpserverregistration.yaml
@@ -11,4 +11,4 @@ spec:
     group: gateway.networking.k8s.io
     kind: HTTPRoute
     name: paperless-mcp
-  toolPrefix: paperless_
+  prefix: paperless_

--- a/kubernetes/apps/mcp-system/prometheus-mcp/app/mcpserverregistration.yaml
+++ b/kubernetes/apps/mcp-system/prometheus-mcp/app/mcpserverregistration.yaml
@@ -9,4 +9,4 @@ spec:
     group: gateway.networking.k8s.io
     kind: HTTPRoute
     name: prometheus-mcp
-  toolPrefix: prom_
+  prefix: prom_

--- a/kubernetes/apps/mcp-system/searxng-mcp/mcp/mcpserverregistration.yaml
+++ b/kubernetes/apps/mcp-system/searxng-mcp/mcp/mcpserverregistration.yaml
@@ -11,4 +11,4 @@ spec:
     group: gateway.networking.k8s.io
     kind: HTTPRoute
     name: searxng-mcp
-  toolPrefix: search_
+  prefix: search_

--- a/kubernetes/apps/mcp-system/time-mcp/mcp/mcpserverregistration.yaml
+++ b/kubernetes/apps/mcp-system/time-mcp/mcp/mcpserverregistration.yaml
@@ -11,4 +11,4 @@ spec:
     group: gateway.networking.k8s.io
     kind: HTTPRoute
     name: time-mcp
-  toolPrefix: time_
+  prefix: time_

--- a/kubernetes/apps/mcp-system/windmill-mcp/mcp/mcpserverregistration.yaml
+++ b/kubernetes/apps/mcp-system/windmill-mcp/mcp/mcpserverregistration.yaml
@@ -11,4 +11,4 @@ spec:
     group: gateway.networking.k8s.io
     kind: HTTPRoute
     name: windmill-mcp
-  toolPrefix: windmill_
+  prefix: windmill_


### PR DESCRIPTION
## What

Replaces the rejected `toolPrefix` field with `spec.prefix` (or removes it) across MCP server registrations.

## Why

The `mcp.kuadrant.io/MCPServerRegistration` CRD declares `spec.prefix`, **not** `toolPrefix`. That field used to be silently pruned; the current CRD **rejects** it:

```
MCPServerRegistration prometheus-tools dry-run failed:
.spec.toolPrefix: field not declared in schema
```

So every registration still on `toolPrefix` failed its Flux dry-run apply and went not-ready, dropping those servers from the federated tool surface (the whole `mcp-system` not-ready cluster).

## Changes

- **10 generic-tool servers** → `toolPrefix` → `prefix`: prometheus, grafana, netbox, omada, searxng, paperless, time, chrome, cilium, windmill.
- **ha-mcp / immich-mcp** → field **removed**. Their tools are natively `ha_*` / `immich_*`; a `prefix:` would double-prefix (`ha_ha_*`) and break operator allowlists (see `reference_mcp_gateway_prefix_field_bug`).

comfyui / kubectl / arr / github / memory already use `spec.prefix` — untouched.

## Validation

`kubectl get crd mcpserverregistrations.mcp.kuadrant.io` confirms `prefix` is a declared spec field and `toolPrefix` is not.