### PR TITLE
fix(hygiene): right-size memory requests (internal apps)

### DIFF
--- a/kubernetes/apps/ai/paperless-ai/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/paperless-ai/app/helmrelease.yaml
@@ -23,7 +23,7 @@ spec:
             resources:
               requests:
                 cpu: 11m
-                memory: 4G
+                memory: 1536Mi
               limits:
                 memory: 4G
 

--- a/kubernetes/apps/collab/it-tools/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/it-tools/app/helmrelease.yaml
@@ -30,6 +30,7 @@ spec:
             resources:
               requests:
                 cpu: 100m
+                memory: 64Mi
               limits:
                 memory: 500Mi
 

--- a/kubernetes/apps/collab/paperless/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/paperless/app/helmrelease.yaml
@@ -63,7 +63,7 @@ spec:
             resources:
               requests:
                 cpu: 15m
-                memory: 3Gi
+                memory: 2Gi
               limits:
                 # 4Gi -> 5Gi: a transient OCR/indexing spike OOMKilled the
                 # pod once (1 restart in 7d; steady-state ~1.5Gi). Slight

--- a/kubernetes/apps/downloads/jdownloader2/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/jdownloader2/app/helmrelease.yaml
@@ -56,7 +56,7 @@ spec:
             resources:
               requests:
                 cpu: 100m
-                memory: 1G
+                memory: 512Mi
               limits:
                 memory: 1G
 

--- a/kubernetes/apps/media/lidarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/lidarr/app/helmrelease.yaml
@@ -81,7 +81,7 @@ spec:
             resources:
               requests:
                 cpu: 100m
-                memory: 2G
+                memory: 1280Mi
               limits:
                 memory: 3Gi
 

--- a/kubernetes/apps/media/romm/app/helmrelease.yaml
+++ b/kubernetes/apps/media/romm/app/helmrelease.yaml
@@ -101,7 +101,7 @@ spec:
             resources:
               requests:
                 cpu: 25m
-                memory: 1Gi
+                memory: 512Mi
               limits:
                 memory: 5Gi
 


### PR DESCRIPTION
## What
Lowers over-provisioned **memory requests** toward each app's 7-day Prometheus peak + margin. **Limits unchanged** (Burstable QoS, consistent with existing jellyfin/windmill pattern) — so burst headroom is preserved; only the scheduler *reservation* shrinks.

| App | req → target | 7d peak |
|---|---|---|
| it-tools | 500Mi → 64Mi (explicit) | 12Mi |
| paperless-ai | 4G → 1536Mi | ~1.1Gi |
| paperless | 3Gi → 2Gi | ~1.6Gi (steady ~1.5Gi) |
| lidarr | 2G → 1280Mi | ~1.0Gi |
| romm | 1Gi → 512Mi | ~0.33Gi |
| jdownloader2 | 1G → 512Mi | ~0.39Gi |

~**5.7 GiB** of requests freed.

## Why
Cluster hygiene / scheduling accuracy (the descheduler-flagged over-commit) — **not** a beast reclaim. Targets set from 14d/7d working-set peaks, skipping the known non-trimmable workloads (Ceph/CSI/cilium/longhorn/CNPG/immich-ML/qbittorrent/dragonfly/ollama) and any pod whose peak ≥ request.

## Scope
All here are **internal apps** → any-night mergeable (pods restart on apply, no Renee-facing streaming/voice impact). Renee-facing trims (jellyfin, wyoming-whisper) are split into a separate PR for the Tuesday window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)