### PR TITLE
chore(init): bump bootstrap kubernetesVersion v1.34.2 -> v1.35.4

### DIFF
--- a/init/clusterconfiguration.yaml
+++ b/init/clusterconfiguration.yaml
@@ -61,7 +61,7 @@ etcd:
       value: http://0.0.0.0:2381
 imageRepository: registry.k8s.io
 kind: ClusterConfiguration
-kubernetesVersion: v1.34.2
+kubernetesVersion: v1.35.4
 networking:
   dnsDomain: cluster.local
   podSubnet: 10.42.0.0/16


### PR DESCRIPTION
## What

`init/clusterconfiguration.yaml` had drifted to `kubernetesVersion: v1.34.2` while the live cluster runs **v1.35.4** (confirmed against the `kubeadm-config` ConfigMap and all three control-plane nodes' kubelet versions). A from-scratch rebuild via `init/create-cluster.sh` would have initialized at the stale version.

## Why now

Surfaced while confirming the apiserver `GOMEMLIMIT` change (PR #12722) is durable across upgrades and new-master joins — those paths read the live `kubeadm-config` CM and are fine; this bootstrap file is the only place that was stale.

No live-cluster impact — this file is only consumed at cluster creation.