### PR TITLE
feat(observability): silence KubeNFSExportFillingUp for security-storage

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/prometheusrule-pv.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/prometheusrule-pv.yaml
@@ -137,11 +137,13 @@ spec:
         # Frigate recording export is *designed* to run pegged near-full
         # (Frigate fills to its retention cap, then GCs the oldest segments —
         # a sawtooth that lives at the top), so <3% free is its healthy steady
-        # state, not an incident. A genuine "GC actually broke and it's heading
-        # to true zero" event is still caught by the predict_linear variant
-        # below, whose 6h trend stays flat during a healthy sawtooth and goes
-        # negative only on a real monotonic decline. Permanent capacity fix is
-        # the NAS rebuild (project_todo_security_storage_new_build).
+        # state, not an incident. The predict_linear warning variant below was
+        # meant to be the real backstop, but in practice its 6h window catches
+        # enough of a fill downslope to trip on the healthy sawtooth too, so
+        # it's silenced for security-storage via silence-operator
+        # (silences/security-storage-diskspace.yaml). Permanent capacity fix
+        # is the NAS rebuild (project_todo_security_storage_new_build); revisit
+        # both exclusions when that box is replaced.
         - alert: KubeNFSExportFillingUp
           annotations:
             description: NFS export on {{ $labels.nfs_server }} is only {{ $value | humanizePercentage }} free. One or more PVCs backed by this server share the same underlying filesystem; check `df` on the server and identify the largest consumer.

--- a/kubernetes/apps/observability/silence-operator/silences/security-storage-diskspace.yaml
+++ b/kubernetes/apps/observability/silence-operator/silences/security-storage-diskspace.yaml
@@ -34,3 +34,23 @@ spec:
     - matchType: "=~"
       name: instance
       value: security-storage.*
+---
+# KubeNFSExportFillingUp fires the same false-positive on security-storage.
+# The 6h predict_linear window was intended to stay flat during a healthy
+# GC sawtooth, but in practice catches enough of a downslope during a fill
+# cycle to trip. Frigate GC keeps the export from ever hitting true zero, so
+# the alert is redundant noise rather than a real backstop for this host.
+# Once security-storage is rebuilt (project_todo_security_storage_new_build)
+# with more headroom, remove this silence and re-evaluate whether the
+# predict_linear can serve as a genuine backstop again.
+apiVersion: observability.giantswarm.io/v1alpha2
+kind: Silence
+metadata:
+  name: kubenfsexportfillingup-security-storage
+spec:
+  matchers:
+    - name: alertname
+      value: KubeNFSExportFillingUp
+    - matchType: "=~"
+      name: nfs_server
+      value: security-storage\..*


### PR DESCRIPTION
## Summary
- Frigate's recording export is designed to run near-full (fill → GC oldest → sawtooth at cap), so \`KubeNFSExportFillingUp\` reads as noise on this host.
- The blunt \`<3%\` critical variant already excludes \`security-storage\` inline. The predict_linear warning variant was intended as the "GC actually broke" backstop, but in practice its 6h window catches enough of a fill downslope to trip on the healthy sawtooth.
- Add a silence-operator \`Silence\` CR scoped to \`nfs_server=~security-storage\\..*\` alongside the existing \`CephNodeDiskspaceWarning\` silence for the same host.
- Update the now-stale comment in \`prometheusrule-pv.yaml\` that claimed predict_linear serves as the backstop for security-storage.

## Tradeoff
This drops the automated backstop for security-storage. Frigate's GC is the operational guarantee that the export won't reach true zero. The comment flags revisiting both exclusions when the NAS rebuild lands (project_todo_security_storage_new_build).

## Test plan
- [ ] CI green
- [ ] After Flux reconcile, \`KubeNFSExportFillingUp\` for \`security-storage.thesteamedcrab.com\` shows as silenced in Alertmanager
- [ ] Other NFS servers still alert normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)