### PR TITLE
fix(aquapured): add NET_BIND_SERVICE for port 80 bind

### DIFF
--- a/kubernetes/apps/home/aquapured/app/helmrelease.yaml
+++ b/kubernetes/apps/home/aquapured/app/helmrelease.yaml
@@ -91,8 +91,10 @@ spec:
               readOnlyRootFilesystem: false
               capabilities:
                 drop: ["ALL"]
-                # socat pty,link= needs to open /dev/ptmx (world-writable on
-                # most Linux distros) — no extra caps required in practice.
+                # aquapured's web server binds port 80; with all caps dropped
+                # even root can't bind a privileged port. NET_BIND_SERVICE is
+                # the one add the restricted PodSecurity standard permits.
+                add: ["NET_BIND_SERVICE"]
 
     service:
       app:


### PR DESCRIPTION
Daemon crashlooped: `Failed to create listener` (web server port 80) → `Can not start mqtt on port`. All caps were dropped, so it couldn't bind a privileged port. Add NET_BIND_SERVICE (restricted-PSS-compliant). 🤖 Generated with [Claude Code](https://claude.com/claude-code)