### PR TITLE
feat(security+resources): securityContext backfill (6 apps) + resource requests/limits backfill (25 HRs)

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/operator/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/operator/helmrelease.yaml
@@ -12,5 +12,11 @@ spec:
   values:
     fullnameOverride: *name
     replicaCount: 1
+    resources:
+      requests:
+        cpu: 10m
+        memory: 128Mi
+      limits:
+        memory: 256Mi
   driftDetection:
     mode: enabled

--- a/kubernetes/apps/ai/paperless-ai/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/paperless-ai/app/helmrelease.yaml
@@ -12,6 +12,13 @@ spec:
   values:
     controllers:
       paperless-ai:
+        pod:
+          securityContext:
+            fsGroup: 1000
+            fsGroupChangePolicy: OnRootMismatch
+            runAsGroup: 1000
+            runAsNonRoot: true
+            runAsUser: 1000
         type: statefulset
 
         containers:
@@ -26,6 +33,14 @@ spec:
                 memory: 1536Mi
               limits:
                 memory: 4G
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - ALL
+              readOnlyRootFilesystem: false
+              seccompProfile:
+                type: RuntimeDefault
 
     service:
       app:

--- a/kubernetes/apps/cert-manager/cert-manager/app/values.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/app/values.yaml
@@ -10,6 +10,13 @@ config:
 dns01RecursiveNameservers: https://1.1.1.1:443/dns-query,https://1.0.0.1:443/dns-query
 dns01RecursiveNameserversOnly: true
 
+resources:
+  requests:
+    cpu: 50m
+    memory: 256Mi
+  limits:
+    memory: 512Mi
+
 prometheus:
   enabled: true
   servicemonitor:
@@ -20,3 +27,17 @@ webhook:
   podDisruptionBudget:
     enabled: true
     minAvailable: 1
+  resources:
+    requests:
+      cpu: 25m
+      memory: 128Mi
+    limits:
+      memory: 256Mi
+
+cainjector:
+  resources:
+    requests:
+      cpu: 25m
+      memory: 128Mi
+    limits:
+      memory: 256Mi

--- a/kubernetes/apps/collab/it-tools/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/it-tools/app/helmrelease.yaml
@@ -21,6 +21,7 @@ spec:
             image:
               repository: ghcr.io/corentinth/it-tools
               tag: 2024.10.22-7ca5933
+            # TODO: add securityContext once upstream ships an unprivileged (non-:80) image variant
 
             probes:
               liveness:

--- a/kubernetes/apps/collab/swiparr/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/swiparr/app/helmrelease.yaml
@@ -13,6 +13,13 @@ spec:
   values:
     controllers:
       swiparr:
+        pod:
+          securityContext:
+            fsGroup: 1000
+            fsGroupChangePolicy: OnRootMismatch
+            runAsGroup: 1000
+            runAsNonRoot: true
+            runAsUser: 1000
         annotations:
           reloader.stakater.com/auto: "true"
 
@@ -48,7 +55,14 @@ spec:
                 memory: 300Mi
               limits:
                 memory: 300Mi
-
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - ALL
+              readOnlyRootFilesystem: true
+              seccompProfile:
+                type: RuntimeDefault
 
     service:
       app:
@@ -80,3 +94,10 @@ spec:
         existingClaim: swiparr-data-pvc
         globalMounts:
           - path: /app/data
+      tmpfs:
+        type: emptyDir
+        advancedMounts:
+          swiparr:
+            app:
+              - path: /tmp
+                subPath: tmp

--- a/kubernetes/apps/databases/cloudnative-pg/plugin-barman-cloud/helmrelease.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/plugin-barman-cloud/helmrelease.yaml
@@ -21,4 +21,10 @@ spec:
     crds:
       create: true
     namespaceOverride: databases
+    resources:
+      requests:
+        cpu: 10m
+        memory: 64Mi
+      limits:
+        memory: 128Mi
   maxHistory: 1

