### PR TITLE
fix(ai): let LightRAG fetch + cache the tiktoken BPE vocab

### DIFF
--- a/kubernetes/apps/ai/lightrag/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/lightrag/app/cnp-allow.yaml
@@ -48,3 +48,16 @@ spec:
         - ports:
             - port: "11434"
               protocol: TCP
+    # tiktoken downloads its BPE vocab (o200k_base) from
+    # openaipublic.blob.core.windows.net on first startup, or LightRAG
+    # CrashLoops at import. Azure blob is an A-record FQDN where Cilium's
+    # toFQDNs.matchPattern silently fails (see
+    # project_cilium_matchpattern_fqdn_limits.md), so world:443 per the
+    # github-mcp / khoj precedent. The vocab is cached to the data PVC
+    # (TIKTOKEN_CACHE_DIR) so this fires once, not every cold start.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/ai/lightrag/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/lightrag/app/helmrelease.yaml
@@ -52,6 +52,11 @@ spec:
               # can't create it → CrashLoop. Point it at the writable tmpfs;
               # logs also go to stdout (Loki), so the file is ephemeral.
               LOG_DIR: /tmp
+              # tiktoken caches its BPE vocab here (on the data PVC) so the
+              # one-time download from openaipublic.blob.core.windows.net
+              # survives pod restarts. Without a writable cache dir it
+              # re-downloads every cold start (and fails under default-deny).
+              TIKTOKEN_CACHE_DIR: /app/data/tiktoken
               # --- LLM: graph extraction + query synthesis via Ollama-Spark ---
               # qwen3-next:80b-a3b is an MoE (~3B active) → fast despite the
               # 80b name, and already warm on the Spark (verified via


### PR DESCRIPTION
After the `LOG_DIR` fix (#12545), LightRAG still CrashLooped — `tiktoken` downloads `o200k_base` from `openaipublic.blob.core.windows.net` at import, blocked by default-deny:

```
requests.exceptions.ConnectTimeout: openaipublic.blob.core.windows.net:443 ... /encodings/o200k_base.tiktoken
```

- **CNP**: allow egress `world:443` (Azure blob is an A-record FQDN where `toFQDNs.matchPattern` is unreliable — `world:443` per the github-mcp/khoj precedent).
- **`TIKTOKEN_CACHE_DIR=/app/data/tiktoken`** so the vocab is fetched once and cached on the data PVC across restarts.

⚠️ Security note: this opens broad HTTPS egress on a doc-processing service. It's the repo's established pattern for A-only external FQDNs, but it could be tightened to a `toFQDNs` allowlist if `matchPattern` proves to walk the Azure CNAME chain. Flagging for awareness.

Verified live against the crashing pod. (codegraph-mcp is unaffected — no tiktoken.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)