### PR TITLE
feat(resources): set Loki SingleBinary memory request

### DIFF
--- a/kubernetes/apps/observability/loki/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/loki/app/helmrelease.yaml
@@ -87,6 +87,12 @@ spec:
 
     singleBinary:
       replicas: 1
+      resources:
+        requests:
+          cpu: 250m
+          memory: 2560Mi
+        limits:
+          memory: 4Gi
       persistence:
         storageClass: ceph-block
         size: 30Gi


### PR DESCRIPTION
## What

Sets a memory request on Loki (SingleBinary mode, `loki-0`), which was running with **no resource requests at all**.

```
singleBinary.resources:
  requests: { cpu: 250m, memory: 2560Mi }
  limits:   { memory: 4Gi }
```

## Why

Loki's real 14-day peak working-set is **2.35Gi** — the single largest *unreserved* memory consumer in the cluster. With no request, the scheduler counts it as ~zero and can over-pack its node while it actually uses 2.3Gi+, contributing to uneven actual load. Request sized for typical load with headroom; the 4Gi limit sits comfortably above the observed peak.

This is the headline item from the no-request-set follow-up. The remaining smaller subchart workloads (vector-aggregator, langfuse-web, grafana, windmill-app) are lower-impact and left for a later pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)