### PR TITLE
feat(descheduler): enable nodeFit on DefaultEvictor

### DIFF
--- a/kubernetes/apps/kube-system/descheduler/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/descheduler/app/helmrelease.yaml
@@ -17,6 +17,7 @@ spec:
         - name: Default
           pluginConfig:
             - args:
+                nodeFit: true
                 podProtections:
                   defaultDisabled:
                     - FailedBarePods


### PR DESCRIPTION
## What

Adds `nodeFit: true` to the descheduler `DefaultEvictor`.

## Why

`LowNodeUtilization` is the cluster's primary load balancer (metrics-based, 30%→70% band), but `DefaultEvictor` had no `nodeFit` guard. Without it the descheduler can evict a pod the scheduler then can't place any better — or bounces straight back — causing churn or pending pods. `nodeFit` simulates scheduling before evicting, so only pods that have a genuinely better home get moved.

Single-line, low-risk policy hardening. Live node load at time of change showed nothing above 70% (balancer currently idle), so no eviction churn expected on merge; this just makes future evictions safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)