### PR TITLE
feat(security): drop privileged from ollama and ollama-spark (#12769)

### DIFF
--- a/kubernetes/apps/ai/ollama-spark/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/ollama-spark/app/helmrelease.yaml
@@ -94,8 +94,21 @@ spec:
                 memory: 80Gi
                 nvidia.com/gpu: 1
 
+            # GPU access is via the device plugin (nvidia.com/gpu: 1),
+            # not privileged mode — /dev/nvidia* devices are mode 666
+            # and injected by the kubelet. ollama does no chown/useradd
+            # at startup, unlike comfyui, so privileged is not needed.
+            # Baseline hardening applied minus runAsNonRoot (ollama's
+            # config paths under /root remain root-owned) and minus
+            # readOnlyRootFilesystem (models cached under /root/.ollama
+            # backed by the PVC; CUDA compiles under /root/.cache).
             securityContext:
-              privileged: true
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - ALL
+              seccompProfile:
+                type: RuntimeDefault
 
     service:
       backend:

--- a/kubernetes/apps/ai/ollama/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/ollama/app/helmrelease.yaml
@@ -76,8 +76,21 @@ spec:
                 memory: 6G
                 nvidia.com/gpu: 1
 
+            # GPU access is via the device plugin (nvidia.com/gpu: 1),
+            # not privileged mode — /dev/nvidia* devices are mode 666
+            # and injected by the kubelet. ollama does no chown/useradd
+            # at startup, unlike comfyui, so privileged is not needed.
+            # Baseline hardening applied minus runAsNonRoot (ollama's
+            # config paths under /root remain root-owned) and minus
+            # readOnlyRootFilesystem (models cached under /root/.ollama
+            # backed by the PVC; CUDA compiles under /root/.cache).
             securityContext:
-              privileged: true
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - ALL
+              seccompProfile:
+                type: RuntimeDefault
 
     service:
       backend:


### PR DESCRIPTION
## Summary

First half of #12769 (2026-07 audit H2). Live investigation showed the four AI GPU HRs split cleanly into two groups:

**Safe to drop now** (this PR): `ollama`, `ollama-spark`. Image runs the binary as PID 1 with no chown/useradd startup, and GPU access is entirely via `nvidia.com/gpu: 1` — devices land at `/dev/nvidia*` mode 666 injected by the kubelet, works without any elevated caps.

**Deferred**: `comfyui` (ai-dock image) and `comfyui-spark` (mmartial image). Both run `chown/useradd/usermod/chpasswd` at init to remap the in-image user to a target UID. Full `privileged: true` is overkill for that; the right follow-up is granular caps (CHOWN + SETUID + SETGID + DAC_OVERRIDE) — separate PR.

## Applied

Baseline container hardening minus two per-app carve-outs:
- runAsNonRoot **not** enforced — ollama's own convention puts config under /root
- readOnlyRootFilesystem **not** enabled — model cache lives under /root/.ollama (PVC), CUDA JIT cache under /root/.cache

Everything else from `.agents/instructions/helmrelease.security.md`: `allowPrivilegeEscalation: false`, `capabilities.drop: [ALL]`, `seccompProfile: RuntimeDefault`.

## Rollout / verification

- Both HRs are single-pod; brief inference blip during pod restart
- Post-merge: `nvidia-smi -L` in each pod → correct GPU enumerated
- Model round-trip: hit each ollama's /api/tags then /api/generate — response streams
- Open WebUI + langgraph-agents inference paths healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)