### PR TITLE
feat(music-assistant): add IoT-VLAN macvlan NIC for WiiM AirPlay ("Deck")

### DIFF
--- a/kubernetes/apps/media/music-assistant/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/music-assistant/app/cnp-allow.yaml
@@ -76,6 +76,14 @@ spec:
               protocol: TCP
             - port: "1900"
               protocol: UDP
+            # AirPlay/zeroconf binds all interfaces, so mDNS also leaks out
+            # eth0 toward 224.0.0.251. The real WiiM discovery + RAOP push
+            # happen on the macvlan net1 (Cilium-blind); this allow only
+            # suppresses POLICY_DENIED drop-burst noise on eth0. Mirrors the
+            # HA mDNS-egress fix. (IGMP proto-2 reports still drop —
+            # CT_UNKNOWN_L4_PROTOCOL, no CNP knob; accepted.)
+            - port: "5353"
+              protocol: UDP
     # Music-assistant calls back into Home Assistant (callback events,
     # entity-state subscriptions) — HA REST + WebSocket on :8123.
     - toEndpoints:

--- a/kubernetes/apps/media/music-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/media/music-assistant/app/helmrelease.yaml
@@ -14,6 +14,25 @@ spec:
     controllers:
       music-assistant:
         pod:
+          # Pin to a VLAN-20-capable node — the macvlan master enp1s0.20
+          # only exists on nodes labeled node.network/vlan-iot=true.
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: node.network/vlan-iot
+                        operator: In
+                        values:
+                          - "true"
+
+          # IoT VLAN (20) secondary NIC — gives MA an L2 presence on the IoT
+          # VLAN so its AirPlay/zeroconf provider can discover and push audio
+          # to the LAN WiiM ("Deck", 10.10.20.26). macvlan net1 bypasses
+          # Cilium; AirPlay is push-based so no publish_ip change is needed.
+          annotations:
+            k8s.v1.cni.cncf.io/networks: music-assistant-iot-static
+
           securityContext:
             # Tier 2 reader — reads media via the world-readable bit on
             # 2775 dirs / 664 files. NOT a member of the media group; runs

--- a/kubernetes/apps/media/music-assistant/ks.yaml
+++ b/kubernetes/apps/media/music-assistant/ks.yaml
@@ -20,5 +20,29 @@ spec:
   dependsOn:
     - name: longhorn
       namespace: longhorn-system
+    - name: music-assistant-multus
+      namespace: media
   postBuild:
     substituteFrom: []
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app music-assistant-multus
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: media
+  path: ./kubernetes/apps/media/music-assistant/net-attach
+  interval: 30m
+  prune: true
+  wait: true
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: multus
+      namespace: network

--- a/kubernetes/apps/media/music-assistant/net-attach/kustomization.yaml
+++ b/kubernetes/apps/media/music-assistant/net-attach/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - net-attach.yaml

--- a/kubernetes/apps/media/music-assistant/net-attach/net-attach.yaml
+++ b/kubernetes/apps/media/music-assistant/net-attach/net-attach.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/k8s.cni.cncf.io/networkattachmentdefinition_v1.json
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: music-assistant-iot-static
+spec:
+  config: |
+    {
+    "cniVersion": "0.3.1",
+    "type": "macvlan",
+    "master": "enp1s0.20",
+    "mode": "bridge",
+    "ipam": {
+    "type": "static",
+    "addresses": [
+    {
+    "address": "10.10.20.106/24"
+    }
+    ]
+    }
+    }


### PR DESCRIPTION
Gives Music Assistant a Multus **macvlan secondary interface on VLAN 20** (the IoT VLAN) so its AirPlay provider can discover and push audio to the LAN **WiiM** at `10.10.20.26`, surfacing it as the **"Deck"** player in MA. Same pattern `home-assistant` / `esphome` already use.

## Why this shape (not egress, not a reflector, not a VLAN move)
- MA's pod is on the Cilium overlay; **LAN mDNS/SSDP multicast doesn't reach the pod netns** — proven with an SSDP M-SEARCH from the MA pod that got **0 responders** on a UPnP-full LAN, even though SSDP egress is already allowed. A real L2 NIC on VLAN 20 is the fix.
- **AirPlay is push-based** (MA → WiiM over RAOP), so it needs **no change to `streams.publish_ip`** (stays the ClusterIP) → **zero risk to the in-cluster squeezelite `pool`/`yard` zones**. (DLNA/Cast are fetch-based and would hit the ClusterIP wall — rejected.)
- **macvlan `net1` bypasses Cilium**, so the AirPlay + mDNS path needs **no CNP egress rule**. The only network-policy change is allowing **UDP 5353 to world** to suppress eth0 mDNS `POLICY_DENIED` drop-burst noise (zeroconf binds all interfaces) — mirrors the HA mDNS-egress fix.

## Changes (5 files, single app)
- `net-attach/` — `NetworkAttachmentDefinition` `music-assistant-iot-static` (macvlan, `master enp1s0.20`, static `10.10.20.106/24` — next free in the `.101–.105` static block: HA/.101, esphome/.102, node-red/.103, matter/.104, aquapured/.105).
- `ks.yaml` — `music-assistant-multus` Flux Kustomization (`dependsOn: multus`); app `dependsOn` it.
- `helmrelease.yaml` — pod `node.network/vlan-iot` affinity + the `k8s.v1.cni.cncf.io/networks` annotation.
- `cnp-allow.yaml` — UDP 5353 world egress (drop-noise only).

## Pre-merge checklist
- [ ] Confirm `10.10.20.106` is unused on the live VLAN (Omada client list — it's outside the DHCP pool by convention but verify).

## Deploy impact / sequencing
- **Renee-facing** (restarts `music-assistant-0`, and adds a VLAN-20 node-affinity constraint) → merge in the **Tue 02:00–04:00 ET** window.
- Post-merge: enable/confirm the AirPlay provider, rename the discovered WiiM player to **"Deck"** in the MA UI (sticky in `settings.json`), then verify: Deck plays, a Deck+pool+yard sync group plays, and `media_player.pool`/`media_player.yard` still play independently with no CiliumPolicyDropBurst page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)