### PR TITLE
fix(docs): repair 15 broken links flagged by lychee

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,7 +540,7 @@ Driver lifecycle is handled by the NVIDIA GPU Operator. Spark is the lone contai
 
 ### 🛟 Disaster recovery
 
-Per-app rclone CronJobs ship Immich originals and Paperless documents — plus their Garage-stored Postgres backups — to encrypted AWS S3 with a 1-day Glacier Deep Archive transition. Recovery procedure is documented at [Offsite recovery](https://rwlove.github.io/home-ops/offsite_recovery.html) and was last validated 2026-05-05.
+Per-app rclone CronJobs ship Immich originals and Paperless documents — plus their Garage-stored Postgres backups — to encrypted AWS S3 with a 1-day Glacier Deep Archive transition. Recovery procedure is documented at [Offsite recovery](https://rwlove.github.io/home-ops/offsite_recovery/) and was last validated 2026-05-05.
 
 ### 🌪️ Strict GitOps
 
@@ -554,18 +554,18 @@ The full operator handbook lives at **<https://rwlove.github.io/home-ops/>**.
 
 Frequently referenced pages:
 
-- [AI architecture](https://rwlove.github.io/home-ops/ai_architecture.html)
-- [Cluster rebuild](https://rwlove.github.io/home-ops/cluster_rebuild.html)
-- [Initialization & teardown](https://rwlove.github.io/home-ops/init_teardown.html)
-- [Cluster upgrade](https://rwlove.github.io/home-ops/cluster_upgrade.html)
-- [Power outage recovery](https://rwlove.github.io/home-ops/power-outage.html)
-- [Limits & requests philosophy](https://rwlove.github.io/home-ops/limits.html)
-- [Debugging playbook](https://rwlove.github.io/home-ops/debugging.html)
-- [Offsite recovery](https://rwlove.github.io/home-ops/offsite_recovery.html)
-- [Immich restore to new CNPG database](https://rwlove.github.io/home-ops/immich_cnpg.html)
-- [NVIDIA P40 GPU setup](https://rwlove.github.io/home-ops/p40.html)
-- [master1 etcd disk swap](https://rwlove.github.io/home-ops/master1_etcd_disk_swap.html)
-- [GitHub webhook](https://rwlove.github.io/home-ops/github_webhook.html)
+- [AI architecture](https://rwlove.github.io/home-ops/ai_architecture/)
+- [Cluster rebuild](https://rwlove.github.io/home-ops/cluster_rebuild/)
+- [Initialization & teardown](https://rwlove.github.io/home-ops/init_teardown/)
+- [Cluster upgrade](https://rwlove.github.io/home-ops/cluster_upgrade/)
+- [Power outage recovery](https://rwlove.github.io/home-ops/power-outage/)
+- [Limits & requests philosophy](https://rwlove.github.io/home-ops/limits/)
+- [Debugging playbook](https://rwlove.github.io/home-ops/debugging/)
+- [Offsite recovery](https://rwlove.github.io/home-ops/offsite_recovery/)
+- [Immich restore to new CNPG database](https://rwlove.github.io/home-ops/immich_cnpg/)
+- [NVIDIA P40 GPU setup](https://rwlove.github.io/home-ops/p40/)
+- [master1 etcd disk swap](https://rwlove.github.io/home-ops/master1_etcd_disk_swap/)
+- [GitHub webhook](https://rwlove.github.io/home-ops/github_webhook/)
 
 Repo-local conventions (auto-loaded by AI agents from [`.agents/instructions/`](https://github.com/rwlove/home-ops/tree/main/.agents/instructions)):
 

--- a/docs/src/p40.md
+++ b/docs/src/p40.md
@@ -118,7 +118,7 @@ resources:
 
 The P40 is on the wrong side of two recent NVIDIA upstream breaks:
 
-1. **PyTorch ≥ 2.7 + cu128 dropped sm_61.** Anything pinned to a torch 2.7+ wheel won't run on the P40. immich-pet-tagger is the canonical example: the cluster pulls the [`rwlove/immich-pet-tagger:v1.2.0-p40` fork](https://github.com/rwlove/immich-pet-tagger) which is pinned to torch 2.6.0+cu124. Drop this fork the day a non-Pascal GPU joins the cluster.
+1. **PyTorch ≥ 2.7 + cu128 dropped sm_61.** Anything pinned to a torch 2.7+ wheel won't run on the P40. immich-pet-tagger is the canonical example: the cluster pulls the `rwlove/immich-pet-tagger:v1.2.0-p40` fork which is pinned to torch 2.6.0+cu124. Drop this fork the day a non-Pascal GPU joins the cluster.
 2. **Open kernel modules are Volta-or-newer.** `useOpenKernelModules: true` will silently fail on Pascal. Keep the proprietary driver.
 
 When `worker8` is rebuilt onto Ubuntu 24.04 LTS (DGX-aligned), `driver.enabled` flips to `true` for that node only — Spark (Blackwell) and any future cards can use the open module variant via `nodeSelector`-scoped operator config.

--- a/docs/src/power-outage.md
+++ b/docs/src/power-outage.md
@@ -27,7 +27,7 @@ Within ~60 seconds, `kube-vip` pods should come up and you can delete the tempor
 ## Why it happens
 
 - `kube-vip` runs as a static pod on each control-plane node, managed by kubelet, not by the apiserver.
-- It uses [BGP ECMP via Cilium](https://github.com/rwlove/home-ops/tree/main/kubernetes/apps/network/cilium) in this cluster, but during cold boot the VIP attach can race against kubelet bringing up the static pod.
+- It uses [BGP ECMP via Cilium](https://github.com/rwlove/home-ops/tree/main/kubernetes/apps/kube-system/cilium) in this cluster, but during cold boot the VIP attach can race against kubelet bringing up the static pod.
 - Once the VIP is up *anywhere*, every node's kubelet can talk to the apiserver and the rest cascades.
 
 ## Related

--- a/docs/src/rook_ceph_dr.md
+++ b/docs/src/rook_ceph_dr.md
@@ -127,7 +127,7 @@ What survives:
    .spec.storageClassName == "ceph-block") | .metadata.namespace +
    "/" + .metadata.name'` — scale them to zero.
 4. Tear down the existing rook-ceph deployment per
-   <https://rook.io/docs/rook/v1.18/Storage-Configuration/Advanced/ceph-teardown/>
+   <https://rook.io/docs/rook/latest-release/Getting-Started/ceph-teardown/>
    — `Cluster`, `OperatorConfig`, then delete the namespace.
 5. Wipe the OSD disks on each worker (Rook-Ceph teardown does NOT
    wipe disks; you must `dd if=/dev/zero of=/dev/<osd-disk>


### PR DESCRIPTION
Follow-up to #12576. With the `fluxcd.io` flake cleared by that PR's lychee retries, 15 genuinely broken links surfaced. All fixed and verified:

| Cause | Count | Fix |
|---|---|---|
| README links to docs site via `.html` paths, but MkDocs serves directory URLs (`/p40/` not `/p40.html`) | 12 | Rewrite to directory form — all 12 verified `200` |
| `power-outage.md` linked cilium at `apps/network/cilium` | 1 | Corrected to `apps/kube-system/cilium` (verified) |
| `p40.md` linked the **private** `rwlove/immich-pet-tagger` fork (404 to anonymous CI) | 1 | Unlinked, text retained |
| `rook_ceph_dr.md` linked a moved rook teardown page | 1 | Repointed to `latest-release/Getting-Started/ceph-teardown/` (verified) |

After this merges, the **Check Links** badge should go green. I'll trigger a `workflow_dispatch` lychee run on main to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)