### PR TITLE
fix(observability): silence two false-firing alert rules

### DIFF
--- a/kubernetes/apps/databases/cloudnative-pg/app/prometheusrule.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/app/prometheusrule.yaml
@@ -71,12 +71,18 @@ spec:
         # clusters — it freezes at the migration timestamp instead of advancing on each
         # successful backup (verified 2026-05-25, all 6 "stale" clusters are actually
         # healthy). Tracking: https://github.com/rwlove/home-ops/issues/12075
+        # changes()[25h] false-fires when the gauge is re-emitted after a CNPG
+        # pod restart, even when the last failure is weeks old (same gauge
+        # re-emission problem documented for BackupStale above). Gate on the
+        # failure timestamp being genuinely recent (<24h) instead.
         - alert: BackupFailed
           annotations:
             description: Cluster {{ $labels.job }} in {{ $labels.namespace }} has a recent backup failure.
             summary: CNPG cluster backup failed recently.
           expr: |-
-            changes(cnpg_collector_last_failed_backup_timestamp[25h]) > 0
+            (cnpg_collector_last_failed_backup_timestamp > 0)
+            and
+            (time() - cnpg_collector_last_failed_backup_timestamp < 86400)
           for: 10m
           labels:
             severity: warning

--- a/kubernetes/apps/observability/kube-prometheus-stack/addons/alerts/node-exporter.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/addons/alerts/node-exporter.yaml
@@ -201,15 +201,12 @@ spec:
             summary: Host swap is filling up (instance {{ $labels.instance }})
             description: "Swap is filling up (>80%) and still growing\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
 
-        - alert: HostSystemdServiceCrashed
-          expr: node_systemd_unit_state{state="failed"} == 1
-          for: 0m
-          labels:
-            severity: warning
-          annotations:
-            summary: Host systemd service crashed (instance {{ $labels.instance }})
-            description: "systemd service crashed\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
-
+        # HostSystemdServiceCrashed removed: the kube-prometheus-stack built-in
+        # NodeSystemdServiceFailed covers the identical condition with a 5m
+        # debounce, and the static-scrape hosts (brain/beast/security-storage)
+        # are relabeled to job=node-exporter, so the built-in's job scope
+        # reaches them too. This custom rule (for: 0m, no job filter) only
+        # duplicated alerts and flapped on transient unit restarts.
         - alert: HostPhysicalComponentTooHot
           expr: node_hwmon_temp_celsius * ignoring(label) group_left(instance, job, node, sensor) node_hwmon_sensor_label{label!="tctl"} > 98
           for: 5m


### PR DESCRIPTION
Two alert rules were firing on conditions that aren't actually problems, adding noise to Alertmanager. Both are pure rule fixes — no workload impact, reconciled by Flux.

## `BackupFailed` — 14 false-firing instances
`changes(cnpg_collector_last_failed_backup_timestamp[25h]) > 0` counts the gauge being **re-emitted after a CNPG pod restart** as a "change," even when the last real failure is weeks old. The 14 firing instances all had last-failure timestamps 33–53 days in the past — no recent backup failures. This is the same gauge-re-emission caveat already documented for `BackupStale` directly above it.

**Fix:** gate on the failure timestamp being genuinely recent:
```promql
(cnpg_collector_last_failed_backup_timestamp > 0)
and
(time() - cnpg_collector_last_failed_backup_timestamp < 86400)
```

## `HostSystemdServiceCrashed` — removed (duplicate)
Duplicated the kube-prometheus-stack built-in `NodeSystemdServiceFailed` (identical expression, `for: 5m` debounce, scoped to `job="node-exporter"`). Both fired for the same failed `vector.service` on brain + security-storage, doubling every systemd alert. The static-scrape hosts (brain/beast/security-storage) are relabeled to `job=node-exporter`, so the built-in's scope already reaches them — **no coverage gap**. The custom rule (`for: 0m`, no job filter) only flapped on transient unit restarts. Confirmed the built-in is present in-cluster before removing.

## Out of scope (correctly-firing alerts, handled separately)
- beast node-exporter down (real — host up, :9100 refused; needs node-exporter restart on beast)
- worker4/worker8 memory over-commit (right-sizing, separate proposal)
- langfuse-3 WAL-timeline conflict (self-healed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)