### PR TITLE
feat(home): add AquapureD salt cell daemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ _Production-grade Kubernetes for a household._
 
 <br/>
 
-![apps](https://img.shields.io/badge/apps-188-blue?style=for-the-badge)
-![helmreleases](https://img.shields.io/badge/HelmReleases-201-326CE5?style=for-the-badge&logo=helm&logoColor=white)
+![apps](https://img.shields.io/badge/apps-189-blue?style=for-the-badge)
+![helmreleases](https://img.shields.io/badge/HelmReleases-202-326CE5?style=for-the-badge&logo=helm&logoColor=white)
 ![nodes](https://img.shields.io/badge/k8s_nodes-11-326CE5?style=for-the-badge&logo=kubernetes&logoColor=white)
 ![cnpg](https://img.shields.io/badge/Postgres_clusters-24-336791?style=for-the-badge&logo=postgresql&logoColor=white)
-![secrets](https://img.shields.io/badge/secrets-116-0572EC?style=for-the-badge&logo=1password&logoColor=white)
+![secrets](https://img.shields.io/badge/secrets-117-0572EC?style=for-the-badge&logo=1password&logoColor=white)
 ![age](https://img.shields.io/badge/cluster_age-5%2B_years-success?style=for-the-badge)
 
 </div>

--- a/kubernetes/apps/home/aquapured/app/configmap.yaml
+++ b/kubernetes/apps/home/aquapured/app/configmap.yaml
@@ -1,0 +1,43 @@
+---
+# ConfigMap holds the aquapured.conf template. The entrypoint script
+# in the container image (see containers/aquapured/entrypoint.sh)
+# uses envsubst to write the final conf to /run/aquapured/aquapured.conf
+# before launching the daemon, substituting ${MQTT_USER} and
+# ${MQTT_PASSWD} from the aquapured Secret.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aquapured-config
+data:
+  aquapured.conf.tmpl: |
+    [AQUACONTROLD]
+
+    # Jandy AquaPure standalone salt cell.
+    # 0x50 = Jandy AquaPure; 0xB0 = Zodiac Tri SWG with Chem (Ph/ORP).
+    SWG_DEVICE_ID = 0x50
+
+    # Use DEBUG_SERIAL for first bring-up; INFO for steady-state.
+    log_level = INFO
+
+    WEB_DIRECTORY = /usr/share/aquapured/web/
+    WEB_PORT = 80
+
+    # pty created by socat; see container entrypoint.
+    SERIAL_PORT = /dev/aquapure
+
+    MQTT_ADDRESS = emqx.home.svc.cluster.local:1883
+    MQTT_USER = ${MQTT_USER}
+    MQTT_PASSWD = ${MQTT_PASSWD}
+    MQTT_TOPIC = aquapured
+
+    # Disable Domoticz integration (no DZIDX_SWG_STATUS_ALERT_SENSOR needed).
+
+    [RS485_DEVICES]
+    [RS485_DEVICE:1]
+    # AquapureD emulates the bus master; RS485_ID is the address it presents.
+    RS485_TYPE = SWG
+    RS485_ID = 0x60
+
+    [ONEWIREDEVICES]
+
+    [GPIOS]

--- a/kubernetes/apps/home/aquapured/app/externalsecret.yaml
+++ b/kubernetes/apps/home/aquapured/app/externalsecret.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: aquapured
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: aquapured
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        # MQTT credentials — sourced from the emqx 1Password item so the
+        # aquapured secret is fully self-contained (not a cross-reference
+        # to the emqx-owned secret in the same namespace).
+        MQTT_USER: "{{ .user_1_username }}"
+        MQTT_PASSWD: "{{ .user_1_password }}"
+  dataFrom:
+    - extract:
+        key: emqx

--- a/kubernetes/apps/home/aquapured/app/helmrelease.yaml
+++ b/kubernetes/apps/home/aquapured/app/helmrelease.yaml
@@ -1,0 +1,120 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app aquapured
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+
+  interval: 30m
+  values:
+    controllers:
+      aquapured:
+        pod:
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: node.network/vlan-iot
+                        operator: In
+                        values:
+                          - "true"
+
+          annotations:
+            k8s.v1.cni.cncf.io/networks: aquapured-iot-static
+
+        # IOT VLAN (20) — socat on net1 reaches Elfin EW11 at 10.10.20.21:8899.
+        # MQTT egress to emqx.home.svc.cluster.local is intra-namespace and
+        # covered by the existing home-ns baseline CNP.
+        annotations:
+          reloader.stakater.com/auto: "true"
+
+        type: deployment
+        replicas: 1
+
+        containers:
+          app:
+            image:
+              # Custom image: AquapureD built from source + socat + entrypoint.
+              # Source: github.com/rwlove/containers → aquapured/
+              # Tag format: aquapured-v<date>
+              # workaround: no upstream prebuilt image with socat available;
+              #   upstream: https://github.com/sfeakes/AquapureD (no Dockerfile)
+              repository: ghcr.io/rwlove/aquapured
+              tag: v0.1.0@sha256:0000000000000000000000000000000000000000000000000000000000000000
+
+            # Entrypoint:
+            #   1. envsubst MQTT_USER/MQTT_PASSWD into /run/aquapured/aquapured.conf
+            #   2. Start socat: TCP→pty bridging Elfin EW11 at 10.10.20.21:8899
+            #      to /dev/aquapure. Elfin is serial 9600/8N1, Protocol None.
+            #   3. exec aquapured pointing at the generated conf file.
+            # The command/args are defined in the image ENTRYPOINT; nothing to
+            # override here unless log level needs to be toggled for bring-up.
+
+            env:
+              # SERIAL_PORT is baked into the conf template at /dev/aquapure.
+              # ELFIN_HOST/PORT passed so the entrypoint can wire socat without
+              # embedding the IP in the image.
+              ELFIN_HOST: "10.10.20.21"
+              ELFIN_PORT: "8899"
+
+            envFrom:
+              - secretRef:
+                  name: aquapured
+
+            probes:
+              liveness:
+                enabled: false
+              readiness:
+                enabled: false
+              startup:
+                enabled: false
+
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
+              limits:
+                memory: 64Mi
+
+            securityContext:
+              # socat needs to create /dev/aquapure pty; running as non-root
+              # with a devpts mount is cleaner but requires capabilities.
+              # For initial bring-up, keep privileged=false and add SYS_ADMIN +
+              # SETUID as needed. Start with minimal caps; widen if pty creation
+              # fails. See bring-up notes in the PR description.
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities:
+                drop: ["ALL"]
+                # socat pty,link= needs to open /dev/ptmx (world-writable on
+                # most Linux distros) — no extra caps required in practice.
+
+    service:
+      app:
+        controller: aquapured
+        ports:
+          http:
+            port: 80
+
+    persistence:
+      config-template:
+        type: configMap
+        name: aquapured-config
+        globalMounts:
+          - path: /etc/aquapured/aquapured.conf.tmpl
+            subPath: aquapured.conf.tmpl
+            readOnly: true
+      run:
+        type: emptyDir
+        globalMounts:
+          - path: /run/aquapured
+      dev:
+        type: emptyDir
+        medium: Memory
+        globalMounts:
+          - path: /dev/pts

--- a/kubernetes/apps/home/aquapured/app/kustomization.yaml
+++ b/kubernetes/apps/home/aquapured/app/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../components/repos/app-template
+resources:
+  - ./configmap.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/home/aquapured/ks.yaml
+++ b/kubernetes/apps/home/aquapured/ks.yaml
@@ -1,0 +1,46 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app aquapured-multus
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: home
+  path: ./kubernetes/apps/home/aquapured/net-attach
+  interval: 30m
+  prune: true
+  wait: true
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: multus
+      namespace: network
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app aquapured
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: home
+  path: ./kubernetes/apps/home/aquapured/app
+  interval: 30m
+  timeout: 5m
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: aquapured-multus
+      namespace: home
+    - name: emqx
+      namespace: home

--- a/kubernetes/apps/home/aquapured/net-attach/kustomization.yaml
+++ b/kubernetes/apps/home/aquapured/net-attach/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - net-attach.yaml

--- a/kubernetes/apps/home/aquapured/net-attach/net-attach.yaml
+++ b/kubernetes/apps/home/aquapured/net-attach/net-attach.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/k8s.cni.cncf.io/networkattachmentdefinition_v1.json
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: aquapured-iot-static
+spec:
+  config: |
+    {
+    "cniVersion": "0.3.1",
+    "type": "macvlan",
+    "master": "enp1s0.20",
+    "mode": "bridge",
+    "ipam": {
+    "type": "static",
+    "addresses": [
+    {
+    "address": "10.10.20.105/24"
+    }
+    ]
+    }
+    }

--- a/kubernetes/apps/home/kustomization.yaml
+++ b/kubernetes/apps/home/kustomization.yaml
@@ -17,6 +17,7 @@ components:
 resources:
   - ./namespace.yaml
   - ./priority-class.yaml
+  - ./aquapured/ks.yaml
   - ./emqx/ks.yaml
   - ./esphome/ks.yaml
   - ./frigate/ks.yaml


### PR DESCRIPTION
## Summary

- Deploys [AquapureD](https://github.com/sfeakes/AquapureD) in the `home` namespace: a daemon that emulates a Jandy AquaLink bus master, polls a standalone AquaPure salt cell over RS485, and publishes salt PPM + SWG output % to EMQX.
- Architecture: `socat` (TCP→pty) + `aquapureD` run in the **same container** (a pty is not shareable across containers). socat bridges the Elfin EW11 at `10.10.20.21:8899` to `/dev/aquapure`; AquapureD opens that pty as its serial device.
- Multus macvlan NAD at `10.10.20.105/24` on `enp1s0.20` (VLAN 20) gives the pod flat L2 access to the Elfin. MQTT egress to `emqx.home.svc.cluster.local` is covered by the existing home-ns baseline CNP — no new network policy needed.
- MQTT credentials sourced from the `emqx` 1Password item via a new `aquapured` ExternalSecret (self-contained; no cross-reference to the emqx-owned secret).

## Image decision

No usable prebuilt image exists upstream (AquapureD has no Dockerfile; no `sfeakes/aquapured` on Docker Hub or GHCR). A custom image at `ghcr.io/rwlove/aquapured` is required:

- **Source**: `containers/aquapured/` in the `containers` repo (separate PR there)
- **Build**: Dockerfile builds AquapureD from source + installs `socat` + `envsubst`; entrypoint renders conf, starts socat in background, execs aquapured
- **Current HelmRelease tag**: `v0.1.0@sha256:000...` — placeholder digest; **must be updated after first build/push**

## Files

```
kubernetes/apps/home/aquapured/
  ks.yaml                         — two Flux Kustomizations (multus + app)
  net-attach/
    net-attach.yaml               — NAD: aquapured-iot-static @ 10.10.20.105/24
    kustomization.yaml
  app/
    helmrelease.yaml              — app-template HelmRelease
    externalsecret.yaml           — pulls MQTT creds from emqx 1P item
    configmap.yaml                — aquapured.conf.tmpl (MQTT_USER/PASSWD substituted at pod start)
    kustomization.yaml
kubernetes/apps/home/kustomization.yaml  — adds ./aquapured/ks.yaml
```

## Before merging (human checklist)

- [ ] **Reserve `10.10.20.105` as a DHCP static exclusion** in Omada / brain so no other device claims it
- [ ] **Build and push the container image**: open and merge the `containers` repo PR, then trigger the `aquapured Release` workflow → `v0.1.0`
- [ ] **Update `helmrelease.yaml` image digest**: replace the `sha256:000...` placeholder with the actual digest from `ghcr.io/rwlove/aquapured:v0.1.0`
- [ ] **Wire Elfin EW11 A/B/GND → AquaPure RS485 terminals**: YEL=A / BLK=B / GRN=GND (same wiring convention as the aqualogic Elfin)
- [ ] **Verify `SWG_DEVICE_ID = 0x50`**: correct for Jandy AquaPure standalone; would be `0xB0` for a Zodiac Tri SWG — confirm against unit label before merge
- [ ] **Merge this PR** — Flux picks it up, pod starts, socat connects to Elfin, AquapureD starts polling
- [ ] **Watch logs**: `kubectl logs -n home deploy/aquapured -f`; look for salt decode messages; if output is garbled/no decode, swap A↔B at the Elfin terminal

## Test plan

- [ ] Pod reaches `Running` state; no `CrashLoopBackOff`
- [ ] `kubectl exec -n home deploy/aquapured -- ls -la /dev/aquapure` — pty symlink present
- [ ] MQTT topic `aquapured/SWG/PPM` shows a non-zero integer in EMQX (via MQTTX or `mosquitto_sub`)
- [ ] HA sensors `sensor.pool_salt_ppm` and `sensor.pool_swg_output` go from `unavailable` → numeric values
- [ ] `sensor.pool_swg_status` shows "Generating Salt" or "Off" (not "Unknown")

🤖 Generated with [Claude Code](https://claude.com/claude-code)