### PR TITLE
fix(home): lightrag-rag-ingest windmill-client import specifier

### DIFF
--- a/kubernetes/apps/home/windmill/workflows/lightrag-rag-ingest.ts
+++ b/kubernetes/apps/home/windmill/workflows/lightrag-rag-ingest.ts
@@ -28,7 +28,7 @@
 // LightRAG's doc status — the stable key for clean updates AND the
 // tombstone sweep (lightrag-rag-tombstone).
 
-import * as wmill from "windmill-client";
+import * as wmill from "npm:windmill-client@1.527.0";
 
 const LIGHTRAG = Deno.env.get("LIGHTRAG_URL") ??
     "http://lightrag.ai.svc.cluster.local:9621";


### PR DESCRIPTION
Bare `import "windmill-client"` fails Windmill's Deno deploy lock (`not in import map`). Use the pinned npm specifier the other state-using flows use (`npm:windmill-client@1.527.0`).

The deployed Windmill script is already fixed + verified (test run: submitted 20 docs, LightRAG received them). This realigns the canonical repo source so a future `wmill-sync` doesn't redeploy the broken import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)