### PR TITLE
feat(pump): treadmill cardio MQTT consumer (v0.0.100)

### DIFF
--- a/kubernetes/apps/collab/pump/app/cnp-allow.yaml
+++ b/kubernetes/apps/collab/pump/app/cnp-allow.yaml
@@ -25,6 +25,16 @@ spec:
         - ports:
             - port: "5432"
               protocol: TCP
+    # EMQX broker in home ns — the treadmill cardio consumer subscribes to
+    # the Z-Wave smart-plug wattage zwave-js-ui publishes here (1883).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: home
+            app.kubernetes.io/name: emqx
+      toPorts:
+        - ports:
+            - port: "1883"
+              protocol: TCP
   # Intra-ns pump-cv:8080 (PUMP_CV_URL admin/preview proxy) is
   # covered by baseline allow-intra-namespace.
   ingress:

--- a/kubernetes/apps/collab/pump/app/externalsecret.yaml
+++ b/kubernetes/apps/collab/pump/app/externalsecret.yaml
@@ -25,6 +25,13 @@ spec:
         # Add a "HEALTH_INGEST_KEY" field to the 1Password "pump" item; set
         # the same value as the webhook app's X-Api-Key custom header.
         HEALTH_INGEST_KEY: "{{ .HEALTH_INGEST_KEY }}"
+        # Treadmill cardio auto-capture: PUMP subscribes to the Z-Wave
+        # smart-plug wattage that zwave-js-ui publishes to the EMQX broker.
+        # Credentials come from the shared 1Password "emqx" item — the same
+        # user every other in-cluster MQTT consumer (zigbee2mqtt, mqtt-exporter)
+        # uses.
+        TREADMILL_MQTT_USERNAME: "{{ .user_1_username }}"
+        TREADMILL_MQTT_PASSWORD: "{{ .user_1_password }}"
 
         # Postgres Init
         INIT_POSTGRES_DBNAME: pump
@@ -38,3 +45,7 @@ spec:
         key: cloudnative-pg
     - extract:
         key: pump
+    # Shared EMQX broker credentials (user_1_username / user_1_password) for
+    # the treadmill MQTT consumer — same item the other consumers extract.
+    - extract:
+        key: emqx

--- a/kubernetes/apps/collab/pump/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump/app/helmrelease.yaml
@@ -32,7 +32,7 @@ spec:
           pump:
             image:
               repository: ghcr.io/rwlove/pump
-              tag: v0.0.99@sha256:93365c9343a5c205cee25e0a67f62288a664ce24be1cb5db5459cb04c7455e93
+              tag: v0.0.100@sha256:c49f2c905fa623d508e147c586804ebd664d602ce3f30c19b6c898d6277c2a2f
 
             env:
               # Activates the /api/cv/* proxy in pump (see internal/web/exercise.go).
@@ -42,6 +42,18 @@ spec:
               # Static-serve the per-set clip mp4s pump-cv writes here. Shared
               # RWX volume (pump-clips-pvc, declared in pump-cv/app/clips-pvc.yaml).
               PUMP_CLIPS_DIR: /clips
+              # Treadmill cardio auto-capture. PUMP subscribes to the gym
+              # treadmill's Z-Wave metering smart plug — its wattage is
+              # published to EMQX by zwave-js-ui (no Home Assistant in the
+              # path) — detects each workout, and logs it as a cardio session.
+              # Credentials TREADMILL_MQTT_USERNAME/PASSWORD come from
+              # pump-secret (1Password "emqx" item). Threshold matches HA's
+              # binary_sensor.treadmill helper (threshold upper=100 W,
+              # hysteresis 0 on sensor.treadmill_electric_w_value).
+              TREADMILL_MQTT_ENABLED: "true"
+              TREADMILL_MQTT_BROKER: tcp://emqx-headless.home.svc.cluster.local:1883
+              TREADMILL_MQTT_TOPIC: zwave/Gym/Treadmill/50/0/value/66049
+              TREADMILL_WATTS_THRESHOLD: "100"
 
             envFrom:
               - secretRef:

--- a/kubernetes/apps/home/emqx/app/cnp-allow.yaml
+++ b/kubernetes/apps/home/emqx/app/cnp-allow.yaml
@@ -82,3 +82,13 @@ spec:
         - ports:
             - port: "1883"
               protocol: TCP
+    # pump (collab ns) subscribes to the treadmill's Z-Wave wattage topic
+    # for cardio auto-capture (read-only consumer).
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: collab
+            app.kubernetes.io/name: pump
+      toPorts:
+        - ports:
+            - port: "1883"
+              protocol: TCP


### PR DESCRIPTION
Wires PUMP v0.0.100's treadmill cardio auto-capture. PUMP subscribes to the gym treadmill's Z-Wave wattage that **zwave-js-ui** publishes to EMQX, detects each workout, and logs it as cardio — **no Home Assistant in the path**.

## Changes
- **helmrelease**: image `v0.0.100`; `TREADMILL_MQTT_*` env — broker `emqx-headless.home:1883`, topic `zwave/Gym/Treadmill/50/0/value/66049`, `TREADMILL_WATTS_THRESHOLD=100` (matches HA's `binary_sensor.treadmill` threshold helper: `upper=100, hysteresis=0`).
- **externalsecret**: pulls MQTT creds from the shared 1Password **`emqx`** item (`user_1_username`/`password`) — no new 1Password field needed.
- **pump cnp-allow**: egress to `emqx:1883`.
- **emqx cnp-allow**: ingress allow for `collab/pump:1883` (read-only consumer on the shared broker — additive, minimal blast radius).

App PR: rwlove/PUMP#43

🤖 Generated with [Claude Code](https://claude.com/claude-code)