### PR TITLE
feat(flux): pull charts direct from upstream registries (drop ZOT from the chart path)

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/operator/ocirepository.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/operator/ocirepository.yaml
@@ -11,6 +11,4 @@ spec:
     operation: copy
   ref:
     tag: 0.14.2
-  # Routed through in-cluster ZOT pull-through cache.
-  insecure: true
-  url: oci://zot.kube-system.svc.cluster.local:5000/ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set-controller
+  url: oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set-controller

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/ocirepository.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/ocirepository.yaml
@@ -11,6 +11,4 @@ spec:
     operation: copy
   ref:
     tag: 0.14.2
-  # Routed through in-cluster ZOT pull-through cache.
-  insecure: true
-  url: oci://zot.kube-system.svc.cluster.local:5000/ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set
+  url: oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set

--- a/kubernetes/apps/cert-manager/cert-manager/app/ocirepository.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/app/ocirepository.yaml
@@ -11,6 +11,4 @@ spec:
     operation: copy
   ref:
     tag: v1.20.2
-  # Routed through in-cluster ZOT pull-through cache.
-  insecure: true
-  url: oci://zot.kube-system.svc.cluster.local:5000/quay.io/jetstack/charts/cert-manager
+  url: oci://quay.io/jetstack/charts/cert-manager

--- a/kubernetes/apps/collab/zulip/app/ocirepository.yaml
+++ b/kubernetes/apps/collab/zulip/app/ocirepository.yaml
@@ -11,6 +11,4 @@ spec:
     operation: copy
   ref:
     tag: 2.0.0
-  # Routed through in-cluster ZOT pull-through cache.
-  insecure: true
-  url: oci://zot.kube-system.svc.cluster.local:5000/ghcr.io/zulip/helm-charts/zulip
+  url: oci://ghcr.io/zulip/helm-charts/zulip

--- a/kubernetes/apps/databases/cloudnative-pg/plugin-barman-cloud/ocirepository.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/plugin-barman-cloud/ocirepository.yaml
@@ -12,6 +12,4 @@ spec:
   ref:
     # Chart version (Chart.yaml: version)
     tag: 0.6.0
-  # Routed through in-cluster ZOT pull-through cache.
-  insecure: true
-  url: oci://zot.kube-system.svc.cluster.local:5000/ghcr.io/cloudnative-pg/charts/plugin-barman-cloud
+  url: oci://ghcr.io/cloudnative-pg/charts/plugin-barman-cloud

--- a/kubernetes/apps/databases/dragonfly/operator/ocirepository.yaml
+++ b/kubernetes/apps/databases/dragonfly/operator/ocirepository.yaml
@@ -11,6 +11,4 @@ spec:
     operation: copy
   ref:
     tag: v1.6.1
-  # Routed through in-cluster ZOT pull-through cache.
-  insecure: true
-  url: oci://zot.kube-system.svc.cluster.local:5000/ghcr.io/dragonflydb/dragonfly-operator/helm/dragonfly-operator
+  url: oci://ghcr.io/dragonflydb/dragonfly-operator/helm/dragonfly-operator

--- a/kubernetes/apps/external-secrets/external-secrets/app/helmrelease.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/app/helmrelease.yaml
@@ -11,9 +11,7 @@ spec:
     operation: copy
   ref:
     tag: 2.6.0
-  # Routed through in-cluster ZOT pull-through cache.
-  insecure: true
-  url: oci://zot.kube-system.svc.cluster.local:5000/ghcr.io/external-secrets/charts/external-secrets
+  url: oci://ghcr.io/external-secrets/charts/external-secrets
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/refs/heads/main/ocirepository-source-v1.json
 apiVersion: helm.toolkit.fluxcd.io/v2

--- a/kubernetes/apps/external-secrets/onepassword-connect/app/ocirepository.yaml
+++ b/kubernetes/apps/external-secrets/onepassword-connect/app/ocirepository.yaml
@@ -11,6 +11,4 @@ spec:
     operation: copy
   ref:
     tag: 5.0.1
