### PR TITLE
chore: remove dead zot.kube-system.svc machinery + re-add yayamlls

### DIFF
--- a/.github/renovate/customManagers.json5
+++ b/.github/renovate/customManagers.json5
@@ -11,32 +11,6 @@
         "oci://(?<depName>[^:]+):(?<currentValue>\\S+)",
       ],
       datasourceTemplate: "docker",
-    },
-    {
-      customType: "regex",
-      // OCIRepository / chartRef routed through the in-cluster ZOT
-      // pull-through cache (kube-system/zot:5000). ZOT's onDemand sync
-      // only proxies *manifest* GETs, not /v2/<image>/tags/list — so
-      // Renovate's built-in flux manager (which queries the URL
-      // verbatim) gets `no-result` for every chart. Strip the ZOT
-      // prefix here so Renovate looks up tags from the real upstream
-      // registry, while Flux keeps pulling through ZOT. The
-      // packageRules entry that disables the flux-manager lookup for
-      // `zot.kube-system.svc.cluster.local:5000/*` lives in
-      // packageRules.json5.
-      description: "OCIRepository / chartRef routed through in-cluster ZOT — look up tags from upstream registry, not ZOT.",
-      managerFilePatterns: [
-        "/^kubernetes/.+\\.ya?ml$/",
-      ],
-      matchStrings: [
-        // `ref.tag` precedes `url` (this repo's convention — see
-        // flux.sorting.instructions.md and every existing
-        // OCIRepository file).
-        "ref:\\s*\\n\\s+tag:\\s+(?<currentValue>\\S+)[\\s\\S]*?url:\\s*oci://zot\\.kube-system\\.svc\\.cluster\\.local:5000/(?<depName>\\S+)",
-        // Defensive — reversed ordering if a future file flips it.
-        "url:\\s*oci://zot\\.kube-system\\.svc\\.cluster\\.local:5000/(?<depName>\\S+)[\\s\\S]*?ref:\\s*\\n\\s+tag:\\s+(?<currentValue>\\S+)",
-      ],
-      datasourceTemplate: "docker",
     }
   ]
 }