--- a/kubernetes/apps/databases/dragonfly/operator/helmrelease.yaml
+++ b/kubernetes/apps/databases/dragonfly/operator/helmrelease.yaml
@@ -17,6 +17,12 @@ spec:
     manager:
       image:
         repository: ghcr.io/dragonflydb/operator
+      resources:
+        requests:
+          cpu: 10m
+          memory: 128Mi
+        limits:
+          memory: 256Mi
     grafanaDashboard:
       annotations:
         name: grafana_folder

--- a/kubernetes/apps/external-secrets/external-secrets/app/values.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/app/values.yaml
@@ -1,6 +1,12 @@
 ---
 installCRDs: true
 leaderElect: true
+resources:
+  requests:
+    cpu: 50m
+    memory: 256Mi
+  limits:
+    memory: 512Mi
 serviceMonitor:
   enabled: true
   interval: 1m
@@ -9,10 +15,22 @@ webhook:
   podDisruptionBudget:
     enabled: true
     minAvailable: 1
+  resources:
+    requests:
+      cpu: 25m
+      memory: 128Mi
+    limits:
+      memory: 256Mi
   serviceMonitor:
     enabled: true
     interval: 1m
 certController:
+  resources:
+    requests:
+      cpu: 25m
+      memory: 128Mi
+    limits:
+      memory: 256Mi
   serviceMonitor:
     enabled: true
     interval: 1m

--- a/kubernetes/apps/flux-system/flux-instance/app/helm/values.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/helm/values.yaml
@@ -50,6 +50,24 @@ instance:
         target:
           kind: Deployment
           name: (kustomize-controller|helm-controller|source-controller)
+      - # Set resource requests for scheduler visibility
+        patch: |
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: all
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: manager
+                    resources:
+                      requests:
+                        cpu: 50m
+                        memory: 256Mi
+        target:
+          kind: Deployment
+          name: (kustomize-controller|helm-controller|source-controller|notification-controller)
       - # Enable in-memory kustomize builds
         patch: |
           - op: add

--- a/kubernetes/apps/flux-system/flux-operator/app/helm/values.yaml
+++ b/kubernetes/apps/flux-system/flux-operator/app/helm/values.yaml
@@ -1,4 +1,10 @@
 ---
+resources:
+  requests:
+    cpu: 50m
+    memory: 128Mi
+  limits:
+    memory: 256Mi
 serviceMonitor:
   create: true
 web:

--- a/kubernetes/apps/flux-system/kustomize-mutating-webhook/app/values.yaml
+++ b/kubernetes/apps/flux-system/kustomize-mutating-webhook/app/values.yaml
@@ -21,6 +21,12 @@ networkpolicy:
   create: false
 podDisruptionBudget:
   enabled: false
+resources:
+  requests:
+    cpu: 25m
+    memory: 128Mi
+  limits:
+    memory: 256Mi
 securityContext:
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true

--- a/kubernetes/apps/home/netbox/app/helmrelease.yaml
+++ b/kubernetes/apps/home/netbox/app/helmrelease.yaml
@@ -88,6 +88,12 @@ spec:
       initialDelaySeconds: 5
       periodSeconds: 10
       timeoutSeconds: 5
+    resources:
+      requests:
+        cpu: 50m
+        memory: 256Mi
+      limits:
+        memory: 512Mi
     service:
       annotations:
         teleport.dev/name: *app

--- a/kubernetes/apps/home/wyoming-services/app/helmrelease.yaml
+++ b/kubernetes/apps/home/wyoming-services/app/helmrelease.yaml
@@ -53,6 +53,13 @@ spec:
               - --custom-model-dir
               - /custom
 
+            resources:
+              requests:
+                cpu: 10m
+                memory: 512Mi
+              limits:
+                memory: 1Gi
+
       whisper:
         annotations:
           reloader.stakater.com/auto: "true"

