### PR TITLE
feat(home): paperless → LightRAG graph-RAG ingest flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ Worker nodes attach to **iot** and **sec** VLANs via Multus for direct camera an
 | **Paperless-ngx** | Document scanning, OCR, tagging (CNPG-backed, offsite-backed) |
 | **Obsidian** + **obsidian-couchdb** | Notes sync (CouchDB w/ Cloudflare rate-limiting) |
 | **Zulip** | Self-hosted team chat (also wired into agent pipeline approvals) |
-| **Windmill** | Workflow automation; 22 checked-in TypeScript flows under `kubernetes/apps/home/windmill/workflows/` cover AlertManager → HolmesGPT, langgraph inbox/approval/digest/DLQ/cost-cap/awaiting-user/reviewer-weekly, weekly operator drift sweeps (storage / network / ml / observability), paperless RAG ingest+tombstone, Zulip triager webhook, the workaround upstream-watcher, and the errand-runner approval-flow smoke driver |
+| **Windmill** | Workflow automation; 24 checked-in TypeScript flows under `kubernetes/apps/home/windmill/workflows/` cover AlertManager → HolmesGPT, langgraph inbox/approval/digest/DLQ/cost-cap/awaiting-user/reviewer-weekly, weekly operator drift sweeps (storage / network / ml / observability), paperless RAG ingest+tombstone (Qdrant) and LightRAG graph-RAG ingest+tombstone, Zulip triager webhook, the workaround upstream-watcher, and the errand-runner approval-flow smoke driver |
 | **ntfy** | Self-hosted push notifications (operator approvals via Android tap actions) |
 | **BentoPDF** | Self-hosted PDF toolkit |
 | **Kitchenowl** | Shopping lists + recipe / meal management |
@@ -324,7 +324,7 @@ flowchart TB
         AM[AlertManager]
     end
 
-    subgraph Bridges[Windmill bridges<br/>22 TS workflows]
+    subgraph Bridges[Windmill bridges<br/>24 TS workflows]
         WInbox[langgraph-inbox.ts]
         WAlert[alertmanager-holmesgpt-notify.ts]
         WApprove[langgraph-approval-post/receive.ts]
@@ -388,7 +388,7 @@ in 1Password.
 - **Khoj** (`ai/`) — parallel personal-AI surface for notes + docs. Self-contained: own embedding pipeline (default gte-small, optionally ollama nomic-embed-text), chat via Ollama-P40. Does **not** consume MCP gateway or langgraph-agents.
 - **HolmesGPT** (`observability/`) — live in production for alert triage. AlertManager firings reach it via Windmill's `alertmanager-holmesgpt-notify.ts`; it reasons over Prometheus + Loki + cluster state and posts a root-cause hypothesis to Zulip / ntfy. Open WebUI also surfaces it as a tool server. Prompt + context budget tuned for qwen3-next:80b-a3b-instruct-q4_K_M on Spark (32K context, 6 tool-call budget per investigation).
 - **langgraph-agents** (`ai/`) — the FastAPI multi-agent runtime (`rwlove/langgraph-agents`, version pinned in `helmrelease.yaml`). Plumbed end-to-end (Postgres checkpoints + memory, live task-queue substrate in `postgres-langgraph-checkpoints`, vault PVCs, Windmill approval loop, cost caps in env). Trigger surface live: alertmanager → 6 namespace-mapped operators, daily 22:00 ET historian digest, weekly Saturday operator drift crons (ml / observability / network / reviewer / storage), errand-runner approval-flow smoke. `ENABLE_CLAUDE_API: false` so Claude API escalation is still gated. Public ingress splits CLI traffic (`hai.${SECRET_DOMAIN}`, Bearer-only) from browser traffic (`hai-web.${SECRET_DOMAIN}`, Authelia).
