### PR TITLE
feat(omada-mcp): set OMADA_SITE_ID default (Lovenet)

### DIFF
--- a/kubernetes/apps/mcp-system/omada-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/omada-mcp/app/helmrelease.yaml
@@ -30,6 +30,11 @@ spec:
             env:
               OMADA_STRICT_SSL: "false"
               OMADA_TOOL_CATEGORIES: "all:r"
+              # Lovenet site — lets site-scoped tools (getClientDetail,
+              # listClients, etc.) default without an explicit siteId.
+              # Non-secret identifier, so a plain literal rather than
+              # routed through the ExternalSecret.
+              OMADA_SITE_ID: "6a3c6b16b32a9e3ac4984fdb"
               MCP_SERVER_USE_HTTP: "true"
               MCP_HTTP_BIND_ADDR: "0.0.0.0"
               MCP_HTTP_PORT: "3000"


### PR DESCRIPTION
## What
Adds `OMADA_SITE_ID` (Lovenet, `6a3c6b16b32a9e3ac4984fdb`) as a literal env on the `omada-mcp` HelmRelease.

## Why
`omada-mcp` had no site default, so site-scoped Open API tools (`getClientDetail`, `listClients`, …) failed with *"A site id must be provided either in the environment or as a parameter."* The siteId is a non-secret identifier, so it's a plain literal env rather than routed through the ExternalSecret.

## Context
Surfaced while restoring Omada Open API auth after the controller upgrade to v6.2.0.17 (which reminted the Omadac ID). Auth itself is fixed via the 1Password `omada` item; this closes the remaining site-default gap.

## Verification
- Pre-commit passed (yamllint, secret detection, CNP rules).
- `reloader.stakater.com/auto: true` on the deployment → pod picks up the new env on reconcile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)