### PR TITLE
docs: sweep oauth2-proxy references after the extAuth migration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ home-ops/
 | Service mesh  | Istio                        | mTLS + traffic mgmt for mcp-system               |
 | DNS           | external-dns                 | Cloudflare + bind9 split-horizon                 |
 | Tunnel        | cloudflared                  | Public ingress without exposing home WAN         |
-| AuthN/Z       | Authelia + oauth2-proxy      | OIDC SSO; ~24 oauth2-proxy instances             |
+| AuthN/Z       | Authelia + Envoy extAuth     | SSO via per-route SecurityPolicy ext-authz       |
 | Secrets       | external-secrets + 1Password | Secret management (109 ExternalSecrets)          |
 | Storage       | Rook/Ceph, Longhorn, Garage  | Tiered durable storage; see `storage-class` instr |
 | Databases     | CloudNative-PG               | 24+ Postgres clusters with Garage Barman backup  |

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Storage tiers are picked deliberately per workload — see [`storage-class.instr
 | **DNS**          | external-dns                        | Cloudflare + bind9 split-horizon                      |
 | **TLS**          | cert-manager                        | Let's Encrypt + internal CA                           |
 | **Tunnel**       | cloudflared                         | Public ingress without exposing home WAN              |
-| **AuthN/Z**      | Authelia + oauth2-proxy             | OIDC SSO; 24 oauth2-proxy instances gate apps         |
+| **AuthN/Z**      | Authelia + Envoy extAuth            | SSO; per-route `SecurityPolicy` ext-authz gates apps  |
 | **Secrets**      | External Secrets Operator + 1Password | 116 ExternalSecrets, zero plain-text in Git         |
 | **VPN**          | wg-easy                             | Operator OOB WireGuard access                         |
 | **Storage**      | Rook-Ceph, Longhorn, Garage, direct NFS | Tiered by durability requirement                  |
@@ -184,7 +184,7 @@ Worker nodes attach to **iot** and **sec** VLANs via Multus for direct camera an
 | **Ollama** (P40) | Local LLM serving on the Pascal P40 (≤8b-class models, embeddings) |
 | **Ollama Spark** | LLM serving on Spark/GB10 (qwen3-next:80b-a3b-instruct-q4_K_M for the agent fleet + HolmesGPT + Open WebUI, bge-m3 embeddings) |
 | **ComfyUI** | Image generation workflows |
-| **Khoj** + **khoj-oauth2-proxy** | Personal AI assistant over notes + docs (Authelia-gated) |
+| **Khoj** | Personal AI assistant over notes + docs (Authelia extAuth-gated) |
 | **LangGraph Agents** | Custom multi-agent runtime (`rwlove/langgraph-agents`, version pinned in `helmrelease.yaml`); Postgres-checkpointed with live `task_queue` + `task_dlq` substrate; MCP-gateway client. See **AI architecture** section below. |
 | **Langfuse** | LLM observability — OTLP trace sink for the langgraph-agents fleet (CNPG-backed; ClickHouse/Valkey/MinIO bundled) |
 | **Paperless-AI** | Auto-tagging for paperless-ngx |
@@ -241,7 +241,7 @@ Worker nodes attach to **iot** and **sec** VLANs via Multus for direct camera an
 | **cloudflared** | Public tunnel without exposed WAN |
 | **Authelia** | OIDC identity provider |
 | **LLDAP** | Lightweight LDAP directory backing Authelia |
-| **oauth2-proxy** | 24 instances gating per-app SSO |
+| **extAuth SecurityPolicies** | per-route Authelia ext-authz gating app SSO |
 | **wg-easy** | Primary OOB WireGuard access |
 | **External Secrets Operator** | 1Password-backed secret materialization |
 | **Flux2** | GitOps reconciler |
@@ -524,7 +524,7 @@ All 116 ExternalSecrets resolve through External Secrets Operator from 1Password
 
 ### 🪪 Authentication — single sign-on everywhere
 
-Authelia (with LLDAP) is the OIDC identity provider; per-app oauth2-proxy instances enforce auth at Envoy Gateway. 24 apps sit behind SSO today. The mcp-gateway validates Authelia-issued JWTs with a daily-rotated signing key for MCP tooling.
+Authelia (with LLDAP) is the identity provider; per-route Envoy Gateway `SecurityPolicy` extAuth (Authelia's ext-authz endpoint) enforces auth at the gateway — 26 apps sit behind SSO today, tiered admin vs household via `access_control` rules (the oauth2-proxy sidecar fleet was retired 2026-07-01, #12767). Native-OIDC apps (immich, paperless, open-webui, …) authenticate against Authelia directly. The mcp-gateway validates Authelia-issued JWTs with a daily-rotated signing key for MCP tooling.
 
 ### 🔭 Observability — metrics, logs, AI triage
 

--- a/docs/src/ai_architecture.md
+++ b/docs/src/ai_architecture.md
@@ -103,7 +103,7 @@ only fires once Langfuse keys are populated in 1Password).
 | HA voice ("inbox …") | Whisper STT → ollama_voice conversation → HA `rest_command` → Authelia-JWT POST | Windmill `langgraph-inbox.ts` (`kubernetes/apps/home/windmill/workflows/langgraph-inbox.ts:42`) |
 | Zulip DM to Triager bot | Outgoing-webhook (bot_type=3) | Windmill `zulip-triager-webhook.ts` → forwards to `langgraph-inbox.ts` |
 | Open WebUI chat | Browser → Authelia OIDC → Open WebUI backend | Routes to ollama-spark (default) or to a langgraph agent via OpenAI-compat API (`kubernetes/apps/collab/open-webui/app/helmrelease.yaml:41-46`) |
-| Khoj UI | Browser → khoj-oauth2-proxy → khoj | Khoj's own embedding pipeline; chat via ollama P40 |
+| Khoj UI | Browser → gateway extAuth (Authelia) → khoj | Khoj's own embedding pipeline; chat via ollama P40 |
 | AlertManager firing alert | Webhook receiver | Windmill `alertmanager-holmesgpt-notify.ts` → HolmesGPT `/investigate` |
 | Operator tap on ntfy | Action button → HMAC-signed URL | `langgraph-agents` `/approval` endpoint (`kubernetes/apps/ai/langgraph-agents/app/route-approval.yaml`) |
 | Cron — daily digest / DLQ / cost-cap / awaiting-user / workaround | Windmill scheduled trigger | Each `.ts` workflow under `kubernetes/apps/home/windmill/workflows/` |
@@ -340,7 +340,7 @@ secret is mirrored into the `ai` namespace by emberstack reflector
 ## File reference (quick index)
 
 - **Khoj** — `kubernetes/apps/ai/khoj/app/helmrelease.yaml`
-- **khoj-oauth2-proxy** — `kubernetes/apps/ai/khoj-oauth2-proxy/`
+- **khoj extAuth** — `SecurityPolicy` in `kubernetes/apps/ai/khoj/` (oauth2-proxy retired 2026-07-01, #12767)
 - **langfuse** — `kubernetes/apps/ai/langfuse/app/helmrelease.yaml`
 - **langgraph-agents** — `kubernetes/apps/ai/langgraph-agents/app/helmrelease.yaml`
 - **ollama** (P40) — `kubernetes/apps/ai/ollama/app/`

--- a/docs/src/audit/repo-audit-2026-07-01.md
+++ b/docs/src/audit/repo-audit-2026-07-01.md
@@ -36,7 +36,7 @@ Ordered by priority. Each issue carries the full plan.
 
 | # | Item | Theme |
 |---|---|---|
-| [#12767](https://github.com/rwlove/home-ops/issues/12767) | Migrate the 26 oauth2-proxy sidecars to Envoy Gateway `SecurityPolicy` extAuth via Authelia — retires ~4,900 lines, 26 Deployments, 26 OIDC clients. Piloted on one app first. | simplification + security |
+| [#12767](https://github.com/rwlove/home-ops/issues/12767) | Migrate the 26 oauth2-proxy sidecars to Envoy Gateway `SecurityPolicy` extAuth via Authelia — retires ~4,900 lines, 26 Deployments, 26 OIDC clients. **Done 2026-07-01** (pilot #12779, fleet #12780, 1P cleanup same evening). | simplification + security |
 | [#12768](https://github.com/rwlove/home-ops/issues/12768) | Default `SecurityPolicy` on the external gateway with explicit public-route exemptions (defense-in-depth; depends on #12767). | security |
 | [#12769](https://github.com/rwlove/home-ops/issues/12769) | Audit `privileged: true` on the four AI GPU workloads — likely only need device-plugin requests. | security |
 | [#12770](https://github.com/rwlove/home-ops/issues/12770) | Backfill the securityContext baseline on the 23 app-template HelmReleases that have none (lldap and the mutating webhook first). | security |

--- a/docs/src/homeaiops_dod.md
+++ b/docs/src/homeaiops_dod.md
@@ -550,7 +550,7 @@ The Stage 1 baseline, captured before stabilization work begins.
 
 - langgraph-agents (0.2.33, 0 restarts at audit time)
 - ollama, ollama-spark, tei-spark
-- khoj + khoj-oauth2-proxy
+- khoj (gateway extAuth-gated)
 - All 16 MCP servers reachable through `mcp-gateway`
 - HolmesGPT, claude-runner (cron-driven, no live pod required)
 - AlertManager (18d uptime)

--- a/docs/src/khoj.md
+++ b/docs/src/khoj.md
@@ -13,10 +13,10 @@
 
 ## Where it lives
 
-`kubernetes/apps/ai/khoj/` and `kubernetes/apps/ai/khoj-oauth2-proxy/`:
+`kubernetes/apps/ai/khoj/`:
 
 - **Pod**: `ghcr.io/khoj-ai/khoj:2.0.0-beta.28`, port 42110
-- **External hostname**: `khoj.${SECRET_DOMAIN}` behind Authelia (oauth2-proxy gate, household auth)
+- **External hostname**: `khoj.${SECRET_DOMAIN}` behind Authelia (gateway extAuth `SecurityPolicy`, admin tier; `/api/*` bypasses gateway auth for khoj API tokens)
 - **Internal mode**: `--anonymous-mode` (every request is the auto-bootstrapped "default" user — safe because oauth2 is the gate)
 - **Database**: `postgres-khoj` (CNPG 3-replica, pgvector embeddings)
 - **PVCs**: `khoj-config` (`/root/.khoj/`), `khoj-models` (`/root/.cache/` for sentence-transformer downloads)

--- a/docs/src/networkpolicy_rollout_plan.md
+++ b/docs/src/networkpolicy_rollout_plan.md
@@ -4,6 +4,15 @@ Status: **19 of 21 in-scope namespaces locked down (default-deny enforced). `dow
 Owner: home-ops
 Last updated: 2026-05-18
 
+> **2026-07-01 update:** the oauth2-proxy fleet this plan references was
+> retired (#12767) — auth now rides per-route Envoy Gateway extAuth
+> SecurityPolicies against Authelia. Mentions of oauth2-proxy CNPs and
+> the proxy → authelia callback chain below are historical. For the
+> remaining default-deny flips (`downloads`, `collab`), validate the
+> gateway flow instead: unauthenticated request → 302 to the portal,
+> login → app loads (no in-namespace proxy hop; envoy-from-network is
+> the ingress source to allow).
+
 ## Decisions (locked)
 
 1. **`flux-system` and `kube-system` are out of scope.** Neither

--- a/docs/src/pod_security_audit.md
+++ b/docs/src/pod_security_audit.md
@@ -51,6 +51,11 @@ count.
 
 ### A1. oauth2-proxy HelmReleases (24 instances, all violate everything)
 
+> **Resolved twice over:** the fleet was hardened with the full baseline
+> securityContext (PRs #11600/#11607), then retired entirely on
+> 2026-07-01 in favor of gateway extAuth SecurityPolicies (#12767) —
+> zero oauth2-proxy pods remain.
+
 `quay.io/oauth2-proxy/oauth2-proxy` containers across 24 HelmReleases
 have **zero** `securityContext` set. The binary is a stateless
 reverse proxy — runs fine as non-root, doesn't write to rootfs, doesn't

--- a/docs/src/stage2_gap_analysis.md
+++ b/docs/src/stage2_gap_analysis.md
@@ -346,7 +346,7 @@ Rob answered Q1-Q5:
 
 1. **Q1 = (a) sync poll.** CLI polls `GET /admin/tasks/<id>/result` until terminal status. Defer SSE to v2.
 2. **Q2 = (a) separate `todo` table.** Distinct lifecycle from `task_queue`.
-3. **Q3 = (a) cloudflared / Authelia.** Public surface from day one — `hai.${SECRET_DOMAIN}` behind Authelia + oauth2-proxy, same pattern as Open WebUI / Khoj / etc. This changes the build plan: a new HTTPRoute for `/admin/*`, new oauth2-proxy instance (or reuse Open WebUI's), DNS via external-dns. The CLI uses a long-lived API token stored at `~/.config/hai/token`; minting flow TBD (likely a one-time `hai auth login` device flow, or operator-issued static token to start).
+3. **Q3 = (a) cloudflared / Authelia.** *(2026-07-01: shipped as gateway extAuth SecurityPolicies on the `hai`/`hai-web` routes rather than an oauth2-proxy instance — the fleet was retired in #12767; `/admin/*` + `/inbox` ride a policy-less public route with app-level auth.)* Public surface from day one — `hai.${SECRET_DOMAIN}` behind Authelia + oauth2-proxy, same pattern as Open WebUI / Khoj / etc. This changes the build plan: a new HTTPRoute for `/admin/*`, new oauth2-proxy instance (or reuse Open WebUI's), DNS via external-dns. The CLI uses a long-lived API token stored at `~/.config/hai/token`; minting flow TBD (likely a one-time `hai auth login` device flow, or operator-issued static token to start).
 4. **Q4 = (a) live in `langgraph-agents` repo.** CLI ships as a console_script in `pyproject.toml`.
 5. **Q5 = (b) pragmatic dogfood.** Acceptance is Rob's credible end-of-day "I used `hai` for everything I'd have asked Claude Code." No instrumented metric.
 


### PR DESCRIPTION
## Summary

Follow-up to #12780 — the fleet migration left 8 docs + README + CLAUDE.md still describing the oauth2-proxy architecture. Per the repo's docs-update-with-the-change rule this belonged in that PR; sweeping it now.

**Living docs — rewritten to current reality:**
- README (tech table, component list, SSO paragraph), CLAUDE.md tech table → "Authelia + Envoy extAuth", per-route SecurityPolicy ext-authz, admin/household tiers
- ai_architecture.md, khoj.md, homeaiops_dod.md → khoj gated by gateway extAuth (and its /api token bypass documented)
- 2026-07 audit page → #12767 roadmap row marked done

**Point-in-time docs — history kept, dated notes added:**
- networkpolicy_rollout_plan.md → note corrects the validation guidance for the remaining downloads/collab default-deny flips (validate the gateway 302 flow; envoy-from-network is the ingress source, the proxy callback chain no longer exists)
- pod_security_audit.md finding A1 → resolved twice over (hardened #11600/#11607, then retired #12767)
- stage2_gap_analysis.md Q3 → shipped as extAuth, not an oauth2-proxy instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)