### PR TITLE
fix(observability): add debounce to flap-prone alert for: clauses

### DIFF
--- a/kubernetes/apps/observability/exporters/pushgateway/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/exporters/pushgateway/app/prometheusrule.yaml
@@ -27,7 +27,7 @@ spec:
         # ── Daily ─────────────────────────────────────────────────────
         - alert: ClaudeApiDailySoft
           expr: claude:cost_usd:increase24h > 10
-          for: 0m
+          for: 5m
           labels:
             severity: warning
             group: claude-cost
@@ -40,7 +40,7 @@ spec:
 
         - alert: ClaudeApiDailyHard
           expr: claude:cost_usd:increase24h > 20
-          for: 0m
+          for: 5m
           labels:
             severity: critical
             group: claude-cost
@@ -57,7 +57,7 @@ spec:
         # ── Weekly ────────────────────────────────────────────────────
         - alert: ClaudeApiWeeklySoft
           expr: claude:cost_usd:increase7d > 20
-          for: 0m
+          for: 5m
           labels:
             severity: warning
             group: claude-cost
@@ -69,7 +69,7 @@ spec:
 
         - alert: ClaudeApiWeeklyHard
           expr: claude:cost_usd:increase7d > 30
-          for: 0m
+          for: 5m
           labels:
             severity: critical
             group: claude-cost
@@ -86,7 +86,7 @@ spec:
         # ── Monthly ───────────────────────────────────────────────────
         - alert: ClaudeApiMonthlyHard
           expr: claude:cost_usd:increase30d > 60
-          for: 0m
+          for: 5m
           labels:
             severity: critical
             group: claude-cost

--- a/kubernetes/apps/observability/exporters/snmp-exporter/app/apc-ups/prometheusrule.yaml
+++ b/kubernetes/apps/observability/exporters/snmp-exporter/app/apc-ups/prometheusrule.yaml
@@ -22,7 +22,9 @@ spec:
             summary: UPS is running on battery.
           # upsBasicOutputStatus: 2=onLine, 3=onBattery
           expr: upsBasicOutputStatus == 3
-          for: 10s
+          # SNMP poll jitter can briefly read onBattery; the UPS carries
+          # the load, so a 1m debounce avoids false pages on a real outage.
+          for: 1m
           labels:
             severity: critical
         - alert: UPSLowRuntime
@@ -39,6 +41,7 @@ spec:
             description: UPS {{ $labels.target }} battery charge is {{ $value }}%, below 50%.
             summary: UPS battery charge low.
           expr: upsAdvBatteryCapacity < 50
+          for: 1m
           labels:
             severity: warning
         - alert: UPSBatteryReplace
@@ -47,7 +50,8 @@ spec:
             summary: Replace UPS battery.
           # upsAdvBatteryReplaceIndicator: 1=noBatteryNeedsReplacing, 2=batteryNeedsReplacing
           expr: upsAdvBatteryReplaceIndicator == 2
-          for: 10s
+          # Non-urgent advisory; 5m debounce kills SNMP-jitter false pages.
+          for: 5m
           labels:
             severity: critical
     # Derived/aggregated power metrics. Single source of truth for the

--- a/kubernetes/apps/observability/kube-prometheus-stack/addons/alerts/node-exporter.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/addons/alerts/node-exporter.yaml
@@ -227,7 +227,9 @@ spec:
 
         - alert: HostOomKillDetected
           expr: increase(node_vmstat_oom_kill[1m]) > 0
-          for: 0m
+          # Avoid firing on a single kernel OOM during a rolling-restart
+          # wave; the pod-level OOMKilled rule covers the real case.
+          for: 2m
           labels:
             severity: warning
           annotations:


### PR DESCRIPTION
Pure debounce additions to nine flap-prone rules — no expr/threshold changes, no behavior change on genuine sustained conditions. Closes out the LOW/MEDIUM tail from the alert-rule audit (the HIGH items shipped in #12538).

| Rule | Sev | `for:` | Why |
|---|---|---|---|
| `UPSOnBattery` | critical | 10s → **1m** | SNMP poll jitter; UPS carries the load |
| `UPSBatteryReplace` | critical | 10s → **5m** | non-urgent advisory |
| `UPSLowBattery` | warning | *(none)* → **1m** | had no debounce at all |
| `ClaudeApiDailySoft` | warning | 0m → **5m** | `increase()` spikes on TSDB reload |
| `ClaudeApiDailyHard` | critical | 0m → **5m** | same |
| `ClaudeApiWeeklySoft` | warning | 0m → **5m** | same |
| `ClaudeApiWeeklyHard` | critical | 0m → **5m** | same |
| `ClaudeApiMonthlyHard` | critical | 0m → **5m** | same |
| `HostOomKillDetected` | warning | 0m → **2m** | avoids firing on a single OOM during a restart wave; pod-level `OOMKilled` covers the real case |

**Left as-is by design:** `UPSLowRuntime` (already `for: 1m`), `HostNodeOvertemperatureAlarm` (`for: 0m` critical — hardware-asserted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)