### PR TITLE
fix(observability): silence noisy predictive CephPoolGrowthWarning

### DIFF
--- a/kubernetes/apps/observability/silence-operator/silences/ceph-pool-growth.yaml
+++ b/kubernetes/apps/observability/silence-operator/silences/ceph-pool-growth.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/observability.giantswarm.io/silence_v1alpha2.json
+#
+# CephPoolGrowthWarning is a predictive alert shipped by the rook-ceph
+# cluster chart (monitoring.createPrometheusRules: true). Its expression is
+#   predict_linear(ceph_pool_percent_used[2d], 5d) >= 95
+# i.e. a linear extrapolation of the last 2 days' slope projected 5 days out.
+# predict_linear is unbounded and very sensitive to short-window slope: a
+# transient write burst (snapshot, backup, bulk import) steepens the 2-day
+# regression enough to momentarily project >=95%, the alert fires + pages
+# Pushover, then resolves minutes later when the slope relaxes. ceph-blockpool
+# actual usage sits at ~46%; the prediction is pure noise at this fill level.
+#
+# This is a chart built-in, so it can't take an inline guard like our own
+# rules can. Silencing the predictive rule is safe because real capacity
+# pressure is still caught by the actual-usage backstops in the SAME shipped
+# rule set: CephPoolNearFull / CephPoolFull (POOL_NEAR_FULL / POOL_FULL),
+# CephOSDNearFull / CephOSDFull, and CephOSDBackfillFull. Those fire on
+# ceph_health_detail flags, not extrapolation, and are not silenced.
+#
+# Revisit if blockpool climbs toward the NearFull threshold — at that point a
+# tuned growth rule (wider window + actual-usage gate) would be worth adding.
+apiVersion: observability.giantswarm.io/v1alpha2
+kind: Silence
+metadata:
+  name: cephpoolgrowthwarning
+spec:
+  matchers:
+    - name: alertname
+      value: CephPoolGrowthWarning

--- a/kubernetes/apps/observability/silence-operator/silences/kustomization.yaml
+++ b/kubernetes/apps/observability/silence-operator/silences/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 resources:
   - ./beast-mass-storage-pvc.yaml
   - ./ceph.yaml
+  - ./ceph-pool-growth.yaml
   - ./frigate-media-pvc.yaml
   - ./prometheus.yaml
   - ./security-storage-diskspace.yaml


### PR DESCRIPTION
## What
Add a `Silence` CR for the rook-ceph chart's `CephPoolGrowthWarning` alert.

## Why
The rule fires on `predict_linear(ceph_pool_percent_used[2d], 5d) >= 95` — an unbounded linear extrapolation. A transient write burst steepens the 2-day slope enough to momentarily project ≥95%, the alert fires + pages Pushover, then resolves within minutes. **ceph-blockpool actual usage is ~46%** — the prediction is noise at this fill level. This was one of the fire/resolve pairs flapping Pushover this morning.

## Why silence (not edit the rule)
It's a chart built-in (`monitoring.createPrometheusRules: true`), so it can't take an inline actual-usage guard like our own rules can. Silencing is safe because real capacity pressure is still caught by the **unsilenced** actual-usage backstops in the same shipped rule set:
- `CephPoolNearFull` / `CephPoolFull` (`POOL_NEAR_FULL` / `POOL_FULL`)
- `CephOSDNearFull` / `CephOSDFull` / `CephOSDBackfillFull`

These fire on `ceph_health_detail` flags, not extrapolation.

## Impact / risk
Observability-only. No silencing of actual-fullness alerts. Matches the established `silences/*.yaml` pattern (e.g. `spark-memory.yaml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)