### PR TITLE
fix(langfuse): size web V8 heap to container, raise web limit to 2Gi

### DIFF
--- a/kubernetes/apps/ai/langfuse/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langfuse/app/helmrelease.yaml
@@ -84,12 +84,26 @@ spec:
     langfuse:
       web:
         replicas: 1
+        # langfuse-web (Next.js 16) crashlooped with V8 heap OOM
+        # (exit 134, `Reached heap limit Allocation failed`) during
+        # init scripts: Node's default old-space (~520Mi) is sized to
+        # the host, not the 1Gi cgroup, so it OOMs the heap well under
+        # the container limit. Pin the heap to the container via
+        # NODE_OPTIONS (see langfuse.additionalEnv) and give the cgroup
+        # headroom above the new 1536Mi heap.
         resources:
           requests:
             cpu: 100m
             memory: 768Mi
           limits:
-            memory: 1Gi
+            memory: 2Gi
+        pod:
+          # Size the V8 heap to the container rather than the host.
+          # Scoped to web only (worker keeps its 1Gi cgroup); the
+          # chart injects this into the web pods exclusively.
+          additionalEnv:
+            - name: NODE_OPTIONS
+              value: --max-old-space-size=1536
       worker:
         replicas: 1
         # The worker container shipped with no resources block at


### PR DESCRIPTION
## What

`langfuse-web` (Next.js 16) was crashlooping (`KubePodCrashLooping` firing, 24 restarts, exit 134) with a V8 heap OOM — `Reached heap limit Allocation failed - JavaScript heap out of memory` — during init scripts, ~23s after start.

## Why

Node's default old-space heap (~520 MiB) is sized to the host's physical memory, not the 1Gi cgroup, and no `NODE_OPTIONS` was set. The heap OOMs well under the container limit.

## Fix

- Set `NODE_OPTIONS=--max-old-space-size=1536` via `langfuse.web.pod.additionalEnv` — scoped to the **web** pods only (the worker keeps its 1Gi cgroup and is untouched).
- Raise the web cgroup limit `1Gi → 2Gi` for headroom above the new 1536 MiB heap.

Render validated; web limit 2Gi + heap env present, worker still 1Gi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)