### PR TITLE
fix(readme): repair broken Renovate and Check Links badges

### DIFF
--- a/.github/workflows/lychee.yaml
+++ b/.github/workflows/lychee.yaml
@@ -39,6 +39,8 @@ jobs:
           args: >
             --verbose
             --no-progress
+            --max-retries 3
+            --retry-wait-time 2
             './**/*.md'
       - name: Find Link Checker Issue
         id: broken-link-check-issue

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ _Production-grade Kubernetes for a household._
 
 <br/>
 
-[![Renovate](https://img.shields.io/github/actions/workflow/status/rwlove/home-ops/renovate.yaml?branch=main&label=Renovate&logo=renovatebot&style=for-the-badge&color=1A1F6C)](https://github.com/rwlove/home-ops/actions/workflows/renovate.yaml)
+[![Renovate](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.thesteamedcrab.com%2Frenovate_last_run&style=for-the-badge&logo=renovatebot&logoColor=white)](https://github.com/rwlove/home-ops/issues/10329)
 [![Flux](https://img.shields.io/badge/Flux-managed-5468FF?style=for-the-badge&logo=flux&logoColor=white)](https://fluxcd.io)
 [![Documentation](https://img.shields.io/badge/docs-Material_for_MkDocs-526CFE?style=for-the-badge&logo=materialformkdocs&logoColor=white)](https://rwlove.github.io/home-ops/)
 [![Check Links](https://img.shields.io/github/actions/workflow/status/rwlove/home-ops/lychee.yaml?label=links&style=for-the-badge)](https://github.com/rwlove/home-ops/actions/workflows/lychee.yaml)

--- a/kubernetes/apps/automation/README.md
+++ b/kubernetes/apps/automation/README.md
@@ -15,8 +15,11 @@ when:
 Tasks that touch cluster state, alert routing, or need multi-step
 approval go through the `ai/langgraph-agents` `/inbox` flow instead.
 
-## Status: scaffolded, NOT activated
+## Status: no active workloads
 
-The `claude-runner` Flux Kustomization ships with `spec.suspend: true`
-intentionally. Activating Phase 4 needs three gating items first; see
-[the claude-runner README](./claude-runner/README.md) for the recipe.
+The `claude-runner` Kustomization that was scaffolded here was retired
+in [#12008](https://github.com/rwlove/home-ops/pull/12008) — the
+cron-Claude-Code approach was superseded by the `ai/langgraph-agents`
+fleet, which now owns the periodic "report on the world" jobs. The
+namespace remains for future automation workloads but currently ships
+no apps.

--- a/kubernetes/apps/observability/kromgo/app/resources/config.yaml
+++ b/kubernetes/apps/observability/kromgo/app/resources/config.yaml
@@ -52,3 +52,15 @@ metrics:
       - {color: "green", min: 0, max: 0}
       - {color: "red", min: 1, max: 9999}
     title: Alerts
+
+  # Hours since the last successful home-ops Renovate run. The
+  # renovate-operator emits no native metrics, so this reads
+  # kube-state-metrics on the Job it spawns hourly (0 * * * *).
+  - name: renovate_last_run
+    query: round((time() - max(kube_job_status_completion_time{namespace="renovate", job_name=~"rwlove-home-ops-rwlove-home-ops-.*"})) / 3600, 0.1)
+    suffix: "h ago"
+    colors:
+      - {color: "green", min: 0, max: 2}
+      - {color: "orange", min: 2, max: 6}
+      - {color: "red", min: 6, max: 9999}
+    title: Renovate


### PR DESCRIPTION
## Problem

Two README header badges were broken:

- **Renovate** rendered `workflow not found` — it pointed at a `renovate.yaml` GitHub Action that has never existed. Renovate runs in-cluster via `renovate-operator`, which reports nothing to GitHub Actions.
- **Check Links** was red from two real `lychee` failures: a dead relative link to `claude-runner/README.md` (retired in #12008) and transient `fluxcd.io` connection flakes.

## Fix

- **Renovate badge → live kromgo endpoint.** Added a `renovate_last_run` metric to kromgo (already deployed, already on the external gateway) that reads kube-state-metrics on the hourly Renovate Job and reports hours since the last successful run (green→orange→red). README badge now wraps the kromgo endpoint through shields, styled to match its neighbors.
- **automation README** — rewrote the stale "scaffolded" section; the `claude-runner` link 404'd after #12008.
- **lychee.yaml** — added `--max-retries 3 --retry-wait-time 2` for the `fluxcd.io` flakes.

## Verification

- kromgo PromQL validated against live Prometheus (single scalar).
- kromgo rolls on configmap change via the Stakater Reloader annotation, so the metric goes live after Flux reconcile — not applied out-of-band.
- The dead-link failure is eliminated; if `fluxcd.io` is a hard runner-IP block rather than a flake, a follow-up `--exclude` may be needed (will confirm with a dispatch run post-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)