### PR TITLE
fix(longhorn): make named recurring-job groups functional + document default-group mechanics

### DIFF
--- a/.agents/instructions/storage-class.instructions.md
+++ b/.agents/instructions/storage-class.instructions.md
@@ -81,7 +81,28 @@ app — see `media/jellyfin/app/longhorn-pvc.yaml` for the pattern.
 
 New Longhorn volumes need:
 
-- Labeled for the recurring backup jobs to pick them up.
+- Labeled for the recurring backup jobs to pick them up. **Important
+  mechanics:** Longhorn's recurring jobs select on the *Volume CR's*
+  `recurring-job-group.longhorn.io/<group>` labels, **not** the PV's.
+  PV labels do not propagate to the Volume CR — Longhorn instead
+  **auto-applies the `default` group** to any volume whose CR has no
+  recurring-job labels, and `default` is what actually protects nearly
+  every volume in this cluster (daily snapshot + weekly + monthly
+  backup + weekly trim). The named groups (`daily-snapshot`,
+  `weekly-backup`, `weekly-snapshot`, `monthly-backup`) are wired into
+  `longhorn/config/recurring-jobs.yaml` as functional aliases, so a
+  volume whose CR *does* carry them is still covered. **Trap to avoid:**
+  if a manual op (e.g. restoring a volume by re-creating the Volume CR)
+  copies the PV's named labels onto the Volume CR, the volume drops out
+  of auto-`default`; ensure a functional group label is present or it
+  is silently un-backed-up. This bit `paperless-data-xfs` after its
+  2026-06-19 restore — see
+  [[reference_longhorn_snapshot_not_crash_consistent_use_backup]].
+- A **detached** volume cannot be backed up (no engine to read from).
+  CronJob-only or scaled-to-zero workloads (e.g. `beets`) whose volume
+  is detached during the Saturday 00:00 UTC backup window silently miss
+  weekly backups — their DR floor is whenever the volume last happened
+  to be attached at backup time.
 - `unmapMarkSnapChainRemoved=enabled` set per-Volume to prevent
   snapshot-pinned slack.
 - `chmod 755` on `lost+found` if the app runs non-root — fresh ext4

--- a/kubernetes/apps/longhorn-system/longhorn/config/recurring-jobs.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn/config/recurring-jobs.yaml
@@ -7,8 +7,17 @@ metadata:
 spec:
   cron: "0 0 * * 6"
   task: "backup"
+  # `default` is auto-applied by Longhorn to any volume with no
+  # recurring-job labels, and is what actually protects the cluster's
+  # volumes today. `weekly-backup` is the named group the repo's PV
+  # convention labels with (see storage-class.instructions.md); listing
+  # it here makes that label functional instead of a silent no-op — a
+  # volume whose CR carries `weekly-backup` (e.g. after a manual restore
+  # that copies PV labels onto the Volume CR) is backed up rather than
+  # dropped out of `default`. See the 2026-06-19 paperless-ai incident.
   groups:
     - default
+    - weekly-backup
   retain: 4
   concurrency: 4
 
@@ -20,8 +29,14 @@ metadata:
 spec:
   cron: "0 0 * * *"
   task: "snapshot"
+  # Both named snapshot-cadence groups alias onto this job. Snapshots
+  # are local COW (no NFS cost), so giving a `weekly-snapshot`-labelled
+  # volume daily snapshots is strictly-more protection at no storage
+  # penalty — it just keeps the named label from being a no-op.
   groups:
     - default
+    - daily-snapshot
+    - weekly-snapshot
   retain: 7
   concurrency: 4
 
@@ -33,8 +48,13 @@ metadata:
 spec:
   cron: "0 0 1 * *"
   task: "backup"
+  # `monthly-backup` is the lighter backup cadence the big regenerable
+  # model volumes (comfyui, ollama) are labelled with — kept distinct
+  # from weekly-backup so those large volumes don't get weekly NFS
+  # backups they don't need.
   groups:
     - default
+    - monthly-backup
   retain: 6
   concurrency: 4
 


### PR DESCRIPTION
## Context

Follow-up to the 2026-06-19 alert cleanup. Auditing Longhorn backup coverage (after `paperless-data-xfs` lost its data to outage corruption and was restored from a clean weekly NFS backup) surfaced a latent trap.

## Problem

The repo's PV convention labels volumes with `recurring-job-group.longhorn.io/{daily-snapshot,weekly-backup,weekly-snapshot,monthly-backup}`, but **every `RecurringJob` served only the `default` group** — so those named labels were silent no-ops.

Longhorn auto-applies `default` to any volume whose **Volume CR** has no recurring-job labels (PV labels don't propagate), and `default` is what actually protects ~all volumes today (39/40 had a fresh backup). **But** a volume whose CR *carries* a named label drops out of auto-`default` and is silently un-backed-up.

This bit `paperless-data-xfs` right after its restore: re-creating the Volume CR copied the PV's named labels onto it, knocking it out of `default`. It was the **only** live volume not getting backups — the volume we'd just restored was sitting unprotected. (Fixed at runtime by relabeling it to `default`; this PR fixes the root cause.)

## Fix

Wire the named groups into the jobs as functional aliases, **preserving the intended tiering**:

| Named label | Mapped to | Rationale |
|---|---|---|
| `weekly-backup` | `weekly-backups` | weekly NFS backup |
| `monthly-backup` | `monthly-backups` | lighter cadence for big *regenerable* comfyui/ollama model volumes |
| `daily-snapshot` + `weekly-snapshot` | `daily-snapshots` | snapshots are local COW — over-covering is free, keeps the label meaningful |

**No behavioral change for currently-working volumes** (their live CRs carry `default`); this only makes a named label do something sensible instead of nothing, closing the silent-disable trap. Also documents the PV-vs-Volume-CR label mechanics and the detached-volume backup gap in `storage-class.instructions.md`.

## Out of scope (flagged separately)

- `beets` (active CronJob) misses weekly backups because its volume is **detached** at the Sat 00:00 window — needs an attach-time backup hook or accepted gap.
- `mealie` / `n8n` Longhorn volumes are orphaned leftovers from decommissioned apps (no ks.yaml, no pods) — cleanup candidates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)