### PR TITLE
fix(scheduling): right-size lidarr/frigate memory requests

### DIFF
--- a/kubernetes/apps/home/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/home/frigate/app/helmrelease.yaml
@@ -127,7 +127,7 @@ spec:
               requests:
                 gpu.intel.com/i915: "1"
                 cpu: 3
-                memory: 14Gi
+                memory: 7Gi
               limits:
                 gpu.intel.com/i915: "1"
                 memory: 14Gi

--- a/kubernetes/apps/media/lidarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/lidarr/app/helmrelease.yaml
@@ -81,7 +81,7 @@ spec:
             resources:
               requests:
                 cpu: 100m
-                memory: 10G
+                memory: 2G
               limits:
                 memory: 10G
 


### PR DESCRIPTION
## Problem
After the power-outage recovery, the cluster is **memory over-committed** — worker nodes sit at ~96–99% of allocatable memory **requests** while actual usage is only ~50–62%. Requests are inflated ~2×, so the scheduler has no room and several node-pinned pods are stuck `Pending`:
- `media/immich-pet-tagger` (worker8)
- `rook-ceph/rook-ceph-exporter-worker4` (worker4)
- `observability/vector-agent`, `kube-system/intel-gpu-exporter`

## Change
Lower the **request** only (frees scheduler reservation), keep limits unchanged (no burst-behavior change):
- **lidarr** request `10G → 2G` (actual usage ~0.7G; limit kept 10G)
- **frigate** request `14Gi → 7Gi` (actual usage ~6G; limit kept 14Gi)

Frees ~8G on worker8 and ~7G on worker4 so the Pending pods can schedule.

## Notes
- Both apps will roll once (lidarr brief; frigate restarts daily anyway).
- Follow-up: a broader right-sizing pass (ollama 6G→~2G used, whisper 3G→0.5G used, etc.) if more headroom is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)