### PR TITLE
fix(renovate): scope operator token to containers + lovenet-network-configuration

### DIFF
--- a/kubernetes/apps/renovate/renovate-operator/auth/github-auth-token.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/auth/github-auth-token.yaml
@@ -9,6 +9,7 @@ spec:
   installID: "111956727"
   repositories: # optional
     - home-ops
+    - containers
   auth:
     privateKey:
       secretRef:

--- a/kubernetes/apps/renovate/renovate-operator/auth/github-auth-token.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/auth/github-auth-token.yaml
@@ -10,6 +10,7 @@ spec:
   repositories: # optional
     - home-ops
     - containers
+    - lovenet-network-configuration
   auth:
     privateKey:
       secretRef:


### PR DESCRIPTION
## Why

`rwlove/containers` has had **no Renovate runs since 2026-06-12**. Its dependency dashboard (containers#58) is frozen, checkbox ticks are no-ops, and the auto-merge/auto-release loop for the thin-wrapper images is dead.

**Root cause:** containers#97 ("drop redundant hourly Renovate workflow") deleted containers' own in-repo `renovate.yaml` on the premise that *this* in-cluster operator already scans it via autodiscover. It doesn't:

- The `rwlove-home-ops` RenovateJob filters `discoveryFilters: ["rwlove/*"]` ✅
- …but the token is minted by the `GithubAccessToken` generator with `repositories: [home-ops]` — a hard repo allowlist the `rwlove/*` filter can't see past.

Confirmed live: the discovery job returns exactly `["rwlove/home-ops"]`. containers fell through the crack — job filter widened, token allowlist not.

## Change

Add `containers` to the token allowlist in `renovate-operator/auth/github-auth-token.yaml`. The App (`2931213`, installation `111956727`) already includes containers — it authored containers#58 — so no GitHub-side change is needed.

## Effect

- The `rwlove/*` job discovers and renovates `rwlove/containers` hourly, in-cluster (off-quota).
- containers#58 starts updating again; the already-ticked python 3.13→3.14 box opens its PR on the next cycle (stays a PR — major docker bump, no automerge).
- `pump` job is filtered to `rwlove/home-ops` and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)