### PR TITLE
ci(renovate): map registry.k8s.io/pause to its full GAR path

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -45,7 +45,14 @@
   // obtaining docker token" + Package lookup failures on Dashboard #10329).
   // Alias the *lookup* to the GAR backend (which Renovate reads natively);
   // the registry.k8s.io reference in the manifests is unchanged.
+  //
+  // Single-segment images (e.g. `pause`) get Docker Hub's `library/` prepend
+  // because they have no namespace slash, so the broad alias resolves them to
+  // the empty GAR repo .../images/library/pause → no-result. Map those
+  // explicitly to their full GAR path (longest-prefix match wins, and the
+  // slash suppresses the `library/` prepend) so they stay tracked.
   registryAliases: {
+    'registry.k8s.io/pause': 'us-central1-docker.pkg.dev/k8s-artifacts-prod/images/pause',
     'registry.k8s.io': 'us-central1-docker.pkg.dev/k8s-artifacts-prod/images',
   },
   flux: {


### PR DESCRIPTION
## Problem

Dashboard #10329 shows **"WARN: Error obtaining docker token"** and a failed lookup: `Failed to look up docker package us-central1-docker.pkg.dev/k8s-artifacts-prod/images/pause: no-result`.

Both are the same root cause. The broad `registry.k8s.io` → GAR alias added in #12702 fixed the multi-segment images (`node-problem-detector/...`, `git-sync/...`, `external-dns/...` all resolve) but broke the lone single-segment one, `registry.k8s.io/pause:3.10` (`kube-system/node-tuning/daemonset.yaml`).

Renovate prepends Docker Hub's `library/` to namespace-less image names, so the aliased lookup resolved to the **empty** `.../images/library/pause` repo → `no-result`.

Verified against GAR:
- `.../images/pause/tags/list` → 200, 33 tags incl. `3.10` ✓
- `.../images/library/pause/tags/list` → 200 but `tags: []` ← what Renovate was hitting

## Fix

Add an explicit, longer-prefix alias mapping `registry.k8s.io/pause` straight to its full GAR path. Longest-prefix match wins, and the slash suppresses the `library/` prepend, so the image stays tracked. The manifest reference is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)