### PR TITLE
fix(flux): unblock three stuck reconciliations

### DIFF
--- a/kubernetes/apps/databases/pgadmin/app/helmrelease.yaml
+++ b/kubernetes/apps/databases/pgadmin/app/helmrelease.yaml
@@ -20,7 +20,6 @@ spec:
       MAX_LOGIN_ATTEMPTS: 1000
       PGADMIN_CONFIG_SERVER_MODE: "False"
       email: "${EMAIL}"
-      password: "password"
 
     envFrom:
       - secretRef:
@@ -44,3 +43,9 @@ spec:
       requests:
         cpu: 15m
         memory: 420M
+
+    # RWO ceph-block PVC: a RollingUpdate surges a second pod that cannot
+    # multi-attach the volume from another node, so the rollout times out and
+    # Flux rolls back. Recreate terminates the old pod first (brief downtime).
+    strategy:
+      type: Recreate

--- a/kubernetes/apps/kube-system/descheduler/app/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/descheduler/app/ocirepository.yaml
@@ -16,3 +16,6 @@ spec:
   url: oci://zot.kube-system.svc.cluster.local:5000/ghcr.io/home-operations/charts-mirror/descheduler
   verify:
     provider: cosign
+    matchOidcIdentity:
+      - issuer: https://token.actions.githubusercontent.com
+        subject: https://github.com/home-operations/charts-mirror.*

--- a/kubernetes/apps/kube-system/intel-device-plugin/app/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/intel-device-plugin/app/ocirepository.yaml
@@ -16,3 +16,6 @@ spec:
   url: oci://zot.kube-system.svc.cluster.local:5000/ghcr.io/home-operations/charts-mirror/intel-device-plugins-operator
   verify:
     provider: cosign
+    matchOidcIdentity:
+      - issuer: https://token.actions.githubusercontent.com
+        subject: https://github.com/home-operations/charts-mirror.*

--- a/kubernetes/apps/kube-system/metrics-server/app/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/metrics-server/app/ocirepository.yaml
@@ -16,3 +16,6 @@ spec:
   url: oci://zot.kube-system.svc.cluster.local:5000/ghcr.io/home-operations/charts-mirror/metrics-server
   verify:
     provider: cosign
+    matchOidcIdentity:
+      - issuer: https://token.actions.githubusercontent.com
+        subject: https://github.com/home-operations/charts-mirror.*

--- a/kubernetes/apps/kube-system/node-feature-discovery/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/node-feature-discovery/app/helmrelease.yaml
@@ -16,6 +16,9 @@ spec:
   url: oci://zot.kube-system.svc.cluster.local:5000/ghcr.io/home-operations/charts-mirror/node-feature-discovery
   verify:
     provider: cosign
+    matchOidcIdentity:
+      - issuer: https://token.actions.githubusercontent.com
+        subject: https://github.com/home-operations/charts-mirror.*
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2

--- a/kubernetes/apps/network/external-dns/app/cloudflare/helmrelease.yaml
+++ b/kubernetes/apps/network/external-dns/app/cloudflare/helmrelease.yaml
@@ -16,6 +16,9 @@ spec:
   url: oci://zot.kube-system.svc.cluster.local:5000/ghcr.io/home-operations/charts-mirror/external-dns
   verify:
     provider: cosign
+    matchOidcIdentity:
+      - issuer: https://token.actions.githubusercontent.com
+        subject: https://github.com/home-operations/charts-mirror.*
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2

--- a/kubernetes/apps/observability/exporters/pushgateway/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/exporters/pushgateway/app/prometheusrule.yaml
@@ -32,10 +32,10 @@ spec:
             severity: warning
             group: claude-cost
           annotations:
-            summary: "Claude API 24h spend at ${{ $value | printf \"%.2f\" }}"
+            summary: "Claude API 24h spend at $${{ $value | printf \"%.2f\" }}"
             description: >-
               langgraph-agents Anthropic API cost over the last 24h is
-              ${{ $value | printf "%.2f" }} (soft limit $10).
+              $${{ $value | printf "%.2f" }} (soft limit $10).
               Consider switching to a lower-cost model tier.
 
         - alert: ClaudeApiDailyHard
@@ -45,10 +45,10 @@ spec:
             severity: critical
             group: claude-cost
           annotations:
-            summary: "Claude API daily gate: ${{ $value | printf \"%.2f\" }}"
+            summary: "Claude API daily gate: $${{ $value | printf \"%.2f\" }}"
             description: >-
               langgraph-agents Anthropic API cost over the last 24h is
