### PR TITLE
chore(flux): trim 5m reconcile intervals to 15m (#12777)

### DIFF
--- a/kubernetes/apps/databases/cloudnative-pg/plugin-barman-cloud/ocirepository.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/plugin-barman-cloud/ocirepository.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: plugin-barman-cloud
 spec:
-  interval: 5m
+  interval: 15m
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/external-secrets/external-secrets/app/helmrelease.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/app/helmrelease.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: external-secrets
 spec:
-  interval: 5m
+  interval: 15m
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/flux-system/flux-instance/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/helmrelease.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: flux-instance
 spec:
-  interval: 5m
+  interval: 15m
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/flux-system/flux-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/flux-operator/app/helmrelease.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: flux-operator
 spec:
-  interval: 5m
+  interval: 15m
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/flux-system/kustomize-mutating-webhook/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/kustomize-mutating-webhook/app/helmrelease.yaml
@@ -13,7 +13,7 @@ spec:
         kind: HelmRepository
         name: fluxcd-kustomize-mutating-webhook
       version: 0.12.0
-  interval: 5m
+  interval: 15m
   install:
     crds: CreateReplace
     createNamespace: true

--- a/kubernetes/apps/istio-system/istio/app/base/helmrelease.yaml
+++ b/kubernetes/apps/istio-system/istio/app/base/helmrelease.yaml
@@ -12,7 +12,7 @@ spec:
         kind: HelmRepository
         name: istio
       version: 1.29.1
-  interval: 5m
+  interval: 15m
   values:
   # https://artifacthub.io/packages/helm/istio-official/base
   # https://github.com/istio/istio/blob/master/manifests/charts/base/values.yaml

--- a/kubernetes/apps/istio-system/istio/app/istiod/helmrelease.yaml
+++ b/kubernetes/apps/istio-system/istio/app/istiod/helmrelease.yaml
@@ -17,7 +17,7 @@ spec:
       # cascading to block all mcp-system reconciliation. Held at 1.30.0
       # (the running, healthy release) until a real >1.30.0 chart exists.
       version: 1.30.2
-  interval: 5m
+  interval: 15m
   dependsOn:
     - name: istio-base
       namespace: istio-system

--- a/kubernetes/apps/kube-system/reflector/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/reflector/helmrelease.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: reflector
 spec:
-  interval: 5m
+  interval: 15m
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/ocirepository.yaml
@@ -5,7 +5,7 @@ kind: OCIRepository
 metadata:
   name: kube-prometheus-stack
 spec:
-  interval: 5m
+  interval: 15m
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy


### PR DESCRIPTION
## Summary

First (and simplest) chunk of #12777. Nine sources reconciled every 5m — 7 bootstrap HelmReleases (flux-instance, flux-operator, kustomize-mutating-webhook, external-secrets, istio base + istiod, reflector) and 2 OCIRepositories (plugin-barman-cloud, kube-prometheus-stack). Everything else in the cluster is 30m or 1h.

15m still lets a broken bootstrap self-heal within a coffee break and cuts ~1,200 reconciles/day off the flux controllers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)