### PR TITLE
fix(media): defeat gonic↔music-assistant startup race

### DIFF
--- a/kubernetes/apps/media/gonic/app/helmrelease.yaml
+++ b/kubernetes/apps/media/gonic/app/helmrelease.yaml
@@ -70,6 +70,29 @@ spec:
               GONIC_PLAYLISTS_PATH: "/data/playlists"
               GONIC_SCAN_INTERVAL: "120"
 
+            probes:
+              # Gate Ready on the Subsonic API actually answering, not just
+              # the port being open. gonic's HTTP listener binds before the
+              # API is fully serving on a cold start; a default TCP probe
+              # would mark the pod Ready too early and put a half-up gonic
+              # into the Service endpoints. Music Assistant's OpenSubsonic
+              # provider loader is one-shot — if it pings a not-yet-serving
+              # gonic and times out, it marks the provider permanently
+              # failed (library shows "no playable items found" until a
+              # manual reload). /rest/ping.view returns 200 unauthenticated
+              # once the API is live. Pairs with MA's wait-for-gonic init.
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /rest/ping.view
+                    port: 4747
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+
             resources:
               requests:
                 cpu: 15m

--- a/kubernetes/apps/media/music-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/media/music-assistant/app/helmrelease.yaml
@@ -28,6 +28,32 @@ spec:
           reloader.stakater.com/auto: "true"
 
         type: statefulset
+
+        initContainers:
+          # Startup-race guard. MA's music library is the OpenSubsonic
+          # provider pointed at gonic.media, and its provider loader is
+          # one-shot: if gonic isn't answering when MA first pings it on
+          # boot — e.g. both pods restart together after a power event and
+          # gonic is still initializing — MA marks the provider failed and
+          # never auto-retries, so every track is unresolvable ("no
+          # playable items found") until someone reloads the provider by
+          # hand. Block MA's start until gonic's Subsonic API returns 200.
+          # Intra-namespace egress is allowed by the allow-intra-namespace
+          # CNP; alpine is multi-arch (MA may land on an arm64 node).
+          wait-for-gonic:
+            image:
+              repository: docker.io/library/alpine
+              tag: "3.24"
+            command:
+              - sh
+              - -c
+              - |
+                until wget -q -T 5 -O /dev/null http://gonic.media/rest/ping.view; do
+                  echo "waiting for gonic to serve its API..."
+                  sleep 3
+                done
+                echo "gonic is up"
+
         containers:
           app:
             image:


### PR DESCRIPTION
## Problem

The Music Assistant phone app reported **"no playable items found"** when playing a playlist. Diagnosis showed it was not a playlist or tag problem — gonic resolves the playlist fine, and the recently-added tracks have clean MBIDs (so the known poison-MBID sync abort was *not* the cause).

Root cause is a **startup race**. MA's music library is the OpenSubsonic provider pointed at `gonic.media`, and its provider loader is **one-shot**. Both pods restarted within ~1 min this morning; gonic's HTTP listener was up but its API was still initializing when MA fired its first ping:

```
WARNING ... Error loading provider opensubsonic--...:
  Connection timeout to host http://gonic.media/rest/ping.view
```

MA marked the provider **permanently failed and never auto-retried**. For ~31 min MA had no music source — it could show the cached playlist from its own DB but couldn't resolve any track to a stream → every item "unplayable." A manual provider reload in the MA UI cleared it.

This will recur on any future co-restart (power event, both pods landing on a rebooted node).

## Fix

Two complementary changes:

- **gonic** — add an httpGet **readiness probe** on `/rest/ping.view` (returns 200 unauthenticated once the API is live). gonic's listener binds before the API fully serves on a cold start; a default TCP probe marks the pod Ready too early and puts a half-up gonic into the Service endpoints. Now gonic only joins endpoints when it can actually answer.

- **music-assistant** — add a `wait-for-gonic` **initContainer** that blocks MA startup until gonic answers 200, so the one-shot provider loader never runs against a not-yet-serving gonic. This is the change that actually defeats the race (the readiness probe alone doesn't, since MA still gives up after one try). `alpine` is multi-arch (MA may schedule on an arm64 node); intra-namespace egress is covered by the `allow-intra-namespace` CNP.

## Validation

- `/rest/ping.view` confirmed to return HTTP 200 unauthenticated on the live gonic pod.
- Probe key structure matches the repo's existing custom-probe pattern (langgraph-agents, authelia, glance).
- `kubectl kustomize` builds clean for both apps; all pre-commit hooks pass.

## Rollout note

Applying this **restarts both pods**, briefly dropping MA's music source. gonic backs a Renee-facing service — per the repo's maintenance windows this is a **Tuesday 02:00–04:00 ET** change unless merged sooner by choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)