### PR TITLE
fix(mcp-system): give codegraph-mcp git-sync a writable /tmp

### DIFF
--- a/kubernetes/apps/mcp-system/codegraph-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/codegraph-mcp/app/helmrelease.yaml
@@ -154,3 +154,7 @@ spec:
           codegraph-mcp:
             app:
               - path: /tmp
+            # git-sync's HOME is /tmp; with readOnlyRootFilesystem it needs a
+            # writable /tmp to create its gitconfig (else FATAL at startup).
+            git-sync:
+              - path: /tmp


### PR DESCRIPTION
codegraph-mcp's `git-sync` sidecar CrashLoopBackOff:

```
FATAL: can't create gitconfig file ... open /tmp/git-sync.gitconfig...: read-only file system
```

git-sync's HOME is `/tmp` and it runs `readOnlyRootFilesystem: true`, but the `tmp` emptyDir was only mounted into the `app` container. Mount it into `git-sync` too.

The `app` container (mcp-proxy → codegraphcontext) was already Ready on `v0.5.1`; this is the last piece for git-sync to clone the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)