### PR TITLE
docs(codegraph-mcp): retarget workaround annotation to canonical #1272

### DIFF
--- a/kubernetes/apps/mcp-system/codegraph-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/codegraph-mcp/app/helmrelease.yaml
@@ -28,9 +28,11 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/codegraph-mcp
-              # -decoratorfix1: build-time patch for codegraphcontext indexing
-              # crash (CodeGraphContext#1285 / rwlove/containers#101). Drop the
-              # suffix when upstream ships the guard and the patch is removed.
+              # workaround: https://github.com/CodeGraphContext/CodeGraphContext/issues/1272 — remove when codegraphcontext > 0.5.1 ships the None-guard in _resolve_decorator_path
+              # -decoratorfix1 = build-time patch (rwlove/containers#101) for the
+              # decorator-None indexing crash. Our original report #1285 was closed
+              # as a duplicate of canonical #1272 on 2026-06-19; track #1272.
+              # Tracking issue: #12562
               tag: v0.5.1-decoratorfix1
             env:
               HOST: "0.0.0.0"


### PR DESCRIPTION
Upstream closed our report [CodeGraphContext#1285](https://github.com/CodeGraphContext/CodeGraphContext/issues/1285) as a **duplicate of canonical [#1272](https://github.com/CodeGraphContext/CodeGraphContext/issues/1272)** (2026-06-19, open, fix unreleased — latest `codegraphcontext` release is v0.4.7). The `v0.5.1-decoratorfix1` pin stays.

This repoints the codegraph-mcp image-pin annotation in `kubernetes/apps/mcp-system/codegraph-mcp/app/helmrelease.yaml`:

- Upstream reference → #1272 (with an inline note on the #1285 dup).
- Converted to the canonical `# workaround:` prefix that `.agents/instructions/workarounds.md` and the upstream-watcher skill key on (it previously used a free-form comment).
- Cites new tracking issue #12562.

Comment-only — no rendered-resource change.

Companion: rwlove/containers#102 (same retarget in the Dockerfile + patch script). Tracking issue: #12562.

🤖 Generated with [Claude Code](https://claude.com/claude-code)