### PR TITLE
fix(home): route Frigate genai egress to ollama-spark for VLM descriptions

### DIFF
--- a/kubernetes/apps/home/frigate/app/cnp-allow.yaml
+++ b/kubernetes/apps/home/frigate/app/cnp-allow.yaml
@@ -103,12 +103,18 @@ spec:
         - ports:
             - port: "1935"
               protocol: TCP
-    # Frigate genai integration — Ollama LLM descriptions for detection
-    # events (genai.provider=ollama, base_url=ollama.ai.svc.cluster.local).
+    # Frigate genai integration — Ollama VLM descriptions for detection
+    # events (genai.provider=ollama, model=llama3.2-vision:11b,
+    # base_url=ollama-spark.ai.svc.cluster.local). Routed to the Spark
+    # Ollama, NOT the P40 (`ollama`): the P40 is already full (immich-ml +
+    # pet-tagger + comfyui ≈ 16Gi resident) and an 11b VLM would thrash
+    # against the qwen2.5:7b that six local-p40 langgraph agents depend on.
+    # Spark (GB10, 480Gi unified) has the headroom and is the routing-doc
+    # home for larger inference.
     - toEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: ai
-            app.kubernetes.io/name: ollama
+            app.kubernetes.io/name: ollama-spark
       toPorts:
         - ports:
             - port: "11434"


### PR DESCRIPTION
## What
Repoint Frigate's genai (object-description) Ollama egress from `ollama` (P40) to `ollama-spark`, so Frigate can use a vision model.

## Why
Frigate genai was set to a **text-only** model (`qwen2.5:7b`) → constant `400 "model does not support multimodal requests"` → empty descriptions ("Description: None"). Fix is a vision model: **llama3.2-vision:11b**.

Per ml-operator review, the 11b VLM **cannot** go on the P40 (`ollama`):
- P40 is ~16 Gi resident (immich-ml + pet-tagger + comfyui), only ~8.6 Gi free — the VLM needs ~8.5–9.5 Gi.
- Co-residency with `qwen2.5:7b` (the model **six local-p40 langgraph agents** depend on) would cause evict/reload thrash on every description (5-min TTL).

`ollama-spark` (GB10, 480 Gi unified) has the headroom and is the routing-doc home for larger inference. Model already pulled there.

## Scope
- This PR: the CNP egress allow (`ollama` → `ollama-spark`).
- Paired change (not in git): Frigate `genai.base_url`/`model` live in the **PVC-authoritative** config; `snapshots/config.yml` syncs from it via the snapshot CronJob.

## Verification
- llama3.2-vision:11b pulled on `ollama-spark-0` ✅
- After merge + Flux reconcile: confirm frigate→ollama-spark reachable, repoint PVC config, restart Frigate, verify a real description generates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)