### PR TITLE
fix(renovate): match discovery Job pods in egress CNP after operator 4.11.0

### DIFF
--- a/kubernetes/apps/renovate/renovate-operator/jobs/cnp-allow.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/jobs/cnp-allow.yaml
@@ -5,16 +5,22 @@ kind: CiliumNetworkPolicy
 metadata:
   name: renovate-jobs-allow
 spec:
-  # Selector covers both `executor` and `discovery` Job pods spawned
-  # by the operator from the RenovateJob CRs in this directory. They
-  # carry `renovate-operator.mogenius.com/job-type` but no
-  # `app.kubernetes.io/name`. Matching the label key without a value
-  # is not supported in CNP, so list both known values.
+  # Egress allowlist for the operator-spawned Job pods (executor +
+  # discovery + the pump jobs). Operator 4.11.0 (#12472) moved repo
+  # discovery into its own Job pod that carries ONLY batch labels — no
+  # `renovate-operator.mogenius.com/job-type` — so the previous
+  # job-type In[executor,discovery] selector silently stopped matching
+  # discovery pods. default-deny then dropped their api.github.com
+  # egress (verified via Hubble: `Policy denied DROPPED` SYN→140.82.x:443),
+  # discovery failed auth every hour, and no executor ever spawned —
+  # stalling the dependency dashboard from 2026-06-12. Match any Job pod
+  # in this renovate-only namespace by label-key presence instead, which
+  # is robust against operator label churn and also covers executors.
+  # Mirrors the ARC allow-job-container-egress pattern.
   endpointSelector:
     matchExpressions:
-      - key: renovate-operator.mogenius.com/job-type
-        operator: In
-        values: ["executor", "discovery"]
+      - key: batch.kubernetes.io/job-name
+        operator: Exists
   # Additive — default-deny is what triggers the lockdown.
   enableDefaultDeny:
     egress: false


### PR DESCRIPTION
## Problem

The Renovate dependency dashboard (#10329) stopped producing PRs on 2026-06-12 — forced "Pending Status Checks" checkboxes were never acted on.

**Root cause:** renovate-operator **4.10.1 → 4.11.0** (#12472, merged 2026-06-12 11:54 UTC) moved repo discovery into its own Job pod. Those discovery pods carry only batch labels — **no `renovate-operator.mogenius.com/job-type`** — so the `renovate-jobs-allow` egress CiliumNetworkPolicy, which selected `job-type In [executor, discovery]`, silently stopped matching them. They fell through to `default-deny`, and their egress to `api.github.com` was dropped.

Renovate then failed platform init with `Authentication failure` after a 60s connect timeout on **every hourly discovery run**, so no executor job was ever spawned and the dashboard stalled. The last successful executor ran at 2026-06-12 11:00 UTC, ~54 min before the operator upgrade reconciled.

### Evidence
- Token is valid (HTTP 200 from outside the cluster, scoped to `rwlove/home-ops`) — not a credential problem.
- `default-deny` CNP is `egressDeny: [{}]` with an empty selector (denies all egress namespace-wide).
- Live discovery pod labels contain no `job-type` key; the executor pod (pre-upgrade) does.
- Hubble, reproduced from an unselected renovate-ns pod:
  ```
  renovate/<pod>:NNNNN <> 140.82.114.6:443 Policy denied DROPPED (TCP Flags: SYN)
  policy-verdict:none
  ```

## Fix

Select **any Job pod** in this renovate-only namespace by label-key presence (`batch.kubernetes.io/job-name` Exists) instead of the operator-specific `job-type` label.

- Robust against operator label churn.
- Strict superset of the old selector — also covers executor + pump Job pods.
- Mirrors the existing `actions-runner-controller/runners/cnp-job-container.yaml` (`allow-job-container-egress`) pattern for the same class of ephemeral, operator-spawned Job pods.

## After merge

Once Flux reconciles, the next hourly discovery succeeds → executor spawns → the still-checked dashboard boxes are read and the pending PRs (dragonfly-operator, prometheus-blackbox-exporter, romm) are created. All three are also past their 3-day `minimumReleaseAge` soak as of 2026-06-15 and would auto-create regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)