--- a/kubernetes/apps/kuadrant/kuadrant-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/kuadrant/kuadrant-operator/app/helmrelease.yaml
@@ -16,3 +16,9 @@ spec:
   # https://artifacthub.io/packages/helm/kuadrant/kuadrant-operator
   # https://github.com/Kuadrant/kuadrant-operator/blob/main/charts/kuadrant-operator/values.yaml
   values:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 128Mi
+      limits:
+        memory: 256Mi

--- a/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
@@ -23,6 +23,12 @@ spec:
     k8sAppLabelOverride: kube-dns
     priorityClassName: system-cluster-critical
     replicaCount: 3
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        memory: 256Mi
     servers:
       - plugins:
           - name: errors

--- a/kubernetes/apps/kube-system/descheduler/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/descheduler/app/helmrelease.yaml
@@ -77,6 +77,12 @@ spec:
     leaderElection:
       enabled: true
     priorityClassName: system-cluster-critical
+    resources:
+      requests:
+        cpu: 10m
+        memory: 128Mi
+      limits:
+        memory: 256Mi
     service:
       enabled: true
     serviceMonitor:

--- a/kubernetes/apps/kube-system/intel-device-plugin/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/intel-device-plugin/app/helmrelease.yaml
@@ -9,3 +9,10 @@ spec:
     kind: OCIRepository
     name: intel-device-plugins-operator
   interval: 1h
+  values:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 64Mi
+      limits:
+        memory: 128Mi

--- a/kubernetes/apps/kube-system/intel-device-plugin/gpu/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/intel-device-plugin/gpu/helmrelease.yaml
@@ -16,4 +16,10 @@ spec:
       hub: docker.io/intel
     name: intel-device-plugin-gpu
     nodeFeatureRule: true
+    resources:
+      requests:
+        cpu: 10m
+        memory: 64Mi
+      limits:
+        memory: 128Mi
     sharedDevNum: 3

--- a/kubernetes/apps/kube-system/k8tz/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/k8tz/app/helmrelease.yaml
@@ -32,6 +32,13 @@ spec:
 
     replicaCount: 2
 
+    resources:
+      requests:
+        cpu: 25m
+        memory: 128Mi
+      limits:
+        memory: 256Mi
+
     timezone: "America/New_York"
     webhook:
       certManager:

--- a/kubernetes/apps/kube-system/kubelet-csr-approver/app/values.yaml
+++ b/kubernetes/apps/kube-system/kubelet-csr-approver/app/values.yaml
@@ -2,3 +2,9 @@
 providerRegex: |
   ^*(master|worker)*$
 bypassDnsResolution: true
+resources:
+  requests:
+    cpu: 10m
+    memory: 64Mi
+  limits:
+    memory: 128Mi

--- a/kubernetes/apps/kube-system/node-problem-detector/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/node-problem-detector/app/helmrelease.yaml
@@ -23,3 +23,9 @@ spec:
     metrics:
       serviceMonitor:
         enabled: true
+    resources:
+      requests:
+        cpu: 25m
+        memory: 128Mi
+      limits:
+        memory: 256Mi

--- a/kubernetes/apps/mcp-system/ha-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/ha-mcp/app/helmrelease.yaml
@@ -35,6 +35,12 @@ spec:
             envFrom:
               - secretRef:
                   name: ha-mcp-secret
+            resources:
+              requests:
+                cpu: 10m
+                memory: 128Mi
+              limits:
+                memory: 256Mi
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true

--- a/kubernetes/apps/mcp-system/mcp-gateway/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/mcp-gateway/app/helmrelease.yaml
@@ -36,6 +36,12 @@ spec:
     controller:
       # Enable/disable controller deployment
       enabled: true
+      resources:
+        requests:
+          cpu: 25m
+          memory: 128Mi
+        limits:
+          memory: 256Mi
 
     # Broker configuration (applied to broker-router deployed by controller)
     gateway:

--- a/kubernetes/apps/media/av1corrector/app/helmrelease.yaml
+++ b/kubernetes/apps/media/av1corrector/app/helmrelease.yaml
@@ -25,6 +25,9 @@ spec:
         # (Pascal's NVDEC had no AV1) but the encoder env stays hevc_nvenc;
         # using AV1 hardware decode is a follow-up tuning.
         pod:
