### PR TITLE
chore: README count reconcile + drop orphaned kromgo metric + lycheeignore

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,5 @@
+# URLs the link checker (.github/workflows/lychee.yaml) skips.
+# crt.sh is a Certificate Transparency search service that chronically
+# returns 502s and rate-limits CI runners; any link to it is illustrative,
+# not a navigable target.
+crt\.sh

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ flowchart LR
     Dev[👤 Operator] -->|git push| Repo[(📦 GitHub<br/>home-ops)]
     Renovate[🤖 Renovate] -.->|automated PRs| Repo
     Repo -->|reconciles| Flux[⚙️ Flux]
-    Flux -->|deploys| Cluster[☸️ Kubernetes<br/>11 nodes · 177 apps]
+    Flux -->|deploys| Cluster[☸️ Kubernetes<br/>11 nodes · 188 apps]
 
     Cluster --> Ceph[(🪨 Ceph<br/>block · default durable)]
     Cluster --> LH[(🐂 Longhorn<br/>+ recurring backups)]
@@ -78,10 +78,10 @@ Storage tiers are picked deliberately per workload — see [`storage-class.instr
 | **TLS**          | cert-manager                        | Let's Encrypt + internal CA                           |
 | **Tunnel**       | cloudflared                         | Public ingress without exposing home WAN              |
 | **AuthN/Z**      | Authelia + oauth2-proxy             | OIDC SSO; 24 oauth2-proxy instances gate apps         |
-| **Secrets**      | External Secrets Operator + 1Password | 111 ExternalSecrets, zero plain-text in Git         |
+| **Secrets**      | External Secrets Operator + 1Password | 116 ExternalSecrets, zero plain-text in Git         |
 | **VPN**          | wg-easy                             | Operator OOB WireGuard access                         |
 | **Storage**      | Rook-Ceph, Longhorn, Garage, direct NFS | Tiered by durability requirement                  |
-| **Databases**    | CloudNative-PG, Dragonfly, Qdrant   | 25 Postgres clusters, KV, vector                      |
+| **Databases**    | CloudNative-PG, Dragonfly, Qdrant   | 24 Postgres clusters, KV, vector                      |
 | **Observability**| kube-prometheus-stack, Loki, Tempo, Grafana, HolmesGPT | Metrics, logs, traces, dashboards, AI alert triage |
 | **Telemetry**    | OpenTelemetry Collector + Vector    | Trace pipeline (→ Tempo) + log shipping (→ Loki)      |
 | **Images**       | ZOT                                 | Pull-through registry / local cache                   |
@@ -219,7 +219,7 @@ Worker nodes attach to **iot** and **sec** VLANs via Multus for direct camera an
 
 | App | Purpose |
 |-----|---------|
-| **CloudNative-PG** | 25 Postgres clusters with WAL archiving to Garage |
+| **CloudNative-PG** | 24 Postgres clusters with WAL archiving to Garage |
 | **Dragonfly** | Redis-compatible in-memory store |
 | **Qdrant** | Vector DB for embeddings / RAG |
 | **pgAdmin** | Postgres admin UI |
@@ -519,7 +519,7 @@ Four tiers, picked by what the data has to survive — node loss, Ceph loss, clu
 
 ### 🔐 Secrets — zero plain-text in Git
 
-All 111 ExternalSecrets resolve through External Secrets Operator from 1Password. Application credentials are templated into `ExternalSecret` resources and never live in YAML. Cross-namespace mirrors use the reflector pattern when consumer charts hard-code secret names.
+All 116 ExternalSecrets resolve through External Secrets Operator from 1Password. Application credentials are templated into `ExternalSecret` resources and never live in YAML. Cross-namespace mirrors use the reflector pattern when consumer charts hard-code secret names.
 
 ### 🪪 Authentication — single sign-on everywhere
 

--- a/kubernetes/apps/observability/kromgo/app/resources/config.yaml
+++ b/kubernetes/apps/observability/kromgo/app/resources/config.yaml
@@ -52,15 +52,3 @@ metrics:
       - {color: "green", min: 0, max: 0}
       - {color: "red", min: 1, max: 9999}
     title: Alerts
-
-  # Hours since the last successful home-ops Renovate run. The
-  # renovate-operator emits no native metrics, so this reads
-  # kube-state-metrics on the Job it spawns hourly (0 * * * *).
-  - name: renovate_last_run
-    query: round((time() - max(kube_job_status_completion_time{namespace="renovate", job_name=~"rwlove-home-ops-rwlove-home-ops-.*"})) / 3600, 0.1)
-    suffix: "h ago"
-    colors:
-      - {color: "green", min: 0, max: 2}
-      - {color: "orange", min: 2, max: 6}
-      - {color: "red", min: 6, max: 9999}
-    title: Renovate


### PR DESCRIPTION
Cleanup of loose ends from the badge work (#12576/#12580/#12581/#12582):

- **README prose counts** drifted from the auto-bumped badges (which the drift check enforces as git truth): apps `177→188`, ExternalSecrets `111→116`, Postgres clusters `25→24`. Reconciled prose to match.
- **Dropped the orphaned `renovate_last_run` kromgo metric** — added for the live Renovate badge, now unused after that badge reverted to static. Was internal-only telemetry with no consumer.
- **Added `.lycheeignore`** for `crt.sh` (chronically 502s / rate-limits CI) to harden the weekly link check.

Not touching git history (the earlier domain leak) — destructive force-push for a domain already public in DNS/CT logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)