### PR TITLE
fix(flaresolverr): leave rootfs writable (chromedriver needs /app writes)

### DIFF
--- a/kubernetes/apps/media/flaresolverr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/flaresolverr/app/helmrelease.yaml
@@ -39,9 +39,15 @@ spec:
                 memory: 500Mi
               limits:
                 memory: 500Mi
+            # flaresolverr downloads chromedriver into /app/chromedriver
+            # at startup and Firefox stores its profile under /app/.local
+            # (HOME=/tmp reroute didn't help since chromedriver-manager
+            # ignores HOME). Leaving rootfs writable is a considered
+            # deviation from the baseline; the rest of the container
+            # hardening still applies.
             securityContext:
               allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: true
+              readOnlyRootFilesystem: false
               capabilities:
                 drop:
                   - ALL


### PR DESCRIPTION
## Summary

Two rounds of hardening attempts (#12792 → tmpfs /tmp, #12798 → HOME=/tmp) caught the wrong constraint each time. Flaresolverr's chromedriver-manager writes to /app/chromedriver at startup and ignores HOME. Leaving rootfs writable is the pragmatic call; all other container hardening (allowPrivilegeEscalation: false, capabilities.drop [ALL], seccompProfile RuntimeDefault, non-root uid 1000, tmpfs /tmp) still applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)