### PR TITLE
refactor(mcp-system): retire arr-mcp deadlock workaround, pin upstream mcp-arr v1.7.2

### DIFF
--- a/.github/renovate/packageRules.json5
+++ b/.github/renovate/packageRules.json5
@@ -2,18 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "packageRules": [
     {
-      // workaround: https://github.com/aplaceforallmystuff/mcp-arr/pull/22
-      // arr-mcp is pinned to a v1.6.5-deadlockfix build (PR #22 patch applied at
-      // build time) because stock v1.6.5 deadlocks behind the mcp-gateway. Keep
-      // Renovate off it so it can't downgrade to the broken stock tag (a
-      // `-deadlockfix1` prerelease sorts below v1.6.5). REMOVE this rule when the
-      // upstream PR merges + a fixed mcp-arr is released and pinned.
-      "description": "WORKAROUND: pin arr-mcp during the mcp-arr#22 deadlock patch",
-      "matchDatasources": ["docker"],
-      "matchPackageNames": ["ghcr.io/rwlove/arr-mcp"],
-      "enabled": false
-    },
-    {
       "description": "Major updates: always open a PR, never auto-merge — manual review",
       "matchUpdateTypes": ["major"],
       "dependencyDashboardApproval": false,

--- a/kubernetes/apps/mcp-system/arr-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/arr-mcp/app/helmrelease.yaml
@@ -25,16 +25,8 @@ spec:
         containers:
           app:
             image:
-              repository: ghcr.io/rwlove/arr-mcp
-              # workaround: https://github.com/aplaceforallmystuff/mcp-arr/pull/22 — remove when merged + a fixed mcp-arr (> v1.6.5) is released and pinned
-              # Stock v1.6.5 deadlocks its http transport behind the mcp-gateway
-              # (serialized queue blocked by the broker's long-lived GET stream),
-              # so arr never federates. This `-deadlockfix1` image is v1.6.5 with
-              # the PR #22 patch applied at build time (see rwlove/containers
-              # arr-mcp/patches). Renovate is pinned off this image in
-              # .github/renovate/packageRules.json5 so it can't downgrade back to
-              # the broken stock tag.
-              tag: v1.6.5-deadlockfix1@sha256:841c0fd73c89ccb37573db9d376aed95e2f8bf90c338309e12d70e3334c7b43e
+              repository: ghcr.io/aplaceforallmystuff/mcp-arr
+              tag: 1.7.2@sha256:46f2356c2161a8561b6f5680429594cf34aaad0712d1a030f8d662b99556c415
             env:
               SONARR_URL: http://sonarr.media.svc.cluster.local:8989
               RADARR_URL: http://radarr.media.svc.cluster.local:7878


### PR DESCRIPTION
## What

Retires the local arr-mcp http-transport deadlock workaround now that the fix is upstream and released.

- **HelmRelease** (`kubernetes/apps/mcp-system/arr-mcp/app/helmrelease.yaml`): repoint image from the self-built `ghcr.io/rwlove/arr-mcp:v1.6.5-deadlockfix1` → stock `ghcr.io/aplaceforallmystuff/mcp-arr:1.7.2` (digest-pinned `sha256:46f2356c…`), drop the workaround comment block.
- **Renovate** (`.github/renovate/packageRules.json5`): remove the `enabled: false` pin that kept Renovate off the patch image. Renovate now tracks the upstream package normally.

## Why

The http transport reused a single module-level `Server` serialized through a global queue. Behind the mcp-gateway, the broker's long-lived `GET` SSE stream never resolved and blocked the queue permanently → every subsequent POST hung → arr-mcp never federated. We shipped v1.6.5 + the fix patch baked in.

Upstream **mcp-arr#22** (Fixes mcp-arr#21) builds a fresh `Server` + transport per request (SDK stateless pattern), **merged + released as v1.7.2 today**. The local patch is now redundant.

## Compatibility (1.6.5 → 1.7.2)

- Env interface unchanged: `SONARR_URL` / `RADARR_URL` / `LIDARR_URL` / `PROWLARR_URL` / `MCP_TRANSPORT` all present in v1.7.2; `*_API_KEY` come from `arr-mcp-secret` (untouched).
- Changelog is non-breaking: additive tools (1.7.0), hono security bump (1.7.1), deadlock fix (1.7.2) — the same patch the `-deadlockfix1` image carried.
- Multi-arch (amd64 + arm64) since 1.7.0.

## Verification

- `1.7.2` image published to GHCR (digest `sha256:46f2356c2161…`); release workflow `docker` job green.
- JSON5 validates; brace/bracket balanced; no residual `rwlove/arr-mcp` / `deadlockfix` refs in repo.
- Local pre-submit hooks passed (yamllint, json, secrets, badges).

## Deploy / window

Internal MCP federation path (`mcp-system`), **not Renee-facing** → routine window (any night 02:00–05:00 ET). On reconcile the arr-mcp pod rolls to the upstream image; brief federation blip while it restarts.

## Follow-up (separate repo, out of scope here)

The `rwlove/containers` patch build (`arr-mcp/Dockerfile` + `patches/0001-http-stateless.patch`, from rwlove/containers#96) and the `ghcr.io/rwlove/arr-mcp` package can be deleted once this lands and reconciles clean.

Closes #12485

🤖 Generated with [Claude Code](https://claude.com/claude-code)