### PR TITLE
fix(mcp-system): correct codegraph-mcp image tag to v0.5.1

### DIFF
--- a/kubernetes/apps/mcp-system/codegraph-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/codegraph-mcp/app/helmrelease.yaml
@@ -28,7 +28,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/codegraph-mcp
-              tag: "0.5.1"
+              tag: v0.5.1
             env:
               HOST: "0.0.0.0"
               PORT: &httpPort 8080


### PR DESCRIPTION
codegraph-mcp pod `ErrImagePull` / `manifest unknown` — the helmrelease pinned `0.5.1` but the release publishes **`v0.5.1`** (the workflow strips only `codegraph-mcp-` from `codegraph-mcp-v0.5.1`, keeping the `v`, same as `time-mcp:v0.1.1`).

Registry confirms tags `[v0.5.1, latest]`; `0.5.1` doesn't exist. One-char... one-line fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)