### PR TITLE
fix(mcp-system): codegraph-mcp → patched image v0.5.1-decoratorfix1

### DIFF
--- a/kubernetes/apps/mcp-system/codegraph-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/codegraph-mcp/app/helmrelease.yaml
@@ -28,7 +28,10 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/codegraph-mcp
-              tag: v0.5.1
+              # -decoratorfix1: build-time patch for codegraphcontext indexing
+              # crash (CodeGraphContext#1285 / rwlove/containers#101). Drop the
+              # suffix when upstream ships the guard and the patch is removed.
+              tag: v0.5.1-decoratorfix1
             env:
               HOST: "0.0.0.0"
               PORT: &httpPort 8080


### PR DESCRIPTION
Bumps codegraph-mcp to the patched image (rwlove/containers#101) that fixes the codegraphcontext indexing crash (`'NoneType' object has no attribute 'split'` in `_resolve_decorator_path`, upstream CodeGraphContext/CodeGraphContext#1285).

Validated live: langgraph-agents goes **FAILED → COMPLETED (225/225, 0 errors)** with the patch. This clears the empty-graph blocker — codegraph-mcp is already deployed and federated (25 `codegraph_*` tools); this lets the index actually populate.

After reconcile I'll re-run the index and verify the graph populates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)