### PR TITLE
feat(jellyfin): add nconnect=8 NFS mountOptions (Tier A)

### DIFF
--- a/kubernetes/apps/media/jellyfin/app/nfs-pvc.yaml
+++ b/kubernetes/apps/media/jellyfin/app/nfs-pvc.yaml
@@ -12,6 +12,7 @@ spec:
     storage: 10Ti
   accessModes:
     - ReadWriteOnce
+  mountOptions: ["nfsvers=4.2", "nconnect=8", "hard", "noatime", "actimeo=600"]
   nfs:
     server: "${NFS_HOST_2}"
     path: /mnt/mass_storage/storage/MP3s/
@@ -44,6 +45,7 @@ spec:
     storage: 20Ti
   accessModes:
     - ReadWriteOnce
+  mountOptions: ["nfsvers=4.2", "nconnect=8", "hard", "noatime", "actimeo=600"]
   nfs:
     server: "${NFS_HOST_2}"
     path: /mnt/mass_storage/storage/video/Movies/
@@ -76,6 +78,7 @@ spec:
     storage: 20Ti
   accessModes:
     - ReadWriteOnce
+  mountOptions: ["nfsvers=4.2", "nconnect=8", "hard", "noatime", "actimeo=600"]
   nfs:
     server: "${NFS_HOST_0}"
     path: /mnt/mass_storage/storage/video/Television/


### PR DESCRIPTION
Final app of the nconnect rollout. Tier A (library reads) → nconnect=8 + actimeo. Merging patches the PVs in place (no jellyfin impact); nconnect activates only on a pod restart, which I'll do when Renee's done streaming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)