### PR TITLE
fix(downloads): rename config Longhorn volume + recover resume DB

### DIFF
--- a/kubernetes/apps/downloads/qbittorrent/app/longhorn-pvc.yaml
+++ b/kubernetes/apps/downloads/qbittorrent/app/longhorn-pvc.yaml
@@ -39,4 +39,4 @@ spec:
     volumeAttributes:
       numberOfReplicas: "2"
       staleReplicaTimeout: "2880"
-    volumeHandle: qbittorrent-config-xfs-new
+    volumeHandle: qbittorrent-config-xfs


### PR DESCRIPTION
## What
Repoint the download client's static config PV from the `-new`-suffixed Longhorn volume to a freshly-created clean-XFS volume of the canonical name.

## Why
The `-new` suffix was a leftover from a December backup-restore. The 2026-06-17 power outage's filesystem recovery (`xfs_repair -L`) zeroed the XFS journal underneath the app's live SQLite WAL, corrupting the resume database — the app silently dropped unreadable entries on startup (missing items + missing categories).

## How
- New clean Longhorn volume created, populated with a SQLite `.recover` of the resume DB (183/184 entries salvaged, `integrity_check: ok`) plus corrected config.
- This PR only flips the `volumeHandle` on the static PV. Cutover (stop pod → delete/recreate PV+PVC → verify) is performed out-of-band; the old volume is retained until verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)