-              ${{ $value | printf "%.2f" }} (hard limit $20). This alert
+              $${{ $value | printf "%.2f" }} (hard limit $20). This alert
               pages but does not block: in-process caps ($5/task,
               $10/agent/day, $30/global/day) remain the live ceiling. To
               hard-pin the fleet local, set ENABLE_CLAUDE_API=false in the
@@ -62,10 +62,10 @@ spec:
             severity: warning
             group: claude-cost
           annotations:
-            summary: "Claude API 7d spend at ${{ $value | printf \"%.2f\" }}"
+            summary: "Claude API 7d spend at $${{ $value | printf \"%.2f\" }}"
             description: >-
               langgraph-agents Anthropic API cost over the last 7 days is
-              ${{ $value | printf "%.2f" }} (soft limit $20).
+              $${{ $value | printf "%.2f" }} (soft limit $20).
 
         - alert: ClaudeApiWeeklyHard
           expr: claude:cost_usd:increase7d > 30
@@ -74,10 +74,10 @@ spec:
             severity: critical
             group: claude-cost
           annotations:
-            summary: "Claude API weekly gate: ${{ $value | printf \"%.2f\" }}"
+            summary: "Claude API weekly gate: $${{ $value | printf \"%.2f\" }}"
             description: >-
               langgraph-agents Anthropic API cost over the last 7 days is
-              ${{ $value | printf "%.2f" }} (hard limit $30). This alert
+              $${{ $value | printf "%.2f" }} (hard limit $30). This alert
               pages but does not block: in-process caps ($5/task,
               $10/agent/day, $30/global/day) remain the live ceiling. To
               hard-pin the fleet local, set ENABLE_CLAUDE_API=false in the
@@ -91,10 +91,10 @@ spec:
             severity: critical
             group: claude-cost
           annotations:
-            summary: "Claude API monthly gate: ${{ $value | printf \"%.2f\" }}"
+            summary: "Claude API monthly gate: $${{ $value | printf \"%.2f\" }}"
             description: >-
               langgraph-agents Anthropic API cost over the last 30 days is
-              ${{ $value | printf "%.2f" }} (hard limit $60). This alert
+              $${{ $value | printf "%.2f" }} (hard limit $60). This alert
               pages but does not block: in-process caps ($5/task,
               $10/agent/day, $30/global/day) remain the live ceiling. To
               hard-pin the fleet local, set ENABLE_CLAUDE_API=false in the


### PR DESCRIPTION
Four reconciliation failures fixed (caught via `flux get kustomizations`/`helmreleases`). All independent.

## 1. observability/pushgateway — `claude-cost-rules` PrometheusRule
The alert annotations write a literal currency `$` immediately before a Go template, e.g. `${{ $value | printf "%.2f" }}`. Flux's postBuild envsubst sees `${{` and tries to parse `{...` as a variable name, aborting the **whole** kustomization (`unable to parse variable name`).

Fix: escape the literal currency `$` as `$$` (10 occurrences). Bare `$value` and `$10` are left untouched by Flux's envsubst (verified against the live frigate/cert-manager rules, which use unescaped `{{ $value }}` and reconcile fine) — only the `${{` collisions needed escaping.

## 2. databases/pgadmin — stuck HelmRelease (not an outage; running on rolled-back 1.62.0)
The chart Deployment uses `RollingUpdate`, but the PVC is **RWO** (`ceph-block`/RBD = single-node attach). On a chart bump the surge pod lands on another node, can't multi-attach the volume, the rollout times out, and Flux rolls back to 1.62.0. Scheduling-dependent — now consistently failing.

Fix: `strategy.type: Recreate` so the old pod releases the volume before the new one starts. Brief downtime on the next roll (admin tool, not Renee-facing). Also drops the dead inline `password: "password"` value — the real credential comes from the 1Password-backed ExternalSecret via `existingSecret`; the inline literal was overridden and tripped the credential-scanning hook.

## 3. kube-system/descheduler + metrics-server — cosign keyless verify
Bare `verify: provider: cosign` (no identity) is rejected at policy build (`can't verify identities without providing at least one identity`) once a tag bump forces a re-verify. The live deployments stayed up (image layers cached); only the version bumps were blocked.

Fix: add the home-operations charts-mirror `matchOidcIdentity`.

## 4. Same cosign fix for the remaining charts-mirror OCIRepos (preventive)
`node-feature-discovery`, `network/external-dns` (cloudflare-dns), and `intel-device-plugins-operator` carry the identical bare-keyless `provider: cosign`. They're green only because their digests are unchanged (no re-verify forced yet) — the next tag bump would fail identically. Added the same `matchOidcIdentity` to all three now so they don't break at 3am on a Renovate bump.

## Validation
- `kubectl kustomize` builds clean for all seven affected paths
- pre-commit (yamllint, credential scan, badge drift, CNP) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)