### PR TITLE
fix(kube-system): cut control-plane memory pressure (operator affinity + apiserver GOMEMLIMIT)

### DIFF
--- a/init/clusterconfiguration.yaml
+++ b/init/clusterconfiguration.yaml
@@ -32,6 +32,16 @@ timeouts:
   upgradeManifests: 5m0s
 ---
 apiVersion: kubeadm.k8s.io/v1beta4
+apiServer:
+  # Cap the kube-apiserver Go heap so its working set stops growing to ~2x the
+  # live heap before GC. Without this the apiserver balloons to 5-6Gi on the
+  # memory-tight control-plane VMs (master2 12Gi / master3 9.6Gi). Cluster-wide
+  # value: master2's ~3.3Gi live heap sets the floor. Applied live via the
+  # kubeadm-config ConfigMap + `kubeadm init phase control-plane apiserver`
+  # per node; this file is bootstrap-only (not Flux-reconciled).
+  extraEnvs:
+  - name: GOMEMLIMIT
+    value: 4GiB
 caCertificateValidityPeriod: 87600h0m0s
 certificateValidityPeriod: 8760h0m0s
 certificatesDir: /etc/kubernetes/pki

--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -44,6 +44,25 @@ spec:
         rollOutPods: true
 
     operator:
+      # Prefer workers, still allow masters as a cold-boot fallback — keeps the
+      # operator's (memory-heavy) leader replica off the tight control-plane VMs
+      # (master2/master3). Setting affinity replaces the chart-default operator
+      # affinity wholesale, so the default podAntiAffinity (replica spread across
+      # hosts) is restated here.
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: DoesNotExist
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  io.cilium/app: operator
+              topologyKey: kubernetes.io/hostname
       dashboards:
         annotations:
           grafana_folder: Cilium

--- a/kubernetes/apps/kube-system/gpu-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/gpu-operator/app/helmrelease.yaml
@@ -23,6 +23,17 @@ spec:
     operator:
       cleanupCRD: false
       upgradeCRD: true
+      # The chart default operator affinity *prefers* control-plane nodes, which
+      # lands the controller on the memory-tight master VMs. Prefer
+      # non-control-plane nodes instead (still allowed on masters as a fallback).
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: DoesNotExist
     # Tolerations applied to every operand DaemonSet (toolkit,
     # device-plugin, dcgmExporter, gfd, nodeStatusExporter, validator).
     # The chart default tolerates `nvidia.com/gpu` only; appending


### PR DESCRIPTION
## Problem

The two control-plane VMs flap `NodeMemoryHighUtilization` / `HostOutOfMemory`. One sits ~89% and oscillates 75–93% all week. Not a leak — etcd DB is small and stable. The dominant consumer is **kube-apiserver (5–6Gi)**, plus a couple of Deployments that don't need to run on a control-plane node.

## Changes (in-repo)

**Lever A — keep movable Deployments off the control plane (GitOps):**
- `cilium-operator`: add a soft `nodeAffinity` preferring non-control-plane nodes (keeps tolerations so a cold boot can still fall back to a master). The chart-default `podAntiAffinity` is restated because setting `affinity` replaces it wholesale.
- `gpu-operator` controller: its chart default *prefers* control-plane nodes (and there's no GPU there) — override with the same non-control-plane preference.

**Lever B — record apiserver `GOMEMLIMIT` (traceability):**
- Add `apiServer.extraEnvs: GOMEMLIMIT=4GiB` to `init/clusterconfiguration.yaml`. apiserver currently runs uncapped, so its Go heap grows to ~2× the live heap before GC. This file is **bootstrap-only (not Flux-reconciled)** — the live apply happens out-of-band via the `kubeadm-config` ConfigMap + per-node static-manifest regeneration, rolled one control-plane node at a time.

## Blast radius

Operator reschedules are brief and don't touch the CNI dataplane (cilium *agent* DaemonSet is unchanged). No node reboots. The apiserver `GOMEMLIMIT` rollout (separate, manual) restarts one apiserver process at a time — etcd quorum is never touched.

## Verification

- `cilium-operator` / `gpu-operator` pods no longer scheduled on control-plane nodes.
- apiserver working-set drops after the (manual) GOMEMLIMIT rollout; apiserver p99 latency stays flat (if it climbs, raise the limit).
- Memory alerts stop firing for the control-plane nodes after 24–48h.