### PR TITLE
feat(network): default extAuth on the external gateway https listener

### DIFF
--- a/kubernetes/apps/ai/langgraph-agents/app/kustomization.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./securitypolicy-langgraph-agents-approval-public.yaml
   - ./securitypolicy-hai.yaml
   - ./httproute-hai.yaml
   - ./backendtrafficpolicy.yaml

--- a/kubernetes/apps/ai/langgraph-agents/app/securitypolicy-langgraph-agents-approval-public.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/app/securitypolicy-langgraph-agents-approval-public.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/gateway.envoyproxy.io/securitypolicy_v1alpha1.json
+#
+# Deliberate PUBLIC exemption from the external gateway's default
+# extAuth (#12768): approval links carry pre-signed single-use HMAC tokens (see
+# route-approval.yaml); a login wall would break approve-from-phone.
+# With mergeType unset, this most-specific policy fully overrides the
+# gateway-level extAuth for this route (per the SecurityPolicy CRD).
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: langgraph-agents-approval-public
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: langgraph-agents-approval
+  authorization:
+    defaultAction: Allow

--- a/kubernetes/apps/auth/authelia/app/kustomization.yaml
+++ b/kubernetes/apps/auth/authelia/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./securitypolicy-public.yaml
   - ./cnp-allow.yaml
   - ./configmap.yaml
   - ./externalsecret.yaml

--- a/kubernetes/apps/auth/authelia/app/referencegrant.yaml
+++ b/kubernetes/apps/auth/authelia/app/referencegrant.yaml
@@ -26,6 +26,10 @@ spec:
     - group: gateway.envoyproxy.io
       kind: SecurityPolicy
       namespace: media
+    # network: the external gateway's default extAuth policy (#12768).
+    - group: gateway.envoyproxy.io
+      kind: SecurityPolicy
+      namespace: network
     - group: gateway.envoyproxy.io
       kind: SecurityPolicy
       namespace: observability

--- a/kubernetes/apps/auth/authelia/app/securitypolicy-public.yaml
+++ b/kubernetes/apps/auth/authelia/app/securitypolicy-public.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/gateway.envoyproxy.io/securitypolicy_v1alpha1.json
+#
+# Deliberate PUBLIC exemption from the external gateway's default
+# extAuth (#12768): the auth portal itself — extAuth here would redirect to itself.
+# With mergeType unset, this most-specific policy fully overrides the
+# gateway-level extAuth for this route (per the SecurityPolicy CRD).
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: authelia-public
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: authelia
+  authorization:
+    defaultAction: Allow

--- a/kubernetes/apps/collab/obsidian-couchdb/app/kustomization.yaml
+++ b/kubernetes/apps/collab/obsidian-couchdb/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./securitypolicy-public.yaml
   - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/collab/obsidian-couchdb/app/securitypolicy-public.yaml
+++ b/kubernetes/apps/collab/obsidian-couchdb/app/securitypolicy-public.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/gateway.envoyproxy.io/securitypolicy_v1alpha1.json
+#
+# Deliberate PUBLIC exemption from the external gateway's default
+# extAuth (#12768): Obsidian LiveSync clients authenticate with CouchDB credentials;
+# no browser session exists on the sync path.
+# With mergeType unset, this most-specific policy fully overrides the
+# gateway-level extAuth for this route (per the SecurityPolicy CRD).
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: obsidian-couchdb-public
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: obsidian-couchdb
+  authorization:
+    defaultAction: Allow

--- a/kubernetes/apps/collab/zulip/app/kustomization.yaml
+++ b/kubernetes/apps/collab/zulip/app/kustomization.yaml
@@ -3,6 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./securitypolicy-public.yaml
   - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/collab/zulip/app/securitypolicy-public.yaml
+++ b/kubernetes/apps/collab/zulip/app/securitypolicy-public.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/gateway.envoyproxy.io/securitypolicy_v1alpha1.json
+#
+# Deliberate PUBLIC exemption from the external gateway's default
+# extAuth (#12768): Zulip enforces its own auth; mobile/desktop clients and incoming
+# webhook bots cannot carry an Authelia session.
+# With mergeType unset, this most-specific policy fully overrides the
+# gateway-level extAuth for this route (per the SecurityPolicy CRD).
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: zulip-public
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: zulip
+  authorization:
+    defaultAction: Allow

--- a/kubernetes/apps/flux-system/flux-instance/app/github/webhooks/kustomization.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/github/webhooks/kustomization.yaml
@@ -3,6 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./securitypolicy-public.yaml
   - ./allow-webhooks-from-gateway.yaml
   - ./externalsecret.yaml
   - ./httproute.yaml

