### PR TITLE
fix(flux): correct cosign verify field to matchOIDCIdentity

### DIFF
--- a/kubernetes/apps/kube-system/descheduler/app/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/descheduler/app/ocirepository.yaml
@@ -16,6 +16,6 @@ spec:
   url: oci://zot.kube-system.svc.cluster.local:5000/ghcr.io/home-operations/charts-mirror/descheduler
   verify:
     provider: cosign
-    matchOidcIdentity:
+    matchOIDCIdentity:
       - issuer: https://token.actions.githubusercontent.com
         subject: https://github.com/home-operations/charts-mirror.*

--- a/kubernetes/apps/kube-system/intel-device-plugin/app/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/intel-device-plugin/app/ocirepository.yaml
@@ -16,6 +16,6 @@ spec:
   url: oci://zot.kube-system.svc.cluster.local:5000/ghcr.io/home-operations/charts-mirror/intel-device-plugins-operator
   verify:
     provider: cosign
-    matchOidcIdentity:
+    matchOIDCIdentity:
       - issuer: https://token.actions.githubusercontent.com
         subject: https://github.com/home-operations/charts-mirror.*

--- a/kubernetes/apps/kube-system/metrics-server/app/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/metrics-server/app/ocirepository.yaml
@@ -16,6 +16,6 @@ spec:
   url: oci://zot.kube-system.svc.cluster.local:5000/ghcr.io/home-operations/charts-mirror/metrics-server
   verify:
     provider: cosign
-    matchOidcIdentity:
+    matchOIDCIdentity:
       - issuer: https://token.actions.githubusercontent.com
         subject: https://github.com/home-operations/charts-mirror.*

--- a/kubernetes/apps/kube-system/node-feature-discovery/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/node-feature-discovery/app/helmrelease.yaml
@@ -16,7 +16,7 @@ spec:
   url: oci://zot.kube-system.svc.cluster.local:5000/ghcr.io/home-operations/charts-mirror/node-feature-discovery
   verify:
     provider: cosign
-    matchOidcIdentity:
+    matchOIDCIdentity:
       - issuer: https://token.actions.githubusercontent.com
         subject: https://github.com/home-operations/charts-mirror.*
 ---

--- a/kubernetes/apps/network/external-dns/app/cloudflare/helmrelease.yaml
+++ b/kubernetes/apps/network/external-dns/app/cloudflare/helmrelease.yaml
@@ -16,7 +16,7 @@ spec:
   url: oci://zot.kube-system.svc.cluster.local:5000/ghcr.io/home-operations/charts-mirror/external-dns
   verify:
     provider: cosign
-    matchOidcIdentity:
+    matchOIDCIdentity:
       - issuer: https://token.actions.githubusercontent.com
         subject: https://github.com/home-operations/charts-mirror.*
 ---


### PR DESCRIPTION
Follow-up to #12498. That PR added the keyless cosign identity matcher as `matchOidcIdentity`, but the Flux `OCIRepository` v1 CRD field is **`matchOIDCIdentity`** (capital OIDC).

The wrong casing slipped through because flux-local CI validates against the fluxcd-community JSON schema (lenient on this), while the cluster's actual CRD rejected it at server-side-apply dry-run:

```
.spec.verify.matchOidcIdentity: field not declared in schema
```

So after #12498 merged, descheduler and metrics-server stayed `Ready=False` on the old chart revisions — the verify block never reached the live objects (the kustomization dry-run failed). The other three (NFD, external-dns, intel) kept working only because their existing apply was untouched.

This corrects the casing in all five charts-mirror OCIRepositories. Verified with `kubectl apply --dry-run=server` against the live CRD (passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)