### PR TITLE
fix(aquapured): shorten MQTT_ADDRESS to fit daemon buffer

### DIFF
--- a/kubernetes/apps/home/aquapured/app/configmap.yaml
+++ b/kubernetes/apps/home/aquapured/app/configmap.yaml
@@ -25,7 +25,10 @@ data:
     # pty created by socat; see container entrypoint.
     SERIAL_PORT = /dev/aquapure
 
-    MQTT_ADDRESS = emqx.home.svc.cluster.local:1883
+    # Short in-namespace name — AquapureD truncates the server address to
+    # ~19 chars, so the full FQDN (emqx.home.svc.cluster.local) gets cut and
+    # fails to resolve. "emqx.home.svc" resolves to the same ClusterIP.
+    MQTT_ADDRESS = emqx.home.svc:1883
     # $$ escapes Flux post-build substitution so the literal ${MQTT_USER}
     # placeholder survives into the cluster for the container's envsubst to fill.
     MQTT_USER = $${MQTT_USER}


### PR DESCRIPTION
AquapureD truncates the MQTT server address to ~19 chars; the 32-char FQDN becomes `emqx.home.svc.clust` and fails to resolve. Use `emqx.home.svc:1883` (same ClusterIP, fits). 🤖 Generated with [Claude Code](https://claude.com/claude-code)