### PR TITLE
feat(pump-cv): v0.5.1 → v0.5.2

### DIFF
--- a/kubernetes/apps/collab/pump-cv/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump-cv/app/helmrelease.yaml
@@ -83,7 +83,7 @@ spec:
           pump-cv:
             image:
               repository: ghcr.io/rwlove/pump-cv
-              tag: v0.5.1@sha256:5d71555e4f62dd131a337ee911aff1c97e301ec3ebc0ca510c60a90c2c511f22
+              tag: v0.5.2@sha256:4f250d23d5c4d2f4b1ab98079be250dfb240ae6f2500a149662a79b44c45ecaf
 
             # Image's default ENTRYPOINT calls bare `python`, which doesn't
             # exist in PATH (only python3 is installed). Use the console-script


### PR DESCRIPTION
Digest bump to [pump-cv-v0.5.2](https://github.com/rwlove/PUMP/releases/tag/pump-cv-v0.5.2) — caches the encoded JPEG per (frame_id, quality) in healthd's `/api/v1/cameras/{name}/snapshot`, so a wall poll landing between fresh frames reuses the previous encode instead of re-running libjpeg. Cold encode 6.1ms → cache hit 0.6µs on a 720p frame.

No config or schema changes; new unit tests included upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)