### PR TITLE
feat(storage): add nconnect=8 to media + download NFS PVs (batch)

### DIFF
--- a/kubernetes/apps/ai/comfyui/app/nfs-pvc.yaml
+++ b/kubernetes/apps/ai/comfyui/app/nfs-pvc.yaml
@@ -12,6 +12,7 @@ spec:
     storage: 4.5T
   accessModes:
     - ReadWriteOnce
+  mountOptions: ["nfsvers=4.2", "nconnect=8", "hard", "noatime"]
   nfs:
     server: "${NFS_HOST_2}"
     path: /mnt/mass_storage/kubernetes/comfyui/output

--- a/kubernetes/apps/downloads/qbittorrent/app/nfs-pvc.yaml
+++ b/kubernetes/apps/downloads/qbittorrent/app/nfs-pvc.yaml
@@ -12,6 +12,7 @@ spec:
     storage: 5Ti
   accessModes:
     - ReadWriteOnce
+  mountOptions: ["nfsvers=4.2", "nconnect=8", "hard", "noatime"]
   nfs:
     server: "${NFS_HOST_0}"
     path: /mnt/downloads-nvme/qbittorrent-incomplete
@@ -46,6 +47,7 @@ spec:
     storage: 5Ti
   accessModes:
     - ReadWriteOnce
+  mountOptions: ["nfsvers=4.2", "nconnect=8", "hard", "noatime"]
   nfs:
     server: "${NFS_HOST_0}"
     path: /mnt/downloads/media/Download
@@ -80,6 +82,7 @@ spec:
     storage: 10Ti
   accessModes:
     - ReadWriteOnce
+  mountOptions: ["nfsvers=4.2", "nconnect=8", "hard", "noatime"]
   nfs:
     server: "${NFS_HOST_0}"
     path: /mnt/mass_storage/storage/Downloads

--- a/kubernetes/apps/downloads/sabnzbd/app/nfs-pvc.yaml
+++ b/kubernetes/apps/downloads/sabnzbd/app/nfs-pvc.yaml
@@ -12,6 +12,7 @@ spec:
     storage: 500Gi
   accessModes:
     - ReadWriteMany
+  mountOptions: ["nfsvers=4.2", "nconnect=8", "hard", "noatime"]
   nfs:
     server: "${NFS_HOST_0}"
     path: /mnt/downloads-nvme/sabnzbd/incomplete
@@ -46,6 +47,7 @@ spec:
     storage: 500Gi
   accessModes:
     - ReadWriteMany
+  mountOptions: ["nfsvers=4.2", "nconnect=8", "hard", "noatime"]
   nfs:
     server: "${NFS_HOST_0}"
     path: /mnt/downloads-nvme/sabnzbd/complete
@@ -80,6 +82,7 @@ spec:
     storage: 10Ti
   accessModes:
     - ReadWriteOnce
+  mountOptions: ["nfsvers=4.2", "nconnect=8", "hard", "noatime"]
   nfs:
     server: "${NFS_HOST_0}"
     path: /mnt/downloads/media/Download

--- a/kubernetes/apps/downloads/slskd/app/nfs-pvc.yaml
+++ b/kubernetes/apps/downloads/slskd/app/nfs-pvc.yaml
@@ -12,6 +12,7 @@ spec:
     storage: 5Gi
   accessModes:
     - ReadWriteMany
+  mountOptions: ["nfsvers=4.2", "nconnect=8", "hard", "noatime"]
   nfs:
     server: "${NFS_HOST_0}"
     path: /mnt/downloads-nvme/soulseek
@@ -47,6 +48,7 @@ spec:
     storage: 3Ti
   accessModes:
     - ReadOnlyMany
+  mountOptions: ["nfsvers=4.2", "nconnect=8", "hard", "noatime"]
   nfs:
     server: "${NFS_HOST_2}"
     path: /mnt/mass_storage/storage/MP3s/

--- a/kubernetes/apps/media/beets/app/nfs-pvc.yaml
+++ b/kubernetes/apps/media/beets/app/nfs-pvc.yaml
@@ -12,6 +12,7 @@ spec:
     storage: 3Ti
   accessModes:
     - ReadWriteMany
+  mountOptions: ["nfsvers=4.2", "nconnect=8", "hard", "noatime"]
   nfs:
     server: "${NFS_HOST_2}"
     path: /mnt/mass_storage/storage/MP3s/

--- a/kubernetes/apps/media/gonic/app/nfs-pvc.yaml
+++ b/kubernetes/apps/media/gonic/app/nfs-pvc.yaml
@@ -12,6 +12,7 @@ spec:
     storage: 3Ti
   accessModes:
     - ReadWriteMany
