### PR TITLE
fix(observability): pushgateway securityContext keys for the chart schema

### DIFF
--- a/kubernetes/apps/observability/exporters/pushgateway/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/exporters/pushgateway/app/helmrelease.yaml
@@ -15,12 +15,14 @@ spec:
     podAnnotations:
       reloader.stakater.com/auto: "true"
 
-    podSecurityContext:
+    # prometheus-pushgateway maps .Values.securityContext to the pod and
+    # .Values.containerSecurityContext to the container (unlike app-template).
+    securityContext:
       runAsNonRoot: true
       runAsUser: 65534
       runAsGroup: 65534
 
-    securityContext:
+    containerSecurityContext:
       allowPrivilegeEscalation: false
       readOnlyRootFilesystem: true
       capabilities:


### PR DESCRIPTION
Surfaced while verifying #12498. The pushgateway **HelmRelease** (separate from the PrometheusRule/kustomization fixed in #12498) was failing and, it turns out, **has never successfully deployed** since it was added in #12148.

## Cause
The `prometheus-pushgateway` chart maps `.Values.securityContext` → **pod** securityContext and `.Values.containerSecurityContext` → **container** securityContext (the opposite of the app-template convention the values were written for). So the container-only fields landed at pod level and server-side apply rejected the Deployment:

```
.spec.template.spec.securityContext.allowPrivilegeEscalation: field not declared in schema
```

The `podSecurityContext:` key was silently ignored by the chart entirely.

## Why it was hidden
While #12498's PrometheusRule envsubst error was failing, the whole pushgateway kustomization never applied, so the HelmRelease never ran. Fixing the kustomization unblocked the HR, which then surfaced this pre-existing misconfiguration.

## Fix
- `podSecurityContext:` → `securityContext:` (pod: runAsNonRoot/runAsUser/runAsGroup)
- `securityContext:` → `containerSecurityContext:` (container: allowPrivilegeEscalation/readOnlyRootFilesystem/capabilities/seccompProfile)

Verified with `helm template` that each block renders at the correct level (container fields under the container, pod fields under `.spec.template.spec.securityContext`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)