+          securityContext:
+            fsGroup: 1000
+            fsGroupChangePolicy: OnRootMismatch
           nodeSelector:
             node-role.kubernetes.io/gpu: blackwell
 
@@ -115,6 +118,17 @@ spec:
               limits:
                 memory: 2Gi
                 nvidia.com/gpu: 1
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - ALL
+              readOnlyRootFilesystem: false
+              runAsGroup: 1000
+              runAsNonRoot: true
+              runAsUser: 1000
+              seccompProfile:
+                type: RuntimeDefault
 
     service:
       app:

--- a/kubernetes/apps/media/kodi-playback-watcher/app/helmrelease.yaml
+++ b/kubernetes/apps/media/kodi-playback-watcher/app/helmrelease.yaml
@@ -13,6 +13,11 @@ spec:
   values:
     controllers:
       kodi-playback-watcher:
+        pod:
+          securityContext:
+            runAsGroup: 1000
+            runAsNonRoot: true
+            runAsUser: 1000
         annotations:
           reloader.stakater.com/auto: "true"
 
@@ -58,6 +63,14 @@ spec:
                 memory: 32Mi
               limits:
                 memory: 128Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - ALL
+              readOnlyRootFilesystem: true
+              seccompProfile:
+                type: RuntimeDefault
 
     service:
       app:
@@ -74,3 +87,10 @@ spec:
         globalMounts:
           - path: /etc/kpw-ssh
             readOnly: true
+      tmpfs:
+        type: emptyDir
+        advancedMounts:
+          kodi-playback-watcher:
+            app:
+              - path: /tmp
+                subPath: tmp

--- a/kubernetes/apps/media/videodupfinder/app/helmrelease.yaml
+++ b/kubernetes/apps/media/videodupfinder/app/helmrelease.yaml
@@ -13,6 +13,10 @@ spec:
   values:
     controllers:
       videodupfinder:
+        pod:
+          securityContext:
+            fsGroup: 1000
+            fsGroupChangePolicy: OnRootMismatch
         annotations:
           reloader.stakater.com/auto: "true"
 
@@ -63,6 +67,17 @@ spec:
                 memory: 512Mi
               limits:
                 memory: 2Gi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - ALL
+              readOnlyRootFilesystem: false
+              runAsGroup: 1000
+              runAsNonRoot: true
+              runAsUser: 1000
+              seccompProfile:
+                type: RuntimeDefault
 
     service:
       app:

--- a/kubernetes/apps/network/external-dns/app/cloudflare/helmrelease.yaml
+++ b/kubernetes/apps/network/external-dns/app/cloudflare/helmrelease.yaml
@@ -87,6 +87,12 @@ spec:
     serviceMonitor:
       enabled: true
 
+    resources:
+      requests:
+        cpu: 25m
+        memory: 128Mi
+      limits:
+        memory: 256Mi
     sources: ["crd", "gateway-httproute", "gateway-tlsroute", "gateway-tcproute"]
     txtOwnerId: default
     txtPrefix: k8s.

--- a/kubernetes/apps/observability/exporters/blackbox-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/exporters/blackbox-exporter/app/helmrelease.yaml
@@ -13,6 +13,13 @@ spec:
   values:
     allowIcmp: true
 
+    resources:
+      requests:
+        cpu: 10m
+        memory: 64Mi
+      limits:
+        memory: 128Mi
+
     config:
       modules:
         http_2xx:

--- a/kubernetes/apps/observability/exporters/smartctl-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/exporters/smartctl-exporter/app/helmrelease.yaml
@@ -37,6 +37,12 @@ spec:
     image:
       repository: ghcr.io/joryirving/smartctl_exporter
       tag: 0.14.0@sha256:04bf03f15e28330f0fc5ce561e97c3cb3cd0fce22e51a141eccee160c6e736f5
