### PR TITLE
feat(pump): v0.0.101 → v0.0.102

### DIFF
--- a/kubernetes/apps/collab/pump/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump/app/helmrelease.yaml
@@ -32,7 +32,7 @@ spec:
           pump:
             image:
               repository: ghcr.io/rwlove/pump
-              tag: v0.0.101@sha256:1527ae0057ab468a1eb5f80fcce5a7e763339293ec9a4b88bc4ace4b1192ebe9
+              tag: v0.0.102@sha256:2d38aa15db713fab72d8d614fd509ba22de41a66bd6522adf6f9ec1a25ec6c3b
 
             env:
               # Activates the /api/cv/* proxy in pump (see internal/web/exercise.go).


### PR DESCRIPTION
Digest bump to [pump-v0.0.102](https://github.com/rwlove/PUMP/releases/tag/pump-v0.0.102) — the full optimization/simplification pass (PUMP PRs #45–#60).

Includes **schema migration v9** (index-only, idempotent, applies automatically on pod start — verified against a prod dump: v8→v9 applies cleanly, re-run is a no-op, no data touched).

Visible UI changes (revertable individually upstream): theme-token chart colors, 44px touch targets on phones, admin/exercise nav links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)