### PR TITLE
fix(security): follow-ups for #12790 and #12792 rollouts

### DIFF
--- a/kubernetes/apps/home/esphome/code/helmrelease.yaml
+++ b/kubernetes/apps/home/esphome/code/helmrelease.yaml
@@ -39,6 +39,11 @@ spec:
               repository: ghcr.io/coder/code-server
               tag: 4.126.0@sha256:e1f03b5faaefd63ba6c7173a5290c6ec0526ac907f23acfe6bc949dd965279e4
 
+            env:
+              # code-server writes $HOME/.config/code-server/config.yaml at
+              # startup; point HOME at the shared PVC so runAsUser 2000
+              # can write it. Prior default was /root (unwritable non-root).
+              HOME: /config
             args:
               - --auth
               - none

--- a/kubernetes/apps/home/home-assistant/code/helmrelease.yaml
+++ b/kubernetes/apps/home/home-assistant/code/helmrelease.yaml
@@ -39,6 +39,11 @@ spec:
               repository: ghcr.io/coder/code-server
               tag: 4.126.0@sha256:e1f03b5faaefd63ba6c7173a5290c6ec0526ac907f23acfe6bc949dd965279e4
 
+            env:
+              # code-server writes $HOME/.config/code-server/config.yaml at
+              # startup; point HOME at the shared PVC so runAsUser 2000
+              # can write it. Prior default was /root (unwritable non-root).
+              HOME: /config
             args:
               - --auth
               - none

--- a/kubernetes/apps/media/flaresolverr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/flaresolverr/app/helmrelease.yaml
@@ -50,3 +50,11 @@ spec:
         ports:
           http:
             port: 8191
+
+    persistence:
+      # readOnlyRootFilesystem needs writable scratch for Python and the
+      # embedded chromedriver / Firefox profile.
+      tmpfs:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp


### PR DESCRIPTION
## Summary

Two follow-ups from today's batches — both caught by live post-merge probes, no user impact (Helm rolled back the code-server change automatically, flaresolverr crashlooped but Prowlarr's fallback keeps working without it).

- **code-server sidecars** (esphome + HA): the image writes `$HOME/.config/code-server/config.yaml` at startup; default $HOME is /root (unwritable non-root). Point HOME at /config (the shared PVC, already used for `--user-data-dir`).
- **flaresolverr**: Python + embedded chromedriver need writable /tmp under readOnlyRootFilesystem; add tmpfs emptyDir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)