### PR TITLE
feat(kyverno): adopt network-policy baseline component

### DIFF
--- a/kubernetes/apps/kyverno/kustomization.yaml
+++ b/kubernetes/apps/kyverno/kustomization.yaml
@@ -5,6 +5,9 @@ kind: Kustomization
 namespace: kyverno
 components:
   - ../../components/alerts
+  # baseline only — default-deny follows the documented audit-soak
+  # process (see components/network-policy/baseline/README.md)
+  - ../../components/network-policy/baseline
 resources:
   - ./namespace.yaml
   - ./kyverno/ks.yaml


### PR DESCRIPTION
## Summary

Repo security audit (2026-07): **kyverno is the only non-exempt namespace without the network-policy baseline component.** The baseline README documents `kube-system` and `flux-system` as intentionally out of scope; kyverno is not listed — this looks like a rollout oversight. Kyverno handles admission for the entire cluster and currently has zero CiliumNetworkPolicies.

## Change

Add `../../components/network-policy/baseline` to `kubernetes/apps/kyverno/kustomization.yaml`, matching the adoption pattern used by the other 23 namespaces (e.g. `observability`).

**Baseline only** — the 5 pure-allow CNPs (apiserver, DNS, host probes, intra-namespace, monitoring scrape). Default-deny is deliberately NOT included; that follows the documented audit-soak process as a separate step.

Verified locally: `kubectl kustomize kubernetes/apps/kyverno` renders the 5 baseline CNPs.

## Post-merge verification

- `flux get ks -A` clean
- `kubectl get cnp -n kyverno` shows the 5 baseline policies
- Kyverno admission still answers: `kubectl get validatingwebhookconfigurations | grep kyverno` + create/label a test resource
- policy-reporter still ingesting

🤖 Generated with [Claude Code](https://claude.com/claude-code)