### PR TITLE
feat(renovate): group immich-server + immich-machine-learning

### DIFF
--- a/.github/renovate/groups.json5
+++ b/.github/renovate/groups.json5
@@ -37,6 +37,15 @@
       },
     },
     {
+      description: "Immich Group",
+      groupName: "Immich",
+      matchDatasources: ["docker"],
+      matchPackageNames: ["/immich-app/immich-/"],
+      group: {
+        commitMessageTopic: "{{{groupName}}} group",
+      },
+    },
+    {
       description: "Kubernetes Group",
       groupName: "Kubernetes",
       matchDatasources: ["docker"],


### PR DESCRIPTION
## Summary
- Group `ghcr.io/immich-app/immich-server` and `ghcr.io/immich-app/immich-machine-learning` under a single Renovate group so future bumps land in one PR.
- Fixes the split seen in #12788, where ML was proposed at v3.0.1 while server stayed at v2.7.5 — server/ML must run matching majors.

## Test plan
- [ ] Renovate reconciles on merge, closes #12788, and opens a grouped Immich PR on next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)