### PR TITLE
fix(home,media): right-size memory requests on worker4/worker8

### DIFF
--- a/kubernetes/apps/home/esphome/app/helmrelease.yaml
+++ b/kubernetes/apps/home/esphome/app/helmrelease.yaml
@@ -67,7 +67,7 @@ spec:
             resources:
               requests:
                 cpu: 20m
-                memory: 512Mi
+                memory: 128Mi
               limits:
                 memory: 6Gi
 

--- a/kubernetes/apps/home/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/home/home-assistant/app/helmrelease.yaml
@@ -80,9 +80,9 @@ spec:
             resources:
               requests:
                 cpu: 100m
-                memory: 2.5G
+                memory: 1536Mi
               limits:
-                memory: 2.5G
+                memory: 2Gi
     service:
       app:
         type: LoadBalancer

--- a/kubernetes/apps/home/windmill/app/helmrelease.yaml
+++ b/kubernetes/apps/home/windmill/app/helmrelease.yaml
@@ -160,14 +160,16 @@ spec:
       # the same env (Windmill execs scripts inline for short flows).
       app:
         extraEnv: *workflow_secrets
-
-      # App pod resources.
-      resources:
-        requests:
-          cpu: 100m
-          memory: 256Mi
-        limits:
-          memory: 1Gi
+        # App pod resources. The chart keys these under
+        # `windmill.app.resources`; a top-level `windmill.resources`
+        # block is a no-op (verified against chart 4.0.175 — the app
+        # pod was silently running on the chart default of 2Gi req=limit).
+        resources:
+          requests:
+            cpu: 100m
+            memory: 768Mi
+          limits:
+            memory: 1536Mi
 
       # Tell Windmill it's behind a TLS-terminating proxy (Envoy).
       proxy:

--- a/kubernetes/apps/media/music-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/media/music-assistant/app/helmrelease.yaml
@@ -37,7 +37,7 @@ spec:
             resources:
               requests:
                 cpu: 15m
-                memory: 2Gi
+                memory: 1536Mi
               limits:
                 memory: 3Gi
 


### PR DESCRIPTION
worker4 (~81%) and worker8 (~86%) memory *requests* leave thin headroom — enough that a rolling update can push node-pinned exporter/agent pods into Pending (the `KubePodNotReady` flare that prompted this; those pods have since scheduled, so this is **preventive**). Trims four over-provisioned requests to observed peak + headroom. Limits keep burst room.

## Changes
| App | Request | Actual usage | New request | Note |
|---|---|---|---|---|
| esphome | 512Mi | ~57Mi | **128Mi** | limit stays 6Gi |
| home-assistant | 2.5G | ~940Mi | **1536Mi** | limit 2.5G→2Gi |
| music-assistant | 2Gi | ~1.0Gi | **1536Mi** | limit stays 3Gi |
| windmill (app pod) | 2Gi req=limit | ~560Mi | **768Mi / 1536Mi** | see below |

Frees **~1.7Gi on worker4**, **~1.25Gi on worker8**.

### windmill — also fixes a latent config bug
The app pod was silently running on the **chart default of 2Gi req=limit**. The HR's existing top-level `windmill.resources` block (commented "App pod resources") is a **no-op** — verified against chart 4.0.175 via `helm template`, the app pod is keyed under `windmill.app.resources`. Moved the block to the correct key and set 768Mi/1536Mi.

## Deliberately excluded
- **Ceph** OSD/mgr/mon — BlueStore cache floor; mgr's headroom is the intentional PR#12513 OOM fix
- **CNPG Postgres** — WAL replay / failover absorbs memory
- **GPU/inference** (immich-ml, ollama, whisper) — low RSS is idle; VRAM weights aren't in the cgroup
- **Frigate** — 7Gi request is bimodal (event-burst ~6-7Gi); needs its own burst-profile review, not a blind trim

## ⚠️ Merge timing
Home Assistant and Music Assistant are **Renee-facing**, and changing a memory request **restarts the pod** → these should land in the **Tuesday 02:00–04:00 ET** maintenance window per repo policy. esphome + windmill are routine-window. Splitting on merge is the caller's choice; if you want, I can split this into a Renee-facing PR (Tue) and a routine PR (now).

Rollback is a one-line revert per file; no alerting/AlertManager config touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)