### PR TITLE
chore(aquapured): DEBUG_SERIAL logging for RS-485 bring-up

### DIFF
--- a/kubernetes/apps/home/aquapured/app/configmap.yaml
+++ b/kubernetes/apps/home/aquapured/app/configmap.yaml
@@ -17,7 +17,7 @@ data:
     SWG_DEVICE_ID = 0x50
 
     # Use DEBUG_SERIAL for first bring-up; INFO for steady-state.
-    log_level = INFO
+    log_level = DEBUG_SERIAL
 
     WEB_DIRECTORY = /usr/share/aquapured/web/
     WEB_PORT = 80


### PR DESCRIPTION
Temporary verbose serial logging to debug the AquaPure no-reply. Revert to INFO once wired. 🤖 Generated with [Claude Code](https://claude.com/claude-code)