### PR TITLE
fix(aquapured): pin real image digest (heal placeholder on main)

### DIFF
--- a/kubernetes/apps/home/aquapured/app/helmrelease.yaml
+++ b/kubernetes/apps/home/aquapured/app/helmrelease.yaml
@@ -45,7 +45,7 @@ spec:
               # workaround: no upstream prebuilt image with socat available;
               #   upstream: https://github.com/sfeakes/AquapureD (no Dockerfile)
               repository: ghcr.io/rwlove/aquapured
-              tag: v0.1.0@sha256:0000000000000000000000000000000000000000000000000000000000000000
+              tag: v0.1.0@sha256:d928b24cd5c904f757f3ee03dd8088f7da355d3ba722233611d6a93a1527716c
 
             # Entrypoint:
             #   1. envsubst MQTT_USER/MQTT_PASSWD into /run/aquapured/aquapured.conf


### PR DESCRIPTION
## What
home-ops #12585 merged with the placeholder digest `sha256:0000…0000` still in the aquapured HelmRelease. Flux cannot pull that ref, so the aquapured pod is in ImagePullBackOff on main.

This pins the real digest published by the `aquapured Release` v0.1.0 build:

```
ghcr.io/rwlove/aquapured:v0.1.0@sha256:d928b24cd5c904f757f3ee03dd8088f7da355d3ba722233611d6a93a1527716c
```

## Effect
Merging heals the image pull. The pod will start, socat dials the Elfin at 10.10.20.21:8899, and aquapured begins polling. Salt won't decode until the Elfin RS485 A/B/GND is physically wired; watch for the `/dev/pts` socat note in logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)