+  mountOptions: ["nfsvers=4.2", "nconnect=8", "hard", "noatime", "actimeo=600"]
   nfs:
     server: "${NFS_HOST_2}"
     path: /mnt/mass_storage/storage/MP3s/
@@ -44,6 +45,7 @@ spec:
     storage: 10Gi
   accessModes:
     - ReadWriteOnce
+  mountOptions: ["nfsvers=4.2", "nconnect=8", "hard", "noatime", "actimeo=600"]
   nfs:
     server: "${NFS_HOST_0}"
     path: /mnt/kubernetes/gonic/podcasts

--- a/kubernetes/apps/media/lidarr-bridge/app/nfs-pvc.yaml
+++ b/kubernetes/apps/media/lidarr-bridge/app/nfs-pvc.yaml
@@ -12,6 +12,7 @@ spec:
     storage: 5Gi
   accessModes:
     - ReadWriteMany
+  mountOptions: ["nfsvers=4.2", "nconnect=8", "hard", "noatime"]
   nfs:
     server: "${NFS_HOST_0}"
     path: /mnt/downloads-nvme/soulseek
@@ -48,6 +49,7 @@ spec:
     storage: 3Ti
   accessModes:
     - ReadWriteMany
+  mountOptions: ["nfsvers=4.2", "nconnect=8", "hard", "noatime"]
   nfs:
     server: "${NFS_HOST_2}"
     path: /mnt/mass_storage/storage/MP3s/

--- a/kubernetes/apps/media/lidarr/app/nfs-pvc.yaml
+++ b/kubernetes/apps/media/lidarr/app/nfs-pvc.yaml
@@ -12,6 +12,7 @@ spec:
     storage: 500Gi
   accessModes:
     - ReadWriteMany
+  mountOptions: ["nfsvers=4.2", "nconnect=8", "hard", "noatime"]
   nfs:
     server: "${NFS_HOST_0}"
     path: /mnt/downloads/media/Download
@@ -46,6 +47,7 @@ spec:
     storage: 500Gi
   accessModes:
     - ReadWriteMany
+  mountOptions: ["nfsvers=4.2", "nconnect=8", "hard", "noatime"]
   nfs:
     server: "${NFS_HOST_0}"
     path: /mnt/downloads-nvme/sabnzbd
@@ -78,6 +80,7 @@ spec:
     storage: 3Ti
   accessModes:
     - ReadWriteMany
+  mountOptions: ["nfsvers=4.2", "nconnect=8", "hard", "noatime"]
   nfs:
     server: "${NFS_HOST_2}"
     path: /mnt/mass_storage/storage/MP3s/
@@ -112,6 +115,7 @@ spec:
     storage: 5Gi
   accessModes:
     - ReadWriteMany
+  mountOptions: ["nfsvers=4.2", "nconnect=8", "hard", "noatime"]
   nfs:
     server: "${NFS_HOST_0}"
     path: /mnt/downloads-nvme/soulseek

--- a/kubernetes/apps/media/medialyze/app/nfs-pvc.yaml
+++ b/kubernetes/apps/media/medialyze/app/nfs-pvc.yaml
@@ -12,6 +12,7 @@ spec:
     storage: 20Ti
   accessModes:
     - ReadWriteOnce
+  mountOptions: ["nfsvers=4.2", "nconnect=8", "hard", "noatime"]
   nfs:
     server: "${NFS_HOST_2}"
     path: /mnt/mass_storage/storage/video/Movies/
@@ -44,6 +45,7 @@ spec:
     storage: 20Ti
   accessModes:
     - ReadWriteOnce
+  mountOptions: ["nfsvers=4.2", "nconnect=8", "hard", "noatime"]
   nfs:
     server: "${NFS_HOST_0}"
     path: /mnt/mass_storage/storage/video/Television/

--- a/kubernetes/apps/media/music-assistant/app/nfs-pvc.yaml
+++ b/kubernetes/apps/media/music-assistant/app/nfs-pvc.yaml
@@ -12,6 +12,7 @@ spec:
     storage: 3Ti
   accessModes:
     - ReadWriteMany
+  mountOptions: ["nfsvers=4.2", "nconnect=8", "hard", "noatime", "actimeo=600"]
   nfs:
     server: "${NFS_HOST_2}"
     path: /mnt/mass_storage/storage/MP3s/

--- a/kubernetes/apps/media/radarr/app/nfs-pvc.yaml
+++ b/kubernetes/apps/media/radarr/app/nfs-pvc.yaml
@@ -12,6 +12,7 @@ spec:
     storage: 500Gi
   accessModes:
     - ReadWriteMany
