### PR TITLE
fix(hygiene): right-size memory requests (Renee-facing — Tuesday window)

### DIFF
--- a/kubernetes/apps/home/wyoming-services/app/helmrelease.yaml
+++ b/kubernetes/apps/home/wyoming-services/app/helmrelease.yaml
@@ -89,7 +89,7 @@ spec:
             resources:
               requests:
                 cpu: 500m
-                memory: 3G
+                memory: 1536Mi
                 nvidia.com/gpu: 1
               limits:
                 memory: 4G

--- a/kubernetes/apps/media/jellyfin/app/helmrelease.yaml
+++ b/kubernetes/apps/media/jellyfin/app/helmrelease.yaml
@@ -51,7 +51,7 @@ spec:
               requests:
                 cpu: 15m
                 gpu.intel.com/i915: 1
-                memory: 5Gi
+                memory: 2560Mi
               limits:
                 gpu.intel.com/i915: 1
                 memory: 10G


### PR DESCRIPTION
## ⚠️ Merge in the Tuesday 02:00–04:00 maintenance window
Both pods restart on apply → brief streaming / voice interruption.

## What
| App | req → target | 7d peak |
|---|---|---|
| jellyfin | 5Gi → 2560Mi | ~1.8Gi (GPU transcode unaffected) |
| wyoming-whisper | 3G → 1536Mi | ~744Mi system RAM (model lives in VRAM) |

Limits unchanged (10G / 4G) → Burstable, burst headroom preserved. ~**3.8 GiB** requests freed.

## Why
Cluster request-hygiene (moderate scope), split from the internal-apps PR so the Renee-facing restarts land in the right window. Targets from 7-day working-set peak + margin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)