### PR TITLE
fix(aquapured): run mosquitto sidecar as uid 1883

### DIFF
--- a/kubernetes/apps/home/aquapured/app/helmrelease.yaml
+++ b/kubernetes/apps/home/aquapured/app/helmrelease.yaml
@@ -104,6 +104,11 @@ spec:
               tag: "2.0.20"
             command: ["/usr/sbin/mosquitto", "-c", "/mosquitto/config/mosquitto.conf"]
             securityContext:
+              # Start AS the mosquitto user (1883) so it never tries to drop
+              # privileges (which fails with caps dropped: setgid not permitted).
+              runAsNonRoot: true
+              runAsUser: 1883
+              runAsGroup: 1883
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: false
               capabilities:


### PR DESCRIPTION
Mosquitto crashlooped dropping privileges with caps removed. Run as uid 1883 directly. 🤖 Generated with [Claude Code](https://claude.com/claude-code)