### PR TITLE
feat(security): backfill baseline on pump + pump-cv (#12770)

### DIFF
--- a/kubernetes/apps/collab/pump-cv/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump-cv/app/helmrelease.yaml
@@ -21,6 +21,13 @@ spec:
           reloader.stakater.com/auto: "true"
 
         pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            # /clips PVC + /basedir emptyDir need writable ownership.
+            fsGroup: 1000
+            fsGroupChangePolicy: OnRootMismatch
           # Pinned to Spark/GB10 (Blackwell, arm64) after the multi-arch
           # rebase (pump-cv v0.5.0 / pump-cv-base on nvcr.io/nvidia/pytorch).
           # Previously bound to worker8 (Pascal P40, amd64); the cu121
@@ -126,6 +133,13 @@ spec:
               limits:
                 memory: 2Gi
                 nvidia.com/gpu: 1
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - ALL
+              seccompProfile:
+                type: RuntimeDefault
 
     # In-cluster Service so pump can proxy /api/cv/* (admin panel,
     # camera list, live snapshot polling) to pump-cv's healthd.

--- a/kubernetes/apps/collab/pump/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump/app/helmrelease.yaml
@@ -13,6 +13,15 @@ spec:
   values:
     controllers:
       pump:
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            # /clips is a shared RWX PVC (also mounted by pump-cv);
+            # fsGroup keeps it writable for the non-root pump process.
+            fsGroup: 1000
+            fsGroupChangePolicy: OnRootMismatch
         annotations:
           reloader.stakater.com/auto: "true"
 
@@ -27,6 +36,14 @@ spec:
             envFrom: &envFrom
               - secretRef:
                   name: pump-secret
+            securityContext: &hardened
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+              seccompProfile:
+                type: RuntimeDefault
         # trigger renovate
         containers:
           pump:
@@ -65,6 +82,7 @@ spec:
                 memory: 128M
               limits:
                 memory: 128M
+            securityContext: *hardened
 
     service:
       frontend:


### PR DESCRIPTION
## Summary

Batch 3 of #12770 — my own Go binaries so I know the images do no chown/entrypoint gymnastics.

- **pump**: fully hardened (rootfs read-only). fsGroup 1000 on the shared `pump-clips` PVC. init-db (postgres-init) also hardened.
- **pump-cv**: pod runAsNonRoot 1000 + container caps hardening, but rootfs stays writable (CUDA JIT cache under /root/.cache). GPU access confirmed via device plugin — never was privileged.

Part of #12770.

🤖 Generated with [Claude Code](https://claude.com/claude-code)