### PR TITLE
feat(ai): add LightRAG graph-RAG service

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ _Production-grade Kubernetes for a household._
 
 <br/>
 
-![apps](https://img.shields.io/badge/apps-187-blue?style=for-the-badge)
-![helmreleases](https://img.shields.io/badge/HelmReleases-200-326CE5?style=for-the-badge&logo=helm&logoColor=white)
+![apps](https://img.shields.io/badge/apps-188-blue?style=for-the-badge)
+![helmreleases](https://img.shields.io/badge/HelmReleases-201-326CE5?style=for-the-badge&logo=helm&logoColor=white)
 ![nodes](https://img.shields.io/badge/k8s_nodes-11-326CE5?style=for-the-badge&logo=kubernetes&logoColor=white)
 ![cnpg](https://img.shields.io/badge/Postgres_clusters-25-336791?style=for-the-badge&logo=postgresql&logoColor=white)
-![secrets](https://img.shields.io/badge/secrets-115-0572EC?style=for-the-badge&logo=1password&logoColor=white)
+![secrets](https://img.shields.io/badge/secrets-116-0572EC?style=for-the-badge&logo=1password&logoColor=white)
 ![age](https://img.shields.io/badge/cluster_age-5%2B_years-success?style=for-the-badge)
 
 </div>

--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
   - ./comfyui-spark/ks.yaml
   - ./langfuse/ks.yaml
   - ./langgraph-agents/ks.yaml
+  - ./lightrag/ks.yaml
   - ./ollama/ks.yaml
   - ./ollama-spark/ks.yaml
   - ./paperless-ai/ks.yaml

--- a/kubernetes/apps/ai/lightrag/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/lightrag/app/cnp-allow.yaml
@@ -1,0 +1,50 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: lightrag-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: lightrag
+  # Additive — default-deny is what triggers the lockdown; these rules
+  # punch holes through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal gateway → lightrag:9621 (lightrag.${SECRET_DOMAIN}
+    # for the WebUI + REST API).
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "9621"
+              protocol: TCP
+    # Ingest pusher: a Windmill flow reads the paperless corpus and POSTs
+    # documents into LightRAG's REST API (mirrors the existing
+    # paperless-rag-ingest → Qdrant flow). Windmill workers live in home ns.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: home
+            app.kubernetes.io/name: windmill-workers
+      toPorts:
+        - ports:
+            - port: "9621"
+              protocol: TCP
+  egress:
+    # LLM (graph extraction + query synthesis) and embeddings (bge-m3) are
+    # both served by ollama-spark in this same ns. Baseline
+    # allow-intra-namespace already covers ai→ai; explicit here for
+    # grep-ability (paperless-ai pattern).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: ai
+            app.kubernetes.io/name: ollama-spark
+      toPorts:
+        - ports:
+            - port: "11434"
+              protocol: TCP

--- a/kubernetes/apps/ai/lightrag/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/lightrag/app/externalsecret.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: lightrag
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: lightrag-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        # Server-to-server API key (the future paperless→LightRAG ingest
+        # pusher authenticates with this) and the WebUI login accounts.
+        # Ollama itself needs no key — LLM + embedding calls are
+        # unauthenticated intra-cluster.
+        LIGHTRAG_API_KEY: "{{ .api_key }}"
+        AUTH_ACCOUNTS: "{{ .auth_accounts }}"
+        TOKEN_SECRET: "{{ .token_secret }}"
+  dataFrom:
+    - extract:
+        key: lightrag

--- a/kubernetes/apps/ai/lightrag/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/lightrag/app/helmrelease.yaml
@@ -1,0 +1,154 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app lightrag
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 1h
+  install:
+    # First start creates the storage layout and warms the Ollama models;
+    # helm-controller's 5-min wait can outlast that cold path.
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    disableWait: true
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+      strategy: rollback
+  values:
+    defaultPodOptions:
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+    controllers:
+      lightrag:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        type: deployment
+        replicas: 1
+        strategy: Recreate  # single replica, RWO data PVC
+        containers:
+          app:
+            image:
+              repository: ghcr.io/hkuds/lightrag
+              tag: v1.5.3
+            env:
+              HOST: "0.0.0.0"
+              PORT: "9621"
+              # All durable paths live under the data PVC mount (/app/data).
+              WORKING_DIR: /app/data/rag_storage
+              INPUT_DIR: /app/data/inputs
+              PROMPT_DIR: /app/data/prompts
+              # --- LLM: graph extraction + query synthesis via Ollama-Spark ---
+              # qwen3-next:80b-a3b is an MoE (~3B active) → fast despite the
+              # 80b name, and already warm on the Spark (verified via
+              # `ollama list`). bge-m3 lives there too, so both calls stay on
+              # one host and never touch the P40 (no model-swap churn).
+              LLM_BINDING: ollama
+              LLM_BINDING_HOST: http://ollama-spark.ai.svc.cluster.local:11434
+              LLM_MODEL: qwen3-next:80b-a3b-instruct-q4_K_M
+              OLLAMA_LLM_NUM_CTX: "32768"
+              LLM_TIMEOUT: "240"
+              # --- Embeddings: bge-m3 (1024-dim) on Ollama-Spark ---
+              EMBEDDING_BINDING: ollama
+              EMBEDDING_BINDING_HOST: http://ollama-spark.ai.svc.cluster.local:11434
+              EMBEDDING_MODEL: bge-m3:latest
+              EMBEDDING_DIM: "1024"
+              OLLAMA_EMBEDDING_NUM_CTX: "8192"
+            envFrom:
+              - secretRef:
+                  name: lightrag-secret
+            probes:
+              # tcpSocket (not httpGet) — robust without asserting an exact
+              # health-endpoint path on first deploy.
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: &httpPort 9621
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: *httpPort
+                  initialDelaySeconds: 15
+                  periodSeconds: 15
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: *httpPort
+                  initialDelaySeconds: 15
+                  periodSeconds: 10
+                  failureThreshold: 30
+            resources:
+              requests:
+                cpu: 100m
+                memory: 1Gi
+              limits:
+                memory: 4Gi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - ALL
+              # readOnlyRootFilesystem omitted for first deploy: the image
+              # may write Python caches / scratch under / at startup.
+              # Durable state is on the data PVC; /tmp is tmpfs below.
+              # Revisit with RO rootfs once the image's write paths are
+              # confirmed clean.
+              seccompProfile:
+                type: RuntimeDefault
+    service:
+      app:
+        controller: lightrag
+        ports:
+          http:
+            port: *httpPort
+    route:
+      app:
+        annotations:
+          glance/name: "LightRAG"
+          glance/show: "true"
+          glance/id: "AI"
+        hostnames:
+          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: *httpPort
+    persistence:
+      data:
+        existingClaim: lightrag-data
+        advancedMounts:
+          lightrag:
+            app:
+              - path: /app/data
+      tmp:
+        type: emptyDir
+        advancedMounts:
+          lightrag:
+            app:
+              - path: /tmp

--- a/kubernetes/apps/ai/lightrag/app/kustomization.yaml
+++ b/kubernetes/apps/ai/lightrag/app/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../components/repos/app-template
+resources:
+  - ./cnp-allow.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./pvc.yaml

--- a/kubernetes/apps/ai/lightrag/app/pvc.yaml
+++ b/kubernetes/apps/ai/lightrag/app/pvc.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: lightrag-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+  # ceph-block per storage-class rule 2: the KV cache / vector store /
+  # knowledge graph are derived state, reconstructable by re-running
+  # extraction over the paperless corpus (the durable source). Survives
+  # node loss + pod restart; rebuild-from-paperless is the DR path. If
+  # re-extraction cost becomes painful, promote to longhorn + backup
+  # labels per rule 3.
+  storageClassName: ceph-block

--- a/kubernetes/apps/ai/lightrag/ks.yaml
+++ b/kubernetes/apps/ai/lightrag/ks.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app lightrag
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: ai
+  path: ./kubernetes/apps/ai/lightrag/app
+  interval: 1h
+  timeout: 10m
+  prune: true
+  wait: false
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: ollama-spark
+      namespace: ai
+    - name: onepassword-connect
+      namespace: external-secrets
+  retryInterval: 2m


### PR DESCRIPTION
## What

Deploys **LightRAG** (`ghcr.io/hkuds/lightrag:v1.5.3`) in the `ai` namespace — a self-hosted Graph-RAG service over the document corpus, running entirely on local inference. This is the second of two knowledge-graph tools being piloted (Serena, a code-intelligence MCP, follows in a separate PR + a containers-repo image build).

## Why

Graph-RAG builds a knowledge graph over documents for better multi-hop Q&A than flat vector RAG. LightRAG clears the durability bar (36k★, MIT, weekly releases), is Ollama-first, and reuses the `bge-m3` embedder already warm on the Spark. Deployed **alongside** the existing Windmill→Qdrant RAG pipeline (non-destructive) as a parallel capability to evaluate.

## How it's wired

| Concern | Choice |
|---|---|
| LLM (extraction + query) | `qwen3-next:80b-a3b-instruct-q4_K_M` on `ollama-spark` (MoE, ~3B active → fast) |
| Embeddings | `bge-m3:latest` (1024-dim) on `ollama-spark` |
| GPU | Spark only — P40 untouched (no model-swap churn) |
| Storage | `ceph-block`, 20Gi — derived state, reconstructable by re-extraction (storage rule 2) |
| Ingress | `lightrag.${SECRET_DOMAIN}` via internal gateway; CNP allows `windmill-workers` (future ingest pusher) |
| Security | non-root uid 1000, fsGroup, dropped caps, seccomp RuntimeDefault |

## ⚠️ Prerequisite before merge/reconcile

Create a 1Password item **`lightrag`** with fields:
- `api_key` — any random string (server-to-server API key)
- `auth_accounts` — e.g. `admin:<password>` (WebUI login)
- `token_secret` — random string (JWT signing)

Without it the `ExternalSecret` won't sync and the pod won't start.

## Follow-ups (not in this PR)
- Windmill ingest flow: read paperless corpus → POST into LightRAG REST API (mirrors existing `paperless-rag-ingest`).
- Optional: gate the WebUI behind oauth2-proxy/Authelia instead of LightRAG's built-in auth.
- Revisit `readOnlyRootFilesystem: true` once the image's write paths are confirmed clean.

## Validation
`kubectl kustomize` builds clean for both `lightrag/app` (5 resources) and the parent `ai` overlay (22). Not yet reconciled — Flux applies on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)