### PR TITLE
fix(gpu-operator): CRI-O CDI setup DaemonSet to restore P40 GPU advertisement

### DIFF
--- a/kubernetes/apps/kube-system/gpu-operator/app/crio-cdi-setup.yaml
+++ b/kubernetes/apps/kube-system/gpu-operator/app/crio-cdi-setup.yaml
@@ -1,0 +1,100 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/daemonset-apps-v1.json
+# workaround: https://github.com/NVIDIA/gpu-operator/issues/1528 — remove when gpu-operator toolkit DS supports CRI-O natively OR when all GPU nodes migrate to containerd
+# Tracking: home-ops#11852
+#
+# On CRI-O GPU nodes (worker8), the nvidia-container-toolkit-daemonset is
+# disabled by the NodeFeatureRule in gpu-operator-runtime-override.yaml
+# (label nvidia.com/gpu.deploy.container-toolkit=false). Starting with
+# gpu-operator v25+, the toolkit DS generates the management.nvidia.com/gpu
+# CDI spec and signals toolkit-ready. On CRI-O nodes where the toolkit DS
+# is suppressed, both are absent, causing the gpu-operator validator and
+# device-plugin init containers to crashloop (unresolvable CDI device
+# management.nvidia.com/gpu=all → GPU unadvertised → all GPU pods Pending).
+#
+# This DaemonSet fills the gap on CRI-O GPU nodes only:
+#   1. Uses nsenter into the host mount namespace (hostPID=true, privileged)
+#      to run the host-installed nvidia-ctk binary with its native glibc
+#      environment.
+#   2. Generates /var/run/cdi/management.nvidia.com-gpu.yaml
+#   3. Creates /run/nvidia/validations/toolkit-ready to unblock the
+#      device-plugin's toolkit-validation init container.
+#   4. Re-runs every hour so the spec stays fresh after driver updates.
+#
+# Scoped exclusively to CRI-O GPU nodes via:
+#   nvidia.com/gpu.present=true (has a GPU)
+#   nvidia.com/gpu.deploy.container-toolkit=false (CRI-O, toolkit DS suppressed)
+#
+# nsenter is used because nvidia-ctk on the host is glibc-linked; the
+# container image uses musl (Alpine). Running in the host mount namespace
+# via nsenter avoids glibc/musl ABI incompatibility.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nvidia-crio-cdi-setup
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: nvidia-crio-cdi-setup
+    app.kubernetes.io/part-of: gpu-operator
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nvidia-crio-cdi-setup
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: nvidia-crio-cdi-setup
+        app.kubernetes.io/part-of: gpu-operator
+    spec:
+      hostPID: true
+      priorityClassName: system-node-critical
+      nodeSelector:
+        nvidia.com/gpu.present: "true"
+        nvidia.com/gpu.deploy.container-toolkit: "false"
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: cdi-setup
+          # Alpine provides a shell + nsenter (via util-linux).
+          # hostPID=true exposes host /proc/1 so nsenter can enter the
+          # host mount namespace where the glibc-linked nvidia-ctk lives.
+          image: docker.io/alpine:3.21
+          command:
+            - sh
+            - -c
+            - |
+              set -e
+              apk add --no-cache util-linux >/dev/null 2>&1
+
+              generate() {
+                nsenter --mount=/proc/1/ns/mnt -- sh -c '
+                  mkdir -p /var/run/cdi /run/nvidia/validations
+                  nvidia-ctk cdi generate \
+                    --mode=management \
+                    --vendor=management.nvidia.com \
+                    --output=/var/run/cdi/management.nvidia.com-gpu.yaml
+                  touch /run/nvidia/validations/toolkit-ready
+                '
+                echo "$(date -u): management CDI spec generated / toolkit-ready signaled"
+              }
+
+              generate
+
+              # Refresh every hour so the spec survives driver-version changes.
+              while true; do
+                sleep 3600
+                generate
+              done
+          securityContext:
+            privileged: true
+            runAsUser: 0
+          resources:
+            requests:
+              cpu: 5m
+              memory: 32Mi
+            limits:
+              memory: 64Mi

