### PR TITLE
fix(actions-runner): allow runner-pod egress to ZOT (enables flate CI)

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/cnp-allow.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/cnp-allow.yaml
@@ -38,3 +38,20 @@ spec:
     # The listener also opens a long-lived gRPC-over-HTTPS session to
     # GitHub's runner service, which uses port 443 (covered by the
     # wildcard above).
+    #
+    # In-cluster ZOT pull-through cache (kube-system/zot:5000). The Flux
+    # Local (flate) workflow now runs the flate binary directly on the
+    # runner pod rather than as a `container:` job, so the runner pod —
+    # not the job-container pod — is what resolves the 30+ OCIRepository
+    # sources pointing at oci://zot.kube-system.svc.cluster.local:5000/...
+    # ZOT's Service DNS isn't matched by the toFQDNs wildcard above, so it
+    # needs an explicit toEndpoints rule (mirrors allow-job-container-egress;
+    # ZOT svc port == targetPort 5000, so no socket-lb rewrite to handle).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: kube-system
+            app.kubernetes.io/name: zot
+      toPorts:
+        - ports:
+            - port: "5000"
+              protocol: TCP


### PR DESCRIPTION
Prerequisite for #12688 (flate CI swap).

flate validation runs the binary **directly on the runner pod**, unlike the old flux-local `container:` job which got ZOT egress via `allow-job-container-egress`. The runner-pod CNP only allows `toFQDNs:* :443/:80`, which doesn't match ZOT's in-cluster Service DNS — so flate times out reaching `oci://zot.kube-system.svc.cluster.local:5000/...`.

This adds the identical ZOT `toEndpoints` rule the job-container policy already carries (ZOT svc port == targetPort 5000, no socket-lb rewrite).

**Merge order:** this must merge + reconcile first; then #12688's flate CI can reach ZOT and pass. This PR itself is validated by the current container-based flux-local CI (unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)