--- a/kubernetes/apps/flux-system/flux-instance/app/github/webhooks/securitypolicy-public.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/github/webhooks/securitypolicy-public.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/gateway.envoyproxy.io/securitypolicy_v1alpha1.json
+#
+# Deliberate PUBLIC exemption from the external gateway's default
+# extAuth (#12768): GitHub delivers HMAC-signed webhooks; the Receiver validates the
+# signature. GitHub cannot log in.
+# With mergeType unset, this most-specific policy fully overrides the
+# gateway-level extAuth for this route (per the SecurityPolicy CRD).
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: github-webhook-public
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: github-webhook
+  authorization:
+    defaultAction: Allow

--- a/kubernetes/apps/home/home-assistant/app/kustomization.yaml
+++ b/kubernetes/apps/home/home-assistant/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./securitypolicy-public.yaml
   - ./cnp-allow.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/home/home-assistant/app/securitypolicy-public.yaml
+++ b/kubernetes/apps/home/home-assistant/app/securitypolicy-public.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/gateway.envoyproxy.io/securitypolicy_v1alpha1.json
+#
+# Deliberate PUBLIC exemption from the external gateway's default
+# extAuth (#12768): HA enforces its own auth; the companion app, voice satellites and
+# inbound webhooks cannot carry an Authelia session.
+# With mergeType unset, this most-specific policy fully overrides the
+# gateway-level extAuth for this route (per the SecurityPolicy CRD).
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: home-assistant-public
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: home-assistant
+  authorization:
+    defaultAction: Allow

--- a/kubernetes/apps/home/ntfy/app/kustomization.yaml
+++ b/kubernetes/apps/home/ntfy/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./securitypolicy-public.yaml
   - ./cnp-allow.yaml
   - ./helmrelease.yaml
   - ./pvc.yaml

--- a/kubernetes/apps/home/ntfy/app/securitypolicy-public.yaml
+++ b/kubernetes/apps/home/ntfy/app/securitypolicy-public.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/gateway.envoyproxy.io/securitypolicy_v1alpha1.json
+#
+# Deliberate PUBLIC exemption from the external gateway's default
+# extAuth (#12768): public notification pub/sub by design; publishers use ntfy access
+# tokens where needed.
+# With mergeType unset, this most-specific policy fully overrides the
+# gateway-level extAuth for this route (per the SecurityPolicy CRD).
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: ntfy-public
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: ntfy
+  authorization:
+    defaultAction: Allow

--- a/kubernetes/apps/media/gonic/app/kustomization.yaml
+++ b/kubernetes/apps/media/gonic/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./securitypolicy-public.yaml
   - ./cnp-allow.yaml
   - ./helmrelease.yaml
   - ./longhorn-pvc.yaml

--- a/kubernetes/apps/media/gonic/app/securitypolicy-public.yaml
+++ b/kubernetes/apps/media/gonic/app/securitypolicy-public.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/gateway.envoyproxy.io/securitypolicy_v1alpha1.json
+#
+# Deliberate PUBLIC exemption from the external gateway's default
+# extAuth (#12768): subsonic clients authenticate with per-user token+salt on every
+# request; no browser session exists.
+# With mergeType unset, this most-specific policy fully overrides the
+# gateway-level extAuth for this route (per the SecurityPolicy CRD).
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: gonic-public
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: gonic
+  authorization:
+    defaultAction: Allow

--- a/kubernetes/apps/media/immich/app/kustomization.yaml
+++ b/kubernetes/apps/media/immich/app/kustomization.yaml
@@ -3,6 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./securitypolicy-public.yaml
   - ./cnp-allow.yaml
   - ./cronjob-offsite-backup.yaml
   - ./externalsecret-offsite-backup.yaml

--- a/kubernetes/apps/media/immich/app/securitypolicy-public.yaml
+++ b/kubernetes/apps/media/immich/app/securitypolicy-public.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/gateway.envoyproxy.io/securitypolicy_v1alpha1.json
+#
+# Deliberate PUBLIC exemption from the external gateway's default
+# extAuth (#12768): immich enforces its own auth; the mobile app (API key) and public
+# shared links cannot carry an Authelia session.
+# With mergeType unset, this most-specific policy fully overrides the
+# gateway-level extAuth for this route (per the SecurityPolicy CRD).
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: immich-public
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: immich
+  authorization:
+    defaultAction: Allow

--- a/kubernetes/apps/network/envoy-gateway/config/kustomization.yaml
+++ b/kubernetes/apps/network/envoy-gateway/config/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - ./external.yaml
   - ./internal.yaml
   - ./podmonitor.yaml
+  - ./securitypolicy-external.yaml

