### PR TITLE
fix(aquapured): bump to v0.1.1 (MQTT buffer fix)

### DIFF
--- a/kubernetes/apps/home/aquapured/app/helmrelease.yaml
+++ b/kubernetes/apps/home/aquapured/app/helmrelease.yaml
@@ -45,7 +45,7 @@ spec:
               # workaround: no upstream prebuilt image with socat available;
               #   upstream: https://github.com/sfeakes/AquapureD (no Dockerfile)
               repository: ghcr.io/rwlove/aquapured
-              tag: v0.1.0@sha256:d928b24cd5c904f757f3ee03dd8088f7da355d3ba722233611d6a93a1527716c
+              tag: v0.1.1@sha256:b3307a33e301bfe7eb342bad81968c0f6f0f2ac6cd5886ecf68a99c4de278c79
 
             # Entrypoint:
             #   1. envsubst MQTT_USER/MQTT_PASSWD into /run/aquapured/aquapured.conf


### PR DESCRIPTION
Pins the rebuilt image with enlarged mqtt_server/mqtt_passwd buffers so the EMQX creds aren't truncated. 🤖 Generated with [Claude Code](https://claude.com/claude-code)