-- **Windmill** (`home/`) — 22 checked-in TypeScript flows under `kubernetes/apps/home/windmill/workflows/` are the bridges that knit the surfaces above together. Every alert webhook, Zulip-triggered DM, approval round-trip, daily digest, weekly vault-hygiene sweep, weekly operator drift sweeps (storage / network / ml / observability), DLQ retry, cost-cap pause, Paperless RAG ingest, and the errand-runner approval-flow smoke driver is a `.ts` file there.
+- **Windmill** (`home/`) — 24 checked-in TypeScript flows under `kubernetes/apps/home/windmill/workflows/` are the bridges that knit the surfaces above together. Every alert webhook, Zulip-triggered DM, approval round-trip, daily digest, weekly vault-hygiene sweep, weekly operator drift sweeps (storage / network / ml / observability), DLQ retry, cost-cap pause, Paperless RAG ingest (Qdrant + LightRAG graph-RAG), and the errand-runner approval-flow smoke driver is a `.ts` file there.
 - **Langfuse** (`ai/`) — OTLP trace sink for langgraph-agents. Chart deploys ClickHouse + Valkey + MinIO bundled; Postgres comes from CNPG `postgres-langfuse`.
 - **memory-mcp** (`mcp-system/`) — cross-agent knowledge graph on `postgres-langgraph-memory` with pgvector(1024). bge-m3 embeds via Ollama-Spark.
 

--- a/kubernetes/apps/home/windmill/app/cnp-allow.yaml
+++ b/kubernetes/apps/home/windmill/app/cnp-allow.yaml
@@ -204,6 +204,17 @@ spec:
         - ports:
             - port: "6333"
               protocol: TCP
+    # LightRAG graph-RAG ingest (lightrag-rag-ingest / -tombstone) →
+    # lightrag (ai ns) REST API. The lightrag CNP already allows the
+    # symmetric ingress from windmill-workers.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: ai
+            app.kubernetes.io/name: lightrag
+      toPorts:
+        - ports:
+            - port: "9621"
+              protocol: TCP
     # External APIs Windmill workflows hit: Pushover + Anthropic + GitHub.
     # Canonical FQDNs via toEntities:world+443 per memory
     # project_cilium_matchpattern_fqdn_limits (matchPattern silently

--- a/kubernetes/apps/home/windmill/app/externalsecret-workflows.yaml
+++ b/kubernetes/apps/home/windmill/app/externalsecret-workflows.yaml
@@ -43,6 +43,10 @@ spec:
         # (`paperless` / field `mcp_token`) that mcp-system/paperless-mcp
         # already uses — keeping a single token-rotation surface.
         PAPERLESS_TOKEN: "{{ .paperless_mcp_token }}"
+        # LightRAG graph-RAG ingest (lightrag-rag-ingest / -tombstone).
+        # api_key from the `lightrag` 1P item — same item the lightrag
+        # ExternalSecret in ai ns reads (single rotation surface).
+        LIGHTRAG_API_KEY: "{{ .lightrag_api_key }}"
         # HAI CLI Bearer token. Required for any Windmill workflow that calls
         # langgraph-agents /admin/* or /inbox endpoints (cost-cap-watcher,
         # awaiting-user-sweep, daily-digest, dlq-watcher). Sourced from the
@@ -84,6 +88,14 @@ spec:
         - regexp:
             source: "(.*)"
             target: "paperless_$1"
+    # LIGHTRAG_API_KEY (field=api_key on the `lightrag` 1P item, prefixed
+    # to avoid colliding with other extracted items).
+    - extract:
+        key: lightrag
+      rewrite:
+        - regexp:
+            source: "(.*)"
+            target: "lightrag_$1"
     # windmill_api_token — for self-introspection (see WINDMILL_TOKEN
     # comment above).
     - extract:

--- a/kubernetes/apps/home/windmill/app/helmrelease.yaml
+++ b/kubernetes/apps/home/windmill/app/helmrelease.yaml
@@ -74,7 +74,7 @@ spec:
           # an explicit allowlist).
           extraEnv: &workflow_secrets
             - name: WHITELIST_ENVS