-  # Routed through in-cluster ZOT pull-through cache.
-  insecure: true
-  url: oci://zot.kube-system.svc.cluster.local:5000/ghcr.io/bjw-s-labs/helm/app-template
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/flux-system/flux-instance/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/helmrelease.yaml
@@ -11,9 +11,7 @@ spec:
     operation: copy
   ref:
     tag: 0.52.0
-  # Routed through in-cluster ZOT pull-through cache.
-  insecure: true
-  url: oci://zot.kube-system.svc.cluster.local:5000/ghcr.io/controlplaneio-fluxcd/charts/flux-instance
+  url: oci://ghcr.io/controlplaneio-fluxcd/charts/flux-instance
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/refs/heads/main/ocirepository-source-v1.json
 apiVersion: helm.toolkit.fluxcd.io/v2

--- a/kubernetes/apps/flux-system/flux-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/flux-operator/app/helmrelease.yaml
@@ -11,9 +11,7 @@ spec:
     operation: copy
   ref:
     tag: 0.52.0
-  # Routed through in-cluster ZOT pull-through cache.
-  insecure: true
-  url: oci://zot.kube-system.svc.cluster.local:5000/ghcr.io/controlplaneio-fluxcd/charts/flux-operator
+  url: oci://ghcr.io/controlplaneio-fluxcd/charts/flux-operator
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/refs/heads/main/ocirepository-source-v1.json
 apiVersion: helm.toolkit.fluxcd.io/v2

--- a/kubernetes/apps/home/netbox/app/ocirepository.yaml
+++ b/kubernetes/apps/home/netbox/app/ocirepository.yaml
@@ -11,6 +11,4 @@ spec:
     operation: copy
   ref:
     tag: 8.3.21
-  # Routed through in-cluster ZOT pull-through cache.
-  insecure: true
-  url: oci://zot.kube-system.svc.cluster.local:5000/ghcr.io/netbox-community/netbox-chart/netbox
+  url: oci://ghcr.io/netbox-community/netbox-chart/netbox

--- a/kubernetes/apps/kube-system/coredns/app/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/coredns/app/ocirepository.yaml
@@ -11,6 +11,4 @@ spec:
     operation: copy
   ref:
     tag: 1.46.0
-  # Routed through in-cluster ZOT pull-through cache.
-  insecure: true
-  url: oci://zot.kube-system.svc.cluster.local:5000/ghcr.io/coredns/charts/coredns
+  url: oci://ghcr.io/coredns/charts/coredns

--- a/kubernetes/apps/kube-system/descheduler/app/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/descheduler/app/ocirepository.yaml
@@ -11,9 +11,7 @@ spec:
     operation: copy
   ref:
     tag: 0.36.0
-  # Routed through in-cluster ZOT pull-through cache.
-  insecure: true
-  url: oci://zot.kube-system.svc.cluster.local:5000/ghcr.io/home-operations/charts-mirror/descheduler
+  url: oci://ghcr.io/home-operations/charts-mirror/descheduler
   verify:
     provider: cosign
     matchOIDCIdentity:

--- a/kubernetes/apps/kube-system/intel-device-plugin/app/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/intel-device-plugin/app/ocirepository.yaml
@@ -11,9 +11,7 @@ spec:
     operation: copy
   ref:
     tag: 0.34.1
-  # Routed through in-cluster ZOT pull-through cache.
-  insecure: true
-  url: oci://zot.kube-system.svc.cluster.local:5000/ghcr.io/home-operations/charts-mirror/intel-device-plugins-operator
+  url: oci://ghcr.io/home-operations/charts-mirror/intel-device-plugins-operator
   verify:
     provider: cosign
     matchOIDCIdentity:

