### PR TITLE
ci: cancel superseded runs on docs and labeler workflows

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -34,6 +34,7 @@ jobs:
     runs-on: arc-runner-set-home-ops
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     steps:
       - name: Generate Token
         if: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -10,6 +10,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   labeler:
     name: Labeler


### PR DESCRIPTION
## Summary

Repo optimization audit (2026-07): several workflows queue superseded runs instead of cancelling them, wasting arc-runner slots on bursty PR days.

## Changes

- **docs.yaml** — already had `concurrency.group`; add `cancel-in-progress: true`. A superseded doc build/deploy is safe to cancel (last push wins; the group is per-ref).
- **labeler.yaml** — no concurrency at all; add per-ref group with cancel.

## Deliberately skipped

- **lychee.yaml** — triggers are weekly cron / manual dispatch / self-file pushes only; no burst potential, concurrency would be dead config.
- **codeql.yml** — security scans should run to completion.
- **bulk-merge-prs.yaml** — manual dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)