### PR TITLE
ci(flux): tolerate Fairwinds index digest mismatch in flate test

### DIFF
--- a/.github/workflows/flux-local.yaml
+++ b/.github/workflows/flux-local.yaml
@@ -80,7 +80,32 @@ jobs:
       - name: Run flate test
         env:
           FLATE_BASE: ""
-        run: flate test all --path "${GITHUB_WORKSPACE}/kubernetes/flux"
+        # workaround: https://github.com/FairwindsOps/charts/issues/1879 — remove when Fairwinds re-indexes
+        # The Fairwinds Helm repo (charts.fairwinds.com, an S3/CloudFront-hosted
+        # index we can't PR) publishes an index.yaml whose `digest:` for
+        # vpa/goldilocks no longer matches the served .tgz, so flate correctly
+        # rejects the chart with "digest mismatch". flate has no digest-skip
+        # flag, so this wrapper tolerates ONLY that exact symptom — a
+        # `fairwinds-charts-*` HelmRelease failing with "digest mismatch" — and
+        # still fails the job on any other error (a real render error alongside
+        # it is not swallowed). When upstream re-indexes, the mismatch vanishes
+        # and this branch matches nothing, restoring normal fail-loud behavior.
+        run: |
+          set +e
+          out="$(flate test all --path "${GITHUB_WORKSPACE}/kubernetes/flux" 2>&1)"
+          rc=$?
+          set -e
+          printf '%s\n' "$out"
+          [ "$rc" -eq 0 ] && exit 0
+          clean="$(printf '%s\n' "$out" | sed 's/\x1b\[[0-9;]*m//g')"
+          failed="$(printf '%s\n' "$clean" | grep -oE '[0-9]+ failed' | grep -oE '[0-9]+' | tail -1)"
+          tolerated="$(printf '%s\n' "$clean" | grep -cE 'HelmRelease.*fairwinds-charts-.*digest mismatch' || true)"
+          if [ -n "$failed" ] && [ "$failed" -gt 0 ] && [ "$failed" -eq "$tolerated" ]; then
+            echo "::warning::flate test: tolerating ${tolerated} Fairwinds index digest mismatch(es) (vpa/goldilocks) — see FairwindsOps/charts#1879. All other resources passed."
+            exit 0
+          fi
+          echo "::error::flate test failed with untolerated errors (failed=${failed:-unknown}, tolerated Fairwinds digest mismatches=${tolerated})."
+          exit "$rc"
 
   diff:
     # Diff-against-default-branch only makes sense on PRs.


### PR DESCRIPTION
## What

Wraps the `flate test all` step in `flux-local.yaml` to tolerate **only** the Fairwinds `index.yaml` digest-mismatch symptom, so `Flux Local Test` stops failing repo-wide.

## Why

Fairwinds' Helm repo (`charts.fairwinds.com`) re-indexed on **2026-06-30** and now serves an `index.yaml` whose `digest:` for **vpa** and **goldilocks** no longer matches the `.tgz` it hosts. Verified independently of flate:

| Chart | index digest | actual .tgz sha256 |
|---|---|---|
| vpa 4.12.2 | `b89cfb58…` | `e15c1fe0…` |
| goldilocks 10.4.0 | `f5ad503a…` | `d5ba0531…` |

The tarballs are valid; the index digest is stale (`helm repo index --merge` footgun). flate correctly rejects the mismatch → **every PR touching a `kubernetes/` manifest fails `Flux Local Test`**, unrelated to its own change. The live cluster is unaffected (charts already reconciled + cached).

Reported upstream: **FairwindsOps/charts#1879**. It can't be fixed by a PR (the index is in Fairwinds' S3/CloudFront, not the git repo), Fairwinds ships no public OCI charts, and flate has no digest-skip flag — so a CI-side tolerance is the only lever until they re-index.

## How

The wrapper runs `flate test`, and if it fails, passes **only when every failure is a `fairwinds-charts-*` HelmRelease `digest mismatch`** (tolerated count == total failed count). Any other failure — including a genuine render error occurring alongside the mismatch — still fails the job.

Unit-tested locally against 5 fixtures (real 2-mismatch output → pass; mismatch + real render error → fail; all-pass → pass; real-only → fail; ANSI-colored → pass). This PR self-validates: it touches `flux-local.yaml`, which the `test` job's path filter includes, so CI runs the new wrapper against the live Fairwinds mismatch.

## Retirement

`# workaround:` annotated with the upstream link. When Fairwinds re-indexes, the mismatch vanishes and the tolerance branch matches nothing (fail-loud restored) — removal is just deleting the block. Tracked by the `workaround`-labeled issue linking #1879; the upstream-watcher retires it.