### PR TITLE
fix(mcp-system): set arr-mcp MCP_TRANSPORT=http (regression from #12752)

### DIFF
--- a/kubernetes/apps/mcp-system/arr-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/arr-mcp/app/helmrelease.yaml
@@ -28,6 +28,12 @@ spec:
               repository: ghcr.io/aplaceforallmystuff/mcp-arr
               tag: 1.7.2@sha256:46f2356c2161a8561b6f5680429594cf34aaad0712d1a030f8d662b99556c415
             env:
+              # Stock mcp-arr defaults to stdio transport; the retired
+              # v1.6.5-deadlockfix1 image baked HTTP in as its default. Set it
+              # explicitly so the pod serves Streamable HTTP on :3000 for the
+              # gateway (see #12752, which dropped the custom image).
+              MCP_TRANSPORT: http
+              HOST: 0.0.0.0
               SONARR_URL: http://sonarr.media.svc.cluster.local:8989
               RADARR_URL: http://radarr.media.svc.cluster.local:7878
               LIDARR_URL: http://lidarr.media.svc.cluster.local:8686


### PR DESCRIPTION
## Problem

`arr-mcp` in `mcp-system` has been CrashLoopBackOff (0/1, 27 restarts) since #12752 merged this morning, firing three alerts off one pod: `KubePodCrashLooping`, `KubePodNotReady`, `KubeDeploymentReplicasMismatch`.

## Root cause

#12752 retired the custom `ghcr.io/rwlove/arr-mcp:v1.6.5-deadlockfix1` image in favor of stock `mcp-arr:1.7.2`. The custom image baked **HTTP transport as its default**; stock 1.7.2 defaults to **stdio** unless `MCP_TRANSPORT=http` is set — and that var was declared nowhere (not in the HelmRelease, not in the secret). The pod booted, printed `running over stdio`, found no stdin peer, exited 0, and crashlooped. The Service/HTTPRoute meanwhile still front HTTP on `:3000`, so nothing federated.

Upstream README: `MCP_TRANSPORT=http` selects Streamable HTTP (default stdio); `HOST` defaults to `127.0.0.1`, `PORT` to `3000`.

## Fix

Declare `MCP_TRANSPORT: http` explicitly, plus `HOST: 0.0.0.0` (default `127.0.0.1` won't accept gateway/sidecar traffic).

## Verification

- YAML parses; env block renders the two new keys ahead of the unchanged `*_URL` set.
- Pre-submit hooks pass.
- Post-merge: expect the pod to reach 1/1 and the three kube-state-metrics alerts to clear.