### PR TITLE
fix(mcp-system): raise omada-mcp memory limit to stop OOMKilled

### DIFF
--- a/kubernetes/apps/mcp-system/omada-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/omada-mcp/app/helmrelease.yaml
@@ -40,9 +40,9 @@ spec:
             resources:
               requests:
                 cpu: 10m
-                memory: 128Mi
+                memory: 192Mi
               limits:
-                memory: 256Mi
+                memory: 512Mi
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true


### PR DESCRIPTION
## What
Bump `omada-mcp` container memory **limit 256Mi → 512Mi** (and request 128Mi → 192Mi).

## Why
`omada-mcp` was `OOMKilled` (exit 137) under the 256Mi limit, firing the `OOMKilled` alert → Pushover. Last termination `2026-06-16T11:10:23Z`, reason `OOMKilled`; 1 restart in 24h. Peak working set occasionally exceeds 256Mi. Raising the limit absorbs the spike.

## Impact / risk
Single internal MCP backend (`mcp-system`), not Renee-facing, not in the inference path. Routine-window change. Reloader picks up the HelmRelease value change.

## Verification
- New pod schedules with the raised limit; watch `kube_pod_container_status_last_terminated_reason{pod=~"omada-mcp.*",reason="OOMKilled"}` stays clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)