### PR TITLE
fix(security): drop root from code-server sidecars (#12771)

### DIFF
--- a/kubernetes/apps/home/esphome/code/helmrelease.yaml
+++ b/kubernetes/apps/home/esphome/code/helmrelease.yaml
@@ -18,12 +18,16 @@ spec:
     controllers:
       esphome-code:
         pod:
+          # Match the esphome app's UID (2000) so files created via the
+          # web editor are readable by esphome without a chown; the
+          # shared /config PVC is already world-writable and populated
+          # with 2000:2000 ownership, so no data migration is needed.
           securityContext:
-            fsGroup: 0
+            runAsNonRoot: true
+            runAsUser: 2000
+            runAsGroup: 2000
+            fsGroup: 2000
             fsGroupChangePolicy: OnRootMismatch
-
-            runAsGroup: 0
-            runAsUser: 0
         annotations:
           reloader.stakater.com/auto: "true"
 

--- a/kubernetes/apps/home/home-assistant/code/helmrelease.yaml
+++ b/kubernetes/apps/home/home-assistant/code/helmrelease.yaml
@@ -18,12 +18,16 @@ spec:
     controllers:
       home-assistant-code:
         pod:
+          # Match the HA app's UID (568) so files created via the web
+          # editor are readable by HA without a chown; the shared
+          # /config PVC is already world-writable and populated with
+          # 568:568 ownership, so no data migration is needed.
           securityContext:
-            fsGroup: 0
+            runAsNonRoot: true
+            runAsUser: 568
+            runAsGroup: 568
+            fsGroup: 568
             fsGroupChangePolicy: OnRootMismatch
-
-            runAsGroup: 0
-            runAsUser: 0
         annotations:
           reloader.stakater.com/auto: "true"
 


### PR DESCRIPTION
## Summary

Closes #12771 (root-user audit from 2026-07 repo audit). On live inspection the audit's initial list was pessimistic — most `runAsUser: 0` occurrences already have in-file justification comments (khoj hardcoded /root paths, zulip writes to / at boot, immich-mcp image owns /app as root, immichkiosk-transcode's justified blast-radius reasoning, gonic/lidarr/stash init-perms chown-then-drop pattern) and node-lifecycle daemons (matter-server, gpu-operator crio-cdi-setup, etcd-defrag, node-exporter) are all documented.

**Only two occurrences genuinely lacked justification and were also fixable:** the esphome and home-assistant `code-server` sidecars. Both edit /config PVCs that are already world-writable (mode 777) and populated with the matching app UID's ownership (2000 esphome / 568 HA). Live-verified before writing.

## Changes

Drop both sidecars to the matching app UID with matching fsGroup — no data migration, no chown, and files created via the web editor now land with the correct ownership rather than root:root (which the main apps couldn't clean up).

## Verification post-merge

1. Both `*-code-0` pods Running as their new UID (`id -u` = 2000 / 568)
2. Create a test file in the code-server browser UI → ownership matches app UID → main app can read/edit
3. Main esphome and HA workloads unaffected (share the PVC, no schema changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)