### PR TITLE
fix(lldap): bypass image entrypoint to complete the non-root rollout

### DIFF
--- a/kubernetes/apps/auth/lldap/app/helmrelease.yaml
+++ b/kubernetes/apps/auth/lldap/app/helmrelease.yaml
@@ -71,6 +71,15 @@ spec:
 
             envFrom: *envFrom
 
+            # Bypass the image entrypoint: it chowns /app + copies a
+            # template config into /data before gosu-dropping to $UID,
+            # which dies under runAsNonRoot + readOnlyRootFilesystem
+            # (PR #12785 rollout halted on this). The binary itself is
+            # rootless-clean — config is fully env-driven, the missing
+            # config file is tolerated, and the server key comes from
+            # LLDAP_SERVER_KEY_SEED (verified live in-pod 2026-07-02).
+            command: ["/app/lldap", "run"]
+
             resources:
               requests:
                 cpu: 15m


### PR DESCRIPTION
## Summary

Completes the lldap hardening from #12785. The new non-root replica CrashLooped because the image entrypoint runs `chown /app` + copies a template config into /data + gosu-drops — all impossible (and all unnecessary) under `runAsNonRoot` + `readOnlyRootFilesystem`. **No outage occurred**: RollingUpdate halted on the first replica; both old root replicas kept serving LDAP throughout.

## Fix

`command: ["/app/lldap", "run"]` — run the binary directly. Verified live in the old pod before writing this (alternate ports, no clash): config is fully env-driven, the absent config file is tolerated, the server key comes from `LLDAP_SERVER_KEY_SEED`, and the DB is postgres — the entrypoint's three jobs are all obsolete here.

## Post-merge verification

1. New ReplicaSet rolls both replicas to Running/Ready, `id -u` = 1000
2. Authelia login round-trip works (LDAP bind path)
3. Old CrashLoop ReplicaSet garbage-collected

🤖 Generated with [Claude Code](https://claude.com/claude-code)