### PR TITLE
feat(mcp-system): add esphome-mcp server

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ _Production-grade Kubernetes for a household._
 
 <br/>
 
-![apps](https://img.shields.io/badge/apps-189-blue?style=for-the-badge)
-![helmreleases](https://img.shields.io/badge/HelmReleases-202-326CE5?style=for-the-badge&logo=helm&logoColor=white)
+![apps](https://img.shields.io/badge/apps-190-blue?style=for-the-badge)
+![helmreleases](https://img.shields.io/badge/HelmReleases-203-326CE5?style=for-the-badge&logo=helm&logoColor=white)
 ![nodes](https://img.shields.io/badge/k8s_nodes-11-326CE5?style=for-the-badge&logo=kubernetes&logoColor=white)
 ![cnpg](https://img.shields.io/badge/Postgres_clusters-24-336791?style=for-the-badge&logo=postgresql&logoColor=white)
 ![secrets](https://img.shields.io/badge/secrets-117-0572EC?style=for-the-badge&logo=1password&logoColor=white)
@@ -277,12 +277,13 @@ Worker nodes attach to **iot** and **sec** VLANs via Multus for direct camera an
 </details>
 
 <details>
-<summary>🔌 <b>MCP Servers</b> — 18 Model Context Protocol servers behind an Authelia-gated gateway</summary>
+<summary>🔌 <b>MCP Servers</b> — 19 Model Context Protocol servers behind an Authelia-gated gateway</summary>
 
 | Server | Exposes |
 |--------|---------|
 | **mcp-gateway** | Aggregating gateway; Envoy SecurityPolicy validates Authelia-issued JWTs (daily-rotated key) |
 | **ha-mcp** | Home Assistant entities + service calls |
+| **esphome-mcp** | ESPHome dashboard: device YAML edit, validate, logs, compile + OTA flash |
 | **immich-mcp** | Immich library search + asset metadata |
 | **kubectl-mcp** | Cluster introspection + safe `kubectl` ops |
 | **grafana-mcp** | Grafana dashboards + Loki/Prom queries |

--- a/kubernetes/apps/home/esphome/app/cnp-allow.yaml
+++ b/kubernetes/apps/home/esphome/app/cnp-allow.yaml
@@ -23,7 +23,20 @@ spec:
         - ports:
             - port: "6052"
               protocol: TCP
+    # esphome-mcp (mcp-system) drives the dashboard API — list/edit/validate
+    # over HTTP and compile/flash/logs over WebSocket, all on 6052.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: mcp-system
+            app.kubernetes.io/name: esphome-mcp
+      toPorts:
+        - ports:
+            - port: "6052"
+              protocol: TCP
   egress:
+    # NOTE: ESPHome devices on the IoT VLAN are reached via the multus-
+    # attached secondary NIC (esphome-iot-static). That traffic bypasses
+    # Cilium entirely — these CNPs only govern eth0 (Pod CIDR) traffic.
     # ESPHome compiles firmware on-demand and reaches out to the public
     # internet during compile: PlatformIO package index, GitHub for
     # libraries / boards, ESPHome release server, PyPI, etc. The set is
@@ -37,6 +50,3 @@ spec:
               protocol: TCP
             - port: "80"
               protocol: TCP
-    # NOTE: ESPHome devices on the IoT VLAN are reached via the multus-
-    # attached secondary NIC (esphome-iot-static). That traffic bypasses
-    # Cilium entirely — these CNPs only govern eth0 (Pod CIDR) traffic.

--- a/kubernetes/apps/mcp-system/esphome-mcp/app/cnp-allow.yaml
+++ b/kubernetes/apps/mcp-system/esphome-mcp/app/cnp-allow.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: esphome-mcp-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: esphome-mcp
+  # Additive — default-deny is what triggers the lockdown. Broker → server
+  # (intra-ns) and the istio gateway path are covered by the baseline
+  # allow-intra-namespace + mcp-gateway-istio-allow, so no ingress rule is
+  # needed here (matches the other MCP backends).
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  egress:
+    # The ESPHome dashboard (home ns) — list/edit/validate over HTTP and
+    # compile/flash/logs over WebSocket, all on 6052. A matching ingress hole
+    # is punched on the dashboard side (home/esphome esphome-allow).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: home
+            app.kubernetes.io/name: esphome
+      toPorts:
+        - ports:
+            - port: "6052"
+              protocol: TCP
+    # get_esphome_schema downloads the component schema zip from GitHub
+    # releases (github.com → codeload / objects.githubusercontent.com), which
+    # are A-only FQDNs where Cilium toFQDNs.matchPattern silently fails — use
+    # world:443, same rationale as the codegraph-mcp / github-mcp CNPs.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/mcp-system/esphome-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/esphome-mcp/app/helmrelease.yaml
@@ -1,0 +1,121 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app esphome-mcp
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 1h
+  values:
+    defaultPodOptions:
+      securityContext:
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+    controllers:
+      esphome-mcp:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        pod:
+          annotations:
+            sidecar.istio.io/inject: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/rwlove/esphome-mcp
+              tag: v0.1.0@sha256:eeb950710cdc0a12c4c6ee580842e492a473294645036500a3c3ad896ad34468
+            env:
+              HOST: "0.0.0.0"
+              PORT: &httpPort 8080
+              # Stateless streamable-HTTP for the Kuadrant broker (stateful
+              # FastMCP sessions deadlock it). Baked into the image too; set
+              # here for visibility.
+              FASTMCP_STATELESS_HTTP: "true"
+              # In-cluster ESPHome dashboard (home ns). HTTP + WebSocket API
+              # on 6052 — compile/OTA runs on the dashboard pod, not here.
+              ESPHOME_DASHBOARD_URL: http://esphome.home.svc.cluster.local:6052
+              # Redirect HOME onto the tmpfs so readOnlyRootFilesystem holds.
+              HOME: /tmp
+            probes:
+              # The server probes the dashboard at startup (up to ~25s of
+              # retries) and only begins serving HTTP once it connects, so the
+              # readiness/liveness delays are generous to avoid a restart loop
+              # before first connect.
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: *httpPort
+                  initialDelaySeconds: 45
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: *httpPort
+                  initialDelaySeconds: 15
+                  periodSeconds: 15
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              startup:
+                enabled: false
+            resources:
+              requests:
+                cpu: 10m
+                memory: 96Mi
+              limits:
+                memory: 256Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - ALL
+              readOnlyRootFilesystem: true
+              seccompProfile:
+                type: RuntimeDefault
+    service:
+      app:
+        controller: esphome-mcp
+        ports:
+          http:
+            port: *httpPort
+    route:
+      app:
+        hostnames:
+          - "esphome-mcp.mcp.local"
+        parentRefs:
+          - name: mcp-gateway
+            namespace: mcp-system
+            sectionName: mcps
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /mcp
+            filters:
+              # Strip the broker Bearer before forwarding (fleet-wide MCP
+              # backend pattern — see time-mcp / codegraph-mcp).
+              - type: RequestHeaderModifier
+                requestHeaderModifier:
+                  remove:
+                    - Authorization
+            backendRefs:
+              - identifier: app
+                port: *httpPort
+    persistence:
+      # readOnlyRootFilesystem: true → give the process a writable scratch.
+      # HOME is redirected here; httpx/fastmcp keep nothing durable.
+      tmp:
+        type: emptyDir
+        advancedMounts:
+          esphome-mcp:
+            app:
+              - path: /tmp
+                subPath: tmp

--- a/kubernetes/apps/mcp-system/esphome-mcp/app/kustomization.yaml
+++ b/kubernetes/apps/mcp-system/esphome-mcp/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../components/repos/app-template
+resources:
+  - ./cnp-allow.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/mcp-system/esphome-mcp/ks.yaml
+++ b/kubernetes/apps/mcp-system/esphome-mcp/ks.yaml
@@ -1,0 +1,48 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app esphome-mcp
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: mcp-system
+  path: ./kubernetes/apps/mcp-system/esphome-mcp/app
+  interval: 1h
+  timeout: 5m
+  prune: true
+  wait: false
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: mcp-gateway
+      namespace: mcp-system
+  retryInterval: 2m
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app esphome-mcp-mcpserverregistration
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: mcp-system
+  path: ./kubernetes/apps/mcp-system/esphome-mcp/mcp
+  interval: 1h
+  timeout: 5m
+  prune: true
+  wait: false
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: esphome-mcp
+      namespace: mcp-system
+  retryInterval: 2m

--- a/kubernetes/apps/mcp-system/esphome-mcp/mcp/kustomization.yaml
+++ b/kubernetes/apps/mcp-system/esphome-mcp/mcp/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./mcpserverregistration.yaml

--- a/kubernetes/apps/mcp-system/esphome-mcp/mcp/mcpserverregistration.yaml
+++ b/kubernetes/apps/mcp-system/esphome-mcp/mcp/mcpserverregistration.yaml
@@ -1,0 +1,14 @@
+---
+# TODO: apply schema
+apiVersion: mcp.kuadrant.io/v1alpha1
+kind: MCPServerRegistration
+metadata:
+  name: esphome-tools
+  labels:
+    mcp.kuadrant.io/managed: "true"
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: esphome-mcp
+  prefix: esphome_

--- a/kubernetes/apps/mcp-system/kustomization.yaml
+++ b/kubernetes/apps/mcp-system/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
   - ./cilium-mcp/ks.yaml
   - ./codegraph-mcp/ks.yaml
   - ./comfyui-mcp/ks.yaml
+  - ./esphome-mcp/ks.yaml
   - ./github-mcp/ks.yaml
   - ./grafana-mcp/ks.yaml
   - ./ha-mcp/ks.yaml


### PR DESCRIPTION
## What

Adds an **esphome-mcp** server behind the Kuadrant `mcp-gateway`, exposing tools (prefix `esphome_`) to manage the cluster's ESPHome dashboard from the AI surface: list devices, read/edit device YAML, validate, stream logs, and **compile + OTA-flash firmware**.

Image: `ghcr.io/rwlove/esphome-mcp` (built in rwlove/containers#105, digest-pinned).

## How it works

- **Thin client** to the in-cluster dashboard at `esphome.home.svc.cluster.local:6052` over its HTTP + WebSocket API. All firmware compilation and OTA upload run on the **dashboard pod** (which has the toolchain, 50Gi buildcache, and IoT-VLAN reach) — the MCP pod needs no device-network access.
- **Stateless streamable-HTTP** (`FASTMCP_STATELESS_HTTP=true`) so it federates through the broker (stateful FastMCP sessions deadlock it). Verified locally: an MCP `initialize` POST returns `200` with no session id.
- **No ExternalSecret** (dashboard has no auth), **no PVC** (stateless), `readOnlyRootFilesystem: true` + tmpfs, uid 1000.

## Files

- `kubernetes/apps/mcp-system/esphome-mcp/` — `ks.yaml`, `app/{kustomization,helmrelease,cnp-allow}.yaml`, `mcp/{kustomization,mcpserverregistration}.yaml`.
- `mcp-system/kustomization.yaml` — register the app.
- `home/esphome/app/cnp-allow.yaml` — ingress hole for `mcp-system/esphome-mcp → 6052` (and relocated a pre-existing trailing NOTE comment to satisfy yamllint).
- `README.md` — MCP count 18 → 19, app/HelmRelease badges bumped, esphome-mcp row added.

## ⚠️ Required before this deploys cleanly

`ghcr.io/rwlove/esphome-mcp` is currently a **private** package (new packages default private; no REST API to flip it). Set it **public** to match the other `rwlove/*` MCP images (the cluster pulls anonymously, no pull secret), otherwise the pod will `ImagePullBackOff`:
<https://github.com/users/rwlove/packages/container/esphome-mcp/settings> → Danger Zone → Change visibility → Public.

## Verify after deploy

- Pod `esphome-mcp` Running 2/2 (app + istio sidecar) in `mcp-system`.
- `esphome_list_device_names` returns devices through the gateway.
- A WebSocket-backed call (`esphome_get_device_logs`) streams — confirms the istio-sidecar → non-mesh-dashboard WS path works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)