### PR TITLE
fix(actions-runner): pin dind sidecar image (was floating :latest)

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/containers.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/containers.yaml
@@ -69,7 +69,7 @@ spec:
                 mountPath: /home/runner/tmpDir
           # The Docker daemon, as a native sidecar (restartPolicy: Always).
           - name: dind
-            image: docker:dind
+            image: docker:29.6.1-dind@sha256:66d292e5c26bd33a6f6f61cacb880de2186339a524ecba1ce098dbbaceed6515
             args:
               - dockerd
               - --host=unix:///var/run/docker.sock


### PR DESCRIPTION
## Summary

Repo audit (2026-07): `kubernetes/apps/actions-runner-system/actions-runner-controller/runners/containers.yaml` used `image: docker:dind` — untagged, so it floats to `:latest`. It was the only unpinned image in the repo. A silent dockerd major-version jump under the CI runners is exactly the kind of drift the digest-pinning convention exists to prevent.

## Change

Pin to the current stable `docker:29.6.1-dind` by tag + manifest digest, matching the repo's `tag@sha256:` convention. Renovate will track and bump it like every other image from here on.

## Verification

- flate/flux-local CI green
- Post-merge: next ARC runner pod pulls the pinned image; `docker version` inside a runner job reports 29.6.1
- Renovate dashboard lists the new dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)