--- a/kubernetes/apps/kube-system/intel-device-plugin/gpu/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/intel-device-plugin/gpu/ocirepository.yaml
@@ -11,6 +11,4 @@ spec:
     operation: copy
   ref:
     tag: 0.34.1
-  # Routed through in-cluster ZOT pull-through cache.
-  insecure: true
-  url: oci://zot.kube-system.svc.cluster.local:5000/ghcr.io/home-operations/charts-mirror/intel-device-plugins-gpu
+  url: oci://ghcr.io/home-operations/charts-mirror/intel-device-plugins-gpu

--- a/kubernetes/apps/kube-system/kubelet-csr-approver/app/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/kubelet-csr-approver/app/ocirepository.yaml
@@ -11,6 +11,4 @@ spec:
     operation: copy
   ref:
     tag: 1.2.14
-  # Routed through in-cluster ZOT pull-through cache.
-  insecure: true
-  url: oci://zot.kube-system.svc.cluster.local:5000/ghcr.io/postfinance/charts/kubelet-csr-approver
+  url: oci://ghcr.io/postfinance/charts/kubelet-csr-approver

--- a/kubernetes/apps/kube-system/metrics-server/app/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/metrics-server/app/ocirepository.yaml
@@ -11,9 +11,7 @@ spec:
     operation: copy
   ref:
     tag: 3.13.1
-  # Routed through in-cluster ZOT pull-through cache.
-  insecure: true
-  url: oci://zot.kube-system.svc.cluster.local:5000/ghcr.io/home-operations/charts-mirror/metrics-server
+  url: oci://ghcr.io/home-operations/charts-mirror/metrics-server
   verify:
     provider: cosign
     matchOIDCIdentity:

--- a/kubernetes/apps/kube-system/node-feature-discovery/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/node-feature-discovery/app/helmrelease.yaml
@@ -11,9 +11,7 @@ spec:
     operation: copy
   ref:
     tag: 0.18.0
-  # Routed through in-cluster ZOT pull-through cache.
-  insecure: true
-  url: oci://zot.kube-system.svc.cluster.local:5000/ghcr.io/home-operations/charts-mirror/node-feature-discovery
+  url: oci://ghcr.io/home-operations/charts-mirror/node-feature-discovery
   verify:
     provider: cosign
     matchOIDCIdentity:

--- a/kubernetes/apps/kube-system/reflector/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/reflector/helmrelease.yaml
@@ -11,9 +11,7 @@ spec:
     operation: copy
   ref:
     tag: 10.0.52
-  # Routed through in-cluster ZOT pull-through cache.
-  insecure: true
-  url: oci://zot.kube-system.svc.cluster.local:5000/ghcr.io/emberstack/helm-charts/reflector
+  url: oci://ghcr.io/emberstack/helm-charts/reflector
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/refs/heads/main/ocirepository-source-v1.json
 apiVersion: helm.toolkit.fluxcd.io/v2

--- a/kubernetes/apps/mcp-system/mcp-gateway/app/ocirepository.yaml
+++ b/kubernetes/apps/mcp-system/mcp-gateway/app/ocirepository.yaml
@@ -11,6 +11,4 @@ spec:
     operation: copy
   ref:
     tag: 0.7.1
-  # Routed through in-cluster ZOT pull-through cache.
-  insecure: true
-  url: oci://zot.kube-system.svc.cluster.local:5000/ghcr.io/kuadrant/charts/mcp-gateway
+  url: oci://ghcr.io/kuadrant/charts/mcp-gateway

--- a/kubernetes/apps/network/envoy-gateway/app/ocirepository.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/ocirepository.yaml
@@ -11,6 +11,4 @@ spec:
     operation: copy
   ref:
     tag: 1.8.1
-  # Routed through in-cluster ZOT pull-through cache.
-  insecure: true
-  url: oci://zot.kube-system.svc.cluster.local:5000/docker.io/envoyproxy/gateway-helm
+  url: oci://docker.io/envoyproxy/gateway-helm

