### PR TITLE
ci(flux-local): move to GitHub-hosted runners + lift ZOT-era version hold

### DIFF
--- a/.github/renovate/packageRules.json5
+++ b/.github/renovate/packageRules.json5
@@ -72,17 +72,6 @@
       matchPackageNames: ["ghcr.io/blakeblackshear/frigate"]
     },
     {
-      // Hold at 8.1.x: v8.2.0 bundles helm 4, which drops plain-HTTP
-      // OCI fallback and breaks `helm template` against our plain-HTTP
-      // zot pull-through cache (zot.kube-system.svc.cluster.local:5000),
-      // failing the Flux Local CI gate cluster-wide. Tracked upstream at
-      // allenporter/flux-local#1102. Re-allow when that lands.
-      description: "Hold flux-local at 8.1.x until allenporter/flux-local#1102 (helm 4 breaks plain-HTTP OCI against zot) is fixed upstream.",
-      matchDatasources: ["docker"],
-      matchPackageNames: ["ghcr.io/allenporter/flux-local"],
-      allowedVersions: "<8.2.0",
-    },
-    {
       // The ollama image serves the fleet's qwen3-next:80b-a3b reasoning
       // model (ollama-spark) which cold-loads in ~9min off ceph — novel
       // hybrid-attention arch + ~50GB weights. Any image bump restarts

--- a/.github/workflows/flux-local.yaml
+++ b/.github/workflows/flux-local.yaml
@@ -24,10 +24,11 @@ permissions:
 jobs:
   filter-changes:
     name: Filter changes
-    # Self-hosted: keep the whole flux-local pipeline off GitHub-hosted
-    # quota. This is a JS action (bundled node), so it runs directly on
-    # the ARC runner pod — no container: needed.
-    runs-on: arc-runner-set-home-ops
+    # GitHub-hosted: chart OCIRepositories pull direct from public
+    # registries now (no in-cluster ZOT), so flux-local needs no cluster
+    # access — GitHub-hosted is free for this public repo and avoids the
+    # self-hosted ARC runner backlog.
+    runs-on: ubuntu-latest
     outputs:
       changed-files: ${{ steps.changed-files.outputs.changed_files }}
     steps:
@@ -42,11 +43,9 @@ jobs:
   test:
     if: ${{ needs.filter-changes.outputs.changed-files != '[]' }}
     name: Flux Local Test
-    # Self-hosted runner so flux-local can resolve oci://zot.kube-system.svc.cluster.local
-    # (Phase 1 routed 30+ HelmReleases through the in-cluster ZOT). Off-cluster GHA
-    # runners can't resolve the in-cluster DNS name. Job runs in the flux-local image
-    # directly so we don't need docker daemon access (ARC is k8s-mode, no DinD).
-    runs-on: arc-runner-set-home-ops
+    # Runs the flux-local image directly (no docker daemon needed). Charts
+    # resolve from public registries, so no in-cluster access is required.
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/allenporter/flux-local:v8.1.0
     needs:
@@ -65,14 +64,11 @@ jobs:
     # Diff-against-default-branch only makes sense on PRs.
     if: ${{ github.event_name == 'pull_request' && needs.filter-changes.outputs.changed-files != '[]' }}
     name: Flux Local Diff
-    # Self-hosted + container: spec because `diff helmrelease` invokes
-    # `helm template` for changed HelmReleases. ZOT-routed chart URLs
-    # only resolve in-cluster. The `uses: docker://` pattern (sibling
-    # pod via ARC's k8s hooks) caused `helm repo update` to time out
-    # consistently against HelmRepository sources — switching to
-    # container: at job level avoids that. Node-based comment posting
-    # moved to a sibling `diff-comment` job (this image lacks node).
-    runs-on: arc-runner-set-home-ops
+    # container: spec runs flux-local directly — `diff helmrelease` invokes
+    # `helm template`, and charts resolve from public registries. Node-based
+    # comment posting lives in the sibling `diff-comment` job (the flux-local
+    # image lacks node).
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/allenporter/flux-local:v8.1.0
     needs:
@@ -135,10 +131,9 @@ jobs:
     # both need.
     if: ${{ github.event_name == 'pull_request' && needs.filter-changes.outputs.changed-files != '[]' }}
     name: Flux Local Comment
-    # Self-hosted: download-artifact + create-github-app-token +
-    # sticky-pull-request-comment are all JS actions (bundled node), so
-    # they run directly on the ARC runner pod — no container: needed.
-    runs-on: arc-runner-set-home-ops
+    # download-artifact + create-github-app-token +
+    # sticky-pull-request-comment are JS actions — no container: needed.
+    runs-on: ubuntu-latest
     needs:
       - filter-changes
       - diff
@@ -193,7 +188,7 @@ jobs:
       - diff-comment
     if: ${{ !cancelled() }}
     name: Flux Local successful
-    runs-on: arc-runner-set-home-ops
+    runs-on: ubuntu-latest
     steps:
       - name: Check job status
         if: ${{ contains(needs.*.result, 'failure') }}

--- a/.github/workflows/image-registry-check.yaml
+++ b/.github/workflows/image-registry-check.yaml
@@ -37,10 +37,9 @@ jobs:
   extract-images:
     if: ${{ needs.filter-changes.outputs.changed-files != '[]' }}
     name: Extract images
-    # Self-hosted runner so flux-local can resolve
-    # oci://zot.kube-system.svc.cluster.local — same reason as the
-    # Flux Local Test job in flux-local.yaml (see PR #11677).
-    runs-on: arc-runner-set-home-ops
+    # Runs flux-local to extract images; charts resolve from public
+    # registries, so GitHub-hosted works (see flux-local.yaml).
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/allenporter/flux-local:v8.1.0
     needs:


### PR DESCRIPTION
Follow-up to #12692 (charts direct from public registries).

- **flux-local CI off ARC → `ubuntu-latest`** — Flux Local test/diff/comment + the image-registry-check extract job. flux-local no longer needs in-cluster ZOT (charts are public-registry direct), so it doesn't need the self-hosted runner. GitHub-hosted is free for this public repo and **takes flux-local out of the ARC backlog** that started this whole thread.
- **Lift the renovate `<8.2.0` hold on flux-local** — its reason (helm 4 drops plain-HTTP OCI fallback vs plain-HTTP ZOT) is moot now. Renovate can propose 8.2.x; the GitHub-hosted CI validates it.
- Refreshed the stale "self-hosted because ZOT" comments.

**Self-validating:** this PR's own Flux Local run executes on `ubuntu-latest`, so it proves flux-local renders all the direct charts off-cluster before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)