### PR TITLE
chore(esphome-mcp): bump to v0.1.1 (None-guard device-lookup fix)

### DIFF
--- a/kubernetes/apps/mcp-system/esphome-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/esphome-mcp/app/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/esphome-mcp
-              tag: v0.1.0@sha256:eeb950710cdc0a12c4c6ee580842e492a473294645036500a3c3ad896ad34468
+              tag: v0.1.1@sha256:5b298ce7f2c7e2b338c460574f1e47ace2a50209d987a0d90dcade330bd350a8
             env:
               HOST: "0.0.0.0"
               PORT: &httpPort 8080


### PR DESCRIPTION
Bumps the esphome-mcp image `v0.1.0 → v0.1.1` to pick up [rwlove/containers#106](https://github.com/rwlove/containers/pull/106).

## Why
Every device-name MCP tool (`get_device_configuration`, `edit`, `validate`, `logs`, `status`) was crashing with `'NoneType' object has no attribute 'lower'` — upstream `server.py` does `device.get("name", "").lower()`, and a device whose `name`/`friendly_name` is explicitly `null` (some HA-Voice devices) makes that `None.lower()`. v0.1.1 guards it with `(... or "")`.

Image: `ghcr.io/rwlove/esphome-mcp:v0.1.1@sha256:5b298ce7f2c7e2b338c460574f1e47ace2a50209d987a0d90dcade330bd350a8`

Single-line change to the HelmRelease tag. Flux will roll the pod on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)