### PR TITLE
fix(observability): two latent alert-rule defects (latch + restart re-fire)

### DIFF
--- a/kubernetes/apps/databases/cloudnative-pg/app/prometheusrule.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/app/prometheusrule.yaml
@@ -47,13 +47,22 @@ spec:
           for: 10m
           labels:
             severity: warning
+        # delta()[5m] false-fires on every CNPG pod restart: the gauge
+        # resets then re-emits the persisted last-failed timestamp, which
+        # reads as a positive delta even when the failure is weeks old
+        # (same restart re-emission class as BackupFailed below). Gate on
+        # the failure timestamp being genuinely recent (<1h) instead. The
+        # metric is -1 when archiving has never failed, so the >0 guard
+        # excludes that case.
         - alert: LastFailedArchiveTime
           annotations:
-            description: Archiving failed for {{ $labels.pod }}
-            summary: Checks the last time archiving failed. Will be -1 when it has not failed.
+            description: Archiving failed recently for {{ $labels.pod }}
+            summary: CNPG WAL archiving failed within the last hour.
           expr: |-
-            delta(cnpg_pg_stat_archiver_last_failed_time[5m]) > 0
-          for: 1m
+            (cnpg_pg_stat_archiver_last_failed_time > 0)
+            and
+            (time() - cnpg_pg_stat_archiver_last_failed_time < 3600)
+          for: 5m
           labels:
             severity: warning
         - alert: DatabaseDeadlockConflicts

--- a/kubernetes/apps/observability/kube-prometheus-stack/addons/alerts/external-dns.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/addons/alerts/external-dns.yaml
@@ -34,9 +34,13 @@ spec:
           labels:
             severity: critical
 
+        # Raw cumulative *_errors_total > 0 latches forever after the
+        # first error until the pod restarts (counter only resets on
+        # restart). Use increase() so the alert fires only while errors
+        # are actively occurring.
         - alert: ExternalDNSSourceError
           expr: |
-            external_dns_source_errors_total > 0
+            increase(external_dns_source_errors_total[15m]) > 0
           for: 5m
           annotations:
             summary: >-
@@ -46,7 +50,7 @@ spec:
 
         - alert: ExternalDNSApplyChangesError
           expr: |
-            external_dns_webhook_provider_applychanges_errors_total > 0
+            increase(external_dns_webhook_provider_applychanges_errors_total[15m]) > 0
           for: 5m
           annotations:
             summary: >-
@@ -56,7 +60,7 @@ spec:
 
         - alert: ExternalDNSRecordsError
           expr: |
-            external_dns_webhook_provider_records_errors_total > 0
+            increase(external_dns_webhook_provider_records_errors_total[15m]) > 0
           for: 5m
           annotations:
             summary: >-


### PR DESCRIPTION
Two alert rules of the same defect families just fixed in #12531 — found by auditing the rest of the rule set. Pure rule changes, Flux-reconciled, no workload impact.

## `LastFailedArchiveTime` — false-fires on every CNPG pod restart
`delta(cnpg_pg_stat_archiver_last_failed_time[5m]) > 0` fires when the timestamp gauge resets-then-re-emits on a pod restart, reading as a positive delta even when the last archive failure was weeks ago (the **same restart-re-emission class as `BackupFailed`**). With 24+ CNPG clusters this churns constantly.

**Fix** — recency gate (metric is `-1` when archiving has never failed, so `> 0` excludes that):
```promql
(cnpg_pg_stat_archiver_last_failed_time > 0)
and
(time() - cnpg_pg_stat_archiver_last_failed_time < 3600)
```
`for: 1m` → `5m`.

## `ExternalDNS{Source,ApplyChanges,Records}Error` — latch forever after first error
All three compared raw cumulative `*_errors_total > 0`, which **stays firing forever** after the first error until the pod restarts (counter only resets on restart). Dormant today (all counters at 0) but a latent landmine — the first transient error would pin three `critical` alerts on indefinitely.

**Fix** — `increase(..._errors_total[15m]) > 0` so they fire only while errors are actively occurring.

## Audit notes
- `FrigateSnapshotSidecarDown` was flagged by the audit but is **correct** — `snapshot` is a native sidecar (`restartPolicy: Always`), so `init_container_status_running == 0` is a valid down-check. Left alone.
- Lower-priority defects deferred (UPS `for: 10s`, Claude-cost `for: 0m`, HostOomKillDetected `for: 0m`).
- Verified already-fixed: BackupFailed, OOMKilled, ClaudeApiCostMetricMissing, HostOutOfMemory (spark), HostSystemdServiceCrashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)