### PR TITLE
feat(cnpg): idle_in_transaction_session_timeout on postgres-home-assistant

### DIFF
--- a/kubernetes/apps/databases/cloudnative-pg/config/home-assistant/cluster.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/home-assistant/cluster.yaml
@@ -20,6 +20,11 @@ spec:
   postgresql:
     parameters:
       timezone: "America/New_York"
+      # Auto-reap connections left idle-in-transaction (5min). Guards against
+      # orphaned backends from ungracefully-killed HA pods holding an xid open
+      # and blocking autovacuum (the client never sends a FIN, so the zombie
+      # sits forever otherwise). 5min is well above HA's normal recorder churn.
+      idle_in_transaction_session_timeout: "300000"
       max_slot_wal_keep_size: 10GB
       shared_buffers: 512MB
       min_wal_size: "1GB"


### PR DESCRIPTION
## Why

Follow-up to the `LongRunningTransaction` alert on `postgres-home-assistant`. Root cause was an **orphaned `idle in transaction` backend** from a prior HA pod that was killed ungracefully — Postgres never received the TCP FIN, so the zombie connection held an xid open (~2h observed 2026-07-01) and blocked autovacuum. Manually terminated to clear the alert; this makes it self-heal.

## Change

Set `idle_in_transaction_session_timeout = 300000` (5min) on the CNPG cluster. Any backend left idle-in-transaction beyond 5min is auto-terminated by Postgres, so an orphaned/leaked connection can no longer wedge autovacuum.

5min is far above HA's normal recorder transaction churn (sub-second), so healthy live connections are never affected.

## Notes

- Rolling parameter — CNPG applies it without a failover (it's not a restart-required GUC).
- No storage/topology change.

## Verification

- YAML parses; parameter renders as `300000`.
- Pre-submit hooks pass.
- Post-merge: `SHOW idle_in_transaction_session_timeout;` on the cluster returns `5min`.