### PR TITLE
feat(selfhosted): add konflate GitOps PR review UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ _Production-grade Kubernetes for a household._
 
 <br/>
 
-![apps](https://img.shields.io/badge/apps-187-blue?style=for-the-badge)
-![helmreleases](https://img.shields.io/badge/HelmReleases-201-326CE5?style=for-the-badge&logo=helm&logoColor=white)
+![apps](https://img.shields.io/badge/apps-189-blue?style=for-the-badge)
+![helmreleases](https://img.shields.io/badge/HelmReleases-203-326CE5?style=for-the-badge&logo=helm&logoColor=white)
 ![nodes](https://img.shields.io/badge/k8s_nodes-11-326CE5?style=for-the-badge&logo=kubernetes&logoColor=white)
 ![cnpg](https://img.shields.io/badge/Postgres_clusters-24-336791?style=for-the-badge&logo=postgresql&logoColor=white)
-![secrets](https://img.shields.io/badge/secrets-117-0572EC?style=for-the-badge&logo=1password&logoColor=white)
+![secrets](https://img.shields.io/badge/secrets-120-0572EC?style=for-the-badge&logo=1password&logoColor=white)
 ![age](https://img.shields.io/badge/cluster_age-5%2B_years-success?style=for-the-badge)
 
 </div>

--- a/kubernetes/apps/selfhosted/konflate-oauth2-proxy/app/cnp-allow.yaml
+++ b/kubernetes/apps/selfhosted/konflate-oauth2-proxy/app/cnp-allow.yaml
@@ -1,0 +1,41 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: konflate-oauth2-proxy-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: konflate-oauth2-proxy
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on internal gateway → konflate-oauth2-proxy:4180.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "4180"
+              protocol: TCP
+  egress:
+    # OIDC discovery + token exchange against Authelia at
+    # auth.${SECRET_DOMAIN}. oauth2-proxy uses the external issuer URL, so
+    # every OIDC request hits split-horizon DNS returning the envoy LB IP;
+    # Cilium socket-lb rewrites connect() to the envoy pod IP + targetPort
+    # 10443 BEFORE policy evaluation (see project_cilium_l4_port_targetport),
+    # so the policy must allow the envoy pod on 10443, not world:443 or
+    # authelia:9091. Mirrors goldilocks-oauth2-proxy.
+    # Upstream → konflate.selfhosted:8080 is intra-ns, covered by the
+    # baseline allow-intra-namespace.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "10443"
+              protocol: TCP

--- a/kubernetes/apps/selfhosted/konflate-oauth2-proxy/app/externalsecret.yaml
+++ b/kubernetes/apps/selfhosted/konflate-oauth2-proxy/app/externalsecret.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: konflate-oauth2-proxy
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: konflate-oauth2-proxy-secret
+    creationPolicy: Owner
+    template:
+      data:
+        OAUTH2_PROXY_CLIENT_SECRET: "{{ .OAUTH_CLIENT_SECRET }}"
+        OAUTH2_PROXY_COOKIE_SECRET: "{{ .COOKIE_SECRET }}"
+  dataFrom:
+    - extract:
+        key: konflate-oauth2-proxy

--- a/kubernetes/apps/selfhosted/konflate-oauth2-proxy/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/konflate-oauth2-proxy/app/helmrelease.yaml
@@ -1,0 +1,84 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app konflate-oauth2-proxy
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 30m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+      strategy: rollback
+  values:
+    controllers:
+      konflate-oauth2-proxy:
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 2000
+            runAsGroup: 2000
+            fsGroup: 2000
+            fsGroupChangePolicy: OnRootMismatch
+
+        annotations:
+          reloader.stakater.com/auto: "true"
+
+        containers:
+          app:
+            image:
+              repository: quay.io/oauth2-proxy/oauth2-proxy
+              tag: v7.15.3
+
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+              seccompProfile:
+                type: RuntimeDefault
+
+            args:
+              - --provider=oidc
+              - --oidc-issuer-url=https://auth.${SECRET_DOMAIN}
+              - --client-id=konflate-oauth2-proxy
+              - --redirect-url=https://konflate.${SECRET_DOMAIN}/oauth2/callback
+              - --upstream=http://konflate.selfhosted.svc.cluster.local:8080
+              - --http-address=0.0.0.0:4180
+              - --cookie-name=_oauth2_proxy_konflate
+              - --cookie-secure=true
+              - --cookie-samesite=lax
+              - --email-domain=*
+              - --whitelist-domain=.${SECRET_DOMAIN}
+              - --reverse-proxy=true
+              - --pass-user-headers=true
+              - --set-xauthrequest=true
+              - --skip-provider-button=true
+              - --scope=openid email profile groups
+              - --code-challenge-method=S256
+
+            envFrom:
+              - secretRef:
+                  name: konflate-oauth2-proxy-secret
+
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 128Mi
+
+    service:
+      app:
+        controller: konflate-oauth2-proxy
+        ports:
+          http:
+            port: 4180

--- a/kubernetes/apps/selfhosted/konflate-oauth2-proxy/app/kustomization.yaml
+++ b/kubernetes/apps/selfhosted/konflate-oauth2-proxy/app/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../components/repos/app-template
+resources:
+  - ./cnp-allow.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/selfhosted/konflate-oauth2-proxy/ks.yaml
+++ b/kubernetes/apps/selfhosted/konflate-oauth2-proxy/ks.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app konflate-oauth2-proxy
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: selfhosted
+  path: ./kubernetes/apps/selfhosted/konflate-oauth2-proxy/app
+  interval: 1h
+  timeout: 5m
+  prune: true
+  wait: false
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: authelia
+      namespace: auth
+    - name: konflate
+      namespace: selfhosted
+    - name: onepassword-connect
+      namespace: external-secrets

--- a/kubernetes/apps/selfhosted/konflate/README.md
+++ b/kubernetes/apps/selfhosted/konflate/README.md
@@ -1,0 +1,69 @@
+# konflate
+
+[konflate](https://github.com/home-operations/konflate) renders this repo's
+open PRs at their merge-base vs head and shows the **rendered** Flux diff
+(HelmRelease / Kustomization / OCIRepository) in a review UI — image changes,
+blast radius, render failures, danger-lint. Internal-only, behind Authelia SSO
+at `konflate.${SECRET_DOMAIN}`. Read-only toward GitHub (no PR comments / status
+write-back — the `flux-local` CI job already posts the diff comment).
+
+## Topology
+
+```text
+envoy (internal gw) ──HTTPRoute──▶ konflate-oauth2-proxy:4180 ──▶ konflate:8080
+                                          │
+                                          └─OIDC─▶ Authelia (auth.${SECRET_DOMAIN})
+konflate ──renders──▶ ZOT (kube-system/zot:5000) + api.github.com + chart upstreams
+```
+
+- `konflate/` — the chart (OCIRepository via ZOT + HelmRelease), its ClusterIP
+  Service, the HTTPRoute, a `ceph-block` PVC for caches/git-mirror/rendered
+  diffs, and the render-egress CNP.
+- `konflate-oauth2-proxy/` — oauth2-proxy fronting konflate (mirrors
+  `observability/goldilocks-oauth2-proxy`).
+
+## GitHub auth
+
+konflate authenticates to GitHub with a **short-lived App installation token**,
+minted by a `GithubAccessToken` generator from the same GitHub App
+(`2931213`) renovate-operator uses — see `app/externalsecret.yaml`. No standing
+PAT. The App's PEM comes from the 1Password `Github` item
+(`renovate_app_private_key`), replicated into this namespace as the
+`github-app-pem` secret. konflate stays read-only (`prComments`/`statusChecks`
+off), so the App's write scope is unused.
+
+## Provisioning (done)
+
+The out-of-Git secrets and the Authelia client were created on 2026-06-24:
+
+- **1Password `konflate-oauth2-proxy`** (Kubernetes vault) — the
+  `OAUTH_CLIENT_SECRET` and `COOKIE_SECRET` fields, consumed by the
+  oauth2-proxy ExternalSecret.
+- **Authelia OIDC client `konflate-oauth2-proxy`** — added to the `authelia`
+  1Password item's `OIDC_CLIENTS_YAML` (a clone of the `goldilocks-oauth2-proxy`
+  client: `admin_only`, PKCE/S256, `client_secret_post`, redirect
+  `https://konflate.${SECRET_DOMAIN}/oauth2/callback`). Validated with
+  `authelia config validate` (zero new errors vs baseline) before propagation;
+  Authelia rolled cleanly.
+
+No further manual 1Password steps are needed to deploy this app.
+
+## Post-deploy validation
+
+- **Egress label match** — the render CNP selects pods labelled
+  `app.kubernetes.io/name: konflate`. If konflate logs show source-fetch /
+  GitHub timeouts, confirm the chart's pod label and check Hubble for
+  `Policy denied DROPPED` egress, then adjust `app/cnp-allow.yaml`.
+- **existingSecret keys** — the chart's `secret.existingSecret` documents keys
+  `KONFLATE_TOKEN / KONFLATE_WEBHOOK_SECRET / ...`. Only `KONFLATE_TOKEN` is
+  provided (read-only mode). If the pod fails on a missing key, add the empty
+  key(s) to the ExternalSecret template.
+- **Chart signing** — `app/ocirepository.yaml` omits cosign `verify` pending
+  confirmation of home-operations/konflate's chart signing identity; add it to
+  match the `descheduler` pattern once known.
+
+## Hardening follow-ups
+
+- Swap the shared renovate App token for a dedicated read-only PAT or a
+  konflate-scoped GitHub App (least privilege; the current token can write
+  though konflate never does).

--- a/kubernetes/apps/selfhosted/konflate/app/cnp-allow.yaml
+++ b/kubernetes/apps/selfhosted/konflate/app/cnp-allow.yaml
@@ -1,0 +1,45 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: konflate-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: konflate
+  # Additive — the selfhosted default-deny component is the enforcer.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  # Ingress is covered by the selfhosted baseline component
+  # (allow-intra-namespace for oauth2-proxy → :8080, allow-monitoring-scrape
+  # for Prometheus → :8081), so only egress rules are needed here.
+  egress:
+    # In-cluster ZOT pull-through cache (kube-system/zot:5000). konflate
+    # renders each PR by fetching the chart/OCI sources our HelmReleases
+    # declare, which point at oci://zot.kube-system.svc:5000/... ZOT's
+    # Service DNS isn't matched by toFQDNs, so it needs an explicit
+    # toEndpoints rule (mirrors renovate-jobs-allow). ZOT svc port ==
+    # targetPort 5000, so no socket-lb targetPort rewrite to worry about.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: kube-system
+            app.kubernetes.io/name: zot
+      toPorts:
+        - ports:
+            - port: "5000"
+              protocol: TCP
+    # konflate lists PRs via api.github.com, clones the repo, and renders
+    # by fetching every helm/OCI/git source a PR's manifests reference
+    # (arbitrary upstream hosts over HTTPS). Like renovate, the upstream
+    # set grows with the repo, so an allow-list would silently break
+    # renders. SSRF to private ranges is bounded by konflate's own egress
+    # guard while fork rendering stays off.
+    # TODO: tighten once all chart sources are ZOT-mediated.
+    - toFQDNs:
+        - matchPattern: "*"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/selfhosted/konflate/app/externalsecret.yaml
+++ b/kubernetes/apps/selfhosted/konflate/app/externalsecret.yaml
@@ -1,0 +1,59 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/generators.external-secrets.io/githubaccesstoken_v1alpha1.json
+apiVersion: generators.external-secrets.io/v1alpha1
+kind: GithubAccessToken
+metadata:
+  name: konflate-github-token
+spec:
+  # Reuses the existing GitHub App (the one renovate-operator authenticates
+  # with) to mint a short-lived, auto-rotating installation token scoped to
+  # rwlove/home-ops — no standing PAT to mint or store. konflate reads PRs
+  # with this; it stays read-only (prComments/statusChecks disabled), so the
+  # App's write scope is unused.
+  appID: "2931213"
+  installID: "111956727"
+  repositories:
+    - home-ops
+  auth:
+    privateKey:
+      secretRef:
+        name: github-app-pem
+        key: private_key_pem
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: github-app-pem
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: github-app-pem
+  data:
+    - secretKey: private_key_pem
+      remoteRef:
+        key: Github
+        property: renovate_app_private_key
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: konflate
+spec:
+  refreshInterval: 30m
+  target:
+    name: konflate-secret
+    template:
+      engineVersion: v2
+      data:
+        KONFLATE_TOKEN: "{{ .token }}"
+  dataFrom:
+    - sourceRef:
+        generatorRef:
+          apiVersion: generators.external-secrets.io/v1alpha1
+          kind: GithubAccessToken
+          name: konflate-github-token

--- a/kubernetes/apps/selfhosted/konflate/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/konflate/app/helmrelease.yaml
@@ -1,0 +1,62 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app konflate
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: *app
+  interval: 1h
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+      strategy: rollback
+  values:
+    config:
+      # Forge URI of the repo konflate reviews.
+      repo: github://rwlove/home-ops
+      # clusterPath empty = repo root, which is correct here: our Flux
+      # Kustomizations use root-relative spec.path (./kubernetes/...),
+      # and flate follows each KS path from the repo root.
+      clusterPath: ""
+      logFormat: json
+      logLevel: info
+      # Periodic re-render backstop (no inbound webhook wired yet).
+      refreshInterval: 30m
+      # Read-only toward GitHub: no PR comments, no commit-status
+      # write-back (Rob's choice — flate already posts the CI diff).
+      prComments: false
+      statusChecks: false
+      # Fork PRs run untrusted code through flate; keep off. With forks
+      # off, konflate's SSRF egress guard also stays off so it can reach
+      # the in-cluster ZOT (a private address) to render.
+      renderForkPrs: false
+    # Token supplied by the konflate ExternalSecret (key KONFLATE_TOKEN).
+    secret:
+      existingSecret: konflate-secret
+    service:
+      port: 8080
+    # State (flate caches + git mirror + rendered diffs) is regenerable
+    # from git/upstream → ceph-block per the storage-class decision tree
+    # (rule 2). Single-instance RWO; chart enforces strategy: Recreate.
+    persistence:
+      enabled: true
+      storageClass: ceph-block
+      accessModes:
+        - ReadWriteOnce
+      size: 5Gi
+    monitoring:
+      serviceMonitor:
+        enabled: true
+    # Exposure is via our konflate-oauth2-proxy + httproute.yaml; network
+    # policy is governed by the selfhosted baseline + cnp-allow.yaml.
+    httpRoute:
+      enabled: false
+    networkPolicy:
+      enabled: false

--- a/kubernetes/apps/selfhosted/konflate/app/httproute.yaml
+++ b/kubernetes/apps/selfhosted/konflate/app/httproute.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: konflate
+  annotations:
+    glance/name: "Konflate"
+    glance/show: "true"
+    glance/icon: "https://raw.githubusercontent.com/home-operations/konflate/main/internal/web/public/favicon.svg"
+    glance/id: "Infrastructure"
+spec:
+  hostnames: ["konflate.${SECRET_DOMAIN}"]
+  parentRefs:
+    - name: internal
+      namespace: network
+      sectionName: https
+  rules:
+    # Fronted by konflate-oauth2-proxy (Authelia SSO); the proxy forwards
+    # to konflate.selfhosted.svc:8080 once authenticated.
+    - backendRefs:
+        - name: konflate-oauth2-proxy
+          namespace: selfhosted
+          port: 4180

--- a/kubernetes/apps/selfhosted/konflate/app/kustomization.yaml
+++ b/kubernetes/apps/selfhosted/konflate/app/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./cnp-allow.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./httproute.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/selfhosted/konflate/app/ocirepository.yaml
+++ b/kubernetes/apps/selfhosted/konflate/app/ocirepository.yaml
@@ -11,8 +11,6 @@ spec:
     operation: copy
   ref:
     tag: 0.2.32
-  # Routed through in-cluster ZOT pull-through cache.
   # TODO: add cosign `verify` once home-operations/konflate's chart
   # signing identity is confirmed (descheduler verifies charts-mirror).
-  insecure: true
-  url: oci://zot.kube-system.svc.cluster.local:5000/ghcr.io/home-operations/charts/konflate
+  url: oci://ghcr.io/home-operations/charts/konflate

--- a/kubernetes/apps/selfhosted/konflate/app/ocirepository.yaml
+++ b/kubernetes/apps/selfhosted/konflate/app/ocirepository.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/ocirepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: konflate
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.2.32
+  # Routed through in-cluster ZOT pull-through cache.
+  # TODO: add cosign `verify` once home-operations/konflate's chart
+  # signing identity is confirmed (descheduler verifies charts-mirror).
+  insecure: true
+  url: oci://zot.kube-system.svc.cluster.local:5000/ghcr.io/home-operations/charts/konflate

--- a/kubernetes/apps/selfhosted/konflate/ks.yaml
+++ b/kubernetes/apps/selfhosted/konflate/ks.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app konflate
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: selfhosted
+  path: ./kubernetes/apps/selfhosted/konflate/app
+  interval: 1h
+  timeout: 5m
+  prune: true
+  wait: false
+  sourceRef:
+    kind: GitRepository
+    name: home-ops-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: onepassword-connect
+      namespace: external-secrets

--- a/kubernetes/apps/selfhosted/kustomization.yaml
+++ b/kubernetes/apps/selfhosted/kustomization.yaml
@@ -13,4 +13,6 @@ components:
   - ../../components/network-policy/default-deny
 resources:
   - ./namespace.yaml
+  - ./konflate/ks.yaml
+  - ./konflate-oauth2-proxy/ks.yaml
   - ./webhook/ks.yaml


### PR DESCRIPTION
Adds [konflate](https://github.com/home-operations/konflate) — a GitOps PR review UI that renders open PRs as rendered Flux diffs. Internal-only, behind Authelia SSO at `konflate.${SECRET_DOMAIN}`, read-only toward GitHub.

## Shape
- **konflate/** — ZOT-routed OCIRepository (chart `0.2.32`) + HelmRelease, ClusterIP, HTTPRoute → oauth2-proxy, `ceph-block` 5Gi PVC, render-egress CNP (ZOT:5000 + `toFQDNs:"*"` :443, mirrors `renovate-jobs-allow`).
- **konflate-oauth2-proxy/** — Authelia SSO front (mirrors `observability/goldilocks-oauth2-proxy`).

## Auth
GitHub: short-lived **App installation token** via a `GithubAccessToken` generator reusing the renovate App `2931213` — no PAT. Read-only (`prComments`/`statusChecks` off).

## Provisioning (already done — no manual steps to deploy)
- 1Password `konflate-oauth2-proxy` item (client + cookie secret) created.
- Authelia OIDC client `konflate-oauth2-proxy` added (cloned from goldilocks: `admin_only`, PKCE/S256), **validated with `authelia config validate` (zero new errors) before propagation; Authelia rolled cleanly**.

See `kubernetes/apps/selfhosted/konflate/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)