### PR TITLE
fix(readme): static Renovate badge, no domain in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ _Production-grade Kubernetes for a household._
 
 <br/>
 
-[![Renovate](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.thesteamedcrab.com%2Frenovate_last_run&style=for-the-badge&logo=renovatebot&logoColor=white)](https://github.com/rwlove/home-ops/issues/10329)
+[![Renovate](https://img.shields.io/badge/Renovate-enabled-1A1F6C?style=for-the-badge&logo=renovatebot&logoColor=white)](https://github.com/rwlove/home-ops/issues/10329)
 [![Flux](https://img.shields.io/badge/Flux-managed-5468FF?style=for-the-badge&logo=flux&logoColor=white)](https://fluxcd.io)
 [![Documentation](https://img.shields.io/badge/docs-Material_for_MkDocs-526CFE?style=for-the-badge&logo=materialformkdocs&logoColor=white)](https://rwlove.github.io/home-ops/)
 [![Check Links](https://img.shields.io/github/actions/workflow/status/rwlove/home-ops/lychee.yaml?label=links&style=for-the-badge)](https://github.com/rwlove/home-ops/actions/workflows/lychee.yaml)


### PR DESCRIPTION
Follow-up to #12576: that PR's kromgo Renovate badge embedded the public cluster domain in the README (GitHub's image proxy must fetch a public URL). Per request, the domain must not appear in the README.

A live kromgo badge and "no domain in README" can't coexist, so this reverts the Renovate badge to a static **Renovate enabled** badge — matching the Flux `managed` badge beside it. The `renovate_last_run` kromgo metric remains in place as internal telemetry (not exposed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)