### PR TITLE
feat(resources): set requests on core-infra DaemonSets (request-only)

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -51,6 +51,10 @@ spec:
       prometheus:
         serviceMonitor:
           enabled: true
+      resources:
+        requests:
+          cpu: 50m
+          memory: 640Mi
 
     # prometheus.enabled exposes the agent metrics port (9962); without
     # it the chart skips the cilium-agent Service + ServiceMonitor even
@@ -60,6 +64,14 @@ spec:
       serviceMonitor:
         enabled: true
         trustCRDsExist: true
+
+    # Request-only (no memory limit): cilium-agent is the CNI dataplane;
+    # a tight limit risks OOM-killing node networking. Sized to 14d peak
+    # working-set ~1.5Gi.
+    resources:
+      requests:
+        cpu: 100m
+        memory: 1Gi
 
   valuesFrom:
     - kind: ConfigMap

--- a/kubernetes/apps/kube-system/gpu-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/gpu-operator/app/helmrelease.yaml
@@ -50,6 +50,10 @@ spec:
         default: any
     dcgmExporter:
       enabled: true
+      resources:
+        requests:
+          cpu: 100m
+          memory: 512Mi
       serviceMonitor:
         enabled: true
     gfd:

--- a/kubernetes/apps/longhorn-system/longhorn/app/helmrelease.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn/app/helmrelease.yaml
@@ -28,6 +28,12 @@ spec:
       imageRegistry: docker.io
 
     longhornManager:
+      # Request-only (no memory limit): storage control plane; a tight
+      # limit risks OOM during volume recovery. Sized to 14d peak ~1.2Gi.
+      resources:
+        requests:
+          cpu: 100m
+          memory: 1Gi
       securityContext:
         privileged: true
     persistence:


### PR DESCRIPTION
## What

Adds **request-only** memory resources (no limit) to four core-infra DaemonSets that ran with none. Sized to 14-day Prometheus peak.

| Workload | request | 14d peak |
|---|---|---|
| cilium (agent) | mem 1Gi | ~1.5Gi |
| cilium (operator) | mem 640Mi | 0.66Gi |
| longhorn (manager) | mem 1Gi | ~1.2Gi |
| gpu-operator (dcgm-exporter) | mem 512Mi | 0.50Gi |

**No memory limits** — cilium-agent is the CNI dataplane and longhorn-manager is the storage control plane; a tight limit risks OOM-killing node networking or volume recovery. Request-only gives the scheduler honest numbers without that risk.

## ⚠️ Why this is held (no auto-merge)

These are **DaemonSets**, so each request reserves on *every* node it runs. cilium-agent + longhorn-manager add ~1Gi each across ~11 nodes ≈ **~22Gi of new reservations**, partially re-inflating the requested total that the earlier right-sizing PRs reduced. It's honest accounting (they genuinely use this memory and the scheduler should know), but it's a deliberate tradeoff against the "keep nodes from looking full" goal — your call whether the accuracy is worth the reservation. I recommended holding on these earlier; opening per your "do them all" but leaving the merge to you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)