### PR TITLE
fix(observability): stop rook-ceph-mgr OOM + latched OOMKilled critical

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/addons/alerts/oomkilled.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/addons/alerts/oomkilled.yaml
@@ -8,19 +8,26 @@ spec:
   groups:
     - name: oom
       rules:
-        # kube_pod_container_status_last_terminated_reason flips 1 → 0
-        # the moment the container restarts (with a non-OOM reason). A
-        # fast crash-loop can flap the metric to 0 before AlertManager
-        # notifies. keep_firing_for: 10m holds the alert across that
-        # window so OOMs in a tight restart cycle don't go silent.
-        # for: 0m fires on the first scrape that catches the OOM
-        # terminated state.
+        # kube_pod_container_status_last_terminated_reason latches at 1 from
+        # the OOM until the pod is *recreated* — so a single one-off OOM
+        # would otherwise fire a permanent critical that never self-clears
+        # while the pod lives. Gate on a restart in the last 15m
+        # (changes(...restarts_total[15m]) > 0) so the alert tracks
+        # "recently OOMing" rather than "ever OOMed". A crash-loop keeps
+        # incrementing restarts, so it stays firing; a stable-after-OOM
+        # container clears once 15m passes without a new restart.
+        # keep_firing_for: 10m holds across the metric flapping to 0 mid
+        # restart cycle so tight crash-loops don't go silent. ignoring(reason)
+        # matches the gating series (no reason label) against the OOM series.
         - alert: OOMKilled
           annotations:
             summary: Container {{ $labels.container }} of pod {{ $labels.pod }} in namespace {{ $labels.namespace }} is out of memory
             message: Container {{ $labels.container }} of pod {{ $labels.pod }} in namespace {{ $labels.namespace }} is out of memory
             description: Container {{ $labels.container }} of pod {{ $labels.pod }} in namespace {{ $labels.namespace }} is out of memory
-          expr: kube_pod_container_status_last_terminated_reason{reason="OOMKilled"}==1
+          expr: |
+            (kube_pod_container_status_last_terminated_reason{reason="OOMKilled"} == 1)
+            and ignoring(reason)
+            (changes(kube_pod_container_status_restarts_total[15m]) > 0)
           for: 0m
           keep_firing_for: 10m
           labels:

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -84,10 +84,14 @@ spec:
       resources:
         mgr:
           limits:
-            memory: 940Mi
+            # Active mgr's memory creeps with enabled modules (prometheus,
+            # pg_autoscaler, balancer, devicehealth). 940Mi was too tight —
+            # the active mgr peaked at 938Mi and OOMKilled. 1.5Gi gives
+            # ~60% headroom over that peak.
+            memory: 1536Mi
           requests:
             cpu: 100m
-            memory: 940Mi
+            memory: 1536Mi
         mgr-sidecar:
           limits:
             memory: 256Mi


### PR DESCRIPTION
## What

Two related fixes for OOM alerting.

### 1. rook-ceph mgr memory: 940Mi → 1536Mi
The active Ceph mgr's memory creeps with enabled modules (prometheus, pg_autoscaler, balancer, devicehealth). The 940Mi limit was too tight — `mgr-a` peaked at **938Mi** and was OOMKilled. Bumped to 1536Mi (req+limit, Guaranteed QoS). worker8 has ~13.7Gi free, so ample headroom.

### 2. OOMKilled alert no longer latches forever
`kube_pod_container_status_last_terminated_reason` stays `1` from the OOM until the pod is *recreated*, so a single one-off OOM fired a **permanent critical** that never self-cleared while the pod lived (the mgr OOM had been firing ~14.5h). Gated the expr on a restart in the last 15m so the alert tracks "recently OOMing" rather than "ever OOMed":

- crash-loops keep incrementing `restarts_total` → stay firing
- a stable-after-OOM container clears on its own once 15m elapses without a new restart

The `ignoring(reason)` join was validated live against Prometheus (matches the mgr series; the `[15m]` gate currently returns empty, correctly suppressing the 14.5h-old latched alert).

## Deploy impact

- The **rule change is non-disruptive** — Flux applies, Prometheus hot-reloads, the stuck mgr critical clears. No workload impact.
- The **mgr bump is the only disruptive part**: it rolls the active mgr (brief failover to standby `mgr-b`, ~seconds; a Prometheus/dashboard module blip). Low blast-radius.

🤖 Generated with [Claude Code](https://claude.com/claude-code)