### PR TITLE
feat(pump): bump pump to v0.0.101

### DIFF
--- a/kubernetes/apps/collab/pump/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump/app/helmrelease.yaml
@@ -32,7 +32,7 @@ spec:
           pump:
             image:
               repository: ghcr.io/rwlove/pump
-              tag: v0.0.100@sha256:c49f2c905fa623d508e147c586804ebd664d602ce3f30c19b6c898d6277c2a2f
+              tag: v0.0.101@sha256:1527ae0057ab468a1eb5f80fcce5a7e763339293ec9a4b88bc4ace4b1192ebe9
 
             env:
               # Activates the /api/cv/* proxy in pump (see internal/web/exercise.go).


### PR DESCRIPTION
Bumps pump to v0.0.101 (digest sha256:1527ae00…).

PUMP #44: period-aware Steps/Sleep stat tiles, sleep-bar hover totals (each stage + total sleep), and a Today button that uses the live device date so a phone left open across midnight no longer jumps to yesterday. Frontend-only; no schema change.