### PR TITLE
fix(observability): demote IoT blackbox probes, scope disk-IO saturation

### DIFF
--- a/kubernetes/apps/observability/exporters/blackbox-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/exporters/blackbox-exporter/app/helmrelease.yaml
@@ -86,14 +86,40 @@ spec:
           for: 5m
           labels:
             severity: critical
+        # Infrastructure reachability — storage NFS path (brain/beast/
+        # security-storage:2049) and the two ollama embed heartbeats.
+        # These are genuinely page-worthy: a sustained failure means a
+        # storage or inference-path outage. The ollama embed probes are
+        # intentionally covered here at critical (the OllamaWedged /
+        # SparkOllamaWedged rules in kubernetes/apps/ai/ollama* add
+        # runbook context on top of this one).
         - alert: BlackboxProbeFailed
           annotations:
             description: |-
               The host {{ $labels.instance }} is currently unreachable
-          expr: probe_success == 0
+          expr: probe_success{job=~"probe/observability/(nfs|ollama-embed|ollama-spark-embed)"} == 0
           for: 5m
           labels:
             severity: critical
+        # IoT / device reachability (the ICMP `devices` probe + the HTTP
+        # `http` probe — WLED, Hue, Kodi, presence sensors, ratgdo, frame
+        # displays, UPS/iDRAC ICMP, cameras). These targets legitimately
+        # sleep or power-cycle, so a critical/5m page floods the surface
+        # (14 distinct devices fired criticals in one day, each waking
+        # HolmesGPT). warning + for:15m absorbs the transient blips and
+        # routes to Pushover only — windmill-investigate (HolmesGPT)
+        # matches severity=critical, so warning bypasses it. Storage
+        # reachability stays critical via the nfs TCP probe above, and
+        # node-down is covered by the Kube*NodeNotReady rules, so nothing
+        # genuinely page-worthy is lost by demoting these.
+        - alert: BlackboxIoTDeviceUnreachable
+          annotations:
+            description: |-
+              IoT/device {{ $labels.instance }} has been unreachable for 15m
+          expr: probe_success{job=~"probe/observability/(devices|http)"} == 0
+          for: 15m
+          labels:
+            severity: warning
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -66,6 +66,12 @@ spec:
         InfoInhibitor: true
         KubePersistentVolumeFillingUp: true
         KubePersistentVolumeInodesFillingUp: true
+        # Replaced by ./prometheusrule-node-disk-io.yaml — the upstream
+        # rule fires on security-storage's dm-6, whose steady state is
+        # bursty NVMe write saturation from the Frigate recording path
+        # (expected, not an incident). The replacement excludes that one
+        # instance and is otherwise identical to upstream.
+        NodeDiskIOSaturation: true
     grafana:
       enabled: false
       forceDeployDashboards: true

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/kustomization.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/kustomization.yaml
@@ -10,5 +10,6 @@ resources:
   - ./ocirepository.yaml
   - ./prometheusrule-cilium-drops.yaml
   - ./prometheusrule-egress-detection.yaml
+  - ./prometheusrule-node-disk-io.yaml
   - ./prometheusrule-pod-pending.yaml
   - ./prometheusrule-pv.yaml

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/prometheusrule-node-disk-io.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/prometheusrule-node-disk-io.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: node-disk-io-rules
+spec:
+  groups:
+    # Replacement for the upstream node-exporter NodeDiskIOSaturation
+    # alert (disabled in helmrelease.yaml via defaultRules.disabled).
+    # Identical to upstream except security-storage is excluded: that
+    # box's dm-6 (NVMe) steady state is bursty IO-queue saturation from
+    # the Frigate recording write path (measured 2026-06-22: max 21.4
+    # aqu-sq, avg 3.65, 57/286 samples over the threshold of 10), which
+    # is expected for a surveillance recorder, not disk distress. Every
+    # other host/device keeps the upstream rule unchanged.
+    - name: node-exporter.node-disk-io
+      rules:
+        - alert: NodeDiskIOSaturation
+          annotations:
+            description: |
+              Disk IO queue (aqu-sq) is high on {{ $labels.device }} at {{ $labels.instance }}, has been above 10 for the last 30 minutes, is currently at {{ printf "%.2f" $value }}.
+              This symptom might indicate disk saturation.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/node/nodediskiosaturation
+            summary: Disk IO queue is high.
+          expr: rate(node_disk_io_time_weighted_seconds_total{device=~"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)",job="node-exporter",instance!~"security-storage.*"}[5m]) > 10
+          for: 30m
+          labels:
+            severity: warning


### PR DESCRIPTION
## What

Two alert-noise fixes from a triage of currently-firing alerts.

### 1. Split `BlackboxProbeFailed` (the big one)
14 IoT devices fired **critical** alerts in a single day just from normal sleep / power-cycle behavior — each waking **both** HolmesGPT and Pushover. Real failures (e.g. a frame display down for hours) get buried under the noise.

- **`BlackboxProbeFailed`** (infra) — now scoped to `nfs` + the two ollama embed heartbeat jobs. Stays `critical / 5m`.
- **`BlackboxIoTDeviceUnreachable`** (new) — the ICMP `devices` + HTTP `http` probes (WLED, Hue, Kodi, presence sensors, ratgdo, frame displays, UPS/iDRAC ICMP, cameras). `warning / 15m`.

`warning` routes to Pushover only (`windmill-investigate` matches `severity=critical`, so HolmesGPT is bypassed), and `for: 15m` absorbs transient blips. Storage reachability stays `critical` via the `nfs` TCP probe; node-down stays covered by the `Kube*NodeNotReady` rules. Verified the two selectors cover every `probe_success` series with zero orphans.

### 2. Scope `NodeDiskIOSaturation` off security-storage
The upstream rule fires on security-storage's `dm-6` (NVMe), whose steady state is bursty IO-queue saturation from the Frigate recording write path — expected for a surveillance recorder, not disk distress (measured: max 21.4 aqu-sq, avg 3.65). Disabled the upstream rule via `defaultRules.disabled` (existing repo pattern) and added a faithful replacement excluding that one instance; every other host keeps the upstream rule. Verified: 13 other instances still covered, security-storage excluded.

## Test
- `kubectl kustomize` renders both app dirs cleanly.
- New PromQL exprs validated against live Prometheus (full job coverage; correct instance exclusion).
- pre-commit (yamllint, schema, secret scan, restricted-name scan) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)