+    resources:
+      requests:
+        cpu: 10m
+        memory: 64Mi
+      limits:
+        memory: 128Mi
     prometheusRules:
       enabled: false
     serviceMonitor:

--- a/kubernetes/apps/observability/exporters/snmp-exporter/app/apc-ups/helmrelease.yaml
+++ b/kubernetes/apps/observability/exporters/snmp-exporter/app/apc-ups/helmrelease.yaml
@@ -38,6 +38,12 @@ spec:
         readOnly: true
         subPath: snmp.yaml
     fullnameOverride: *app
+    resources:
+      requests:
+        cpu: 10m
+        memory: 64Mi
+      limits:
+        memory: 128Mi
     serviceMonitor:
       enabled: true
       params:

--- a/kubernetes/apps/observability/exporters/snmp-exporter/app/dell-idrac/helmrelease.yaml
+++ b/kubernetes/apps/observability/exporters/snmp-exporter/app/dell-idrac/helmrelease.yaml
@@ -45,6 +45,12 @@ spec:
 
     image:
       repository: quay.io/prometheus/snmp-exporter
+    resources:
+      requests:
+        cpu: 10m
+        memory: 64Mi
+      limits:
+        memory: 128Mi
     serviceMonitor:
       enabled: true
       namespace: observability

--- a/kubernetes/apps/observability/netdata/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/netdata/app/helmrelease.yaml
@@ -35,4 +35,10 @@ spec:
         storageclass: "ceph-block"
 
       enabled: true
+      resources:
+        requests:
+          cpu: 25m
+          memory: 256Mi
+        limits:
+          memory: 512Mi
   releaseName: netdata

--- a/kubernetes/apps/observability/silence-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/silence-operator/app/helmrelease.yaml
@@ -13,3 +13,9 @@ spec:
     alertmanagerAddress: http://kube-prometheus-stack-alertmanager.observability:9093
     networkPolicy:
       enabled: false
+    resources:
+      requests:
+        cpu: 10m
+        memory: 64Mi
+      limits:
+        memory: 128Mi

--- a/kubernetes/apps/observability/vector/aggregator/helmrelease.yaml
+++ b/kubernetes/apps/observability/vector/aggregator/helmrelease.yaml
@@ -18,6 +18,9 @@ spec:
       vector-aggregator:
 
         pod:
+          securityContext:
+            fsGroup: 1000
+            fsGroupChangePolicy: OnRootMismatch
           topologySpreadConstraints:
             - maxSkew: 1
               topologyKey: kubernetes.io/hostname
@@ -60,6 +63,17 @@ spec:
                 memory: 512Mi
               limits:
                 memory: 768Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - ALL
+              readOnlyRootFilesystem: true
+              runAsGroup: 1000
+              runAsNonRoot: true
+              runAsUser: 1000
+              seccompProfile:
+                type: RuntimeDefault
     service:
       app:
         # ClusterIP: vector-agent + Prometheus reach this via cluster DNS

--- a/kubernetes/apps/renovate/renovate-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/app/helmrelease.yaml
@@ -32,5 +32,11 @@ spec:
         glance/show: "true"
         glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/renovate.png"
         glance/id: "Renovate"
+    resources:
+      requests:
+        cpu: 50m
+        memory: 256Mi
+      limits:
+        memory: 512Mi
     webhook:
       enabled: true

--- a/kubernetes/apps/selfhosted/konflate/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/konflate/app/helmrelease.yaml
@@ -60,3 +60,9 @@ spec:
       enabled: false
     networkPolicy:
       enabled: false
+    resources:
+      requests:
+        cpu: 50m
+        memory: 256Mi
+      limits:
+        memory: 512Mi

--- a/kubernetes/flux/cluster/ks.yaml
+++ b/kubernetes/flux/cluster/ks.yaml
@@ -42,6 +42,25 @@ spec:
         name: cluster-secrets
   deletionPolicy: WaitForTermination
   patches:
