### PR TITLE
fix(collab): allow medikeep egress to internal gateway for paperless integration

### DIFF
--- a/kubernetes/apps/collab/medikeep/app/cnp-allow.yaml
+++ b/kubernetes/apps/collab/medikeep/app/cnp-allow.yaml
@@ -34,3 +34,18 @@ spec:
         - ports:
             - port: "5432"
               protocol: TCP
+    # Paperless-ngx integration: medikeep dials the external paperless
+    # FQDN, which split-horizon DNS resolves to the envoy LB IP. Cilium's
+    # socket-lb rewrites the connect() to the envoy pod on its container
+    # port 10443 BEFORE policy evaluation (per memory
+    # project_cilium_l4_port_targetport.md), so the policy must allow the
+    # envoy pod on its container port, NOT world:443 (which doesn't match
+    # cluster LB IPs). Mirrors paperless's own OIDC egress rule.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "10443"
+              protocol: TCP


### PR DESCRIPTION
## Problem

MediKeep's **Paperless-ngx integration** Test Connection fails with *"Unable to connect to the Paperless server."* The failure is at the TCP/TLS layer — before any API token is evaluated.

## Root cause

`collab` is default-deny egress (re-enabled 2026-05-18, Phase 3). medikeep's `cnp-allow.yaml` only punched a hole to its Postgres (`:5432`).

When medikeep dials the external paperless FQDN:
1. DNS resolves (baseline allows kube-dns) → returns the **envoy internal-gateway LB IP** (`10.45.0.12`).
2. Cilium socket-lb rewrites the `connect()` to the **envoy pod on container port `10443`** before policy evaluation.
3. No egress allow for `network/envoy:10443` → silent drop → TCP timeout → "Unable to connect."

Verified live: `connect(10.45.0.12:443)` from `medikeep-0` returns `TimeoutError`.

## Fix

Add an egress allow to `network/envoy:10443`, mirroring paperless's own OIDC egress rule (`paperless/app/cnp-allow.yaml` lines 94–101). Additive, non-destructive, consistent with the established pattern.

## Blast radius

Opens medikeep egress to the internal gateway only — same scope every other internal-gateway-fronted caller already has.

🤖 Generated with [Claude Code](https://claude.com/claude-code)