### PR TITLE
chore(music-assistant): set helm timeout 15m for slow large-image pulls

### DIFF
--- a/kubernetes/apps/media/music-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/media/music-assistant/app/helmrelease.yaml
@@ -10,6 +10,11 @@ spec:
     name: app-template
 
   interval: 30m
+  # The MA server image is large (~2.5 GB); a cold pull on a new tag can take
+  # 5+ min, exceeding helm-controller's default 5m operation timeout. That
+  # caused a failed upgrade + rollback during the 2.10.0b1→b2 bump. Give helm
+  # room so a slow first pull can't time out and roll back mid-upgrade.
+  timeout: 15m
   values:
     controllers:
       music-assistant:


### PR DESCRIPTION
## What
Add `spec.timeout: 15m` to the music-assistant HelmRelease.

## Why
The MA server image is ~2.5 GB. A cold pull on a new tag took **5m30s** during the `2.10.0b1 → 2.10.0b2` bump, exceeding helm-controller's default **5m** operation timeout. Helm marked the upgrade failed and **rolled back** the StatefulSet to the previous spec — which, combined with the same PR pruning the overlay ConfigMap, left the rolled-back pod unable to mount it (`FailedMount`) and MA briefly down.

A 15m timeout gives the StatefulSet roll room to finish a slow cold pull without timing out, so a routine image bump can't fall into that rollback path.

## Validated
`kubectl kustomize` renders `spec.timeout: 15m` on the HelmRelease.

🤖 Generated with [Claude Code](https://claude.com/claude-code)