### PR TITLE
feat(paperless-ai): allow egress to raw.githubusercontent.com for nltk_data

### DIFF
--- a/kubernetes/apps/ai/paperless-ai/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/paperless-ai/app/cnp-allow.yaml
@@ -50,3 +50,12 @@ spec:
         - ports:
             - port: "11434"
               protocol: TCP
+    # RAG subsystem downloads nltk corpora (punkt, punkt_tab, stopwords)
+    # from raw.githubusercontent.com/nltk/nltk_data on startup. Without
+    # this hole the app runs but RAG features are degraded.
+    - toFQDNs:
+        - matchName: raw.githubusercontent.com
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP


### PR DESCRIPTION
## Summary
- paperless-ai's RAG subsystem calls \`nltk.download()\` for \`punkt\`, \`punkt_tab\`, \`stopwords\` on startup, which fetches from \`raw.githubusercontent.com/nltk/nltk_data\`.
- Under default-deny egress in the \`ai\` namespace, the requests error with \`Network is unreachable\`. The server starts fine but RAG features are degraded.
- Add \`toFQDNs: raw.githubusercontent.com:443\` to the paperless-ai CNP. The \`allow-dns\` baseline in the ai namespace keeps the L7 DNS proxy active, so FQDN cache population works out of the box.

## Test plan
- [ ] CI green
- [ ] After Flux reconcile, restart paperless-ai-0 and confirm no more \`nltk_data\` urlopen errors in startup logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)