### PR TITLE
ci(renovate): drop :automergeBranch so automerges flow through PRs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,7 +8,6 @@
     ':semanticCommits',
     ':enablePreCommit',
     ':automergeDigest',
-    ':automergeBranch',
     'github>rwlove/home-ops//.github/renovate/autoMerge.json5',
     'github>rwlove/home-ops//.github/renovate/commitMessage.json5',
     'github>rwlove/home-ops//.github/renovate/customManagers.json5',


### PR DESCRIPTION
**Why renovate automerges weren't going through** (the "Pending Status Checks" pile-up on Dashboard #10329):

The root config extended **`:automergeBranch`** → `automergeType: branch`. Branch-automerge pushes a `renovate/…` branch and merges it directly **once that branch's status checks pass — with no PR.** But our CI workflows (flux-local, lint, image-registry-check) trigger **`on: pull_request` only**, so they never run on a bare branch push. The renovate branches therefore accumulate **zero checks**, branch-automerge can never satisfy "checks passed," and every automerge candidate stalls forever under *Pending Status Checks*. (Manually ticking the box forces PR creation → the PR gets checked → it merges; that's why the workaround worked.)

It also directly contradicted `autoMerge.json5`, which sets `automergeType: pr` everywhere with the comment *"we always want a PR (no silent merges)."*

**Fix:** drop `:automergeBranch`. Automerge candidates now open PRs (which **do** get checked), and `autoMerge.json5` auto-merges them when green — consistent with the stated "always want a PR" intent. `:automergeDigest` stays (digests still auto-merge, just via PR now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)