+    # Inject sourceRef and prune defaults into every child Kustomization.
+    # Strategic-merge sets these on KSes that omit them; for KSes that
+    # already carry the same values the patch is a no-op.  wait/interval/
+    # timeout are intentionally NOT included here — they vary per-KS
+    # (e.g. 79 KSes have wait:true, interval splits 30m/1h, timeout 3m/5m).
+    - patch: |-
+        apiVersion: kustomize.toolkit.fluxcd.io/v1
+        kind: Kustomization
+        metadata:
+          name: _
+        spec:
+          prune: true
+          sourceRef:
+            kind: GitRepository
+            name: home-ops-kubernetes
+            namespace: flux-system
+      target:
+        group: kustomize.toolkit.fluxcd.io
+        kind: Kustomization
     # Add Kustomization defaults for all child Kustomizations
     - patch: |-
         apiVersion: kustomize.toolkit.fluxcd.io/v1

--- a/tools/README.md
+++ b/tools/README.md
@@ -9,7 +9,6 @@ flow — they're for ad-hoc operator work.
 | Script | Purpose |
 |---|---|
 | `run-on-all-nodes.sh` | Run a command via `ssh root@<node>` on every node (discovered via kubectl). |
-| `reconcile-cluster.sh` | Force-reconcile the `cluster-apps` Flux Kustomization. |
 | `events.sh` | Watch cluster events with the chatty Flux ones filtered out. Env vars: `NAMESPACE`, `WARNINGS_ONLY=1`, `SHOW_FILTERED=1` (audit), `EVENTS_FILTER_EXTRA`. |
 | `get_unfulfilled_deployments.sh` | List Deployments / ReplicaSets / StatefulSets whose ready < desired. |
 
@@ -20,14 +19,12 @@ flow — they're for ad-hoc operator work.
 | `check-postgres-dbs.sh` | Show Status / Instances / Ready instances for every CNPG cluster. |
 | `check-cnpg-soak.sh` | Post-rollout soak check (restarts, OOMs, memory headroom). |
 | `kill-postgres-pod.sh` | Wipe a CNPG replica's PV+PVC+pod so cnpg re-clones from primary. |
-| `onetime-cnpg-backup.sh` | Apply the one-time backup manifest. |
 
 ## Rook / Ceph
 
 | Script | Purpose |
 |---|---|
 | `destroy-rook-ceph-cluster.sh` | Catastrophic: tear down the entire Ceph cluster. |
-| `get-ceph-password.sh` | Print the Ceph dashboard admin password. |
 
 ## NFS
 
@@ -44,15 +41,12 @@ flow — they're for ad-hoc operator work.
 | `check_k8s-gateway.sh` | nslookup against the in-cluster gateway DNS. |
 | `check_smtp-relay.sh` | Send a test email through smtp-relay. |
 | `clear-stuck-cni-sandbox.sh` | Force-remove a cri-o sandbox stuck on a missing CNI plugin. |
-| `netshoot.sh` | Spawn a `netshoot` shell in the `downloads` namespace. |
 
 ## GPU / NVIDIA
 
 | Script | Purpose |
 |---|---|
-| `nvidia-runtime-run-nvidia-smi.sh` | Spawn a CUDA pod on a GPU node and run `nvidia-smi`. |
 | `list_pods_on_nvidia_runtimeclass.sh` | List pods using `runtimeClassName: nvidia`. |
-| `nvtop.sh` | ssh to worker8 and run `nvtop`. |
 
 ## Cilium / etcd
 
@@ -77,11 +71,22 @@ flow — they're for ad-hoc operator work.
 | `gen-oauth-client-secret.sh` | Generate an Authelia OAuth2 client secret + matching argon2 hash (paste both into `clients.yaml` / 1Password). |
 | `check-image-registry.sh` | Verify image registries used in the repo against the allowlist (renovate / PR-review aid). |
 
-## Lint
+## Lint + pre-commit hooks
 
 | Script | Purpose |
 |---|---|
