### PR TITLE
fix(aquapured): drop /dev/pts mount so socat can create the pty

### DIFF
--- a/kubernetes/apps/home/aquapured/app/helmrelease.yaml
+++ b/kubernetes/apps/home/aquapured/app/helmrelease.yaml
@@ -113,8 +113,3 @@ spec:
         type: emptyDir
         globalMounts:
           - path: /run/aquapured
-      dev:
-        type: emptyDir
-        medium: Memory
-        globalMounts:
-          - path: /dev/pts


### PR DESCRIPTION
## Problem
aquapured pod crashlooped on startup:
```
socat[3] E openpty(...): No such file or directory
[entrypoint] socat failed to start; exiting
```
The HelmRelease mounted an empty `emptyDir` over `/dev/pts`, shadowing the container runtime's devpts. socat's `openpty()` then had no `/dev/pts/ptmx` to allocate `/dev/aquapure` from → ENOENT.

## Fix
Remove the `dev` emptyDir mount; the runtime provides a working `/dev/pts` by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)