--- a/kubernetes/apps/kube-system/gpu-operator/app/kustomization.yaml
+++ b/kubernetes/apps/kube-system/gpu-operator/app/kustomization.yaml
@@ -3,6 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./crio-cdi-setup.yaml
   - ./helmrelease.yaml
   - ./helmrepository.yaml
   - ./monitoring


### PR DESCRIPTION
## Problem

`nvidia.com/gpu` allocatable = 0 on worker8 (P40 host, CRI-O) for ~19 days. Root cause: gpu-operator v25+ expects the container-toolkit DS to generate the `management.nvidia.com/gpu` CDI spec and create `/run/nvidia/validations/toolkit-ready` before the device-plugin and validator init containers run. On worker8, the toolkit DS is deliberately disabled (CRI-O can't use it — it writes containerd-specific config). Neither the CDI spec nor the toolkit-ready sentinel were being generated, so:

- `nvidia-operator-validator` init container: `CreateContainerError` — `failed to inject CDI devices: unresolvable CDI devices management.nvidia.com/gpu=all` (~729 restarts over 19 days)
- `nvidia-device-plugin-daemonset` init container: stuck waiting for `toolkit-ready`
- `nvidia.com/gpu` allocatable: 0
- 5 GPU workloads stuck Pending: `ai/ollama-0`, `ai/comfyui-0`, `home/wyoming-services-whisper-0`, `media/immich-machine-learning-0`, `media/immich-pet-tagger`

## Fix

### Live (already applied)

Generated `/var/run/cdi/management.nvidia.com-gpu.yaml` on worker8 directly:

```bash
nvidia-ctk cdi generate --mode=management --vendor=management.nvidia.com \
  --output=/var/run/cdi/management.nvidia.com-gpu.yaml
```

Deleted stuck pods → all gpu-operator DS pods recovered → `nvidia.com/gpu: 8` allocatable restored → 4/5 GPU workloads running.

### GitOps-persistent (this PR)

Adds `nvidia-crio-cdi-setup` DaemonSet that targets only CRI-O GPU nodes (`nvidia.com/gpu.present=true` + `nvidia.com/gpu.deploy.container-toolkit=false`) and:
1. Uses `hostPID=true` + Alpine's `nsenter` to enter the host mount namespace, so the glibc-linked host `nvidia-ctk` binary can run without musl/glibc ABI mismatch
2. Generates `/var/run/cdi/management.nvidia.com-gpu.yaml` with `kind: management.nvidia.com/gpu`
3. Creates `/run/nvidia/validations/toolkit-ready`
4. Refreshes every hour (survives driver updates)

nsenter approach validated with a live test pod before committing.

The DaemonSet does NOT run on Spark (containerd) — the existing toolkit DS handles that node, and the `nvidia.com/gpu.deploy.container-toolkit=false` label is not set there.

## Relationship to PR #11760

PR #11760 added the NFD rule that disables the toolkit DS on CRI-O nodes — that rule is correct and stays. This DaemonSet is the missing complement: it does the subset of toolkit DS work that CRI-O GPU nodes need (CDI spec generation + toolkit-ready sentinel) without the containerd-specific parts that caused the crashloop.

Workaround for https://github.com/NVIDIA/gpu-operator/issues/1528

## Current state after live fix

- `nvidia.com/gpu` allocatable on worker8: **8** (was 0)
- `ai/ollama-0`: Running ✓
- `ai/comfyui-0`: Running ✓
- `home/wyoming-services-whisper-0`: Running ✓
- `media/immich-machine-learning-0`: Running (starting up)
- `media/immich-pet-tagger`: Pending — worker8 memory at 99% (pre-existing condition, unrelated to GPU fix)

## Test plan

- [ ] Merge and confirm Flux reconciles the DaemonSet
- [ ] Confirm `nvidia-crio-cdi-setup` pod is Running on worker8 and not on Spark
- [ ] Reboot worker8 and verify `nvidia.com/gpu` allocatable recovers without manual intervention
- [ ] Verify `/var/run/cdi/management.nvidia.com-gpu.yaml` exists with `kind: management.nvidia.com/gpu` after reboot

🤖 Generated with [Claude Code](https://claude.com/claude-code)