-| `lint-cnp-empty-rules.py` | Reject CiliumNetworkPolicy manifests that select endpoints but define no ingress/egress rules — Cilium 1.19 silently fails to apply them. Also wired into the `Lint` GitHub Actions workflow. |
+| `lint-cnp-empty-rules.py` | Reject CiliumNetworkPolicy manifests that select endpoints but define no ingress/egress rules — Cilium 1.19 silently fails to apply them. Wired into `.pre-commit-config.yaml` and the `Lint` GitHub Actions workflow. |
+| `lint-readme-drift.py` | Verify that `README.md` badge values match live cluster data. Wired into `.pre-commit-config.yaml`. |
+| `check-readme-drift-vs-main.sh` | CI helper that compares README badge values against `origin/main`. Wired into `.pre-commit-config.yaml`. |
+
+## Claude Code operator
+
+> TODO: consider relocating these to `~/.claude-personal/scripts/` — they are Claude Code session helpers, not cluster ops tools, and don't belong alongside `destroy-rook-ceph-cluster.sh`.
+
+| Script | Purpose |
+|---|---|
+| `claude-worktree.sh` | Create a dated git worktree (`home-ops.worktrees/YYYY-MM-DD-<slug>`) on a new `claude/<…>` branch off `origin/main`. |
+| `claude-worktree-cleanup.sh` | Remove merged Claude worktrees and their branches. |
 
 ## App-specific
 
@@ -90,3 +95,16 @@ flow — they're for ad-hoc operator work.
 | `frigate_copy_speed.sh` | Tail Frigate logs and print recording copy throughput. |
 | `ollama-pull-models.sh` | Pull a predefined set of models into the Ollama instance. |
 | `romm-apply-tags.sh` | Apply per-ROM tags in the RomM database after a scan. |
+
+## One-liner operations (retired scripts)
+
+These were previously stand-alone scripts; recorded here as `kubectl`/`flux`/`ssh` one-liners so the history is grep-able without the file noise.
+
+| Operation | Command |
+|---|---|
+| Force-reconcile cluster-apps | `flux --namespace flux-system reconcile kustomization cluster-apps --with-source` |
+| Print Ceph dashboard password | `kubectl -n rook-ceph get secret rook-ceph-dashboard-password -o jsonpath="{['data']['password']}" \| base64 --decode && echo` |
+| Spawn netshoot in downloads ns | `kubectl -n downloads run tmp-shell --rm -i --tty --image nicolaka/netshoot` |
+| Run nvidia-smi on a GPU node | `kubectl -n default run nvidia-shell -i --tty --overrides='{"apiVersion":"v1","spec":{"nodeSelector":{"nvidia.com/gpu.present":"true"},"runtimeClassName":"nvidia"}}' --image nvidia/cuda:12.6.2-devel-ubuntu22.04 -- nvidia-smi` |
+| nvtop on worker8 | `ssh -t root@worker8 nvtop` |
+| Apply one-time CNPG backup | `kubectl apply -f kubernetes/apps/databases/cloudnative-pg/config/onetimebackup.yaml` |

--- a/tools/get-ceph-password.sh
+++ b/tools/get-ceph-password.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-kubectl -n rook-ceph get secret rook-ceph-dashboard-password -o jsonpath="{['data']['password']}" | base64 --decode && echo

--- a/tools/netshoot.sh
+++ b/tools/netshoot.sh
@@ -1,1 +1,0 @@
-kubectl -n downloads run tmp-shell --rm -i --tty --image nicolaka/netshoot

--- a/tools/nvidia-runtime-run-nvidia-smi.sh
+++ b/tools/nvidia-runtime-run-nvidia-smi.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-kubectl -n default run nvidia-shell -i --tty --overrides='{"apiVersion": "v1", "spec": {"nodeSelector": {"nvidia.com/gpu.present": "true"}, "runtimeClassName": "nvidia"}}' --image nvidia/cuda:12.6.2-devel-ubuntu22.04 -- nvidia-smi

