### PR TITLE
refactor(media): rename squeezelite zone deck → yard

### DIFF
--- a/kubernetes/apps/kube-system/generic-device-plugin/app/daemonset.yaml
+++ b/kubernetes/apps/kube-system/generic-device-plugin/app/daemonset.yaml
@@ -33,8 +33,8 @@ spec:
             #
             # master1 AND worker2 — Intel HDA ALC294 (onboard analog +
             # HDMI), identical minor layout, so they share this one
-            # group: master1 serves snapclient-pool, worker2 serves
-            # snapclient-deck. seq + timer are required by ALSA's dmix
+            # group: master1 serves the pool zone, worker2 serves the
+            # yard zone. seq + timer are required by ALSA's dmix
             # plugin (the default PCM target snapclient resolves to),
             # not optional.
             - --device

--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -47,10 +47,10 @@ resources:
   - ./soularr/ks.yaml
   - ./soularr-oauth2-proxy/ks.yaml
   # Multiroom audio on squeezelite (SlimProto) — replaced snapclient.
-  # Both zones (pool=master1, deck=worker2) proven end-to-end 2026-05-31;
+  # Both zones (pool=master1, yard=worker2) proven end-to-end 2026-05-31;
   # snapclient dirs and the MA Snapcast provider have been decommissioned.
-  - ./squeezelite-deck/ks.yaml
   - ./squeezelite-pool/ks.yaml
+  - ./squeezelite-yard/ks.yaml
   - ./stash/ks.yaml
   - ./suggestarr/ks.yaml
   - ./suggestarr-oauth2-proxy/ks.yaml

--- a/kubernetes/apps/media/music-assistant/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/music-assistant/app/cnp-allow.yaml
@@ -31,7 +31,7 @@ spec:
     # media_player, the phone app on :8095, etc.). These arrive from
     # `reserved:world`. :3483 here is for LAN SlimProto clients — notably
     # the future LAN-based BOOM Pi bridge. The in-cluster squeezelite
-    # pool/deck pods do NOT use this rule: they reach MA via the ClusterIP
+    # pool/yard pods do NOT use this rule: they reach MA via the ClusterIP
     # for SlimProto control (:3483) and fetch the audio flow from the
     # streamserver (:8097, publish_ip=ClusterIP) — both intra-namespace,
     # covered by the baseline allow-intra-namespace policy.

--- a/kubernetes/apps/media/squeezelite-yard/app/helmrelease.yaml
+++ b/kubernetes/apps/media/squeezelite-yard/app/helmrelease.yaml
@@ -3,7 +3,7 @@
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: &app squeezelite-deck
+  name: &app squeezelite-yard
 spec:
   chartRef:
     kind: OCIRepository
@@ -19,16 +19,16 @@ spec:
       strategy: rollback
   values:
     controllers:
-      squeezelite-deck:
+      squeezelite-yard:
         pod:
           # Pin to worker2 — the ALC294 Headphone jack is the physical
-          # path to the amp serving the Deck speakers. worker2's audio
+          # path to the amp serving the Yard speakers. worker2's audio
           # card is an identical ALC294 with the same /dev/snd minor
           # layout as master1, so it shares the generic-device-plugin
           # `snd` group rather than needing its own.
           nodeSelector:
             kubernetes.io/hostname: worker2.thesteamedcrab.com
-          # WAF tier — deck audio dropouts are user-visible, so evict
+          # WAF tier — yard audio dropouts are user-visible, so evict
           # janitorr / recyclarr / metadata syncs before us. Stays well
           # below system-cluster-critical so we never preempt infra.
           priorityClassName: media-cluster-critical
@@ -54,7 +54,7 @@ spec:
               # SlimProto server = Music Assistant's built-in provider.
               SQUEEZELITE_SERVER_PORT: music-assistant.media.svc.cluster.local:3483
               # Friendly name in the MA player list (squeezelite -n).
-              SQUEEZELITE_NAME: Deck
+              SQUEEZELITE_NAME: Yard
               # SlimProto identity is the 6-byte MAC sent in the HELO. The
               # container NIC MAC is ephemeral, so pin a stable, unique,
               # locally-administered address — this is what stops MA from

--- a/kubernetes/apps/media/squeezelite-yard/app/kustomization.yaml
+++ b/kubernetes/apps/media/squeezelite-yard/app/kustomization.yaml
@@ -7,5 +7,5 @@ components:
 resources:
   - ./helmrelease.yaml
 commonLabels:
-  app.kubernetes.io/instance: squeezelite-deck
-  app.kubernetes.io/name: squeezelite-deck
+  app.kubernetes.io/instance: squeezelite-yard
+  app.kubernetes.io/name: squeezelite-yard

--- a/kubernetes/apps/media/squeezelite-yard/ks.yaml
+++ b/kubernetes/apps/media/squeezelite-yard/ks.yaml
@@ -3,13 +3,13 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app squeezelite-deck
+  name: &app squeezelite-yard
 spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
   targetNamespace: media
-  path: ./kubernetes/apps/media/squeezelite-deck/app
+  path: ./kubernetes/apps/media/squeezelite-yard/app
   interval: 30m
   prune: true
   wait: false


### PR DESCRIPTION
Renames the worker2 outdoor audio zone from **Deck** to **Yard** across the squeezelite/MA stack. Companion `media_player.deck → media_player.yard` HA changes (entity registry + `home-assistant-config` YAML + live dashboard) are handled out-of-band.

## Changes
- `git mv squeezelite-deck → squeezelite-yard` — HelmRelease + Flux Kustomization name, controller key, instance/name labels, reconcile path.
- `SQUEEZELITE_NAME: Deck → Yard` (Music Assistant player friendly name).
- **Pinned SlimProto MAC `aa:bb:cc:00:00:02` kept** — MA keys players on MAC, so the player identity is preserved (no ghost player); only the friendly name changes.
- Reordered `media/kustomization.yaml` to keep the list alphabetical (`pool` before `yard`); refreshed stale zone comments in the `generic-device-plugin` DaemonSet and `music-assistant` cnp-allow.

## Scope / non-changes
- The Frigate **`deck` camera** (`loryta-deck`) and **`binary_sensor.deck_person_occupancy`** are intentionally **unchanged** — different concept from the audio zone.

## Deploy impact
- On merge, Flux prunes the `squeezelite-deck` Kustomization and creates `squeezelite-yard`; the pod recreates on worker2 (same node, same MAC). Renee-facing media, but the player is **idle** at authoring time, so no audible dropout expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)