### PR TITLE
fix(ai): point LightRAG LOG_DIR at writable tmpfs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ _Production-grade Kubernetes for a household._
 
 <br/>
 
-![apps](https://img.shields.io/badge/apps-188-blue?style=for-the-badge)
-![helmreleases](https://img.shields.io/badge/HelmReleases-201-326CE5?style=for-the-badge&logo=helm&logoColor=white)
+![apps](https://img.shields.io/badge/apps-189-blue?style=for-the-badge)
+![helmreleases](https://img.shields.io/badge/HelmReleases-202-326CE5?style=for-the-badge&logo=helm&logoColor=white)
 ![nodes](https://img.shields.io/badge/k8s_nodes-11-326CE5?style=for-the-badge&logo=kubernetes&logoColor=white)
 ![cnpg](https://img.shields.io/badge/Postgres_clusters-25-336791?style=for-the-badge&logo=postgresql&logoColor=white)
-![secrets](https://img.shields.io/badge/secrets-116-0572EC?style=for-the-badge&logo=1password&logoColor=white)
+![secrets](https://img.shields.io/badge/secrets-117-0572EC?style=for-the-badge&logo=1password&logoColor=white)
 ![age](https://img.shields.io/badge/cluster_age-5%2B_years-success?style=for-the-badge)
 
 </div>

--- a/kubernetes/apps/ai/lightrag/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/lightrag/app/helmrelease.yaml
@@ -48,6 +48,10 @@ spec:
               WORKING_DIR: /app/data/rag_storage
               INPUT_DIR: /app/data/inputs
               PROMPT_DIR: /app/data/prompts
+              # lightrag.log defaults to cwd (/app, root-owned) → uid 1000
+              # can't create it → CrashLoop. Point it at the writable tmpfs;
+              # logs also go to stdout (Loki), so the file is ephemeral.
+              LOG_DIR: /tmp
               # --- LLM: graph extraction + query synthesis via Ollama-Spark ---
               # qwen3-next:80b-a3b is an MoE (~3B active) → fast despite the
               # 80b name, and already warm on the Spark (verified via


### PR DESCRIPTION
LightRAG (#12539) CrashLoopBackOffs as uid 1000 because it writes `lightrag.log` to its cwd `/app` (root-owned in the image):

```
PermissionError: [Errno 13] Permission denied: '/app/lightrag.log'
  → ValueError: Unable to configure handler 'file'
```

Fix: `LOG_DIR=/tmp` (the mounted tmpfs). Logs also stream to stdout → Loki, so the file is ephemeral. Verified against the live crashing pod. Also resyncs README badges (the two parallel app merges stacked and left the counts one behind).

🤖 Generated with [Claude Code](https://claude.com/claude-code)