### PR TITLE
fix(langfuse): raise bundled valkey memory limit to stop OOM cascade

### DIFF
--- a/kubernetes/apps/ai/langfuse/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/langfuse/app/helmrelease.yaml
@@ -73,6 +73,20 @@ spec:
       auth:
         existingSecret: langfuse-secret
         existingSecretPasswordKey: REDIS_PASSWORD
+      primary:
+        # The bundled valkey shipped at the chart's tiny default
+        # (~192Mi limit) and was OOMKilled (exit 137) repeatedly under
+        # langfuse v3's queue load. Each death dropped langfuse-worker's
+        # redis connection and crashed it (exit 1) — the worker was a
+        # downstream victim, not the cause. Bump to 512Mi with a
+        # matching request; AOF is persisted on ceph-block so the
+        # reconcile restart is lossless.
+        resources:
+          requests:
+            cpu: 150m
+            memory: 256Mi
+          limits:
+            memory: 512Mi
     s3:
       deploy: true
       auth:


### PR DESCRIPTION
## What

The langfuse chart's bundled redis (valkey) ran at its tiny default (~192Mi limit) and was **OOMKilled (exit 137) repeatedly** under langfuse v3's queue load. Each death dropped `langfuse-worker`'s redis connection (`Connection to redis lost. Retry attempt: 5`) and crashed the worker (exit 1). The worker was a **downstream victim, not the cause**.

## Fix

Set `redis.primary.resources` → 512Mi limit + 256Mi/150m request. Verified via `helm template` that the override lands on the `valkey` container of the `redis-primary` StatefulSet. AOF is persisted on ceph-block, so the reconcile restart is lossless.

## Context

Found during the post-outage compute-health sweep. After the `langfuse-web` heap fix ([#12561](https://github.com/rwlove/home-ops/pull/12561)) this was the only remaining live instability in the cluster — the rest of the high restart counts were historical (cumulative counters last-terminated on the 2026-06-17 outage day). Internal service, routine window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)