### PR TITLE
feat(pump-cv): v0.5.2 → v0.6.0

### DIFF
--- a/kubernetes/apps/collab/pump-cv/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump-cv/app/helmrelease.yaml
@@ -95,7 +95,7 @@ spec:
           pump-cv:
             image:
               repository: ghcr.io/rwlove/pump-cv
-              tag: v0.5.2@sha256:4f250d23d5c4d2f4b1ab98079be250dfb240ae6f2500a149662a79b44c45ecaf
+              tag: v0.6.0@sha256:477a8d4c6b5ca8582c907b381906c9e05e82d6b4a824377a1329c63fe051944e
 
             # Image's default ENTRYPOINT calls bare `python`, which doesn't
             # exist in PATH (only python3 is installed). Use the console-script


### PR DESCRIPTION
Digest bump to [pump-cv-v0.6.0](https://github.com/rwlove/PUMP/releases/tag/pump-cv-v0.6.0).

Decouples frame capture from GPU inference for live sources. Measured 2.1× throughput on 15 fps cam + 100 ms predict, 5.2× when the predictor is the bottleneck. Drop-newest single-slot buffer keeps the rep detector on the freshest frame instead of a stale FIFO.

No config or schema changes; new async unit tests included upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)