-              value: LANGGRAPH_APPROVAL_SIGNING_KEY,NTFY_URL,NTFY_WRITE_TOKEN,ZULIP_API_URL,ZULIP_BOT_EMAIL,ZULIP_BOT_API_KEY,ROB_ZULIP_USER_ID,PAPERLESS_TOKEN,WINDMILL_TOKEN,HAI_CLI_TOKEN,ADMIN_NAME
+              value: LANGGRAPH_APPROVAL_SIGNING_KEY,NTFY_URL,NTFY_WRITE_TOKEN,ZULIP_API_URL,ZULIP_BOT_EMAIL,ZULIP_BOT_API_KEY,ROB_ZULIP_USER_ID,PAPERLESS_TOKEN,LIGHTRAG_API_KEY,WINDMILL_TOKEN,HAI_CLI_TOKEN,ADMIN_NAME
             - name: LANGGRAPH_APPROVAL_SIGNING_KEY
               valueFrom:
                 secretKeyRef:
@@ -110,6 +110,14 @@ spec:
                 secretKeyRef:
                   name: windmill-workflows-secret
                   key: PAPERLESS_TOKEN
+            # LIGHTRAG_API_KEY: used by lightrag-rag-ingest / -tombstone to
+            # POST/DELETE LightRAG's /documents API (X-API-Key). Sourced
+            # from the `lightrag.api_key` 1P field.
+            - name: LIGHTRAG_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: windmill-workflows-secret
+                  key: LIGHTRAG_API_KEY
             # WINDMILL_TOKEN: used by `windmill-failure-watcher` to query
             # its own /api/w/.../jobs/list_completed. Sourced from the
             # `windmill.windmill_api_token` 1P field (PR #11953).

--- a/kubernetes/apps/home/windmill/workflows/README.md
+++ b/kubernetes/apps/home/windmill/workflows/README.md
@@ -30,6 +30,7 @@ or the inline curl in the README two levels up).
 | `ZULIP_BOT_API_KEY` | `zulip-windmill-bot.ZULIP_BOT_API_KEY` |
 | `ROB_ZULIP_USER_ID` | `zulip-windmill-bot.ROB_ZULIP_USER_ID` |
 | `PAPERLESS_TOKEN` | `paperless.mcp_token` (shared with paperless-mcp) |
+| `LIGHTRAG_API_KEY` | `lightrag.api_key` (shared with the ai-ns lightrag ExternalSecret) |
 
 ## Approval-token signing (pre-sign at post-time)
 

