### PR TITLE
ci(renovate): fix registry.k8s.io lookups (alias to GAR backend)

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -41,6 +41,14 @@
   // orphan branch (see Dashboard #10329 stall on 2026-05-17). Trade-off
   // is unsigned commits from the bot, which we accept.
   platformCommit: 'disabled',
+  // registry.k8s.io is a redirector to Google Artifact Registry whose OCI
+  // /tags/list returns 405, so Renovate can't enumerate tags ("Error
+  // obtaining docker token" + Package lookup failures on Dashboard #10329).
+  // Alias the *lookup* to the GAR backend (which Renovate reads natively);
+  // the registry.k8s.io reference in the manifests is unchanged.
+  registryAliases: {
+    'registry.k8s.io': 'us-central1-docker.pkg.dev/k8s-artifacts-prod/images',
+  },
   flux: {
     managerFilePatterns: [
       '/kubernetes/.+\\.ya?ml$/',


### PR DESCRIPTION
Fixes the two "Repository Problems" on the Renovate Dashboard (#10329): **"Error obtaining docker token"** + **"Package lookup failures"**.

**Cause:** `registry.k8s.io` is a redirector to Google Artifact Registry (`pkg.dev/k8s-artifacts-prod/images`), and GAR's OCI `/tags/list` returns **405** — so Renovate can't enumerate tags for any `registry.k8s.io` image. Reproduced the redirect chain directly. This is unrelated to the chart repointing (#12692); it only ever affected *images*.

**Fix:** a `registryAlias` so Renovate looks up tags at the GAR backend (which it reads natively via its docker datasource), keeping the `registry.k8s.io/...` reference in the manifests unchanged. Verified `external-dns`, `git-sync`, and `node-problem-detector` all return HTTP 200 at `us-central1-docker.pkg.dev/k8s-artifacts-prod/images`.

Effect: the registry.k8s.io app images get update tracking again, and the two dashboard warnings clear on the next renovate run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)