### PR TITLE
feat(resources): set memory requests for scheduler accuracy

### DIFF
--- a/kubernetes/apps/media/seerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/seerr/app/helmrelease.yaml
@@ -49,6 +49,7 @@ spec:
             resources:
               requests:
                 cpu: 10m
+                memory: 384Mi
               limits:
                 memory: 2Gi
             securityContext:

--- a/kubernetes/apps/network/envoy-gateway/app/helmrelease.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/helmrelease.yaml
@@ -23,5 +23,13 @@ spec:
             deploy:
               type: GatewayNamespace
           type: Kubernetes
+    deployment:
+      envoyGateway:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 768Mi
+          limits:
+            memory: 1024Mi
     global:
       imageRegistry: mirror.gcr.io

--- a/kubernetes/apps/observability/kube-ops-view/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-ops-view/app/helmrelease.yaml
@@ -26,6 +26,12 @@ spec:
             image:
               repository: docker.io/hjacobs/kube-ops-view
               tag: 23.5.0@sha256:a4fae38f93d7e0475b2bcef28c72a65d39d824daed22b26c4cef0a6da89aac7e
+            resources:
+              requests:
+                cpu: 10m
+                memory: 256Mi
+              limits:
+                memory: 384Mi
 
 
     service:

--- a/kubernetes/apps/storage/garage/app/helmrelease.yaml
+++ b/kubernetes/apps/storage/garage/app/helmrelease.yaml
@@ -42,6 +42,7 @@ spec:
             resources:
               requests:
                 cpu: 100m
+                memory: 384Mi
               limits:
                 memory: 512Mi
             securityContext:


### PR DESCRIPTION
## What

Adds memory **requests** to four workloads that were running with none (or only a CPU request), sized to 14-day Prometheus peak working-set. Existing limits already cover the peaks.

| Workload | request added | 14d peak | limit |
|---|---|---|---|
| network/envoy-gateway (controller) | 768Mi | 0.56Gi | 1Gi (unchanged) |
| storage/garage | 384Mi | 0.38Gi | 512Mi |
| media/seerr | 384Mi | 0.35Gi | 2Gi |
| observability/kube-ops-view | 256Mi (new block) | 0.20Gi | 384Mi |

## Why

With no memory request, the scheduler treats these as ~zero and can over-pack the nodes they run on, while they actually consume real memory — a hidden contributor to uneven *actual* load. Setting requests makes the accounting honest so the scheduler and descheduler place/balance them correctly. This also closes the deferred envoy-gateway item from the earlier right-sizing work.

## Follow-up (not in this PR)

The remaining no-request workloads are upstream subcharts needing per-chart resource keys: **loki** (real peak **2.35Gi** — the largest unreserved memory user), vector-aggregator, langfuse-web, grafana, windmill-app. Worth a dedicated pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)