### PR TITLE
fix(flux-operator): raise memory limit 256Mi -> 512Mi

### DIFF
--- a/kubernetes/apps/flux-system/flux-operator/app/helm/values.yaml
+++ b/kubernetes/apps/flux-system/flux-operator/app/helm/values.yaml
@@ -4,7 +4,7 @@ resources:
     cpu: 50m
     memory: 128Mi
   limits:
-    memory: 256Mi
+    memory: 512Mi
 serviceMonitor:
   create: true
 web:


### PR DESCRIPTION
## Summary
- flux-operator manager container OOMKilled 2026-07-03 06:05 ET during a Renovate merge storm; pod took ~90m to recover.
- 256Mi is tight for a Go operator under FluxInstance reconciliation load. Bump limit to 512Mi; request stays at 128Mi.
- The operator itself doesn't run day-to-day HelmRelease reconciliation (that's flux-instance's controllers), so the outage didn't propagate to workloads — but the next OOM re-fires the critical \`OOMKilled\` alert.

## Test plan
- [ ] CI green
- [ ] Flux reconciles, flux-operator pod restarts cleanly with new limit
- [ ] No further OOMKill alerts on flux-operator

🤖 Generated with [Claude Code](https://claude.com/claude-code)