### PR TITLE
fix(aquapured): bump image to v0.1.2 (foreground daemon)

### DIFF
--- a/kubernetes/apps/home/aquapured/app/helmrelease.yaml
+++ b/kubernetes/apps/home/aquapured/app/helmrelease.yaml
@@ -45,7 +45,7 @@ spec:
               # workaround: no upstream prebuilt image with socat available;
               #   upstream: https://github.com/sfeakes/AquapureD (no Dockerfile)
               repository: ghcr.io/rwlove/aquapured
-              tag: v0.1.1@sha256:b3307a33e301bfe7eb342bad81968c0f6f0f2ac6cd5886ecf68a99c4de278c79
+              tag: v0.1.2@sha256:3f314dff04b4393eb7d23babe6857ecd472905f433b9819051ae98ee6ad002ac
 
             # Entrypoint:
             #   1. envsubst MQTT_USER/MQTT_PASSWD into /run/aquapured/aquapured.conf


### PR DESCRIPTION
## Problem

`home/aquapured` has been in **CrashLoopBackOff** (189 restarts in ~16h since first deploy). The `app` container prints its banner and exits **0 in ~1s**; the `mosquitto` bridge sidecar is healthy. This is first-time bring-up, not a regression.

## Root cause

The image entrypoint launched `aquapured -c <conf>` **without `-d`**, so the daemon took the `daemonise()` fork path. As PID 1 in the container the parent exits 0 and the pod is torn down. (Upstream also leaves `deamonize` uninitialized when `-d` is absent — `aquapure.c` `main()`.)

Fixed in the image: rwlove/containers#107 → `exec aquapured -d -c <conf>` (foreground). Built and pushed as `v0.1.2`.

## Change

Repin `ghcr.io/rwlove/aquapured` `v0.1.1` → `v0.1.2@sha256:3f314dff…`.

## Validation after merge

- `app` container stays `Running`, restart count flat.
- Daemon proceeds into `main_loop()` and begins RS-485 polling via the socat→`10.10.20.21:8899` (salt-cell Elfin EW11) bridge. Salt-cell link health to be assessed from the daemon's DEBUG_SERIAL logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)