### PR TITLE
feat(mcp-system): add codegraph-mcp (CodeGraphContext behind the gateway)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ _Production-grade Kubernetes for a household._
 
 <br/>
 
-![apps](https://img.shields.io/badge/apps-187-blue?style=for-the-badge)
-![helmreleases](https://img.shields.io/badge/HelmReleases-200-326CE5?style=for-the-badge&logo=helm&logoColor=white)
+![apps](https://img.shields.io/badge/apps-188-blue?style=for-the-badge)
+![helmreleases](https://img.shields.io/badge/HelmReleases-201-326CE5?style=for-the-badge&logo=helm&logoColor=white)
 ![nodes](https://img.shields.io/badge/k8s_nodes-11-326CE5?style=for-the-badge&logo=kubernetes&logoColor=white)
 ![cnpg](https://img.shields.io/badge/Postgres_clusters-25-336791?style=for-the-badge&logo=postgresql&logoColor=white)
-![secrets](https://img.shields.io/badge/secrets-115-0572EC?style=for-the-badge&logo=1password&logoColor=white)
+![secrets](https://img.shields.io/badge/secrets-116-0572EC?style=for-the-badge&logo=1password&logoColor=white)
 ![age](https://img.shields.io/badge/cluster_age-5%2B_years-success?style=for-the-badge)
 
 </div>
@@ -277,7 +277,7 @@ Worker nodes attach to **iot** and **sec** VLANs via Multus for direct camera an
 </details>
 
 <details>
-<summary>🔌 <b>MCP Servers</b> — 17 Model Context Protocol servers behind an Authelia-gated gateway</summary>
+<summary>🔌 <b>MCP Servers</b> — 18 Model Context Protocol servers behind an Authelia-gated gateway</summary>
 
 | Server | Exposes |
 |--------|---------|
@@ -298,6 +298,7 @@ Worker nodes attach to **iot** and **sec** VLANs via Multus for direct camera an
 | **memory-mcp** | Cross-agent knowledge graph backed by Postgres + pgvector (bge-m3 1024-dim) |
 | **cilium-mcp** | Read-only Cilium / Hubble introspection (kubectl-mcp-style, Cilium-scoped) |
 | **windmill-mcp** | Aggregated Windmill workspace tools (script run, flow trigger) |
+| **codegraph-mcp** | Code knowledge-graph queries (CodeGraphContext via `mcp-proxy --stateless`) |
 
 </details>
 

--- a/kubernetes/apps/mcp-system/codegraph-mcp/app/cnp-allow.yaml
+++ b/kubernetes/apps/mcp-system/codegraph-mcp/app/cnp-allow.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: codegraph-mcp-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: codegraph-mcp
+  # Additive — default-deny is what triggers the lockdown. Broker → server
+  # (intra-ns) and the istio gateway path are covered by the baseline
+  # allow-intra-namespace + mcp-gateway-istio-allow, so no ingress rule
+  # is needed here (matches the other MCP backends).
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  egress:
+    # git-sync clones the repo to index from GitHub over HTTPS.
+    # github.com / codeload.github.com are canonical A-only FQDNs where
+    # Cilium toFQDNs.matchPattern silently fails (see
+    # project_cilium_matchpattern_fqdn_limits.md), so use world:443 —
+    # same rationale as the github-mcp CNP.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/mcp-system/codegraph-mcp/app/externalsecret.yaml
+++ b/kubernetes/apps/mcp-system/codegraph-mcp/app/externalsecret.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: codegraph-mcp
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: codegraph-mcp-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        # git-sync HTTPS credentials for cloning the repo to index. Use a
+        # fine-grained PAT scoped to read-only Contents on the target repo
+        # (e.g. rwlove/langgraph-agents). USERNAME is the GitHub username
+        # (or x-access-token); PASSWORD is the PAT.
+        GITSYNC_USERNAME: "{{ .username }}"
+        GITSYNC_PASSWORD: "{{ .pat }}"
+  dataFrom:
+    - extract:
+        key: codegraph-mcp

--- a/kubernetes/apps/mcp-system/codegraph-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/codegraph-mcp/app/helmrelease.yaml
@@ -1,0 +1,156 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app codegraph-mcp
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 1h
+  values:
+    defaultPodOptions:
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+    controllers:
+      codegraph-mcp:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        pod:
+          annotations:
+            sidecar.istio.io/inject: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/rwlove/codegraph-mcp
+              tag: "0.5.1"
+            env:
+              HOST: "0.0.0.0"
+              PORT: &httpPort 8080
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: *httpPort
+                  initialDelaySeconds: 20
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: *httpPort
+                  initialDelaySeconds: 10
+                  periodSeconds: 15
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+            resources:
+              requests:
+                cpu: 50m
+                memory: 256Mi
+              limits:
+                memory: 2Gi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - ALL
+              # readOnlyRootFilesystem omitted for first deploy: tree-sitter
+              # grammar handling / embedded graph engine may write outside
+              # the mounted volumes at startup. Durable graph is on the PVC
+              # (~/.codegraphcontext); /tmp is tmpfs. Revisit with RO once
+              # the write paths are confirmed clean.
+              seccompProfile:
+                type: RuntimeDefault
+          git-sync:
+            image:
+              repository: registry.k8s.io/git-sync/git-sync
+              tag: v4.4.0
+            env:
+              # Repo to index. Change to whichever repo you want graphed;
+              # the credentials in codegraph-mcp-secret must grant read
+              # Contents on it.
+              GITSYNC_REPO: https://github.com/rwlove/langgraph-agents
+              GITSYNC_ROOT: /workspace
+              GITSYNC_LINK: langgraph-agents
+              GITSYNC_PERIOD: 5m
+              GITSYNC_ONE_TIME: "false"
+            envFrom:
+              - secretRef:
+                  name: codegraph-mcp-secret
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
+              limits:
+                memory: 128Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - ALL
+              readOnlyRootFilesystem: true
+              seccompProfile:
+                type: RuntimeDefault
+    service:
+      app:
+        controller: codegraph-mcp
+        ports:
+          http:
+            port: *httpPort
+    route:
+      app:
+        hostnames:
+          - "codegraph-mcp.mcp.local"
+        parentRefs:
+          - name: mcp-gateway
+            namespace: mcp-system
+            sectionName: mcps
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /mcp
+            filters:
+              # Strip the broker Bearer before forwarding (fleet-wide MCP
+              # backend pattern — see time-mcp).
+              - type: RequestHeaderModifier
+                requestHeaderModifier:
+                  remove:
+                    - Authorization
+            backendRefs:
+              - identifier: app
+                port: *httpPort
+    persistence:
+      # Embedded code knowledge graph (FalkorDB-Lite/KuzuDB) — CodeGraphContext
+      # persists it under HOME/.codegraphcontext.
+      graph:
+        existingClaim: codegraph-graph
+        advancedMounts:
+          codegraph-mcp:
+            app:
+              - path: /home/app/.codegraphcontext
+      # Shared checkout: git-sync writes, the app reads /workspace/<repo>.
+      workspace:
+        type: emptyDir
+        advancedMounts:
+          codegraph-mcp:
+            app:
+              - path: /workspace
+            git-sync:
+              - path: /workspace
+      tmp:
+        type: emptyDir
+        advancedMounts:
+          codegraph-mcp:
+            app:
+              - path: /tmp

--- a/kubernetes/apps/mcp-system/codegraph-mcp/app/kustomization.yaml
+++ b/kubernetes/apps/mcp-system/codegraph-mcp/app/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../components/repos/app-template
+resources:
+  - ./cnp-allow.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./pvc.yaml

--- a/kubernetes/apps/mcp-system/codegraph-mcp/app/pvc.yaml
+++ b/kubernetes/apps/mcp-system/codegraph-mcp/app/pvc.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: codegraph-graph
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  # ceph-block per storage-class rule 2: the code knowledge graph is
+  # derived state, reconstructable by re-indexing the source repo (the
+  # durable upstream). Survives node loss + pod restart; rebuild = re-run
+  # the codegraph index tool.
+  storageClassName: ceph-block

--- a/kubernetes/apps/mcp-system/codegraph-mcp/ks.yaml
+++ b/kubernetes/apps/mcp-system/codegraph-mcp/ks.yaml
@@ -1,0 +1,50 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app codegraph-mcp
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: mcp-system
+  path: ./kubernetes/apps/mcp-system/codegraph-mcp/app
+  interval: 1h
+  timeout: 5m
+  prune: true
+  wait: false
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: mcp-gateway
+      namespace: mcp-system
+    - name: onepassword-connect
+      namespace: external-secrets
+  retryInterval: 2m
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app codegraph-mcp-mcpserverregistration
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: mcp-system
+  path: ./kubernetes/apps/mcp-system/codegraph-mcp/mcp
+  interval: 1h
+  timeout: 5m
+  prune: true
+  wait: false
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: codegraph-mcp
+      namespace: mcp-system
+  retryInterval: 2m

--- a/kubernetes/apps/mcp-system/codegraph-mcp/mcp/kustomization.yaml
+++ b/kubernetes/apps/mcp-system/codegraph-mcp/mcp/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./mcpserverregistration.yaml

--- a/kubernetes/apps/mcp-system/codegraph-mcp/mcp/mcpserverregistration.yaml
+++ b/kubernetes/apps/mcp-system/codegraph-mcp/mcp/mcpserverregistration.yaml
@@ -1,0 +1,14 @@
+---
+# TODO: apply schema
+apiVersion: mcp.kuadrant.io/v1alpha1
+kind: MCPServerRegistration
+metadata:
+  name: codegraph-tools
+  labels:
+    mcp.kuadrant.io/managed: "true"
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: codegraph-mcp
+  prefix: codegraph_

--- a/kubernetes/apps/mcp-system/kustomization.yaml
+++ b/kubernetes/apps/mcp-system/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
   - ./chrome-mcp/ks.yaml
   - ./chrome-smoke-sweep/ks.yaml
   - ./cilium-mcp/ks.yaml
+  - ./codegraph-mcp/ks.yaml
   - ./comfyui-mcp/ks.yaml
   - ./github-mcp/ks.yaml
   - ./grafana-mcp/ks.yaml


### PR DESCRIPTION
## What

A code knowledge-graph MCP backend in `mcp-system`, federated through the Kuadrant gateway (prefix `codegraph_`). The fleet can query a graph of a codebase (symbols, calls, imports) instead of re-reading source. This is the cluster side of the "Serena" ask — see the architecture note for why the tool changed.

## Why not Serena

Serena is a **stateful** LSP MCP — it can't federate through your **stateless** broker (the constraint that bit `arr-mcp`), and unlike arr-mcp its statefulness is architectural, not patchable. **CodeGraphContext** answers each call as an independent graph-DB query, so fronting its stdio server with `mcp-proxy --stateless` produces a broker-compatible `/mcp` endpoint. (You chose in-cluster-behind-gateway; this is the only way to honor that with a working federation.)

## Shape

```
mcp-gateway (stateless /mcp)
  └─ codegraph-mcp pod
       ├─ app: mcp-proxy --stateless → codegraphcontext mcp start (stdio)
       │        └─ embedded graph (FalkorDB-Lite/KuzuDB) on ceph-block PVC
       └─ git-sync sidecar → /workspace/langgraph-agents
```

- Istio sidecar + `/mcp` route w/ Authorization strip (fleet pattern).
- `ceph-block` PVC for the graph (derived state, re-indexable → storage rule 2).
- CNP egress `world:443` for git-sync; non-root uid 1000, dropped caps.
- v1 indexes **langgraph-agents** (Python — highest code-graph value). Edit `GITSYNC_REPO` to change.

## ⚠️ Depends on / prerequisites
1. **rwlove/containers#100** must merge first — it publishes `ghcr.io/rwlove/codegraph-mcp:0.5.1`. Until then the pod ImagePullBackOffs.
2. **1Password item `codegraph-mcp`** with fields `username` + `pat` (a fine-grained PAT with read-only Contents on the indexed repo).

## After deploy
Trigger the initial index once via the `codegraph_` MCP tools against `/workspace/langgraph-agents`.

## Validation
`kubectl kustomize` clean: app (5 resources), mcp registration, parent `mcp-system` overlay (45). Not reconciled — Flux applies on merge (after the image exists).

## Note
`mcp-proxy --stateless` streamable-HTTP `/mcp` wiring gets its first live exercise here; if the broker handshake needs a tweak it's a one-line CMD fix in the containers image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)