--- a/kubernetes/apps/network/external-dns/app/cloudflare/helmrelease.yaml
+++ b/kubernetes/apps/network/external-dns/app/cloudflare/helmrelease.yaml
@@ -11,9 +11,7 @@ spec:
     operation: copy
   ref:
     tag: 1.21.1
-  # Routed through in-cluster ZOT pull-through cache.
-  insecure: true
-  url: oci://zot.kube-system.svc.cluster.local:5000/ghcr.io/home-operations/charts-mirror/external-dns
+  url: oci://ghcr.io/home-operations/charts-mirror/external-dns
   verify:
     provider: cosign
     matchOIDCIdentity:

--- a/kubernetes/apps/network/multus/app/ocirepository.yaml
+++ b/kubernetes/apps/network/multus/app/ocirepository.yaml
@@ -11,6 +11,4 @@ spec:
     operation: copy
   ref:
     tag: 1.3.2
-  # Routed through in-cluster ZOT pull-through cache.
-  insecure: true
-  url: oci://zot.kube-system.svc.cluster.local:5000/ghcr.io/bjw-s-labs/helm/multus
+  url: oci://ghcr.io/bjw-s-labs/helm/multus

--- a/kubernetes/apps/observability/exporters/blackbox-exporter/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/exporters/blackbox-exporter/app/ocirepository.yaml
@@ -11,6 +11,4 @@ spec:
     operation: copy
   ref:
     tag: 11.13.0
-  # Routed through in-cluster ZOT pull-through cache.
-  insecure: true
-  url: oci://zot.kube-system.svc.cluster.local:5000/ghcr.io/prometheus-community/charts/prometheus-blackbox-exporter
+  url: oci://ghcr.io/prometheus-community/charts/prometheus-blackbox-exporter

--- a/kubernetes/apps/observability/exporters/pushgateway/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/exporters/pushgateway/app/ocirepository.yaml
@@ -11,5 +11,4 @@ spec:
     operation: copy
   ref:
     tag: 3.6.1
-  insecure: true
-  url: oci://zot.kube-system.svc.cluster.local:5000/ghcr.io/prometheus-community/charts/prometheus-pushgateway
+  url: oci://ghcr.io/prometheus-community/charts/prometheus-pushgateway

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/ocirepository.yaml
@@ -11,6 +11,4 @@ spec:
     operation: copy
   ref:
     tag: 87.1.0
-  # Routed through in-cluster ZOT pull-through cache.
-  insecure: true
-  url: oci://zot.kube-system.svc.cluster.local:5000/ghcr.io/prometheus-community/charts/kube-prometheus-stack
+  url: oci://ghcr.io/prometheus-community/charts/kube-prometheus-stack

--- a/kubernetes/apps/observability/silence-operator/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/silence-operator/app/ocirepository.yaml
@@ -5,13 +5,10 @@ kind: OCIRepository
 metadata:
   name: silence-operator
 spec:
-  insecure: true
   interval: 15m
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
     tag: 0.20.1
-  # Routed through in-cluster ZOT pull-through cache. insecure: true
-  # because the in-cluster service is plain HTTP.
-  url: oci://zot.kube-system.svc.cluster.local:5000/gsoci.azurecr.io/charts/giantswarm/silence-operator
+  url: oci://gsoci.azurecr.io/charts/giantswarm/silence-operator

--- a/kubernetes/apps/renovate/renovate-operator/app/ocirepository.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/app/ocirepository.yaml
@@ -11,6 +11,4 @@ spec:
     operation: copy
   ref:
     tag: 4.13.0
-  # Routed through in-cluster ZOT pull-through cache.
-  insecure: true
-  url: oci://zot.kube-system.svc.cluster.local:5000/ghcr.io/mogenius/helm-charts/renovate-operator
+  url: oci://ghcr.io/mogenius/helm-charts/renovate-operator

