### PR TITLE
fix(paperless-ai): mount tmpfs at /app/logs to survive non-root UID

### DIFF
--- a/kubernetes/apps/ai/paperless-ai/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/paperless-ai/app/helmrelease.yaml
@@ -74,3 +74,9 @@ spec:
           paperless-ai:
             app:
               - path: /app/data
+      logs:
+        type: emptyDir
+        advancedMounts:
+          paperless-ai:
+            app:
+              - path: /app/logs


### PR DESCRIPTION
## Summary
- paperless-ai has been in CrashLoopBackOff since 2026-07-02 19:30 ET (160 restarts as of this morning), firing `KubePodCrashLooping` / `KubePodNotReady` / `KubeStatefulSetReplicasMismatch`.
- Regression from #12803's securityContext backfill: pod now runs as UID 1000, but the clusterzx/paperless-ai image's `/app` is root-owned, so the app's startup `mkdir('logs')` fails with `EACCES: permission denied, mkdir 'logs'`.
- Fix: mount a tmpfs `emptyDir` at `/app/logs`. Logs are ephemeral (PM2 owns process supervision; log retention isn't the goal), so scratch storage is the right tier per `.agents/instructions/storage-class.instructions.md` rule 6.

## Related follow-up
The other 5 apps touched by #12803 could have similar UID-mismatch traps against paths their images expect to write. Worth a sweep after this lands.

## Test plan
- [ ] CI green
- [ ] Flux reconciles, `paperless-ai-0` reaches Running without EACCES in logs
- [ ] `KubePodCrashLooping` alert clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)