### PR TITLE
fix(arc): spread home-ops runners + add resources, raise cap 10→16

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/home-ops.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/home-ops.yaml
@@ -21,7 +21,11 @@ spec:
     # the docs publish job now also land here, so one busy PR can demand
     # ~7 concurrent runner pods (filter + test + diff×2 + comment×2 +
     # success). 6 would queue and stall PR feedback.
-    maxRunners: 10
+    # Raised 10→16: a full Renovate batch (~35+ PRs) saturates 10 slots and
+    # serializes the heavy flux-local Test/Diff jobs (~15–30min compute each)
+    # through too few runners. Pairs with the resources + topologySpread
+    # below — bumping the cap without real requests just dogpiles one node.
+    maxRunners: 16
 
     containerMode:
       type: kubernetes
@@ -39,6 +43,18 @@ spec:
 
     template:
       spec:
+        # Spread runners across worker hostnames. ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER
+        # is false, so flux-local's Test/Diff jobs run inside these pods — with no
+        # requests the scheduler dogpiled 6 of 10 onto one node (97% CPU) while
+        # peers sat at 20%, starving the heavy jobs. Soft (ScheduleAnyway) so a
+        # backlog larger than the node count still schedules.
+        topologySpreadConstraints:
+          - maxSkew: 1
+            topologyKey: kubernetes.io/hostname
+            whenUnsatisfiable: ScheduleAnyway
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/component: runner
         containers:
           - name: runner
             image: ghcr.io/home-operations/actions-runner:2.335.1@sha256:3d544e5eed58722c0b6a97212a31eada0f9f2e99f189c41911a5573a23d7386a
@@ -50,6 +66,16 @@ spec:
                     fieldPath: status.hostIP
               - name: ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER
                 value: "false"
+            # flux-local Test/Diff are bursty CPU-heavy kustomize builds that run
+            # in-pod. Request 1 core so the scheduler costs/spreads them honestly;
+            # allow bursting to 4 so a build isn't throttled when the node is free.
+            resources:
+              requests:
+                cpu: "1"
+                memory: 2Gi
+              limits:
+                cpu: "4"
+                memory: 6Gi
 
   valuesFrom:
     - kind: Secret


### PR DESCRIPTION
## Why

A full Renovate batch (~38 PRs) saturates the home-ops runner cap and the queue drains slowly. Investigation found it's not just the cap:

- **Cap = 10**, all 10 busy, ~13 jobs queued. Every arc-bound job from every PR serializes through 10 slots.
- **Flux Local is the dominant per-PR cost** — `Test` 3–19 min, `Diff (kustomization)` 6–9 min, `Diff (helmrelease)` 1–6 min → ~15–30 min of compute per PR. The other six required checks finish in <1 min.
- **Runner pods had no resource requests**, so the scheduler dogpiled **6 of 10 runners onto one worker (97% CPU)** while peers sat at 20–26%. With `ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER=false`, Flux Local runs *inside* the runner pod — so those crammed runners were CPU-starved, inflating the very job times backing up the queue.

## Change

- Add CPU/mem **requests** (1 core / 2Gi) + burstable **limits** (4 / 6Gi) to the runner container, so the scheduler costs runners honestly and Flux Local isn't throttled on an idle node.
- Add a **soft hostname `topologySpread`** (`maxSkew: 1`, `ScheduleAnyway`) so runners distribute across the 7 workers instead of stacking on one. Soft so a backlog larger than the node count still schedules.
- Raise **`maxRunners` 10 → 16** for batch headroom — only safe paired with the requests above (bumping the cap alone would worsen the dogpile).

## Risk

Low. Ephemeral runners cycle per-job, so the new template applies as the current backlog drains — no in-flight job disruption. 16 × 1-core requests = 16 cores reserved across ~64 worker cores, shared with cluster workloads but well within headroom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)