### PR TITLE
feat(resources): set requests on no-request subchart workloads

### DIFF
--- a/kubernetes/apps/ai/langfuse/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langfuse/app/helmrelease.yaml
@@ -84,6 +84,12 @@ spec:
     langfuse:
       web:
         replicas: 1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 768Mi
+          limits:
+            memory: 1Gi
       worker:
         replicas: 1
         # The worker container shipped with no resources block at

--- a/kubernetes/apps/kube-system/reflector/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/reflector/helmrelease.yaml
@@ -50,3 +50,9 @@ spec:
     configuration:
       logging:
         minimumLevel: Information
+    resources:
+      requests:
+        cpu: 10m
+        memory: 512Mi
+      limits:
+        memory: 768Mi

--- a/kubernetes/apps/kube-system/reloader/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/reloader/app/helmrelease.yaml
@@ -18,10 +18,10 @@ spec:
     deployment:
       resources:
         limits:
-          memory: 256Mi
+          memory: 512Mi
         requests:
           cpu: 5m
-          memory: 256Mi
+          memory: 320Mi
     podMonitor:
       enabled: true
 

--- a/kubernetes/apps/observability/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/grafana/app/helmrelease.yaml
@@ -381,6 +381,13 @@ spec:
       secret.reloader.stakater.com/reload: *secret
     replicas: 1
 
+    resources:
+      requests:
+        cpu: 50m
+        memory: 512Mi
+      limits:
+        memory: 768Mi
+
     route:
       main:
         annotations:

--- a/kubernetes/apps/observability/kube-state-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-state-metrics/app/helmrelease.yaml
@@ -21,3 +21,9 @@ spec:
       monitor:
         enabled: true
         honorLabels: true
+    resources:
+      requests:
+        cpu: 10m
+        memory: 320Mi
+      limits:
+        memory: 512Mi

--- a/kubernetes/apps/observability/vector/aggregator/helmrelease.yaml
+++ b/kubernetes/apps/observability/vector/aggregator/helmrelease.yaml
@@ -54,6 +54,12 @@ spec:
               repository: ghcr.io/vectordotdev/vector
               tag: 0.56.0-debian@sha256:93b072b416fd29152f1bfe5bd2925a0b48999aeb069f3ae000691f82a135c200
             args: ["--config", "/etc/vector/vector.yaml"]
+            resources:
+              requests:
+                cpu: 50m
+                memory: 512Mi
+              limits:
+                memory: 768Mi
     service:
       app:
         # ClusterIP: vector-agent + Prometheus reach this via cluster DNS


### PR DESCRIPTION
## What

Adds memory **requests** to workloads the scheduler was counting as ~zero (no request set), and fixes two running with a limit below their observed peak. Sized to 14-day Prometheus peak working-set.

| Workload | change | 14d peak |
|---|---|---|
| ai/langfuse (web) | +req 768Mi / limit 1Gi | 0.84Gi |
| observability/vector-aggregator | +req 512Mi / limit 768Mi | 0.64Gi |
| kube-system/reflector | +req 512Mi / limit 768Mi | 0.60Gi |
| observability/grafana | +req 512Mi / limit 768Mi | 0.49Gi |
| observability/kube-state-metrics | +req 320Mi / limit 512Mi | 0.30Gi |
| kube-system/reloader | limit 256→512Mi, req 256→320Mi | 0.32Gi (was OOM-tight) |

## Why

No request → scheduler over-packs the node while the pod uses real memory. Reloader's limit was below its peak. Each chart's resources key was verified against the actual chart (kube-state-metrics is standalone — the kps subchart is disabled).

## Excluded after verification

**windmill-app** — already requests 768Mi (above its 0.57Gi peak); the VPA "no request" reading was stale from rotated replicasets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)