--- a/.github/renovate/packageRules.json5
+++ b/.github/renovate/packageRules.json5
@@ -83,19 +83,6 @@
       allowedVersions: "<8.2.0",
     },
     {
-      // Suppresses the built-in flux manager's failing lookup for
-      // OCIRepositories pointing at `oci://zot.kube-system...:5000/*`.
-      // The companion customManager in customManagers.json5 captures
-      // the upstream path as depName and queries the real registry
-      // for tags — keep that path enabled, disable only the
-      // ZOT-prefixed duplicate.
-      description: "Suppress flux-manager lookups for ZOT-prefixed OCIRepositories — customManager handles upstream resolution.",
-      matchPackageNames: [
-        "/^zot\\.kube-system\\.svc\\.cluster\\.local:5000\\//",
-      ],
-      enabled: false
-    },
-    {
       // The ollama image serves the fleet's qwen3-next:80b-a3b reasoning
       // model (ollama-spark) which cold-loads in ~9min off ceph — novel
       // hybrid-attention arch + ~50GB weights. Any image bump restarts

--- a/.yayamlls.yaml
+++ b/.yayamlls.yaml
@@ -1,0 +1,19 @@
+---
+# yayamlls workspace config — https://github.com/home-operations/yayamlls
+#
+# Kubernetes apiVersion+kind schema auto-detect and the schemastore catalog are
+# enabled by default, so the only thing worth setting is the Flux renderer:
+# flate renders HelmReleases and Kustomizations inline (code lens + diagnostics)
+# by following Flux source references from the cluster root. Now that chart
+# OCIRepositories pull direct from public registries (no plain-HTTP ZOT), flate
+# resolves them cleanly.
+#
+# Install (per developer, not committed):
+#   brew install home-operations/tap/yayamlls
+#   brew install --cask home-operations/tap/flate   # required for the renderer
+# then enable yayamlls in your editor (see the project README for VS Code /
+# Neovim setup).
+renderers:
+  flate:
+    enabled: true
+    path: kubernetes

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/cnp-allow.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/cnp-allow.yaml
@@ -35,23 +35,3 @@ spec:
               protocol: TCP
             - port: "80"
               protocol: TCP
-    # The listener also opens a long-lived gRPC-over-HTTPS session to
-    # GitHub's runner service, which uses port 443 (covered by the
-    # wildcard above).
-    #
-    # In-cluster ZOT pull-through cache (kube-system/zot:5000). The Flux
-    # Local (flate) workflow now runs the flate binary directly on the
-    # runner pod rather than as a `container:` job, so the runner pod —
-    # not the job-container pod — is what resolves the 30+ OCIRepository
-    # sources pointing at oci://zot.kube-system.svc.cluster.local:5000/...
-    # ZOT's Service DNS isn't matched by the toFQDNs wildcard above, so it
-    # needs an explicit toEndpoints rule (mirrors allow-job-container-egress;
-    # ZOT svc port == targetPort 5000, so no socket-lb rewrite to handle).
-    - toEndpoints:
-        - matchLabels:
-            io.kubernetes.pod.namespace: kube-system
-            app.kubernetes.io/name: zot
-      toPorts:
-        - ports:
-            - port: "5000"
-              protocol: TCP

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/cnp-job-container.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/cnp-job-container.yaml
@@ -30,15 +30,3 @@ spec:
               protocol: TCP
             - port: "80"
               protocol: TCP
-    # ZOT pull-through cache in kube-system. Phase 1 routed 30+ HelmReleases
-    # through oci://zot.kube-system.svc.cluster.local:5000/... — Flux Local
-    # Test runs `helm template` against those URLs, which is why we route
-    # this workflow to the self-hosted runner in the first place.
-    - toEndpoints:
-        - matchLabels:
-            io.kubernetes.pod.namespace: kube-system
-            app.kubernetes.io/name: zot
-      toPorts:
-        - ports:
-            - port: "5000"
-              protocol: TCP

--- a/kubernetes/apps/renovate/renovate-operator/jobs/cnp-allow.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/jobs/cnp-allow.yaml
@@ -37,21 +37,6 @@ spec:
         - ports:
             - port: "6379"
               protocol: TCP
-    # In-cluster ZOT pull-through cache (kube-system/zot:5000). Renovate
-    # tracks the 41 OCIRepository sources that now point at
-    # `oci://zot.kube-system.svc.cluster.local:5000/<upstream>/<repo>`
-    # (see [[project_zot_chart_cache_phase1_done]]), and the job pods
-    # query ZOT directly for available tags/digests. toFQDNs:* doesn't
-    # match in-cluster Service DNS, so this needs an explicit
-    # toEndpoints rule.
-    - toEndpoints:
-        - matchLabels:
-            io.kubernetes.pod.namespace: kube-system
-            app.kubernetes.io/name: zot
-      toPorts:
-        - ports:
-            - port: "5000"
-              protocol: TCP
     # Conservative wildcard for renovate scanning: discovery + executor
     # pods clone GitHub repos, query every registry mentioned by every
     # tracked dependency (ghcr.io, registry.k8s.io, docker.io, quay.io,

--- a/kubernetes/apps/selfhosted/konflate/app/cnp-allow.yaml
+++ b/kubernetes/apps/selfhosted/konflate/app/cnp-allow.yaml
@@ -16,27 +16,12 @@ spec:
   # (allow-intra-namespace for oauth2-proxy → :8080, allow-monitoring-scrape
   # for Prometheus → :8081), so only egress rules are needed here.
   egress:
-    # In-cluster ZOT pull-through cache (kube-system/zot:5000). konflate
-    # renders each PR by fetching the chart/OCI sources our HelmReleases
-    # declare, which point at oci://zot.kube-system.svc:5000/... ZOT's
-    # Service DNS isn't matched by toFQDNs, so it needs an explicit
-    # toEndpoints rule (mirrors renovate-jobs-allow). ZOT svc port ==
-    # targetPort 5000, so no socket-lb targetPort rewrite to worry about.
-    - toEndpoints:
-        - matchLabels:
-            io.kubernetes.pod.namespace: kube-system
-            app.kubernetes.io/name: zot
-      toPorts:
-        - ports:
-            - port: "5000"
-              protocol: TCP
     # konflate lists PRs via api.github.com, clones the repo, and renders
     # by fetching every helm/OCI/git source a PR's manifests reference
     # (arbitrary upstream hosts over HTTPS). Like renovate, the upstream
     # set grows with the repo, so an allow-list would silently break
     # renders. SSRF to private ranges is bounded by konflate's own egress
     # guard while fork rendering stays off.
-    # TODO: tighten once all chart sources are ZOT-mediated.
     - toFQDNs:
         - matchPattern: "*"
       toPorts:


### PR DESCRIPTION
Comprehensive hygiene after #12692 (charts direct from upstream registries). `zot.kube-system.svc:5000` is plain HTTP and flate/konflate can't use plain HTTP, so it's genuinely out of every path now — this removes the dead references to it.

- **4 CNPs** — drop the ZOT `:5000` `toEndpoints` egress allows (runner, ARC job-container, renovate-jobs, konflate). Each keeps `toFQDNs:* :443`. Verified 0 in-cluster sources dial it.
- **renovate customManager** — drop the ZOT-prefix tag-lookup workaround; the built-in **flux manager** now resolves the direct `oci://ghcr.io/...` URLs natively.
- **renovate packageRule** — drop the "disable flux-manager for ZOT-prefixed OCIRepositories" rule (matched nothing after #12692).
- **`.yayamlls.yaml`** re-added — render lens works against direct charts.

JSON5 validated (customManagers=1, packageRules=11). flux-local CI renders charts direct, so removing the allows can't break it.

**Verify after merge:** renovate's flux manager picks up the 31 direct charts on its next run (it should — that's its default for OCIRepository).

**Deliberately not bundled (follow-ups):** the flux-local `<8.2.0` hold (rationale now moot — lift when validating helm-4) and the "self-hosted because ZOT" workflow comments (flux-local CI no longer needs in-cluster ZOT, so it could move off the ARC runner — a real speedup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)