### PR TITLE
fix(home): repoint zigbee2mqtt config PV to renamed Longhorn volume [DO NOT MERGE until volume exists]

### DIFF
--- a/kubernetes/apps/home/zigbee2mqtt/app/longhorn-pvc.yaml
+++ b/kubernetes/apps/home/zigbee2mqtt/app/longhorn-pvc.yaml
@@ -37,4 +37,4 @@ spec:
     volumeAttributes:
       numberOfReplicas: "2"
       staleReplicaTimeout: "2880"
-    volumeHandle: zigbee2mqtt-config-xfs-new
+    volumeHandle: zigbee2mqtt-config-xfs


### PR DESCRIPTION
Drops the `-new` suffix the zigbee2mqtt config PV's `volumeHandle` carries from a December restore, mirroring the qbittorrent cleanup (#12604).

## ⛔ DO NOT MERGE until `zigbee2mqtt-config-xfs` exists

The target Longhorn volume does **not** exist yet. If this reconciles first, the CSI attach fails and zigbee2mqtt can't mount its config → **Zigbee control (lights/locks/climate) goes down.**

Unlike qbittorrent (which intentionally started from a clean XFS volume after the outage corrupted its SQLite resume DB), zigbee2mqtt's config is **intact and irreplaceable** — the new volume must be a **data copy** (snapshot → backup → restore), not a fresh empty volume, or the Zigbee device database (coordinator backup, friendly names, bindings) is lost and every device re-interviews.

## Merge order (Renee-facing → Tuesday 02:00–04:00 window)
1. Merge #12607 (RBAC grant), wait for Flux reconcile.
2. Suspend the zigbee2mqtt Flux Kustomization.
3. Agent: snapshot → backup → restore current volume to `zigbee2mqtt-config-xfs`; scale STS to 0; delete bound PVC + PV.
4. **Merge this PR** → Flux recreates PV (→ `zigbee2mqtt-config-xfs`) + PVC, binds.
5. Resume the Kustomization; scale STS to 1.
6. Verify device count + a live Zigbee toggle.
7. Merge the RBAC revert (#12607 counterpart); delete the old `-new` volume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)