### PR TITLE
docs(readme): right-size beast VM RAM allocations

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,15 +93,15 @@ Storage tiers are picked deliberately per workload — see [`storage-class.instr
 | Role | Hostname  | Device              | CPU | RAM   | OS         | Storage / Accelerators       | Notes                                 |
 |------|-----------|---------------------|-----|-------|------------|------------------------------|---------------------------------------|
 | 🧠   | master1   | bare-metal          | 4   | 32 GB | CentOS 10  | NVMe (Longhorn)              | Intel iGPU · RTL-SDR · control plane  |
-| 🧠   | master2   | VM on **beast**     | 3   | 12 GB | CentOS 9   |                              | virtualized control plane             |
-| 🧠   | master3   | VM on **beast**     | 3   | 10 GB | CentOS 9   |                              | virtualized control plane             |
+| 🧠   | master2   | VM on **beast**     | 3   | 10.5 GB | CentOS 9   |                              | virtualized control plane             |
+| 🧠   | master3   | VM on **beast**     | 3   | 10.5 GB | CentOS 9   |                              | virtualized control plane             |
 | 💪   | worker2   | ThinkCentre M910x   | 8   | 32 GB | CentOS 9   | NVMe (Longhorn + Ceph OSD)   | ZWA-2 Z-Wave dongle                   |
 | 💪   | worker3   | ThinkCentre M910x   | 8   | 64 GB | CentOS 9   | NVMe (Longhorn + Ceph OSD)   | Sonoff Zigbee dongle                  |
 | 💪   | worker4   | ThinkCentre M910x   | 8   | 32 GB | CentOS 9   | NVMe (Longhorn + Ceph OSD)   | Coral USB TPU                         |
-| 💪   | worker5   | VM on **beast**     | 10  | 24 GB | CentOS 9   | NVMe (Longhorn + Ceph OSD)   |                                       |
-| 💪   | worker6   | VM on **beast**     | 10  | 30 GB | CentOS 9   | NVMe (Longhorn + Ceph OSD)   |                                       |
-| 💪   | worker7   | VM on **beast**     | 10  | 30 GB | CentOS 9   | NVMe (Longhorn + Ceph OSD)   |                                       |
-| 🎮   | worker8   | VM on **beast**     | 10  | 55 GB | CentOS 9   | NVMe (Longhorn + Ceph OSD)   | NVIDIA **P40** (24 GB VRAM)           |
+| 💪   | worker5   | VM on **beast**     | 10  | 21.5 GB | CentOS 9   | NVMe (Longhorn + Ceph OSD)   |                                       |
+| 💪   | worker6   | VM on **beast**     | 10  | 26.5 GB | CentOS 9   | NVMe (Longhorn + Ceph OSD)   |                                       |
+| 💪   | worker7   | VM on **beast**     | 10  | 26.5 GB | CentOS 9   | NVMe (Longhorn + Ceph OSD)   |                                       |
+| 🎮   | worker8   | VM on **beast**     | 10  | 51.5 GB | CentOS 9   | NVMe (Longhorn + Ceph OSD)   | NVIDIA **P40** (24 GB VRAM)           |
 | 🚀   | spark     | NVIDIA DGX Spark    | 20  | 128 GB| Ubuntu 24.04 | NVMe + 8 GPU slots         | NVIDIA **GB10** (Grace-Blackwell, 128 GB unified); arm64 · containerd outlier |
 
 ### Off-cluster infrastructure


### PR DESCRIPTION
Updates the hardware inventory table to reflect the new memory allocations for the **beast**-hosted VMs after a right-sizing pass. Reclaims **~14 GiB** to the host (page-cache headroom — the host's small cache was the NFS limiter).

| Node | Before | After |
|---|---|---|
| master2 | 12 GB | **10.5 GB** |
| master3 | 10 GB | **10.5 GB** |
| worker5 | 24 GB | **21.5 GB** |
| worker6 | 30 GB | **26.5 GB** |
| worker7 | 30 GB | **26.5 GB** |
| worker8 | 55 GB | **51.5 GB** |

Masters equalized to 10.5 GiB each (etcd-gated, one at a time); workers trimmed with healthy guest headroom retained. All resizes executed live (drain → resize → reboot) with no data loss.

The VM definitions live in libvirt on beast and aren't GitOps-managed, so this PR is the documentation half of that change — doc-only, no manifest impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)