### PR TITLE
feat(jdownloader2): add nconnect=8 NFS mountOptions (proof app)

### DIFF
--- a/kubernetes/apps/downloads/jdownloader2/app/nfs-pvc.yaml
+++ b/kubernetes/apps/downloads/jdownloader2/app/nfs-pvc.yaml
@@ -12,6 +12,7 @@ spec:
     storage: 500Gi
   accessModes:
     - ReadWriteOnce
+  mountOptions: ["nfsvers=4.2", "nconnect=8", "hard", "noatime"]
   nfs:
     server: "${NFS_HOST_0}"
     path: /mnt/downloads-nvme/jdownloader


### PR DESCRIPTION
First app of the NFS `nconnect` rollout. Tier B (scratch). PV `mountOptions` is immutable, so on merge this needs the scale-down → delete PV/PVC → recreate procedure (runbook); I'll do it live right after merge. Zero Renee impact (download client).

🤖 Generated with [Claude Code](https://claude.com/claude-code)