### PR TITLE
fix(media): allow MA stream-server port 8097 from world in CNP

### DIFF
--- a/kubernetes/apps/media/music-assistant/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/music-assistant/app/cnp-allow.yaml
@@ -26,12 +26,13 @@ spec:
         - ports:
             - port: "8095"
               protocol: TCP
-    # LoadBalancer Service at 10.45.0.20 exposes :1780 (HTTP2 streaming)
-    # and :3483 (SlimProto) directly to LAN clients (sonos, HA
-    # media_player, the phone app on :8095, etc.). These arrive from
-    # `reserved:world`. :3483 remains for any LAN SlimProto clients; the
-    # outdoor zones are now network-attached WiiM streamers, so there are
-    # no longer any in-cluster SlimProto/squeezelite pods behind this rule.
+    # LoadBalancer Service at 10.45.0.20 exposes :1780 (HTTP2 streaming),
+    # :3483 (SlimProto), and :8097 (stream server / audio pull) directly
+    # to LAN and IoT clients. :8097 is the MA stream server that WiiM and
+    # other SlimProto players pull audio from — required alongside :3483
+    # (control). These arrive from `reserved:world`. Brain's iot-policy
+    # firewall must also allow 10.10.20.{26,30,31} → 10.45.0.20 tcp
+    # 3483+8097 (see lovenet-network-configuration iot-policy.xml).
     - fromEntities:
         - world
       toPorts:
@@ -41,6 +42,8 @@ spec:
             - port: "3483"
               protocol: TCP
             - port: "8095"
+              protocol: TCP
+            - port: "8097"
               protocol: TCP
     # Home Assistant integration: HA music_assistant integration polls
     # + sends commands via the local music-assistant Service:8095.


### PR DESCRIPTION
## Summary

- Port 8097 (MA stream server / audio pull) was missing from the `fromEntities: world` ingress block in the music-assistant CNP
- WiiM SlimProto players require both :3483 (SlimProto control) and :8097 (audio stream) to reach the MA LoadBalancer VIP at 10.45.0.20
- Without :8097, Cilium silently dropped audio-stream connections from any external client (IoT VLAN and main LAN alike)

## What's NOT fixed by this PR (requires human action on brain)

Brain's `firewalld/policies/iot-policy.xml` has `target="DROP"` (default deny) on the iot→trusted/external policy. The three WiiM streamers need explicit allow rules:

```xml
<!-- wiim-deck .26 — replace the TEMPORARY full-passthrough with these scoped rules -->
<!-- Remove existing: <rule><source address="10.10.20.26"/><accept/></rule> -->
<rule family="ipv4">
  <source address="10.10.20.26"/>
  <destination address="10.45.0.20"/>
  <port port="3483" protocol="tcp"/>
  <accept/>
</rule>
<rule family="ipv4">
  <source address="10.10.20.26"/>
  <destination address="10.45.0.20"/>
  <port port="8097" protocol="tcp"/>
  <accept/>
</rule>

<!-- wiim-yard .30 -->
<rule family="ipv4">
  <source address="10.10.20.30"/>
  <destination address="10.45.0.20"/>
  <port port="3483" protocol="tcp"/>
  <accept/>
</rule>
<rule family="ipv4">
  <source address="10.10.20.30"/>
  <destination address="10.45.0.20"/>
  <port port="8097" protocol="tcp"/>
  <accept/>
</rule>

<!-- wiim-pool .31 -->
<rule family="ipv4">
  <source address="10.10.20.31"/>
  <destination address="10.45.0.20"/>
  <port port="3483" protocol="tcp"/>
  <accept/>
</rule>
<rule family="ipv4">
  <source address="10.10.20.31"/>
  <destination address="10.45.0.20"/>
  <port port="8097" protocol="tcp"/>
  <accept/>
</rule>
```

After editing `firewalld/policies/iot-policy.xml` in `lovenet-network-configuration`, push to brain and run `firewall-cmd --reload`.

## Test plan

- [ ] Merge PR → Flux reconciles CNP → verify `kubectl get cnp -n media music-assistant-allow` shows port 8097 in ingress rules
- [ ] After brain iot-policy update: test from a WiiM device that SlimProto connects and audio streams (MA player shows "playing" and audio is audible)
- [ ] Verify existing MA functionality unaffected: web UI via Envoy gateway, HA integration