### PR TITLE
fix(home): allow Frigate+ S3 (us-east-2) egress on :443

### DIFF
--- a/kubernetes/apps/home/frigate/app/cnp-allow.yaml
+++ b/kubernetes/apps/home/frigate/app/cnp-allow.yaml
@@ -68,6 +68,23 @@ spec:
         - ports:
             - port: "443"
               protocol: TCP
+    # Frigate+ serves model blobs and snapshot uploads from an S3 bucket in
+    # us-east-2 (api.frigate.video hands back a presigned S3 URL). That host
+    # isn't covered by *.frigate.video, so the fetch was POLICY_DENIED and
+    # fired FrigateUnauthorizedEgressAttempt. matchPattern only matches one
+    # DNS label (see [[project_cilium_matchpattern_fqdn_limits]]), so the
+    # path-style host needs an explicit matchName while the virtual-hosted
+    # bucket form (<bucket>.s3.us-east-2.amazonaws.com) needs the pattern.
+    # NOTE: Frigate caches DNS, so a fresh resolution (pod restart) is
+    # required for the cached S3 IPs to bind to this rule — same caveat as
+    # the YouTube RTMP path above.
+    - toFQDNs:
+        - matchName: s3.us-east-2.amazonaws.com
+        - matchPattern: "*.s3.us-east-2.amazonaws.com"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
     # go2rtc birdcam publish destination — RTMP to YouTube Live
     # (rtmp://a.rtmp.youtube.com/live2/{BIRDCAM_YOUTUBE_KEY} in
     # snapshots/config.yml). YouTube ingest IPs are AWS-fronted Google


### PR DESCRIPTION
## What

`FrigateUnauthorizedEgressAttempt` was firing because `frigate-0` hit `POLICY_DENIED` on TCP :443 to **`s3.us-east-2.amazonaws.com`** (`52.219.108.25`, `3.5.128.245`, confirmed via reverse DNS).

Frigate+ redirects model-blob fetches and snapshot uploads from `api.frigate.video` (allowed) to a **presigned S3 URL** in us-east-2, which the `*.frigate.video` allowlist doesn't cover. Adds a scoped `toFQDNs` rule for the S3 us-east-2 host.

## Diagnosis

- Captured the drop live via Hubble on `cilium-8nxm5` (worker4): repeated SYN drops to the S3 IPs.
- Running config has `model.path: plus://3e711036…` — Frigate+ is active.
- **Detection was not degraded**: the plus model `3e711036…` is already cached in `/config/model_cache/` and the EdgeTPU detector loaded (`TPU found`). The denied egress is the Frigate+ cloud path (model freshness check / snapshot upload), not live inference.
- Triggered by the Frigate restart at ~06:31 ET.

## Why this shape

`matchPattern` only matches a single DNS label (per `[[project_cilium_matchpattern_fqdn_limits]]`), so:
- `matchName: s3.us-east-2.amazonaws.com` — path-style host
- `matchPattern: "*.s3.us-east-2.amazonaws.com"` — virtual-hosted bucket form

## Deploy note

Frigate caches DNS, so the already-cached S3 IPs won't bind to the new FQDN policy until Frigate re-resolves — **a frigate-0 restart is needed after merge** for the rule to take effect (same caveat documented on the YouTube RTMP path). Frigate OOM-restarts ~daily anyway, but a manual restart applies it immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)