--- a/tools/nvtop.sh
+++ b/tools/nvtop.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-ssh -t root@worker8 nvtop

--- a/tools/onetime-cnpg-backup.sh
+++ b/tools/onetime-cnpg-backup.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-kubectl apply -f kubernetes/apps/databases/cloudnative-pg/config/onetimebackup.yaml

--- a/tools/reconcile-cluster.sh
+++ b/tools/reconcile-cluster.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-flux --namespace flux-system reconcile kustomization cluster-apps --with-source


### PR DESCRIPTION
## Summary

Multiple roadmap initiatives executed on one branch — see individual commits for details.

### securityContext backfill (#12770 tail)

Hardens remaining unhardened app-template HelmReleases with the baseline from \`.agents/instructions/helmrelease.security.md\`:

- **swiparr, paperless-ai, kodi-playback-watcher** — full pod + container baseline, tmpfs at \`/tmp\`, \`readOnlyRootFilesystem: true\`; paperless-ai gets \`false\` (Node.js runtime writes)
- **it-tools** — no unprivileged image variant exists upstream; \`# TODO\` comment added, deferred
- **av1corrector, videodupfinder** — GPU ffmpeg workloads, \`readOnlyRootFilesystem: false\`; full remaining baseline applied
- **vector-aggregator** — pod-level \`fsGroup\` only (init-geoip may run as root); full container baseline on main app container with \`readOnlyRootFilesystem: true\`

### Resource requests/limits backfill (#12772)

Adds \`resources:\` blocks to 26 HelmReleases that were running BestEffort QoS. Conservative starters; no CPU limits (repo convention).

- **Batch A** — cert-manager, external-secrets, coredns (100m, cluster-critical DNS), descheduler, kubelet-csr-approver, kustomize-mutating-webhook, flux-instance (4 controllers), flux-operator
- **Batch B+C** — blackbox-exporter, smartctl-exporter, snmp-exporter (apc-ups + dell-idrac), silence-operator, netdata (parent), node-problem-detector; actions-runner-controller, dragonfly-operator, kuadrant-operator, renovate-operator, intel-device-plugin (operator + gpu), k8tz
- **Batch D** — netbox, mcp-gateway (controller), ha-mcp, konflate, external-dns-cloudflare, plugin-barman-cloud
- **wyoming-services** — adds missing resources for openwakeword container (kokoro/whisper already had them)

Skipped: openebs (sub-chart resource path requires verification).

### Flux KS defaults patch (#12775 PR 1)

Adds a strategic-merge patch to \`cluster-apps\` that injects \`prune: true\` and \`sourceRef\` defaults into every child Kustomization rendered from \`./kubernetes/apps\`. For KSes that already carry these fields (all of them), the patch is a no-op; values are identical. Enables PR 2 to sweep-remove the boilerplate after a 48h soak.

\`wait/interval/timeout\` intentionally excluded — they have per-KS variation (79 KSes use \`wait: true\`, interval splits 30m/1h, timeout splits 3m/5m).

### Tools cleanup (#12776 tail)

Retires 6 one-liner shell scripts (netshoot, nvtop, reconcile-cluster, get-ceph-password, nvidia-runtime-run-nvidia-smi, onetime-cnpg-backup). None were referenced by CI, hooks, or \`.agents/\`. Their commands are preserved verbatim in a new "One-liner operations" section in \`tools/README.md\`.

\`tools/README.md\` also gains 4 previously-undocumented scripts (lint-readme-drift.py, check-readme-drift-vs-main.sh, claude-worktree.sh, claude-worktree-cleanup.sh).

## Test plan

- [ ] All 7 required CI contexts pass (Lint, Image, Flux Local, Webhook Validate, Secret Scan, Inline Credential Scan, Analyze)
- [ ] Post-merge: \`kubectl describe pod -n <ns>\` shows QoS class as Burstable for apps that previously had no resources
- [ ] Flux KS defaults: \`flux get ks -A --status-selector ready=false\` returns empty after the patch soaks