--- a/kubernetes/apps/home/windmill/workflows/lightrag-rag-ingest.ts
+++ b/kubernetes/apps/home/windmill/workflows/lightrag-rag-ingest.ts
@@ -1,0 +1,158 @@
+// Cron: every 30 min.
+//
+// Streams modified Paperless documents into LightRAG (graph-RAG) so its
+// knowledge graph covers the same corpus as the Qdrant vector pipeline
+// (paperless-rag-ingest). Runs ALONGSIDE that flow, not replacing it —
+// vector RAG and graph RAG over the same docs, for comparison.
+//
+// We push Paperless's OCR TEXT (doc.content), not the original PDF: the
+// deployed LightRAG image parses PDFs with pypdf only (no Docling/OCR),
+// whereas Paperless already OCR'd everything (tesseract). LightRAG chunks,
+// embeds (bge-m3 on Spark), and runs LLM entity/relationship extraction
+// itself — we only hand it text.
+//
+// LightRAG ingestion is async + LLM-heavy (extraction per doc on the
+// Spark), so we CAP docs per run and let the cron iterate. This paces the
+// initial backfill across many runs instead of flooding the pipeline.
+//
+// Per doc:
+//   1. fetch OCR text from Paperless (doc.content)
+//   2. on update, delete any existing LightRAG docs for this paperless id
+//      (matched by file_path == "paperless:<id>") so re-ingest replaces
+//      cleanly instead of orphaning the old content-hash doc
+//   3. POST /documents/text { text, file_source: "paperless:<id>" }
+//      (X-API-Key) — fire-and-forget; LightRAG processes in its pipeline
+//
+// Watermark: persisted in Windmill state (max Paperless `modified` seen).
+// Identity: file_source "paperless:<id>" surfaces as file_path in
+// LightRAG's doc status — the stable key for clean updates AND the
+// tombstone sweep (lightrag-rag-tombstone).
+
+import * as wmill from "windmill-client";
+
+const LIGHTRAG = Deno.env.get("LIGHTRAG_URL") ??
+    "http://lightrag.ai.svc.cluster.local:9621";
+const PAPERLESS = Deno.env.get("PAPERLESS_URL") ??
+    "http://paperless.collab.svc.cluster.local:8000";
+const PAGE_SIZE = 50;
+const MAX_DOCS_PER_RUN = 20; // pace the LLM-heavy extraction pipeline
+const MIN_TEXT_LEN = 50;
+const MAX_DOC_CHARS = 500_000; // safety: refuse runaway docs
+const SOURCE_PREFIX = "paperless:";
+const EPOCH = "1970-01-01T00:00:00Z";
+
+type PaperlessDoc = { id: number; title: string; content: string; modified: string };
+type PaperlessList = { count: number; next: string | null; results: PaperlessDoc[] };
+type DocStatus = { id: string; file_path: string };
+type DocsStatusesResponse = { statuses: Record<string, DocStatus[]> };
+
+export async function main() {
+    const token = Deno.env.get("PAPERLESS_TOKEN");
+    if (!token) throw new Error("PAPERLESS_TOKEN env not set");
+    const apiKey = Deno.env.get("LIGHTRAG_API_KEY");
+    if (!apiKey) throw new Error("LIGHTRAG_API_KEY env not set");
+
+    const started = new Date().toISOString();
+    const watermark = ((await wmill.getState()) as string | null) ?? EPOCH;
+    const existing = await lightragSourceMap(apiKey); // "paperless:<id>" -> [docId]
+    console.log(`[lightrag-ingest] watermark=${watermark} known_sources=${existing.size}`);
+
+    let submitted = 0, replaced = 0, skipped = 0;
+    let maxModified = watermark;
+    let page = 1;
+    let capped = false;
+
+    outer:
+    while (true) {
+        const list = await paperlessList(token, watermark, page);
+        if (list.results.length === 0) break;
+        for (const doc of list.results) {
+            if (submitted >= MAX_DOCS_PER_RUN) { capped = true; break outer; }
+            const text = (doc.content ?? "").slice(0, MAX_DOC_CHARS).trim();
+            const src = `${SOURCE_PREFIX}${doc.id}`;
+            if (text.length < MIN_TEXT_LEN) {
+                skipped++;
+                if (doc.modified > maxModified) maxModified = doc.modified;
+                continue;
+            }
+            const prior = existing.get(src);
+            if (prior?.length) { await lightragDelete(apiKey, prior); replaced++; }
+            await lightragInsert(apiKey, text, src);
+            submitted++;
+            if (doc.modified > maxModified) maxModified = doc.modified;
+        }
+        if (!list.next) break;
+        page += 1;
+    }
+
+    // Advance the watermark only as far as the docs we actually decided this
+    // run — `capped` means more remain; the next run resumes from here.
+    await wmill.setState(maxModified);
+
+    return {
+        started,
+        finished: new Date().toISOString(),
+        watermark_in: watermark,
+        watermark_out: maxModified,
+        submitted,
+        replaced,
+        skipped,
+        capped,
+    };
+}
+
+async function lightragSourceMap(apiKey: string): Promise<Map<string, string[]>> {
+    const r = await fetch(`${LIGHTRAG}/documents`, {
+        headers: { "X-API-Key": apiKey },
+        signal: AbortSignal.timeout(60_000),
+    });
+    if (!r.ok) throw new Error(`lightrag GET /documents ${r.status}: ${await r.text()}`);
+    const body = (await r.json()) as DocsStatusesResponse;
+    const map = new Map<string, string[]>();
+    for (const docs of Object.values(body.statuses ?? {})) {
+        for (const d of docs) {
+            if (!d.file_path?.startsWith(SOURCE_PREFIX)) continue;
+            const arr = map.get(d.file_path) ?? [];
+            arr.push(d.id);
+            map.set(d.file_path, arr);
+        }
+    }
+    return map;
+}
+
+async function lightragInsert(apiKey: string, text: string, source: string): Promise<void> {
+    const r = await fetch(`${LIGHTRAG}/documents/text`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "X-API-Key": apiKey },
+        body: JSON.stringify({ text, file_source: source }),
+        signal: AbortSignal.timeout(60_000),
+    });
+    if (!r.ok) throw new Error(`lightrag insert ${source} ${r.status}: ${await r.text()}`);
+}
+
+async function lightragDelete(apiKey: string, docIds: string[]): Promise<void> {
+    const r = await fetch(`${LIGHTRAG}/documents/delete_document`, {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json", "X-API-Key": apiKey },
+        body: JSON.stringify({ doc_ids: docIds, delete_llm_cache: true }),
+        signal: AbortSignal.timeout(120_000),
+    });
+    // 404 = already gone; tolerate.
+    if (!r.ok && r.status !== 404) {
+        throw new Error(`lightrag delete ${JSON.stringify(docIds)} ${r.status}: ${await r.text()}`);
+    }
+}
+
+async function paperlessList(token: string, modified_gt: string, page: number): Promise<PaperlessList> {
+    const url = new URL(`${PAPERLESS}/api/documents/`);
+    url.searchParams.set("page", String(page));
+    url.searchParams.set("page_size", String(PAGE_SIZE));
+    url.searchParams.set("ordering", "modified");
+    url.searchParams.set("modified__gt", modified_gt);
+    const r = await fetch(url, {
+        headers: { Authorization: `Token ${token}` },
+        signal: AbortSignal.timeout(60_000),
+    });
+    if (!r.ok) throw new Error(`paperless list ${r.status}: ${await r.text()}`);
+    return (await r.json()) as PaperlessList;
+}

