### PR TITLE
chore(observability): drop bond-bridge blackbox probe (device removed)

### DIFF
--- a/kubernetes/apps/observability/exporters/blackbox-exporter/app/probes.yaml
+++ b/kubernetes/apps/observability/exporters/blackbox-exporter/app/probes.yaml
@@ -90,7 +90,6 @@ spec:
     staticConfig:
       static:
         - hue
-        - bond-bridge
         - wled-nightlight
         - wled-gym-1
         - wled-gym-3


### PR DESCRIPTION
## What

Removes the `bond-bridge` target from the blackbox-exporter `http` Probe.

## Why

The Bond Bridge IoT device was physically removed from the home. Its
HTTP probe had been firing `BlackboxIoTDeviceUnreachable` continuously
for >24h (not a flap — `max_over_time(probe_success[24h]) == 0`, zero
state changes). Removing the target retires the alert at its source.

Network-side cleanup (split-horizon DNS A/PTR, dhcpd host reservation,
Omada known-client entry) is handled separately outside this repo.

## Verification

- `kustomize build` unaffected (one list item removed)
- pre-commit (yamllint, schema) passed locally