### PR TITLE
fix(observability): stop ClaudeApiCostMetricMissing false-firing when fleet is all-local

### DIFF
--- a/kubernetes/apps/observability/exporters/pushgateway/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/exporters/pushgateway/app/prometheusrule.yaml
@@ -102,10 +102,19 @@ spec:
               The Anthropic Console billing limit is the account-side backstop.
 
         # ── Metric dark alert ─────────────────────────────────────────
-        # Fires if langgraph_cost_usd_total stops being scraped — ensures
-        # a gate-metric blackout doesn't silently disable the gates.
+        # Fires only when Claude calls ARE happening but their cost is not
+        # being recorded — the genuine "gates blind while spending" case.
+        # A bare absent() can't be used here: langgraph_cost_usd_total is a
+        # lazily-created counter that only exists after the first Claude
+        # on_llm_end, so it is legitimately absent whenever the fleet routes
+        # 100% local (the Layer 6 MAX-to-local steady state) and would
+        # false-fire. The `unless` guard mirrors the `or vector(0)` pattern
+        # in the sibling LangGraphClaudeEscalationFailing alert.
         - alert: ClaudeApiCostMetricMissing
-          expr: absent(langgraph_cost_usd_total{group="claude"})
+          expr: >-
+            (sum(increase(langgraph_calls_total{group="claude"}[1h])) > 0)
+            unless
+            (sum(increase(langgraph_cost_usd_total{group="claude"}[1h])) > 0)
           for: 1h
           labels:
             severity: warning
@@ -113,5 +122,6 @@ spec:
           annotations:
             summary: "Claude API cost metric absent"
             description: >-
-              langgraph_cost_usd_total{group="claude"} has been absent for 1h.
+              Claude API calls happened in the last hour but
+              langgraph_cost_usd_total{group="claude"} recorded no spend.
               Cost gates are blind. Check langgraph-agents pod and ServiceMonitor.


### PR DESCRIPTION
## What

`ClaudeApiCostMetricMissing` fired at 07:53 EDT today as a false positive.

## Root cause

The dark-alert used `absent(langgraph_cost_usd_total{group="claude"})`. That
counter is **lazily created** — it only exists after the first Claude
`on_llm_end`. The fleet has routed **100% local** for the whole ~44h pod
lifetime (every router decision `local_default`; `langgraph_calls_total`
shows only `local-spark` / `local-spark-coder`, zero `claude`), so the
counter was never instantiated and `absent()` fired after 1h — despite a
fully healthy scrape pipeline (pod up, every other `langgraph_*` metric
flowing). The fresh fire lines up with #12498 reloading the rule and
resetting the `for: 1h` timer.

This is the Layer 6 MAX-to-local migration working as intended; the
`absent()` predicate just couldn't tell "scrape blackout" (the real risk)
from "legitimately zero Claude spend" (now the steady state).

## Fix

Re-key the alert to the genuine *gates-blind* condition — Claude calls
happened but no cost was recorded:

```promql
(sum(increase(langgraph_calls_total{group="claude"}[1h])) > 0)
unless
(sum(increase(langgraph_cost_usd_total{group="claude"}[1h])) > 0)
```

Stays silent when Claude usage is zero; fires only when spend isn't landing
while Claude is actually used. Mirrors the `or vector(0)` guard in the
sibling `LangGraphClaudeEscalationFailing` alert.

## Verification

- New expr evaluated live against Prometheus → empty (no false fire under
  current all-local state).
- Pre-submit hooks (yamllint, schema, secrets) all pass.
- Once Flux reconciles, the currently-firing alert clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)