### PR TITLE
fix(paperless-ai): mount tmpfs at /app/OPENAPI for spec dump

### DIFF
--- a/kubernetes/apps/ai/paperless-ai/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/paperless-ai/app/helmrelease.yaml
@@ -80,3 +80,9 @@ spec:
           paperless-ai:
             app:
               - path: /app/logs
+      openapi:
+        type: emptyDir
+        advancedMounts:
+          paperless-ai:
+            app:
+              - path: /app/OPENAPI


### PR DESCRIPTION
## Summary
- Follow-up to #12808. After the \`/app/logs\` tmpfs unblocked startup, the app still logs \`EACCES: permission denied, open '/app/OPENAPI/openapi.json'\` on every boot — same non-root-UID vs root-owned-image-path pattern, second directory.
- Non-fatal (server starts on port 3000 anyway) but noisy in logs.
- Fix: mount a tmpfs \`emptyDir\` at \`/app/OPENAPI\`.

## Test plan
- [ ] CI green
- [ ] After Flux reconcile, no more OPENAPI EACCES in \`paperless-ai-0\` startup logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)