--- a/kubernetes/apps/home/windmill/workflows/lightrag-rag-tombstone.ts
+++ b/kubernetes/apps/home/windmill/workflows/lightrag-rag-tombstone.ts
@@ -1,0 +1,98 @@
+// Cron: daily.
+//
+// Deletes LightRAG docs whose Paperless source no longer exists — the
+// graph-RAG mirror of paperless-rag-tombstone (which does this for Qdrant).
+// The ingest flow keys every doc on file_source "paperless:<id>"; this
+// sweep removes any LightRAG doc whose <id> is gone from Paperless.
+
+const LIGHTRAG = Deno.env.get("LIGHTRAG_URL") ??
+    "http://lightrag.ai.svc.cluster.local:9621";
+const PAPERLESS = Deno.env.get("PAPERLESS_URL") ??
+    "http://paperless.collab.svc.cluster.local:8000";
+const PAGE_SIZE = 100;
+const SOURCE_PREFIX = "paperless:";
+const DELETE_BATCH = 20;
+
+type DocStatus = { id: string; file_path: string };
+type DocsStatusesResponse = { statuses: Record<string, DocStatus[]> };
+
+export async function main() {
+    const token = Deno.env.get("PAPERLESS_TOKEN");
+    if (!token) throw new Error("PAPERLESS_TOKEN env not set");
+    const apiKey = Deno.env.get("LIGHTRAG_API_KEY");
+    if (!apiKey) throw new Error("LIGHTRAG_API_KEY env not set");
+
+    const started = new Date().toISOString();
+    const liveIds = await paperlessIds(token);            // Set<number> currently in Paperless
+    const indexed = await lightragPaperlessDocs(apiKey);  // [{ paperlessId, docId }]
+
+    const stale = indexed.filter((d) => !liveIds.has(d.paperlessId));
+    const docIds = stale.map((d) => d.docId);
+
+    let deleted = 0;
+    for (let i = 0; i < docIds.length; i += DELETE_BATCH) {
+        const batch = docIds.slice(i, i + DELETE_BATCH);
+        await lightragDelete(apiKey, batch);
+        deleted += batch.length;
+    }
+
+    return {
+        started,
+        finished: new Date().toISOString(),
+        paperless_live: liveIds.size,
+        lightrag_indexed: indexed.length,
+        deleted_stale: deleted,
+    };
+}
+
+async function paperlessIds(token: string): Promise<Set<number>> {
+    const ids = new Set<number>();
+    let page = 1;
+    while (true) {
+        const url = new URL(`${PAPERLESS}/api/documents/`);
+        url.searchParams.set("page", String(page));
+        url.searchParams.set("page_size", String(PAGE_SIZE));
+        url.searchParams.set("ordering", "id");
+        const r = await fetch(url, {
+            headers: { Authorization: `Token ${token}` },
+            signal: AbortSignal.timeout(60_000),
+        });
+        if (!r.ok) throw new Error(`paperless list ${r.status}: ${await r.text()}`);
+        const body = (await r.json()) as { next: string | null; results: { id: number }[] };
+        for (const d of body.results) ids.add(d.id);
+        if (!body.next) break;
+        page += 1;
+    }
+    return ids;
+}
+
+async function lightragPaperlessDocs(apiKey: string): Promise<{ paperlessId: number; docId: string }[]> {
+    const r = await fetch(`${LIGHTRAG}/documents`, {
+        headers: { "X-API-Key": apiKey },
+        signal: AbortSignal.timeout(60_000),
+    });
+    if (!r.ok) throw new Error(`lightrag GET /documents ${r.status}: ${await r.text()}`);
+    const body = (await r.json()) as DocsStatusesResponse;
+    const out: { paperlessId: number; docId: string }[] = [];
+    for (const docs of Object.values(body.statuses ?? {})) {
+        for (const d of docs) {
+            if (!d.file_path?.startsWith(SOURCE_PREFIX)) continue;
+            const pid = Number(d.file_path.slice(SOURCE_PREFIX.length));
+            if (Number.isFinite(pid)) out.push({ paperlessId: pid, docId: d.id });
+        }
+    }
+    return out;
+}
+
+async function lightragDelete(apiKey: string, docIds: string[]): Promise<void> {
+    if (docIds.length === 0) return;
+    const r = await fetch(`${LIGHTRAG}/documents/delete_document`, {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json", "X-API-Key": apiKey },
+        body: JSON.stringify({ doc_ids: docIds, delete_llm_cache: true }),
+        signal: AbortSignal.timeout(120_000),
+    });
+    if (!r.ok && r.status !== 404) {
+        throw new Error(`lightrag delete ${JSON.stringify(docIds)} ${r.status}: ${await r.text()}`);
+    }
+}