+  mountOptions: ["nfsvers=4.2", "nconnect=8", "hard", "noatime"]
   nfs:
     server: "${NFS_HOST_0}"
     path: /mnt/downloads/media/Download
@@ -44,6 +45,7 @@ spec:
     storage: 500Gi
   accessModes:
     - ReadWriteMany
+  mountOptions: ["nfsvers=4.2", "nconnect=8", "hard", "noatime"]
   nfs:
     server: "${NFS_HOST_0}"
     path: /mnt/downloads-nvme/sabnzbd
@@ -76,6 +78,7 @@ spec:
     storage: 300Gi
   accessModes:
     - ReadWriteMany
+  mountOptions: ["nfsvers=4.2", "nconnect=8", "hard", "noatime"]
   nfs:
     server: "${NFS_HOST_2}"
     path: /mnt/mass_storage/storage/video/Movies/

--- a/kubernetes/apps/media/romm/app/nfs-pvc.yaml
+++ b/kubernetes/apps/media/romm/app/nfs-pvc.yaml
@@ -13,6 +13,7 @@ spec:
     - ReadWriteOnce
   persistentVolumeReclaimPolicy: Retain
   storageClassName: romm-games-storage-class
+  mountOptions: ["nfsvers=4.2", "nconnect=8", "hard", "noatime", "actimeo=600"]
   nfs:
     server: "${NFS_HOST_2}"
     path: /mnt/mass_storage/storage/games/

--- a/kubernetes/apps/media/sonarr/app/nfs-pvc.yaml
+++ b/kubernetes/apps/media/sonarr/app/nfs-pvc.yaml
@@ -12,6 +12,7 @@ spec:
     storage: 500Gi
   accessModes:
     - ReadWriteMany
+  mountOptions: ["nfsvers=4.2", "nconnect=8", "hard", "noatime"]
   nfs:
     server: "${NFS_HOST_0}"
     path: /mnt/downloads/media/Download
@@ -44,6 +45,7 @@ spec:
     storage: 500Gi
   accessModes:
     - ReadWriteMany
+  mountOptions: ["nfsvers=4.2", "nconnect=8", "hard", "noatime"]
   nfs:
     server: "${NFS_HOST_0}"
     path: /mnt/downloads-nvme/sabnzbd
@@ -76,6 +78,7 @@ spec:
     storage: 20Ti
   accessModes:
     - ReadWriteMany
+  mountOptions: ["nfsvers=4.2", "nconnect=8", "hard", "noatime"]
   nfs:
     server: "${NFS_HOST_0}"
     path: /mnt/mass_storage/storage/video/Television/

--- a/kubernetes/apps/media/soularr/app/nfs-pvc.yaml
+++ b/kubernetes/apps/media/soularr/app/nfs-pvc.yaml
@@ -12,6 +12,7 @@ spec:
     storage: 5Gi
   accessModes:
     - ReadWriteMany
+  mountOptions: ["nfsvers=4.2", "nconnect=8", "hard", "noatime"]
   nfs:
     server: "${NFS_HOST_0}"
     path: /mnt/downloads-nvme/soulseek
@@ -46,6 +47,7 @@ spec:
     storage: 3Ti
   accessModes:
     - ReadWriteMany
+  mountOptions: ["nfsvers=4.2", "nconnect=8", "hard", "noatime"]
   nfs:
     server: "${NFS_HOST_2}"
     path: /mnt/mass_storage/storage/MP3s/

--- a/kubernetes/apps/media/stash/app/nfs-pvc.yaml
+++ b/kubernetes/apps/media/stash/app/nfs-pvc.yaml
@@ -29,6 +29,7 @@ spec:
     storage: 6Ti
   accessModes:
     - ReadWriteMany
+  mountOptions: ["nfsvers=4.2", "nconnect=8", "hard", "noatime", "actimeo=600"]
   nfs:
     server: "${NFS_HOST_2}"
     path: "/mnt/mass_storage/Adult/Favorites/"


### PR DESCRIPTION
Batch of the NFS `nconnect` rollout — 15 apps / 31 PVs. Tier A library reads get `actimeo=600`; Tier B scratch/pull don't. **Excludes jellyfin** (Renee-facing → separate, when idle).

⚠️ PV `mountOptions` is immutable, so merging this alone puts these kustomizations into failed-reconcile until each app's PV is recreated (scale-down → delete PV/PVC → reconcile, per runbook). **Couple merge with the recreates.** Procedure proven on #12570 (jdownloader2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)