### PR TITLE
feat(pump-cv): v0.6.0 → v0.6.1

### DIFF
--- a/kubernetes/apps/collab/pump-cv/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump-cv/app/helmrelease.yaml
@@ -95,7 +95,7 @@ spec:
           pump-cv:
             image:
               repository: ghcr.io/rwlove/pump-cv
-              tag: v0.6.0@sha256:477a8d4c6b5ca8582c907b381906c9e05e82d6b4a824377a1329c63fe051944e
+              tag: v0.6.1@sha256:6afac3a6fb0dd7f4a005a0192e85edf3e6aa185a8b29612be8443ac6f2046652
 
             # Image's default ENTRYPOINT calls bare `python`, which doesn't
             # exist in PATH (only python3 is installed). Use the console-script


### PR DESCRIPTION
Digest bump to [pump-cv-v0.6.1](https://github.com/rwlove/PUMP/releases/tag/pump-cv-v0.6.1).

Refactor-only, no behavior change:
- Shared `build_prototype_from_video` core: healthd's `/api/v1/reference` and the `add_reference` CLI both thin-wrap it (was ~40% duplicated pipeline)
- `PipelineRunner` admin-panel introspection methods moved from module-level monkey-patches into the class body (the file's own comment admitted the arrangement was odd)

47 tests pass / 1 skip (was 42/1). Ruff clean. No schema or config changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)