### PR TITLE
fix(observability): detune CiliumPolicyDropsSustained to stop benign flap

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/prometheusrule-cilium-drops.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/prometheusrule-cilium-drops.yaml
@@ -31,14 +31,18 @@ spec:
               a dependency it needs; check recent netpol changes and Hubble
               flows for the offending source/destination pair.
             summary: Sustained CiliumNetworkPolicy drops into {{ $labels.destination_namespace }}.
-          # >5 drops/min (0.083 pkt/s) sustained for 10m = real policy gap,
-          # not a transient reconcile race. Drops with no destination_namespace
-          # label (host-network or unmapped) get aggregated into the empty
-          # bucket but still alert.
+          # >30 drops/min (0.5 pkt/s) sustained for 10m = real policy gap,
+          # not a transient reconcile race. The prior 5/min (0.083) tripped on
+          # benign audit noise — chiefly envoy<->observability same-node
+          # identity/conntrack races (~1/min) where the traffic actually
+          # succeeds. A genuinely broken egress rule drops hundreds/min, so
+          # 0.5 still catches it. Drops with no destination_namespace label
+          # (host-network or unmapped) get aggregated into the empty bucket
+          # but still alert.
           expr: |
             sum by (destination_namespace) (
               rate(hubble_drop_total{reason="POLICY_DENIED"}[5m])
-            ) > 0.083
+            ) > 0.5
           for: 10m
           labels:
             severity: warning


### PR DESCRIPTION
## What
Raise `CiliumPolicyDropsSustained` from `> 0.083` (5 drops/min) to `> 0.5` (30/min).

## Why
Part of stopping the morning Pushover flap. Investigation (network-operator) found the sustained warning trips on **benign** POLICY_DENIED noise, not real connectivity loss:
- `network → observability` ~1274/24h: envoy→backend connections that **succeed** — a transient same-node identity/conntrack race; no `cx_connect_fail` in envoy cluster stats.
- Other contributors are low-rate telemetry/version-checks and correctly-denied ICMP.

A genuinely broken egress rule drops **hundreds/min**, so 30/min still catches it. `CiliumPolicyDropBurst` (`>200`/2m, critical) is left untouched — it caught the real bursts.

## Risk
Observability-only. Higher floor on one warning rule; the critical burst rule still guards real regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)