--- a/kubernetes/apps/rook-ceph/rook-ceph/app/operator/ocirepository.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/app/operator/ocirepository.yaml
@@ -11,6 +11,4 @@ spec:
     operation: copy
   ref:
     tag: v1.20.1
-  # Routed through in-cluster ZOT pull-through cache.
-  insecure: true
-  url: oci://zot.kube-system.svc.cluster.local:5000/ghcr.io/rook/rook-ceph
+  url: oci://ghcr.io/rook/rook-ceph

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/ocirepository.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/ocirepository.yaml
@@ -11,6 +11,4 @@ spec:
     operation: copy
   ref:
     tag: v1.20.1
-  # Routed through in-cluster ZOT pull-through cache.
-  insecure: true
-  url: oci://zot.kube-system.svc.cluster.local:5000/ghcr.io/rook/rook-ceph-cluster
+  url: oci://ghcr.io/rook/rook-ceph-cluster

--- a/kubernetes/apps/storage/openebs/app/ocirepository.yaml
+++ b/kubernetes/apps/storage/openebs/app/ocirepository.yaml
@@ -11,6 +11,4 @@ spec:
     operation: copy
   ref:
     tag: 4.5.1
-  # Routed through in-cluster ZOT pull-through cache.
-  insecure: true
-  url: oci://zot.kube-system.svc.cluster.local:5000/ghcr.io/openebs/charts/openebs
+  url: oci://ghcr.io/openebs/charts/openebs


### PR DESCRIPTION
Repoints **all 31 ZOT-routed chart `OCIRepository`s** from the in-cluster ZOT pull-through cache straight to their upstream registries over HTTPS, and removes `insecure: true` entirely.

```diff
-  insecure: true
-  url: oci://zot.kube-system.svc.cluster.local:5000/ghcr.io/home-operations/charts-mirror/descheduler
+  url: oci://ghcr.io/home-operations/charts-mirror/descheduler
```

## Why this shape (vs routing charts through ZOT-over-TLS)
charts and images are different paths, and ZOT only earns its keep on one of them:
- **Images** (large, the real bandwidth concern, pulled by kubelet/CRI-O): **stay on ZOT** via the node `registries.conf` mirror. spegel — the lightweight P2P cache onedr0p/bjw-s use — is containerd-only and can't run on our CRI-O nodes, so ZOT is the right runtime-agnostic image cache and is unchanged here.
- **Charts** (small, infrequent, Flux caches the artifact itself, pulled by source-controller): **go direct** to `ghcr.io` / `quay.io` / `docker.io` over HTTPS with verified public certs.

## What it removes
- `insecure: true` everywhere — charts come from real-cert HTTPS registries.
- The **foundational cold-boot exception** — charts no longer come from a cluster service that depends on the gateway/cert/storage it bootstraps, so all 31 are uniform (cert-manager, flux, rook-ceph, envoy-gateway included).
- The flate/konflate blocker — they render public-registry HTTPS natively. This is the onedr0p / bjw-s pattern.

## Validation
`flate test all` locally against the branch: **351 passed, 0 scheme/ZOT errors.** The only 2 failures are pre-existing `emqx` / `gpu-operator` **HelmRepository** `.tgz` 404s (separate sources, unrelated to this change).

## Trade-off
A Flux reconcile that needs a not-yet-cached chart now requires the upstream registry reachable (you lose ZOT's offline cushion *for chart pulls*). Mitigated by source-controller caching the chart artifact (re-pulls only on version bumps), and nearly all sources being ghcr.io/quay.io (no Docker Hub rate limits). Images keep ZOT's cushion.

> Supersedes the earlier "route charts through the gateway-fronted ZOT over TLS" version of this PR — that kept ZOT in the chart path (and the foundational exception); this removes it. _Branch name `zot-https-ocirepos` is now a misnomer; kept to preserve the PR._

🤖 Generated with [Claude Code](https://claude.com/claude-code)