### PR TITLE
feat(smartctl-exporter): warn on drive write-endurance (percentage_used >= 80%)

### DIFF
--- a/kubernetes/apps/observability/exporters/smartctl-exporter/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/exporters/smartctl-exporter/app/prometheusrule.yaml
@@ -76,3 +76,16 @@ spec:
           for: 15m
           labels:
             severity: critical
+        # Wear / endurance leading indicator. available_spare catches
+        # end-of-life; percentage_used warns while there's still runway
+        # to plan a replacement. warning -> Pushover only (no HolmesGPT),
+        # which is right for a "schedule a swap" signal, not an incident.
+        - alert: SmartDeviceEnduranceHigh
+          annotations:
+            summary:
+              Device {{ $labels.device }} on instance {{ $labels.instance }}
+              has used {{ $value }}% of its rated write endurance.
+          expr: smartctl_device_percentage_used >= 80
+          for: 1h
+          labels:
+            severity: warning


### PR DESCRIPTION
## What

Adds a `SmartDeviceEnduranceHigh` alert to the existing smartctl-exporter PrometheusRule.

## Why

The current rule set covers temperature, SMART self-test failure, critical warning, media errors, available-spare threshold, and NVMe interface speed — but nothing on **write endurance**. `available_spare` is an end-of-life signal; `smartctl_device_percentage_used` is the leading indicator, giving runway to plan a replacement before a drive is spent.

Surfaced while verifying smartctl-exporter is healthy: master1's `nvme0n1` (a no-name 1TB) is already at **48%** used, well ahead of the SN570 (osd.1) at **7%**. Nothing would page as either climbs.

## Details

- `expr: smartctl_device_percentage_used >= 80`, `for: 1h`
- `severity: warning` → Pushover only, no HolmesGPT (a "schedule a swap" signal, not an incident)
- Silent at current fleet levels; fires only when there's something to act on

Validated with `kubectl kustomize` (renders clean, 7 rules total).

🤖 Generated with [Claude Code](https://claude.com/claude-code)