### PR TITLE
fix(security): pump-cv init container + flaresolverr HOME

### DIFF
--- a/kubernetes/apps/collab/pump-cv/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump-cv/app/helmrelease.yaml
@@ -85,6 +85,11 @@ spec:
             envFrom:
               - secretRef:
                   name: pump-cv-secret
+            # `apk add` writes to /etc/apk/cache — needs root. Overrides
+            # the pod's runAsNonRoot for this bootstrap step only.
+            securityContext:
+              runAsNonRoot: false
+              runAsUser: 0
 
         containers:
           pump-cv:

--- a/kubernetes/apps/media/flaresolverr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/flaresolverr/app/helmrelease.yaml
@@ -28,6 +28,10 @@ spec:
 
             env:
               LOG_LEVEL: info
+              # Redirect $HOME so webdriver-manager and Firefox profile
+              # writes land in /tmp (tmpfs) rather than the read-only
+              # /app/.local. Image runs as USER 1000 with $HOME=/app.
+              HOME: /tmp
 
             resources:
               requests:


### PR DESCRIPTION
## Summary

Two follow-ups caught by post-merge probes on #12795 and the earlier #12794.

**pump-cv config-render init container**: pod securityContext (runAsNonRoot: 1000) from #12795 propagated to the init container, which needs root to `apk add gettext`. Override to UID 0 for that bootstrap step; main container stays 1000.

**flaresolverr**: tmpfs /tmp alone wasn't enough — the embedded chromedriver/Firefox also writes to `$HOME/.local`. Image runs with HOME=/app which is read-only. Redirect HOME to /tmp so those writes land on the existing tmpfs. Also required force-recreating the failed sts (`kubectl delete sts --cascade=orphan` + `flux reconcile hr --reset --force`) — the previous rollout left Helm in a rollback-failed state where subsequent upgrades couldn't apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)