### PR TITLE
feat(observability): exclude spark (GB10 unified memory) from host-memory alerts

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/addons/alerts/node-exporter.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/addons/alerts/node-exporter.yaml
@@ -16,7 +16,14 @@ spec:
           # whose steady state is <10% MemAvailable because the Frigate write
           # path keeps page cache pegged. Expected, not an incident — the real
           # fix is the NAS rebuild (project_todo_security_storage_new_build).
-          expr: node_memory_MemAvailable_bytes{instance!~"security-storage.*"} / node_memory_MemTotal_bytes{instance!~"security-storage.*"} * 100 < 10
+          #
+          # spark excluded: GB10/Grace-Blackwell uses unified memory, so models
+          # warm-pinned in ollama-spark/comfyui (e.g. qwen2.5-coder:32b) live in
+          # system RAM (what would be VRAM on a discrete GPU) and read as <10%
+          # MemAvailable by design. kubectl top undercounts because the weights
+          # are GPU-mapped outside cgroups. Real inference failure is caught by
+          # SparkOllamaWedged + the ollama-spark-embed probe, not this rule.
+          expr: node_memory_MemAvailable_bytes{instance!~"security-storage.*|spark.*"} / node_memory_MemTotal_bytes{instance!~"security-storage.*|spark.*"} * 100 < 10
           for: 2m
           labels:
             severity: warning

--- a/kubernetes/apps/observability/silence-operator/silences/kustomization.yaml
+++ b/kubernetes/apps/observability/silence-operator/silences/kustomization.yaml
@@ -9,4 +9,5 @@ resources:
   - ./prometheus.yaml
   - ./security-storage-diskspace.yaml
   - ./security-storage-memory.yaml
+  - ./spark-memory.yaml
   - ./zot-data-pvc.yaml

--- a/kubernetes/apps/observability/silence-operator/silences/spark-memory.yaml
+++ b/kubernetes/apps/observability/silence-operator/silences/spark-memory.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/observability.giantswarm.io/silence_v1alpha2.json
+#
+# spark is the GB10 / Grace-Blackwell inference node. Its memory is unified:
+# models warm-pinned in ollama-spark / comfyui (e.g. qwen2.5-coder:32b, ~38 GB,
+# kept resident to avoid cold loads) occupy what would be VRAM on a discrete
+# GPU but is system RAM here. node_exporter correctly reports MemAvailable
+# <10%, while kubectl top sees only a few GiB because the weights are GPU-mapped
+# outside any cgroup. High memory is the designed steady state, not an incident.
+#
+# NodeMemoryHighUtilization is a kube-prometheus-stack chart built-in (can't take
+# a per-instance exclusion inline like our own rules can), so it's silenced here
+# scoped to this one instance only — every other host still alerts normally.
+#
+# Companion change: spark is also excluded from our own HostOutOfMemory rule
+# (kube-prometheus-stack/addons/alerts/node-exporter.yaml). A genuine inference
+# failure is still caught by SparkOllamaWedged + the ollama-spark-embed probe.
+apiVersion: observability.giantswarm.io/v1alpha2
+kind: Silence
+metadata:
+  name: nodememoryhighutilization-spark
+spec:
+  matchers:
+    - name: alertname
+      value: NodeMemoryHighUtilization
+    - matchType: "=~"
+      name: instance
+      value: spark.*


### PR DESCRIPTION
## What

Excludes the `spark` node from `HostOutOfMemory` and `NodeMemoryHighUtilization`.

## Why

`spark` is the GB10 / Grace-Blackwell inference node, which uses **unified memory**. Models warm-pinned in `ollama-spark` / `comfyui` (`qwen2.5-coder:32b` ~38 GB kept resident to avoid cold loads, plus `bge-m3`) occupy what would be VRAM on a discrete GPU but is system RAM here. So:

- `node_exporter` reports `MemAvailable` ~9.7% (`MemTotal` 121.6 GiB, `MemAvailable` 11.8 GiB) — correct for Linux, triggers both alerts.
- `kubectl top node spark` shows only ~8% used — the model weights are GPU-mapped outside any cgroup, so cAdvisor doesn't count them.

High memory is the **designed steady state** for this node, not an incident — same situation class as security-storage's RAM-by-design (already excluded/silenced).

## Changes

- **HostOutOfMemory** (our rule, `kube-prometheus-stack/addons/alerts/node-exporter.yaml`): add `spark` to the existing `instance!~` exclusion alongside security-storage.
- **NodeMemoryHighUtilization** (kps chart built-in): scoped `Silence` CR (`spark-memory.yaml`), mirroring `security-storage-memory.yaml`.

## Backstop preserved

A genuine inference failure is still caught by the `SparkOllamaWedged` rule + the `ollama-spark-embed` synthetic probe. This mutes redundant node-memory noise, not the catch.