### PR TITLE
feat(resources): right-size over-provisioned memory requests (trims)

### DIFF
--- a/kubernetes/apps/collab/searxng/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/searxng/app/helmrelease.yaml
@@ -45,9 +45,9 @@ spec:
             resources:
               requests:
                 cpu: 15m
-                memory: 1Gi
+                memory: 384Mi
               limits:
-                memory: 1Gi
+                memory: 768Mi
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true

--- a/kubernetes/apps/downloads/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/sabnzbd/app/helmrelease.yaml
@@ -64,9 +64,9 @@ spec:
             resources:
               requests:
                 cpu: 15m
-                memory: 2G
+                memory: 512Mi
               limits:
-                memory: 2G
+                memory: 1Gi
 
     service:
       app:

--- a/kubernetes/apps/downloads/slskd/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/slskd/app/helmrelease.yaml
@@ -109,9 +109,9 @@ spec:
             resources:
               requests:
                 cpu: 25m
-                memory: 2G
+                memory: 1Gi
               limits:
-                memory: 2G
+                memory: 2Gi
 
             securityContext:
               allowPrivilegeEscalation: false

--- a/kubernetes/apps/media/immichkiosk/app/helmrelease.yaml
+++ b/kubernetes/apps/media/immichkiosk/app/helmrelease.yaml
@@ -108,9 +108,9 @@ spec:
             resources:
               requests:
                 cpu: 15m
-                memory: 1Gi
+                memory: 256Mi
               limits:
-                memory: 1Gi
+                memory: 512Mi
 
     service:
       app:

--- a/kubernetes/apps/media/lidarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/lidarr/app/helmrelease.yaml
@@ -83,7 +83,7 @@ spec:
                 cpu: 100m
                 memory: 2G
               limits:
-                memory: 10G
+                memory: 3Gi
 
             securityContext:
               allowPrivilegeEscalation: false

--- a/kubernetes/apps/media/soularr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/soularr/app/helmrelease.yaml
@@ -55,9 +55,9 @@ spec:
             resources:
               requests:
                 cpu: 10m
-                memory: 1Gi
+                memory: 512Mi
               limits:
-                memory: 1Gi
+                memory: 768Mi
 
             securityContext:
               allowPrivilegeEscalation: false

--- a/kubernetes/apps/media/suggestarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/suggestarr/app/helmrelease.yaml
@@ -35,9 +35,9 @@ spec:
             resources:
               requests:
                 cpu: 15m
-                memory: 1G
+                memory: 384Mi
               limits:
-                memory: 1G
+                memory: 512Mi
 
             securityContext:
               allowPrivilegeEscalation: false


### PR DESCRIPTION
## What

Trims memory requests/limits on 7 apps that request far more than they use, verified against 14-day peak working-set from Prometheus (not just VPA targets).

| App | req→ | limit→ | 14d peak |
|---|---|---|---|
| lidarr | 2G (keep) | 10G→3Gi | 1.16Gi |
| sabnzbd | 2G→512Mi | 2G→1Gi | 0.35Gi |
| slskd | 2G→1Gi | 2G (keep) | 1.00Gi |
| searxng | 1Gi→384Mi | 1Gi→768Mi | 0.13Gi |
| soularr | 1Gi→512Mi | 1Gi→768Mi | 0.27Gi |
| suggestarr | 1G→384Mi | 1G→512Mi | 0.11Gi |
| immichkiosk | 1Gi→256Mi | 1Gi→512Mi | 0.08Gi |

## Why

Over-provisioned requests make the scheduler treat workers as full (96–99% requested vs ~50% actual usage), which defeats bin-packing and leaves the descheduler's `LowNodeUtilization` balance pass unable to do useful work. Every new limit keeps comfortable headroom over the observed peak.

## Verification caught two traps

Excluded after checking real peaks: **qbittorrent** (14d peak 9.94Gi despite a 0.03Gi VPA target) and **dragonfly** (deliberately sized to its `--maxmemory=768Mi` budget with a documented OOM rationale).

🤖 Generated with [Claude Code](https://claude.com/claude-code)