### PR TITLE
fix(metrics-server): drop privileged securityContext to upstream hardened defaults

### DIFF
--- a/kubernetes/apps/kube-system/metrics-server/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/metrics-server/app/helmrelease.yaml
@@ -28,13 +28,14 @@ spec:
         cpu: 30m
         memory: 140M
     securityContext:
-      allowPrivilegeEscalation: true
+      allowPrivilegeEscalation: false
       capabilities:
-        add:
-          - CAP_NET_BIND_SERVICE
-          - NET_ADMIN
-          - NET_RAW
-      privileged: true
+        drop:
+          - ALL
+      readOnlyRootFilesystem: true
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
 
     serviceMonitor:
       enabled: true


### PR DESCRIPTION
## Summary

Repo security audit (2026-07) flagged this as the highest-leverage single fix: **metrics-server has been running `privileged: true` with `allowPrivilegeEscalation: true`, `NET_ADMIN`, and `NET_RAW`** — none of which a resource-metrics scraper needs.

`git blame` traces the elevated context to 2022–2023 debug-era commits ("delme", "revert-metrics-server-priv") that were never cleaned up. Upstream metrics-server ships hardened defaults: `readOnlyRootFilesystem: true`, all capabilities dropped, non-root.

## Change

Replace the elevated `securityContext` with the `.agents/instructions/helmrelease.security.md` baseline (matches upstream chart defaults):

- `allowPrivilegeEscalation: false`
- `capabilities.drop: [ALL]`
- `readOnlyRootFilesystem: true`
- `runAsNonRoot: true`
- `seccompProfile: RuntimeDefault`

## Rollout / verification

Non-disruptive — metrics-server restart is routine. Post-merge:
- `kubectl top nodes` / `kubectl top pods` return data
- metrics-server pod Running, no CrashLoop
- `kubectl get apiservice v1beta1.metrics.k8s.io` Available

🤖 Generated with [Claude Code](https://claude.com/claude-code)