### PR TITLE
fix(emqx): add inter-node clustering CNP rules and remove dead probles key

### DIFF
--- a/kubernetes/apps/home/emqx/app/cnp-allow.yaml
+++ b/kubernetes/apps/home/emqx/app/cnp-allow.yaml
@@ -57,7 +57,28 @@ spec:
         - ports:
             - port: "1883"
               protocol: TCP
-    # Egress: no external integrations. zigbee2mqtt in same ns connects
-    # to emqx:1883; baseline allow-intra-namespace covers that as
-    # ingress for emqx and egress for zigbee2mqtt. emqx clustering is
-    # over the headless service inside the StatefulSet — also intra-ns.
+    # emqx inter-node clustering: Erlang distribution (4370) and gen_rpc
+    # TCP server (5369) must be open between the 3 StatefulSet pods.
+    # allow-intra-namespace is in audit-mode so does NOT permit this;
+    # these rules are the authoritative allow for clustering traffic.
+    # zigbee2mqtt (home ns) → emqx:1883 is also covered here.
+    - fromEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: emqx
+      toPorts:
+        - ports:
+            - port: "4370"
+              protocol: TCP
+            - port: "5369"
+              protocol: TCP
+            - port: "1883"
+              protocol: TCP
+    # zigbee2mqtt (home ns) connects to emqx:1883.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: home
+            app.kubernetes.io/name: zigbee2mqtt
+      toPorts:
+        - ports:
+            - port: "1883"
+              protocol: TCP

--- a/kubernetes/apps/home/emqx/app/helmrelease.yaml
+++ b/kubernetes/apps/home/emqx/app/helmrelease.yaml
@@ -46,14 +46,6 @@ spec:
       storageClassName: ceph-block
     priorityClassName: home-cluster-critical
 
-    probles:
-      liveness:
-        enabled: false
-
-      readiness:
-        enabled: false
-      startup:
-        enabled: false
     recreatePods: true
 
     replicaCount: 3


### PR DESCRIPTION
## Summary

Two bugs prevented the emqx 3-node cluster from recovering after a full power outage:

- **CNP missing clustering ports (root cause):** `emqx-allow` had no ingress rules for Erlang distribution (4370) and gen_rpc TCP server (5369) between emqx pods. The `allow-intra-namespace` baseline CNP is in **audit-mode only** — it logs but does NOT permit traffic. With `default-deny` enforced, all inter-pod clustering traffic was silently dropped by Cilium. This caused `mria_schema` to deadlock waiting for table copies it could never receive via gen_rpc, preventing EMQX listeners from ever starting. Added explicit `fromEndpoints` rules for emqx peers on 4370/5369/1883, plus an explicit rule for zigbee2mqtt → emqx:1883.

- **Dead `probles` key (cosmetic):** The HelmRelease had a `probles` (typo, should be `probes`) block attempting to disable liveness/readiness probes. The emqx 5.8.9 chart has no such values hook — probes are hardcoded in the StatefulSet template with no conditional. The block was silently ignored for the entire lifetime of the deployment. Removed to avoid future confusion.

## Test plan

- [ ] Flux reconciles cleanly from main after merge
- [ ] All 3 emqx pods remain 1/1 Ready with 0 restarts after reconcile
- [ ] `emqx ctl cluster status` shows all 3 in `running_nodes`, none in `stopped_nodes`
- [ ] `emqx ctl listeners` shows tcp:default (:1883) running on all nodes
- [ ] zigbee2mqtt-0 connects and publishes without CrashLoopBackOff
- [ ] Home Assistant MQTT integration recovers (Zigbee entity states update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)