### PR TITLE
feat(pump): v0.0.102 → v0.0.103

### DIFF
--- a/kubernetes/apps/collab/pump/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump/app/helmrelease.yaml
@@ -32,7 +32,7 @@ spec:
           pump:
             image:
               repository: ghcr.io/rwlove/pump
-              tag: v0.0.102@sha256:2d38aa15db713fab72d8d614fd509ba22de41a66bd6522adf6f9ec1a25ec6c3b
+              tag: v0.0.103@sha256:0bb8e6ecd9a8bd08dba88ebaa5af3606b4d2d1113a6504c398473015b05c163a
 
             env:
               # Activates the /api/cv/* proxy in pump (see internal/web/exercise.go).


### PR DESCRIPTION
Digest bump to [pump-v0.0.103](https://github.com/rwlove/PUMP/releases/tag/pump-v0.0.103).

Fixes a lurking bug: every `/config/` save was in-memory only, so pod restarts silently reset color / pagestep / frequency_days / display_days / autofill / cv_autolog back to env-var defaults. **Migration v10** (app_config table, single row, idempotent) applies automatically on first boot. Existing DB values are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)