--- a/kubernetes/apps/network/envoy-gateway/config/securitypolicy-external.yaml
+++ b/kubernetes/apps/network/envoy-gateway/config/securitypolicy-external.yaml
@@ -1,0 +1,48 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/gateway.envoyproxy.io/securitypolicy_v1alpha1.json
+#
+# Default extAuth on the external gateway's https listener (#12768).
+# Any HTTPRoute that attaches WITHOUT its own SecurityPolicy is gated
+# by Authelia — closing the "every new external route must remember to
+# bring auth" gap found in the 2026-07 repo audit. Intentionally-public
+# routes each carry an explicit `<route>-public` SecurityPolicy
+# (authorization defaultAction Allow) that, with mergeType unset, fully
+# overrides this policy for that route (per the SecurityPolicy CRD:
+# "only the most specific configuration takes effect").
+#
+# sectionName pins this to the https listener so the http→https
+# redirect route keeps working unauthenticated.
+#
+# Note: Authelia's access_control has default_policy deny — a new
+# domain passing through this extAuth is still denied until a rule in
+# auth/authelia/app/configmap.yaml lists it. Defense in depth: new
+# route → 302 to portal → denied post-login until deliberately opened.
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: external-default-extauth
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: external
+      sectionName: https
+  extAuth:
+    failOpen: false
+    headersToExtAuth:
+      - accept
+      - cookie
+      - authorization
+      - proxy-authorization
+      - x-forwarded-proto
+    http:
+      backendRefs:
+        - name: authelia
+          namespace: auth
+          port: 9091
+      path: /api/authz/ext-authz/
+      headersToBackend:
+        - Remote-User
+        - Remote-Groups
+        - Remote-Name
+        - Remote-Email

--- a/kubernetes/apps/observability/kromgo/app/kustomization.yaml
+++ b/kubernetes/apps/observability/kromgo/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./securitypolicy-public.yaml
   - ./cnp-allow.yaml
   - ./helmrelease.yaml
 configMapGenerator:

--- a/kubernetes/apps/observability/kromgo/app/securitypolicy-public.yaml
+++ b/kubernetes/apps/observability/kromgo/app/securitypolicy-public.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/gateway.envoyproxy.io/securitypolicy_v1alpha1.json
+#
+# Deliberate PUBLIC exemption from the external gateway's default
+# extAuth (#12768): serves the public README badge endpoints; must stay anonymous.
+# With mergeType unset, this most-specific policy fully overrides the
+# gateway-level extAuth for this route (per the SecurityPolicy CRD).
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: kromgo-public
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: kromgo
+  authorization:
+    defaultAction: Allow

--- a/kubernetes/apps/selfhosted/webhook/app/kustomization.yaml
+++ b/kubernetes/apps/selfhosted/webhook/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 components:
   - ../../../../components/repos/app-template
 resources:
+  - ./securitypolicy-public.yaml
   - ./cnp-allow-from-gateway.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/selfhosted/webhook/app/securitypolicy-public.yaml
+++ b/kubernetes/apps/selfhosted/webhook/app/securitypolicy-public.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/gateway.envoyproxy.io/securitypolicy_v1alpha1.json
+#
+# Deliberate PUBLIC exemption from the external gateway's default
+# extAuth (#12768): Renovate/GitHub deliver HMAC-signed webhooks; signature is
+# validated app-side.
+# With mergeType unset, this most-specific policy fully overrides the
+# gateway-level extAuth for this route (per the SecurityPolicy CRD).
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: webhook-public
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: webhook
+  authorization:
+    defaultAction: Allow


### PR DESCRIPTION
## Summary

Closes #12768 (2026-07 audit finding H1). The `external` Gateway previously had no gateway-level auth — every route trusted its own app, and nothing forced a new route to remember auth. Now:

- **`external-default-extauth`** SecurityPolicy targets the gateway's `https` listener (sectionName spares the http→https redirect): any route without its own policy gets Authelia extAuth, `failOpen: false`.
- **11 explicit `<route>-public` exemptions** — one per currently-attached route, each documenting why it's deliberately public (HMAC webhooks ×2, the auth portal itself, HA companion-app/webhooks, immich mobile/shared links, zulip clients, obsidian-couchdb sync, subsonic token auth, ntfy pub/sub, kromgo README badges, langgraph approval links). Per the SecurityPolicy CRD, with `mergeType` unset "only the most specific configuration takes effect" — the exemption fully overrides the gateway default, so **this PR is a strict no-op for existing traffic**.
- Defense in depth: Authelia `access_control` is default-deny, so even a login on an unlisted new domain is denied until the domain is deliberately added.
- ReferenceGrant in `auth` gains the `network` namespace for the gateway policy's backendRef.

## Post-merge verification (all must be non-302 / unchanged)

1. `SecurityPolicy` external-default-extauth + 11 `-public` policies all `Accepted`
2. Public surfaces still answer anonymously: flux-webhook (4xx from Receiver, not 302), ntfy 200, kromgo badge 200, gonic subsonic ping, HA /api, immich /api/server/ping, zulip 200, obsidian 401-from-couchdb, auth portal 200, renovate-webhook 4xx-from-app, langgraph approval 401/410-from-app
3. Negative test: temporary hostname on the external gateway without a policy → 302 to portal

## Risk

If override semantics were wrong this would break Renee-facing mobile apps — mitigated by the CRD-documented override behavior and immediate post-merge probes of all 11 surfaces; instant revert path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)