### PR TITLE
feat(cilium): add source_pod to hubble drop metric labels

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/values.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/values.yaml
@@ -77,7 +77,11 @@ hubble:
       # novel-destination alerting from
       # docs/src/egress_restriction_design.md (approach E).
       - dns:query;ignoreAAAA;labelsContext=source_namespace,source_pod
-      - drop:labelsContext=source_namespace,destination_namespace
+      # source_pod lets a drop burst be attributed to the offending pod
+      # without live `hubble observe` (drops are bursty and rarely caught
+      # live). Bounded cardinality — only pods that actually get denied
+      # appear. Pairs with the dns metric's source_pod label above.
+      - drop:labelsContext=source_namespace,source_pod,destination_namespace
       - tcp
       - flow
       - port-distribution


### PR DESCRIPTION
## What
Add `source_pod` to the hubble `drop` metric `labelsContext` in cilium values:
`drop:labelsContext=source_namespace,destination_namespace` → `...,source_pod,destination_namespace`.

## Why
Investigating this morning's `CiliumPolicyDrop` flap, the drop metric only carried namespace labels, so bursts could only be narrowed to a namespace **pair** (e.g. `mcp-system → network`) — not the offending pod. Drops are bursty and rarely caught by live `hubble observe`. `source_pod` makes the next burst attributable from the metric alone, which would have pinned the QUIC source directly (see the mcp-system UDP-allow PR).

Mirrors the `dns` metric's existing `source_pod` label already in this file.

## Risk
Bounded cardinality — only pods that actually get *denied* contribute a series (a correctly-configured cluster has ~none). Hubble metrics reload with the cilium-agent rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)