### PR TITLE
fix(flux): set targetNamespace on cluster-config Kustomization

### DIFF
--- a/kubernetes/flux/cluster/ks.yaml
+++ b/kubernetes/flux/cluster/ks.yaml
@@ -6,6 +6,7 @@ metadata:
   name: cluster-config
   namespace: flux-system
 spec:
+  targetNamespace: flux-system
   path: ./kubernetes/flux/meta
   interval: 1h
   prune: true


### PR DESCRIPTION
**Hotfix for #12734.** The new `cluster-config` Kustomization was missing `targetNamespace: flux-system`. The ConfigMap manifest has no namespace, so Flux rejected the apply (`ConfigMap/cluster-config namespace not specified: the server could not find the requested resource`) — and since the old `flux-instance` Kustomization had already pruned the ConfigMap, `cluster-config` went missing and `cluster-apps` blocked on the dependency.

The original `flux-instance` Kustomization supplied `targetNamespace: flux-system`; this restores it on the dedicated Kustomization.

Neither flate nor flux-local caught it — it's an apply-time API-server requirement, not a static render error (the exact failure mode the #12734 rollout caveat warned about).

🤖 Generated with [Claude Code](https://claude.com/claude-code)