### PR TITLE
feat(security): backfill securityContext baseline — batch 1 of #12770

### DIFF
--- a/kubernetes/apps/auth/lldap/app/helmrelease.yaml
+++ b/kubernetes/apps/auth/lldap/app/helmrelease.yaml
@@ -13,6 +13,14 @@ spec:
     controllers:
       lldap:
         pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            # /data is an emptyDir (key material via env); fsGroup keeps
+            # it writable for the non-root UID.
+            fsGroup: 1000
+            fsGroupChangePolicy: OnRootMismatch
           topologySpreadConstraints:
             - maxSkew: 1
               topologyKey: kubernetes.io/hostname
@@ -35,6 +43,14 @@ spec:
             envFrom: &envFrom
               - secretRef:
                   name: *app
+            securityContext: &hardened
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+              seccompProfile:
+                type: RuntimeDefault
 
         containers:
           app:
@@ -61,6 +77,7 @@ spec:
                 memory: 64M
               limits:
                 memory: 64M
+            securityContext: *hardened
 
     service:
       app:

--- a/kubernetes/apps/collab/kitchenowl/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/kitchenowl/app/helmrelease.yaml
@@ -13,6 +13,13 @@ spec:
   values:
     controllers:
       kitchenowl:
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            fsGroupChangePolicy: OnRootMismatch
         type: statefulset
 
         containers:
@@ -37,6 +44,14 @@ spec:
                 memory: 256Mi
               limits:
                 memory: 512Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+              seccompProfile:
+                type: RuntimeDefault
 
     service:
       app:
@@ -68,3 +83,7 @@ spec:
         existingClaim: kitchenowl-data-pvc
         globalMounts:
           - path: /data
+      tmpfs:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/collab/nametag/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/nametag/app/helmrelease.yaml
@@ -13,6 +13,13 @@ spec:
   values:
     controllers:
       nametag:
+        pod:
+          # image USER is 1001 — match it (baseline default 1000 would
+          # fight the image's chown'd /app files).
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+            runAsGroup: 1001
         annotations:
           reloader.stakater.com/auto: "true"
 
@@ -26,6 +33,14 @@ spec:
             envFrom: &envFrom
               - secretRef:
                   name: nametag-secret
+            securityContext: &hardened
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+              seccompProfile:
+                type: RuntimeDefault
 
         containers:
           app:
@@ -46,6 +61,7 @@ spec:
                 memory: 200Mi
               limits:
                 memory: 200Mi
+            securityContext: *hardened
 
     service:
       app:
@@ -71,3 +87,8 @@ spec:
           - backendRefs:
               - identifier: app
                 port: *httpPort
+    persistence:
+      tmpfs:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/network/whoami/app/helmrelease.yaml
+++ b/kubernetes/apps/network/whoami/app/helmrelease.yaml
@@ -13,6 +13,11 @@ spec:
   values:
     controllers:
       whoami:
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
         annotations:
           reloader.stakater.com/auto: "true"
 
@@ -30,6 +35,14 @@ spec:
                 memory: 80M
               limits:
                 memory: 80M
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+              seccompProfile:
+                type: RuntimeDefault
 
     service:
       app:

--- a/kubernetes/apps/observability/kube-ops-view/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-ops-view/app/helmrelease.yaml
@@ -16,6 +16,11 @@ spec:
 
     controllers:
       kube-ops-view:
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
         serviceAccount:
           identifier: kube-ops-view
 
@@ -32,6 +37,14 @@ spec:
                 memory: 256Mi
               limits:
                 memory: 384Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+              seccompProfile:
+                type: RuntimeDefault
 
 
     service:
@@ -61,3 +74,8 @@ spec:
                 port: *httpPort
     serviceAccount:
       kube-ops-view: {}
+    persistence:
+      tmpfs:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp


### PR DESCRIPTION
## Summary

First batch of #12770 (2026-07 audit M1): 5 of the 22 app-template HelmReleases running with no `securityContext` at all, picked for value and verified feasibility — including **lldap** (the identity store behind Authelia, highest-value target).

Per-app notes (live UIDs probed before writing):

| App | Was | Now | Notes |
|---|---|---|---|
| lldap | root | 1000, hardened | fsGroup for the /data emptyDir; init-db hardened too |
| whoami | root (scratch image) | 1000, hardened | static binary, :8080 |
| kube-ops-view | root | 1000, hardened | tmpfs /tmp for python scratch |
| nametag | 1001 (image USER) | pinned 1001, hardened | baseline-default 1000 would fight the image |
| kitchenowl | root | 1000, hardened | fsGroup on the /data PVC; tmpfs /tmp |

## Deferred with reasons

- **it-tools** — nginx binds :80 in-container; non-root needs the unprivileged image variant (port 8080) first
- **vector aggregator, kustomize-mutating-webhook** — not app-template; their charts need their own values shapes
- Remaining 14 gap apps → batches 2-3

## Risk / rollout

**lldap is the SPOF here** — if it fails to start non-root, Authelia logins break (existing sessions survive; extAuth checks against live sessions keep working). lldap runs 2 replicas with RollingUpdate, so a bad rollout halts at the first replica without dropping service. Post-merge verification below runs immediately; instant revert path.

## Post-merge verification

1. All 5 pods Running non-root (`kubectl get pod -o jsonpath` runAsUser / `id -u` where exec exists)
2. lldap: both replicas Ready, Authelia login round-trip works (portal login → 302 rd completes)
3. kitchenowl loads + existing data intact; nametag, whoami, kube-ops-view answer
4. No CrashLoop / OOM across the 5

Part of #12770

🤖 Generated with [Claude Code](https://claude.com/claude-code)