### PR DESCRIPTION
## What

Two Windmill workflows feeding the paperless corpus into **LightRAG's graph-RAG**, running **alongside** the existing Qdrant vector pipeline (vector RAG vs graph RAG over the same docs):

- **`lightrag-rag-ingest.ts`** (cron 30m) — streams Paperless docs modified since a Windmill-state watermark into `POST /documents/text`, keyed on `file_source = "paperless:<id>"` for clean updates (delete-then-insert). **Caps docs/run** to pace LightRAG's LLM-heavy extraction on ollama-spark, so the initial backfill spreads across runs instead of flooding the pipeline.
- **`lightrag-rag-tombstone.ts`** (cron daily) — deletes LightRAG docs whose paperless source is gone (mirrors `paperless-rag-tombstone`).

## Why OCR text, not original PDFs
Per the investigation: the deployed LightRAG image (`v0.5.1-decoratorfix1`) ships **pypdf only** — no Docling/MinerU/OCR. Paperless already OCR'd everything (tesseract), and OCR text is exactly what LightRAG's graph extraction consumes. Pushing raw PDFs would degrade scanned docs. (Docling-on-original-PDFs remains a future option via a custom image.)

## Wiring
- `LIGHTRAG_API_KEY` → worker env via the `windmill-workflows` ExternalSecret (`lightrag.api_key` 1P field) + `WHITELIST_ENVS` passthrough.
- CNP egress `windmill → ai/lightrag:9621` (the LightRAG ingress side already allows windmill-workers).

## ⚠️ Post-merge deploy steps (not automatic)
1. ESO syncs `LIGHTRAG_API_KEY` into `windmill-workflows-secret`; **restart windmill workers** to pick up the new env.
2. **Push the `.ts` to Windmill** (`tools/wmill-sync.sh` or the API) — the repo files are canonical source; runtime lives in Windmill's DB.
3. **Create the two schedules** (ingest 30m, tombstone daily).

I'll handle 2–3 once this merges and the secret lands.

## Validation
`kubectl kustomize` clean (windmill app, 5 resources); `LIGHTRAG_API_KEY` wired through ExternalSecret + helmrelease.

🤖 Generated with [Claude Code](https://claude.com/claude-code)