### PR TITLE
fix(aquapured): escape MQTT cred placeholders from Flux substitution

### DIFF
--- a/kubernetes/apps/home/aquapured/app/configmap.yaml
+++ b/kubernetes/apps/home/aquapured/app/configmap.yaml
@@ -26,8 +26,10 @@ data:
     SERIAL_PORT = /dev/aquapure
 
     MQTT_ADDRESS = emqx.home.svc.cluster.local:1883
-    MQTT_USER = ${MQTT_USER}
-    MQTT_PASSWD = ${MQTT_PASSWD}
+    # $$ escapes Flux post-build substitution so the literal ${MQTT_USER}
+    # placeholder survives into the cluster for the container's envsubst to fill.
+    MQTT_USER = $${MQTT_USER}
+    MQTT_PASSWD = $${MQTT_PASSWD}
     MQTT_TOPIC = aquapured
 
     # Disable Domoticz integration (no DZIDX_SWG_STATUS_ALERT_SENSOR needed).


### PR DESCRIPTION
Flux post-build substitution blanked `${MQTT_USER}`/`${MQTT_PASSWD}` in the ConfigMap before the container's envsubst ran → empty MQTT creds → EMQX auth-fail loop. Escape with `$$` so the literal placeholder survives for envsubst. 🤖 Generated with [Claude Code](https://claude.com/claude-code)