### PR TITLE
fix(mcp-system): allow QUIC (UDP) egress to envoy on :10443

### DIFF
--- a/kubernetes/apps/mcp-system/chrome-mcp/app/cnp-allow.yaml
+++ b/kubernetes/apps/mcp-system/chrome-mcp/app/cnp-allow.yaml
@@ -35,3 +35,10 @@ spec:
         - ports:
             - port: "10443"
               protocol: TCP
+            # HTTP/3 is enabled on the gateway (envoy.yaml: http3 {}), so
+            # envoy advertises Alt-Svc on :10443 and clients retry over QUIC
+            # (UDP). chrome-mcp runs a real browser and does this; without the
+            # UDP sibling the attempt is default-denied (it falls back to TCP,
+            # but the drop flaps the CiliumPolicyDrop alerts).
+            - port: "10443"
+              protocol: UDP

--- a/kubernetes/apps/mcp-system/ha-mcp/app/cnp-allow.yaml
+++ b/kubernetes/apps/mcp-system/ha-mcp/app/cnp-allow.yaml
@@ -26,5 +26,10 @@ spec:
         - ports:
             - port: "10443"
               protocol: TCP
+            # HTTP/3: envoy advertises Alt-Svc on :10443; allow the QUIC (UDP)
+            # sibling so a client upgrade isn't default-denied (would flap the
+            # CiliumPolicyDrop alerts even though QUIC falls back to TCP).
+            - port: "10443"
+              protocol: UDP
             - port: "443"
               protocol: TCP

--- a/kubernetes/apps/mcp-system/mcp-gateway/app/cnp-allow.yaml
+++ b/kubernetes/apps/mcp-system/mcp-gateway/app/cnp-allow.yaml
@@ -117,5 +117,10 @@ spec:
         - ports:
             - port: "10443"
               protocol: TCP
+            # HTTP/3: envoy advertises Alt-Svc on :10443; allow the QUIC (UDP)
+            # sibling so a client upgrade isn't default-denied (would flap the
+            # CiliumPolicyDrop alerts even though QUIC falls back to TCP).
+            - port: "10443"
+              protocol: UDP
             - port: "443"
               protocol: TCP

--- a/kubernetes/apps/mcp-system/netbox-mcp/app/cnp-allow.yaml
+++ b/kubernetes/apps/mcp-system/netbox-mcp/app/cnp-allow.yaml
@@ -26,5 +26,10 @@ spec:
         - ports:
             - port: "10443"
               protocol: TCP
+            # HTTP/3: envoy advertises Alt-Svc on :10443; allow the QUIC (UDP)
+            # sibling so a client upgrade isn't default-denied (would flap the
+            # CiliumPolicyDrop alerts even though QUIC falls back to TCP).
+            - port: "10443"
+              protocol: UDP
             - port: "443"
               protocol: TCP

--- a/kubernetes/apps/mcp-system/paperless-mcp/app/cnp-allow.yaml
+++ b/kubernetes/apps/mcp-system/paperless-mcp/app/cnp-allow.yaml
@@ -25,5 +25,10 @@ spec:
         - ports:
             - port: "10443"
               protocol: TCP
+            # HTTP/3: envoy advertises Alt-Svc on :10443; allow the QUIC (UDP)
+            # sibling so a client upgrade isn't default-denied (would flap the
+            # CiliumPolicyDrop alerts even though QUIC falls back to TCP).
+            - port: "10443"
+              protocol: UDP
             - port: "443"
               protocol: TCP


### PR DESCRIPTION
## What
Add `protocol: UDP` on `:10443` to the envoy-egress rule in 5 mcp-system CNPs: `chrome-mcp`, `ha-mcp`, `netbox-mcp`, `paperless-mcp`, `mcp-gateway`.

## Why
HTTP/3 is enabled on the gateway (`config/envoy.yaml: http3 {}`; the LB exposes `443/UDP → 10443/UDP`). Envoy advertises Alt-Svc on `:10443`, so clients retry over QUIC (UDP). These CNPs allowed `10443/TCP` to envoy but **not UDP** → the QUIC attempt hit default-deny, producing the recurring `mcp-system → network` POLICY_DENIED bursts that flapped `CiliumPolicyDropBurst` this morning.

QUIC falls back to TCP cleanly, so nothing was *broken* — but the drop flaps the alert. This completes each rule (TCP+UDP for the same envoy listener).

## Attribution caveat
`chrome-mcp` runs a real browser and is the most likely QUIC source. The hubble drop metric only carries namespace labels today, so I can't pin the exact pod — see the companion source_pod-label PR. The other four are completed for rule consistency (a no-op allow if they never emit UDP).

## Risk
Additive egress allow to an already-allowed destination/port, different protocol. No blast radius.

🤖 Generated with [Claude Code](https://claude.com/claude-code)