### PR TITLE
fix(media): give music-assistant a writable cache so Smart Fades loads

### DIFF
--- a/kubernetes/apps/media/music-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/media/music-assistant/app/helmrelease.yaml
@@ -60,6 +60,17 @@ spec:
               repository: ghcr.io/music-assistant/server
               tag: 2.9.0b16
 
+            env:
+              # Smart Fades' Beat This! beat-tracking model downloads its
+              # ~8MB checkpoint via torch.hub → $HOME/.cache/torch. The
+              # container has HOME=/ and runs non-root (uid 1113), so the
+              # default /.cache is unwritable and the model load fails
+              # ("Could not load the checkpoint ... small0"), leaving Smart
+              # Fades in a permanent error state. Point the cache at the
+              # writable, persistent data PVC (already MA's cache dir) so the
+              # model downloads once and survives restarts.
+              XDG_CACHE_HOME: /data/.cache
+
             resources:
               requests:
                 cpu: 15m


### PR DESCRIPTION
## Problem

MA logs a warning on every boot:
```
WARNING ... Error loading provider(instance) Smart Fades:
  ('Could not load the checkpoint given the provided name', 'small0')
```
Smart Fades (MA's beat-matched crossfade feature) stays in a permanent error state and never runs.

## Root cause (reproduced live)

Smart Fades uses the **Beat This!** beat-tracking model. On init it downloads an ~8 MB checkpoint (`small0`) via `torch.hub`, which writes to `$HOME/.cache/torch`. The MA container has **`HOME=/`** and runs **non-root as uid 1113**, so `os.makedirs('/.cache')` fails with `PermissionError`; beat_this catches it and re-raises the generic *"Could not load the checkpoint … small0."*

It is **not** a CPU issue (worker3 is an i7-7700 *with* AVX2), **not** network, **not** a bad checkpoint name. It would fail on every node, and explains why no model file existed on the PVC — torch.hub could never write one.

Reproduced in-pod:
```
PermissionError: [Errno 13] Permission denied: '/.cache'
ValueError: ('Could not load the checkpoint given the provided name', 'small0')
```

## Fix

Set `XDG_CACHE_HOME=/data/.cache` on the MA container. `torch.hub` resolves its dir to `$XDG_CACHE_HOME/torch`, landing the model at `/data/.cache/torch` on the existing data PVC — persistent, group-writable by 1113, co-located with MA's current cache. No change to where MA stores its existing cache (already `/data/.cache`).

## Validation

With the env var set, in-pod:
```
Downloading: https://cloud.cp.jku.at/.../small0.ckpt -> /data/.cache/torch/hub/checkpoints/beat_this-small0.ckpt
LOAD OK — model type: BeatThis
cached: .../beat_this-small0.ckpt  8451101 bytes
```
The checkpoint is already pre-seeded to that path, so on the next pod restart Smart Fades loads immediately with no first-run download.

`kubectl kustomize` builds clean; all pre-commit hooks pass.

## Rollout note

Restarts the MA pod (Renee-facing) — brief music-source blip. Low risk; one env var.

🤖 Generated with [Claude Code](https://claude.com/claude-code)