### PR TITLE
chore(flux): remove redundant sourceRef+prune from per-app Kustomizations

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/ks.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/actions-runner-system/actions-runner-controller/operator
   interval: 30m
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: onepassword-connect
       namespace: external-secrets
@@ -35,12 +30,7 @@ spec:
   path: ./kubernetes/apps/actions-runner-system/actions-runner-controller/runners
   interval: 30m
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: actions-runner-controller
     - name: openebs

--- a/kubernetes/apps/ai/comfyui-spark/ks.yaml
+++ b/kubernetes/apps/ai/comfyui-spark/ks.yaml
@@ -11,12 +11,7 @@ spec:
   targetNamespace: ai
   path: ./kubernetes/apps/ai/comfyui-spark/app
   interval: 30m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: gpu-operator
       namespace: kube-system

--- a/kubernetes/apps/ai/comfyui/ks.yaml
+++ b/kubernetes/apps/ai/comfyui/ks.yaml
@@ -11,12 +11,7 @@ spec:
   targetNamespace: ai
   path: ./kubernetes/apps/ai/comfyui/app
   interval: 30m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: gpu-operator
       namespace: kube-system

--- a/kubernetes/apps/ai/khoj/ks.yaml
+++ b/kubernetes/apps/ai/khoj/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/ai/khoj/app
   interval: 1h
   timeout: 10m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: authelia
       namespace: auth

--- a/kubernetes/apps/ai/langfuse/ks.yaml
+++ b/kubernetes/apps/ai/langfuse/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/ai/langfuse/app
   interval: 1h
   timeout: 10m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: langfuse
       namespace: databases

--- a/kubernetes/apps/ai/langgraph-agents/ks.yaml
+++ b/kubernetes/apps/ai/langgraph-agents/ks.yaml
@@ -11,12 +11,7 @@ spec:
   targetNamespace: ai
   path: "./kubernetes/apps/ai/langgraph-agents/app"
   interval: 30m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: authelia
       namespace: auth

--- a/kubernetes/apps/ai/lightrag/ks.yaml
+++ b/kubernetes/apps/ai/lightrag/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/ai/lightrag/app
   interval: 1h
   timeout: 10m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: ollama-spark
       namespace: ai

--- a/kubernetes/apps/ai/ollama-spark/ks.yaml
+++ b/kubernetes/apps/ai/ollama-spark/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: "./kubernetes/apps/ai/ollama-spark/app"
   interval: 30m
   timeout: 5m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: onepassword-connect
       namespace: external-secrets

--- a/kubernetes/apps/ai/ollama/ks.yaml
+++ b/kubernetes/apps/ai/ollama/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: "./kubernetes/apps/ai/ollama/app"
   interval: 30m
   timeout: 3m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: onepassword-connect
       namespace: external-secrets

--- a/kubernetes/apps/ai/paperless-ai/ks.yaml
+++ b/kubernetes/apps/ai/paperless-ai/ks.yaml
@@ -11,12 +11,7 @@ spec:
   targetNamespace: ai
   path: "./kubernetes/apps/ai/paperless-ai/app"
   interval: 30m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: longhorn
       namespace: longhorn-system

--- a/kubernetes/apps/ai/sync-receiver/ks.yaml
+++ b/kubernetes/apps/ai/sync-receiver/ks.yaml
@@ -11,12 +11,7 @@ spec:
   targetNamespace: ai
   path: "./kubernetes/apps/ai/sync-receiver/app"
   interval: 30m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: langgraph-agents
       namespace: ai

--- a/kubernetes/apps/ai/tei-spark/ks.yaml
+++ b/kubernetes/apps/ai/tei-spark/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: "./kubernetes/apps/ai/tei-spark/app"
   interval: 30m
   timeout: 5m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: onepassword-connect
       namespace: external-secrets

--- a/kubernetes/apps/auth/authelia/ks.yaml
+++ b/kubernetes/apps/auth/authelia/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/auth/authelia/app
   interval: 1h
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: lldap
       namespace: auth

--- a/kubernetes/apps/auth/lldap/ks.yaml
+++ b/kubernetes/apps/auth/lldap/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/auth/lldap/app
   interval: 30m
   timeout: 5m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: lldap
       namespace: databases

--- a/kubernetes/apps/cert-manager/cert-manager/ks.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/ks.yaml
@@ -13,12 +13,7 @@ spec:
   targetNamespace: cert-manager
   path: ./kubernetes/apps/cert-manager/cert-manager/app
   interval: 1h
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: cilium
       namespace: kube-system
@@ -37,12 +32,7 @@ spec:
   targetNamespace: cert-manager
   path: ./kubernetes/apps/cert-manager/cert-manager/issuers
   interval: 1h
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: cert-manager
       namespace: cert-manager

--- a/kubernetes/apps/collab/atuin/ks.yaml
+++ b/kubernetes/apps/collab/atuin/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/collab/atuin/app
   interval: 30m
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: atuin
       namespace: databases

--- a/kubernetes/apps/collab/bentopdf/ks.yaml
+++ b/kubernetes/apps/collab/bentopdf/ks.yaml
@@ -12,9 +12,4 @@ spec:
   path: ./kubernetes/apps/collab/bentopdf/app
   interval: 30m
   timeout: 5m
-  prune: true
   wait: false # no flux ks dependents
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system

--- a/kubernetes/apps/collab/glance-user/ks.yaml
+++ b/kubernetes/apps/collab/glance-user/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/collab/glance-user/app
   interval: 1h
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: authelia
       namespace: auth

--- a/kubernetes/apps/collab/glance/ks.yaml
+++ b/kubernetes/apps/collab/glance/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/collab/glance/app
   interval: 1h
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: authelia
       namespace: auth

--- a/kubernetes/apps/collab/it-tools/ks.yaml
+++ b/kubernetes/apps/collab/it-tools/ks.yaml
@@ -12,9 +12,4 @@ spec:
   path: ./kubernetes/apps/collab/it-tools/app
   interval: 30m
   timeout: 5m
-  prune: true
   wait: false # no flux ks dependents
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system

--- a/kubernetes/apps/collab/kitchenowl/ks.yaml
+++ b/kubernetes/apps/collab/kitchenowl/ks.yaml
@@ -12,11 +12,6 @@ spec:
   path: ./kubernetes/apps/collab/kitchenowl/app
   interval: 30m
   timeout: 3m
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: longhorn
       namespace: longhorn-system

--- a/kubernetes/apps/collab/medikeep/ks.yaml
+++ b/kubernetes/apps/collab/medikeep/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/collab/medikeep/app
   interval: 30m
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: medikeep
       namespace: databases

--- a/kubernetes/apps/collab/nametag/ks.yaml
+++ b/kubernetes/apps/collab/nametag/ks.yaml
@@ -11,12 +11,7 @@ spec:
   targetNamespace: collab
   path: "./kubernetes/apps/collab/nametag/app"
   interval: 30m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: dragonfly-cluster
       namespace: databases

--- a/kubernetes/apps/collab/obsidian-couchdb/ks.yaml
+++ b/kubernetes/apps/collab/obsidian-couchdb/ks.yaml
@@ -11,12 +11,7 @@ spec:
   targetNamespace: collab
   path: "./kubernetes/apps/collab/obsidian-couchdb/app"
   interval: 30m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: longhorn
       namespace: longhorn-system

--- a/kubernetes/apps/collab/open-webui/ks.yaml
+++ b/kubernetes/apps/collab/open-webui/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: "./kubernetes/apps/collab/open-webui/app"
   interval: 30m
   timeout: 3m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: ollama
       namespace: ai

--- a/kubernetes/apps/collab/paperless/ks.yaml
+++ b/kubernetes/apps/collab/paperless/ks.yaml
@@ -11,12 +11,7 @@ spec:
   targetNamespace: collab
   path: "./kubernetes/apps/collab/paperless/app"
   interval: 30m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: dragonfly-cluster
       namespace: databases

--- a/kubernetes/apps/collab/pump-cv/ks.yaml
+++ b/kubernetes/apps/collab/pump-cv/ks.yaml
@@ -14,11 +14,6 @@ spec:
   path: ./kubernetes/apps/collab/pump-cv/app
   interval: 30m
   timeout: 3m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: pump

--- a/kubernetes/apps/collab/pump/ks.yaml
+++ b/kubernetes/apps/collab/pump/ks.yaml
@@ -14,12 +14,7 @@ spec:
   path: ./kubernetes/apps/collab/pump/app
   interval: 30m
   timeout: 3m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: authelia
       namespace: auth

--- a/kubernetes/apps/collab/searxng/ks.yaml
+++ b/kubernetes/apps/collab/searxng/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/collab/searxng/app
   interval: 30m
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: dragonfly-cluster
       namespace: databases

--- a/kubernetes/apps/collab/swiparr/ks.yaml
+++ b/kubernetes/apps/collab/swiparr/ks.yaml
@@ -11,12 +11,7 @@ spec:
   targetNamespace: collab
   path: "./kubernetes/apps/collab/swiparr/app"
   interval: 30m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: longhorn
       namespace: longhorn-system

--- a/kubernetes/apps/collab/zulip/ks.yaml
+++ b/kubernetes/apps/collab/zulip/ks.yaml
@@ -12,11 +12,6 @@ spec:
   path: ./kubernetes/apps/collab/zulip/app
   interval: 30m
   timeout: 5m
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: zulip
       namespace: databases

--- a/kubernetes/apps/databases/cloudnative-pg/ks.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/ks.yaml
@@ -14,12 +14,7 @@ spec:
   path: ./kubernetes/apps/databases/cloudnative-pg/app
   interval: 30m
   timeout: 5m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: rook-ceph-cluster
       namespace: rook-ceph
@@ -39,12 +34,7 @@ spec:
   path: ./kubernetes/apps/databases/cloudnative-pg/plugin-barman-cloud
   interval: 30m
   timeout: 5m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: cloudnative-pg
       namespace: databases
@@ -65,12 +55,7 @@ spec:
   path: ./kubernetes/apps/databases/cloudnative-pg/config/immich
   interval: 30m
   timeout: 5m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: cloudnative-pg
       namespace: databases
@@ -103,12 +88,7 @@ spec:
   path: ./kubernetes/apps/databases/cloudnative-pg/config/paperless
   interval: 30m
   timeout: 5m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: cloudnative-pg
       namespace: databases
@@ -141,12 +121,7 @@ spec:
   path: ./kubernetes/apps/databases/cloudnative-pg/config/home-assistant
   interval: 30m
   timeout: 5m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: cloudnative-pg
       namespace: databases
@@ -179,12 +154,7 @@ spec:
   path: ./kubernetes/apps/databases/cloudnative-pg/config/lldap
   interval: 30m
   timeout: 5m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: cloudnative-pg
       namespace: databases
@@ -217,12 +187,7 @@ spec:
   path: ./kubernetes/apps/databases/cloudnative-pg/config/authelia
   interval: 30m
   timeout: 5m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: cloudnative-pg
       namespace: databases
@@ -255,12 +220,7 @@ spec:
   path: ./kubernetes/apps/databases/cloudnative-pg/config/atuin
   interval: 30m
   timeout: 5m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: cloudnative-pg
       namespace: databases
@@ -293,12 +253,7 @@ spec:
   path: ./kubernetes/apps/databases/cloudnative-pg/config/nametag
   interval: 30m
   timeout: 5m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: cloudnative-pg
       namespace: databases
@@ -331,12 +286,7 @@ spec:
   path: ./kubernetes/apps/databases/cloudnative-pg/config/netbox
   interval: 30m
   timeout: 5m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: cloudnative-pg
       namespace: databases
@@ -369,12 +319,7 @@ spec:
   path: ./kubernetes/apps/databases/cloudnative-pg/config/sparkyfitness
   interval: 30m
   timeout: 5m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: cloudnative-pg
       namespace: databases
@@ -407,12 +352,7 @@ spec:
   path: ./kubernetes/apps/databases/cloudnative-pg/config/medikeep
   interval: 30m
   timeout: 5m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: cloudnative-pg
       namespace: databases
@@ -446,12 +386,7 @@ spec:
   path: ./kubernetes/apps/databases/cloudnative-pg/config/romm
   interval: 30m
   timeout: 5m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: cloudnative-pg
       namespace: databases
@@ -485,12 +420,7 @@ spec:
   path: ./kubernetes/apps/databases/cloudnative-pg/config/pump
   interval: 30m
   timeout: 5m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: cloudnative-pg
       namespace: databases
@@ -523,12 +453,7 @@ spec:
   path: ./kubernetes/apps/databases/cloudnative-pg/config/av1corrector
   interval: 30m
   timeout: 5m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: cloudnative-pg
       namespace: databases
@@ -561,12 +486,7 @@ spec:
   path: ./kubernetes/apps/databases/cloudnative-pg/config/videodupfinder
   interval: 30m
   timeout: 5m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: cloudnative-pg
       namespace: databases
@@ -599,12 +519,7 @@ spec:
   path: ./kubernetes/apps/databases/cloudnative-pg/config/lidarr
   interval: 30m
   timeout: 5m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: cloudnative-pg
       namespace: databases
@@ -637,12 +552,7 @@ spec:
   path: ./kubernetes/apps/databases/cloudnative-pg/config/sonarr
   interval: 30m
   timeout: 5m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: cloudnative-pg
       namespace: databases
@@ -675,12 +585,7 @@ spec:
   path: ./kubernetes/apps/databases/cloudnative-pg/config/radarr
   interval: 30m
   timeout: 5m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: cloudnative-pg
       namespace: databases
@@ -713,12 +618,7 @@ spec:
   path: ./kubernetes/apps/databases/cloudnative-pg/config/prowlarr
   interval: 30m
   timeout: 5m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: cloudnative-pg
       namespace: databases
@@ -751,12 +651,7 @@ spec:
   path: ./kubernetes/apps/databases/cloudnative-pg/config/zulip
   interval: 30m
   timeout: 5m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: cloudnative-pg
       namespace: databases
@@ -789,12 +684,7 @@ spec:
   path: ./kubernetes/apps/databases/cloudnative-pg/config/langgraph-checkpoints
   interval: 30m
   timeout: 5m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: cloudnative-pg
       namespace: databases
@@ -827,12 +717,7 @@ spec:
   path: ./kubernetes/apps/databases/cloudnative-pg/config/langgraph-memory
   interval: 30m
   timeout: 5m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: cloudnative-pg
       namespace: databases
@@ -865,12 +750,7 @@ spec:
   path: ./kubernetes/apps/databases/cloudnative-pg/config/khoj
   interval: 30m
   timeout: 5m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: cloudnative-pg
       namespace: databases
@@ -903,12 +783,7 @@ spec:
   path: ./kubernetes/apps/databases/cloudnative-pg/config/windmill
   interval: 30m
   timeout: 5m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: cloudnative-pg
       namespace: databases
@@ -941,12 +816,7 @@ spec:
   path: ./kubernetes/apps/databases/cloudnative-pg/config/langfuse
   interval: 30m
   timeout: 5m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: cloudnative-pg
       namespace: databases

--- a/kubernetes/apps/databases/dragonfly/ks.yaml
+++ b/kubernetes/apps/databases/dragonfly/ks.yaml
@@ -11,12 +11,7 @@ spec:
   targetNamespace: databases
   path: ./kubernetes/apps/databases/dragonfly/operator
   interval: 10m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -30,12 +25,7 @@ spec:
   targetNamespace: databases
   path: ./kubernetes/apps/databases/dragonfly/cluster
   interval: 10m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: dragonfly-operator
       namespace: databases

--- a/kubernetes/apps/databases/pgadmin/ks.yaml
+++ b/kubernetes/apps/databases/pgadmin/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/databases/pgadmin/app
   interval: 30m
   timeout: 3m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: rook-ceph-cluster
       namespace: rook-ceph

--- a/kubernetes/apps/databases/qdrant/ks.yaml
+++ b/kubernetes/apps/databases/qdrant/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/databases/qdrant/app
   interval: 30m
   timeout: 3m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: rook-ceph-cluster
       namespace: rook-ceph

--- a/kubernetes/apps/downloads/jdownloader2/ks.yaml
+++ b/kubernetes/apps/downloads/jdownloader2/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/downloads/jdownloader2/app
   interval: 30m
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: authelia
       namespace: auth

--- a/kubernetes/apps/downloads/prowlarr/ks.yaml
+++ b/kubernetes/apps/downloads/prowlarr/ks.yaml
@@ -12,11 +12,6 @@ spec:
   path: ./kubernetes/apps/downloads/prowlarr/app
   interval: 30m
   timeout: 3m
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: authelia
       namespace: auth

--- a/kubernetes/apps/downloads/qbittorrent/ks.yaml
+++ b/kubernetes/apps/downloads/qbittorrent/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/downloads/qbittorrent/secrets
   interval: 30m
   timeout: 5m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: authelia
       namespace: auth
@@ -41,11 +36,6 @@ spec:
   path: ./kubernetes/apps/downloads/qbittorrent/app
   interval: 30m
   timeout: 3m
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: downloads-gateway
       namespace: vpn

--- a/kubernetes/apps/downloads/sabnzbd/ks.yaml
+++ b/kubernetes/apps/downloads/sabnzbd/ks.yaml
@@ -12,11 +12,6 @@ spec:
   path: ./kubernetes/apps/downloads/sabnzbd/app
   interval: 30m
   timeout: 3m
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: authelia
       namespace: auth

--- a/kubernetes/apps/downloads/slskd/ks.yaml
+++ b/kubernetes/apps/downloads/slskd/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/downloads/slskd/app
   interval: 30m
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: authelia
       namespace: auth

--- a/kubernetes/apps/external-secrets/external-secrets/ks.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/external-secrets/external-secrets/app
   interval: 1h
   timeout: 5m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease

--- a/kubernetes/apps/external-secrets/onepassword-connect/ks.yaml
+++ b/kubernetes/apps/external-secrets/onepassword-connect/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/external-secrets/onepassword-connect/app
   interval: 1h
   timeout: 5m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: external-secrets
       namespace: external-secrets

--- a/kubernetes/apps/flux-system/flux-instance/ks.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/flux-system/flux-instance/app
   interval: 1h
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: flux-operator
       namespace: flux-system

--- a/kubernetes/apps/flux-system/flux-operator/ks.yaml
+++ b/kubernetes/apps/flux-system/flux-operator/ks.yaml
@@ -12,8 +12,4 @@ spec:
   path: ./kubernetes/apps/flux-system/flux-operator/app
   interval: 1h
   timeout: 5m
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
   retryInterval: 2m

--- a/kubernetes/apps/flux-system/kustomize-mutating-webhook/ks.yaml
+++ b/kubernetes/apps/flux-system/kustomize-mutating-webhook/ks.yaml
@@ -12,10 +12,5 @@ spec:
   path: "./kubernetes/apps/flux-system/kustomize-mutating-webhook/app"
   interval: 30m
   timeout: 3m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   retryInterval: 1m

--- a/kubernetes/apps/home/aquapured/ks.yaml
+++ b/kubernetes/apps/home/aquapured/ks.yaml
@@ -11,12 +11,7 @@ spec:
   targetNamespace: home
   path: ./kubernetes/apps/home/aquapured/net-attach
   interval: 30m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: multus
       namespace: network
@@ -34,11 +29,6 @@ spec:
   path: ./kubernetes/apps/home/aquapured/app
   interval: 30m
   timeout: 5m
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: aquapured-multus
       namespace: home

--- a/kubernetes/apps/home/emqx/ks.yaml
+++ b/kubernetes/apps/home/emqx/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/home/emqx/app
   interval: 30m
   timeout: 5m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: rook-ceph-cluster
       namespace: rook-ceph

--- a/kubernetes/apps/home/esphome/ks.yaml
+++ b/kubernetes/apps/home/esphome/ks.yaml
@@ -12,11 +12,6 @@ spec:
   path: ./kubernetes/apps/home/esphome/app
   interval: 30m
   timeout: 3m
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: longhorn
       namespace: longhorn-system
@@ -35,12 +30,7 @@ spec:
   targetNamespace: home
   path: ./kubernetes/apps/home/esphome/net-attach
   interval: 30m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: multus
       namespace: network
@@ -58,9 +48,4 @@ spec:
   path: ./kubernetes/apps/home/esphome/code
   interval: 30m
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system

--- a/kubernetes/apps/home/frigate/ks.yaml
+++ b/kubernetes/apps/home/frigate/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/home/frigate/app
   interval: 1h
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: authelia
       namespace: auth
@@ -44,12 +39,7 @@ spec:
   targetNamespace: home
   path: ./kubernetes/apps/home/frigate/net-attach
   interval: 30m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: multus
       namespace: network

--- a/kubernetes/apps/home/home-assistant/ks.yaml
+++ b/kubernetes/apps/home/home-assistant/ks.yaml
@@ -12,11 +12,6 @@ spec:
   path: ./kubernetes/apps/home/home-assistant/app
   interval: 30m
   timeout: 3m
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: emqx
       namespace: home
@@ -43,12 +38,7 @@ spec:
   targetNamespace: home
   path: ./kubernetes/apps/home/home-assistant/net-attach
   interval: 30m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: multus
       namespace: network
@@ -66,9 +56,4 @@ spec:
   path: ./kubernetes/apps/home/home-assistant/code
   interval: 30m
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system

--- a/kubernetes/apps/home/matter-server/ks.yaml
+++ b/kubernetes/apps/home/matter-server/ks.yaml
@@ -11,12 +11,7 @@ spec:
   targetNamespace: home
   path: ./kubernetes/apps/home/matter-server/net-attach
   interval: 30m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: multus
       namespace: network
@@ -34,12 +29,7 @@ spec:
   path: ./kubernetes/apps/home/matter-server/app
   interval: 30m
   timeout: 3m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: longhorn
       namespace: longhorn-system

--- a/kubernetes/apps/home/netbox/ks.yaml
+++ b/kubernetes/apps/home/netbox/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/home/netbox/app
   interval: 1h
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: netbox
       namespace: databases

--- a/kubernetes/apps/home/node-red/ks.yaml
+++ b/kubernetes/apps/home/node-red/ks.yaml
@@ -12,11 +12,6 @@ spec:
   path: ./kubernetes/apps/home/node-red/app
   interval: 30m
   timeout: 3m
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: longhorn
       namespace: longhorn-system
@@ -35,12 +30,7 @@ spec:
   targetNamespace: home
   path: ./kubernetes/apps/home/node-red/net-attach
   interval: 30m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: multus
       namespace: network

--- a/kubernetes/apps/home/ntfy/ks.yaml
+++ b/kubernetes/apps/home/ntfy/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/home/ntfy/app
   interval: 30m
   timeout: 3m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: onepassword-connect
       namespace: external-secrets

--- a/kubernetes/apps/home/rtl-433/ks.yaml
+++ b/kubernetes/apps/home/rtl-433/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/home/rtl-433/app
   interval: 30m
   timeout: 3m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: node-feature-discovery
       namespace: kube-system

--- a/kubernetes/apps/home/smtp-relay/ks.yaml
+++ b/kubernetes/apps/home/smtp-relay/ks.yaml
@@ -12,11 +12,6 @@ spec:
   path: ./kubernetes/apps/home/smtp-relay/app
   interval: 30m
   timeout: 3m
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: onepassword-connect
       namespace: external-secrets

--- a/kubernetes/apps/home/windmill/ks.yaml
+++ b/kubernetes/apps/home/windmill/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/home/windmill/app
   interval: 30m
   timeout: 10m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: authelia
       namespace: auth

--- a/kubernetes/apps/home/wyoming-services/ks.yaml
+++ b/kubernetes/apps/home/wyoming-services/ks.yaml
@@ -11,12 +11,7 @@ spec:
   targetNamespace: home
   path: "./kubernetes/apps/home/wyoming-services/app"
   interval: 30m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: gpu-operator
       namespace: kube-system

--- a/kubernetes/apps/home/zigbee2mqtt/ks.yaml
+++ b/kubernetes/apps/home/zigbee2mqtt/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/home/zigbee2mqtt/app
   interval: 30m
   timeout: 3m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: longhorn
       namespace: longhorn-system

--- a/kubernetes/apps/home/zwave-js-ui/ks.yaml
+++ b/kubernetes/apps/home/zwave-js-ui/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/home/zwave-js-ui/app
   interval: 30m
   timeout: 3m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: longhorn
       namespace: longhorn-system

--- a/kubernetes/apps/istio-system/istio/ks.yaml
+++ b/kubernetes/apps/istio-system/istio/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: "./kubernetes/apps/istio-system/istio/app/base"
   interval: 1h
   timeout: 5m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: envoy-gateway-config
       namespace: network
@@ -35,12 +30,7 @@ spec:
   path: "./kubernetes/apps/istio-system/istio/app/istiod"
   interval: 1h
   timeout: 5m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: istio-base
       namespace: istio-system

--- a/kubernetes/apps/kuadrant/kuadrant-operator/ks.yaml
+++ b/kubernetes/apps/kuadrant/kuadrant-operator/ks.yaml
@@ -12,11 +12,6 @@ spec:
   path: "./kubernetes/apps/kuadrant/kuadrant-operator/app"
   interval: 1h
   timeout: 5m
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease

--- a/kubernetes/apps/kube-system/cilium/ks.yaml
+++ b/kubernetes/apps/kube-system/cilium/ks.yaml
@@ -12,16 +12,11 @@ spec:
   path: "./kubernetes/apps/kube-system/cilium/app"
   interval: 1h
   timeout: 5m
-  prune: true
   # `wait: true` is required for `cilium-config`'s `dependsOn` to
   # honor readiness — without it, the dependent Kustomization fires
   # as soon as this one's resources are applied, not when the chart
   # has actually installed its CRDs. Mirrors cert-manager / kyverno.
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -37,12 +32,7 @@ spec:
   path: "./kubernetes/apps/kube-system/cilium/config"
   interval: 1h
   timeout: 5m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   # CiliumBGPAdvertisement + CiliumLoadBalancerIPPool here use CRDs
   # the cilium chart provides. Without dependsOn, fresh deploys /
   # full reconciles race the chart's CRD install (chicken-and-egg).

--- a/kubernetes/apps/kube-system/coredns/ks.yaml
+++ b/kubernetes/apps/kube-system/coredns/ks.yaml
@@ -14,7 +14,3 @@ spec:
   timeout: 5m
   prune: false # Never delete this
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system

--- a/kubernetes/apps/kube-system/descheduler/ks.yaml
+++ b/kubernetes/apps/kube-system/descheduler/ks.yaml
@@ -12,9 +12,4 @@ spec:
   path: ./kubernetes/apps/kube-system/descheduler/app
   interval: 30m
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system

--- a/kubernetes/apps/kube-system/gpu-operator/ks.yaml
+++ b/kubernetes/apps/kube-system/gpu-operator/ks.yaml
@@ -12,9 +12,4 @@ spec:
   path: ./kubernetes/apps/kube-system/gpu-operator/app
   interval: 30m
   timeout: 15m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system

--- a/kubernetes/apps/kube-system/intel-device-plugin/ks.yaml
+++ b/kubernetes/apps/kube-system/intel-device-plugin/ks.yaml
@@ -11,12 +11,7 @@ spec:
   targetNamespace: kube-system
   path: ./kubernetes/apps/kube-system/intel-device-plugin/app
   interval: 30m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: node-feature-discovery
       namespace: kube-system
@@ -36,12 +31,7 @@ spec:
   path: ./kubernetes/apps/kube-system/intel-device-plugin/gpu
   interval: 30m
   timeout: 3m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: intel-device-plugin-operator
       namespace: kube-system
@@ -59,11 +49,6 @@ spec:
   path: ./kubernetes/apps/kube-system/intel-device-plugin/exporter
   interval: 30m
   timeout: 3m
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: intel-device-plugin-gpu
       namespace: kube-system

--- a/kubernetes/apps/kube-system/k8tz/ks.yaml
+++ b/kubernetes/apps/kube-system/k8tz/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: "./kubernetes/apps/kube-system/k8tz/app"
   interval: 30m
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: cert-manager
       namespace: cert-manager

--- a/kubernetes/apps/kube-system/kubelet-csr-approver/ks.yaml
+++ b/kubernetes/apps/kube-system/kubelet-csr-approver/ks.yaml
@@ -14,7 +14,3 @@ spec:
   timeout: 5m
   prune: false # never should be deleted
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system

--- a/kubernetes/apps/kube-system/metrics-server/ks.yaml
+++ b/kubernetes/apps/kube-system/metrics-server/ks.yaml
@@ -12,9 +12,4 @@ spec:
   path: ./kubernetes/apps/kube-system/metrics-server/app
   interval: 30m
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system

--- a/kubernetes/apps/kube-system/node-feature-discovery/ks.yaml
+++ b/kubernetes/apps/kube-system/node-feature-discovery/ks.yaml
@@ -14,12 +14,7 @@ spec:
   path: ./kubernetes/apps/kube-system/node-feature-discovery/app
   interval: 30m
   timeout: 3m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -36,12 +31,7 @@ spec:
   path: ./kubernetes/apps/kube-system/node-feature-discovery/rules
   interval: 30m
   timeout: 3m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: node-feature-discovery
       namespace: kube-system

--- a/kubernetes/apps/kube-system/node-problem-detector/ks.yaml
+++ b/kubernetes/apps/kube-system/node-problem-detector/ks.yaml
@@ -14,9 +14,4 @@ spec:
   path: ./kubernetes/apps/kube-system/node-problem-detector/app
   interval: 30m
   timeout: 3m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system

--- a/kubernetes/apps/kube-system/reloader/ks.yaml
+++ b/kubernetes/apps/kube-system/reloader/ks.yaml
@@ -12,9 +12,4 @@ spec:
   path: ./kubernetes/apps/kube-system/reloader/app
   interval: 30m
   timeout: 3m
-  prune: true
   wait: false # no flux ks dependents
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system

--- a/kubernetes/apps/kube-system/vpa/ks.yaml
+++ b/kubernetes/apps/kube-system/vpa/ks.yaml
@@ -12,9 +12,4 @@ spec:
   path: ./kubernetes/apps/kube-system/vpa/app
   interval: 30m
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system

--- a/kubernetes/apps/kube-system/zot/ks.yaml
+++ b/kubernetes/apps/kube-system/zot/ks.yaml
@@ -11,12 +11,7 @@ spec:
   targetNamespace: kube-system
   path: ./kubernetes/apps/kube-system/zot/app
   interval: 10m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: onepassword-connect
       namespace: external-secrets

--- a/kubernetes/apps/kyverno/kyverno/ks.yaml
+++ b/kubernetes/apps/kyverno/kyverno/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/kyverno/kyverno/app
   interval: 30m
   timeout: 5m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -32,12 +27,7 @@ spec:
   path: ./kubernetes/apps/kyverno/kyverno/policies
   interval: 30m
   timeout: 5m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: kyverno
       namespace: kyverno

--- a/kubernetes/apps/kyverno/policy-reporter/ks.yaml
+++ b/kubernetes/apps/kyverno/policy-reporter/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/kyverno/policy-reporter/app
   interval: 30m
   timeout: 5m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: kyverno
       namespace: kyverno

--- a/kubernetes/apps/longhorn-system/longhorn/ks.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn/ks.yaml
@@ -14,12 +14,7 @@ spec:
   path: ./kubernetes/apps/longhorn-system/longhorn/app
   interval: 30m
   timeout: 3m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
 ---
 # # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -36,12 +31,7 @@ spec:
   path: ./kubernetes/apps/longhorn-system/longhorn/config
   interval: 30m
   timeout: 3m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: longhorn
       namespace: longhorn-system

--- a/kubernetes/apps/mcp-system/arr-mcp/ks.yaml
+++ b/kubernetes/apps/mcp-system/arr-mcp/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/mcp-system/arr-mcp/app
   interval: 1h
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: mcp-gateway
       namespace: mcp-system
@@ -36,12 +31,7 @@ spec:
   path: ./kubernetes/apps/mcp-system/arr-mcp/mcp
   interval: 1h
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: arr-mcp
       namespace: mcp-system

--- a/kubernetes/apps/mcp-system/chrome-mcp/ks.yaml
+++ b/kubernetes/apps/mcp-system/chrome-mcp/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/mcp-system/chrome-mcp/app
   interval: 1h
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: mcp-gateway
       namespace: mcp-system
@@ -36,12 +31,7 @@ spec:
   path: ./kubernetes/apps/mcp-system/chrome-mcp/mcp
   interval: 1h
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: chrome-mcp
       namespace: mcp-system

--- a/kubernetes/apps/mcp-system/chrome-smoke-sweep/ks.yaml
+++ b/kubernetes/apps/mcp-system/chrome-smoke-sweep/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/mcp-system/chrome-smoke-sweep/app
   interval: 1h
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: chrome-mcp
       namespace: mcp-system

--- a/kubernetes/apps/mcp-system/cilium-mcp/ks.yaml
+++ b/kubernetes/apps/mcp-system/cilium-mcp/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/mcp-system/cilium-mcp/app
   interval: 1h
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: mcp-gateway
       namespace: mcp-system
@@ -36,12 +31,7 @@ spec:
   path: ./kubernetes/apps/mcp-system/cilium-mcp/mcp
   interval: 1h
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: cilium-mcp
       namespace: mcp-system

--- a/kubernetes/apps/mcp-system/codegraph-mcp/ks.yaml
+++ b/kubernetes/apps/mcp-system/codegraph-mcp/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/mcp-system/codegraph-mcp/app
   interval: 1h
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: mcp-gateway
       namespace: mcp-system
@@ -38,12 +33,7 @@ spec:
   path: ./kubernetes/apps/mcp-system/codegraph-mcp/mcp
   interval: 1h
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: codegraph-mcp
       namespace: mcp-system

--- a/kubernetes/apps/mcp-system/comfyui-mcp/ks.yaml
+++ b/kubernetes/apps/mcp-system/comfyui-mcp/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/mcp-system/comfyui-mcp/app
   interval: 1h
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: mcp-gateway
       namespace: mcp-system
@@ -36,12 +31,7 @@ spec:
   path: ./kubernetes/apps/mcp-system/comfyui-mcp/mcp
   interval: 1h
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: comfyui-mcp
       namespace: mcp-system

--- a/kubernetes/apps/mcp-system/esphome-mcp/ks.yaml
+++ b/kubernetes/apps/mcp-system/esphome-mcp/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/mcp-system/esphome-mcp/app
   interval: 1h
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: mcp-gateway
       namespace: mcp-system
@@ -36,12 +31,7 @@ spec:
   path: ./kubernetes/apps/mcp-system/esphome-mcp/mcp
   interval: 1h
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: esphome-mcp
       namespace: mcp-system

--- a/kubernetes/apps/mcp-system/github-mcp/ks.yaml
+++ b/kubernetes/apps/mcp-system/github-mcp/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/mcp-system/github-mcp/app
   interval: 1h
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: mcp-gateway
       namespace: mcp-system
@@ -36,12 +31,7 @@ spec:
   path: ./kubernetes/apps/mcp-system/github-mcp/mcp
   interval: 1h
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: github-mcp
       namespace: mcp-system

--- a/kubernetes/apps/mcp-system/grafana-mcp/ks.yaml
+++ b/kubernetes/apps/mcp-system/grafana-mcp/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/mcp-system/grafana-mcp/app
   interval: 1h
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: mcp-gateway
       namespace: mcp-system
@@ -36,12 +31,7 @@ spec:
   path: ./kubernetes/apps/mcp-system/grafana-mcp/mcp
   interval: 1h
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: grafana-mcp
       namespace: mcp-system

--- a/kubernetes/apps/mcp-system/ha-mcp/ks.yaml
+++ b/kubernetes/apps/mcp-system/ha-mcp/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: "./kubernetes/apps/mcp-system/ha-mcp/app"
   interval: 1h
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: mcp-gateway
       namespace: mcp-system
@@ -36,12 +31,7 @@ spec:
   path: "./kubernetes/apps/mcp-system/ha-mcp/mcp"
   interval: 1h
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: ha-mcp
       namespace: mcp-system

--- a/kubernetes/apps/mcp-system/immich-mcp/ks.yaml
+++ b/kubernetes/apps/mcp-system/immich-mcp/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/mcp-system/immich-mcp/app
   interval: 1h
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: mcp-gateway
       namespace: mcp-system
@@ -36,12 +31,7 @@ spec:
   path: ./kubernetes/apps/mcp-system/immich-mcp/mcp
   interval: 1h
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: immich-mcp
       namespace: mcp-system

--- a/kubernetes/apps/mcp-system/kubectl-mcp/ks.yaml
+++ b/kubernetes/apps/mcp-system/kubectl-mcp/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/mcp-system/kubectl-mcp/app
   interval: 1h
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: mcp-gateway
       namespace: mcp-system
@@ -36,12 +31,7 @@ spec:
   path: ./kubernetes/apps/mcp-system/kubectl-mcp/mcp
   interval: 1h
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: kubectl-mcp
       namespace: mcp-system

--- a/kubernetes/apps/mcp-system/mcp-gateway/ks.yaml
+++ b/kubernetes/apps/mcp-system/mcp-gateway/ks.yaml
@@ -12,11 +12,6 @@ spec:
   path: "./kubernetes/apps/mcp-system/mcp-gateway/app"
   interval: 1h
   timeout: 5m
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: authelia
       namespace: auth

--- a/kubernetes/apps/mcp-system/memory-mcp/ks.yaml
+++ b/kubernetes/apps/mcp-system/memory-mcp/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/mcp-system/memory-mcp/app
   interval: 1h
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: mcp-gateway
       namespace: mcp-system
@@ -38,12 +33,7 @@ spec:
   path: ./kubernetes/apps/mcp-system/memory-mcp/mcp
   interval: 1h
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: memory-mcp
       namespace: mcp-system

--- a/kubernetes/apps/mcp-system/netbox-mcp/ks.yaml
+++ b/kubernetes/apps/mcp-system/netbox-mcp/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/mcp-system/netbox-mcp/app
   interval: 1h
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: mcp-gateway
       namespace: mcp-system
@@ -36,12 +31,7 @@ spec:
   path: ./kubernetes/apps/mcp-system/netbox-mcp/mcp
   interval: 1h
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: netbox-mcp
       namespace: mcp-system

--- a/kubernetes/apps/mcp-system/observability/ks.yaml
+++ b/kubernetes/apps/mcp-system/observability/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/mcp-system/observability/app
   interval: 1h
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: memory-mcp
       namespace: mcp-system

--- a/kubernetes/apps/mcp-system/omada-mcp/ks.yaml
+++ b/kubernetes/apps/mcp-system/omada-mcp/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/mcp-system/omada-mcp/app
   interval: 1h
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: mcp-gateway
       namespace: mcp-system
@@ -36,12 +31,7 @@ spec:
   path: ./kubernetes/apps/mcp-system/omada-mcp/mcp
   interval: 1h
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: omada-mcp
       namespace: mcp-system

--- a/kubernetes/apps/mcp-system/paperless-mcp/ks.yaml
+++ b/kubernetes/apps/mcp-system/paperless-mcp/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/mcp-system/paperless-mcp/app
   interval: 1h
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: mcp-gateway
       namespace: mcp-system
@@ -36,12 +31,7 @@ spec:
   path: ./kubernetes/apps/mcp-system/paperless-mcp/mcp
   interval: 1h
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: paperless-mcp
       namespace: mcp-system

--- a/kubernetes/apps/mcp-system/prometheus-mcp/ks.yaml
+++ b/kubernetes/apps/mcp-system/prometheus-mcp/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/mcp-system/prometheus-mcp/app
   interval: 1h
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: mcp-gateway
       namespace: mcp-system

--- a/kubernetes/apps/mcp-system/searxng-mcp/ks.yaml
+++ b/kubernetes/apps/mcp-system/searxng-mcp/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/mcp-system/searxng-mcp/app
   interval: 1h
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: mcp-gateway
       namespace: mcp-system
@@ -36,12 +31,7 @@ spec:
   path: ./kubernetes/apps/mcp-system/searxng-mcp/mcp
   interval: 1h
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: searxng-mcp
       namespace: mcp-system

--- a/kubernetes/apps/mcp-system/time-mcp/ks.yaml
+++ b/kubernetes/apps/mcp-system/time-mcp/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/mcp-system/time-mcp/app
   interval: 1h
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: mcp-gateway
       namespace: mcp-system
@@ -36,12 +31,7 @@ spec:
   path: ./kubernetes/apps/mcp-system/time-mcp/mcp
   interval: 1h
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: time-mcp
       namespace: mcp-system

--- a/kubernetes/apps/mcp-system/windmill-mcp/ks.yaml
+++ b/kubernetes/apps/mcp-system/windmill-mcp/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/mcp-system/windmill-mcp/app
   interval: 1h
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: mcp-gateway
       namespace: mcp-system
@@ -36,12 +31,7 @@ spec:
   path: ./kubernetes/apps/mcp-system/windmill-mcp/mcp
   interval: 1h
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: windmill-mcp
       namespace: mcp-system

--- a/kubernetes/apps/media/av1corrector/ks.yaml
+++ b/kubernetes/apps/media/av1corrector/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/media/av1corrector/secrets
   interval: 30m
   timeout: 5m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: authelia
       namespace: auth
@@ -41,12 +36,7 @@ spec:
   path: ./kubernetes/apps/media/av1corrector/app
   interval: 30m
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: av1corrector
       namespace: databases

--- a/kubernetes/apps/media/batocera-webdashboard-pro/ks.yaml
+++ b/kubernetes/apps/media/batocera-webdashboard-pro/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/media/batocera-webdashboard-pro/app
   interval: 30m
   timeout: 3m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: authelia
       namespace: auth

--- a/kubernetes/apps/media/beets/ks.yaml
+++ b/kubernetes/apps/media/beets/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/media/beets/app
   interval: 1h
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: longhorn
       namespace: longhorn-system

--- a/kubernetes/apps/media/flaresolverr/ks.yaml
+++ b/kubernetes/apps/media/flaresolverr/ks.yaml
@@ -12,9 +12,4 @@ spec:
   path: ./kubernetes/apps/media/flaresolverr/app
   interval: 30m
   timeout: 3m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system

--- a/kubernetes/apps/media/gonic/ks.yaml
+++ b/kubernetes/apps/media/gonic/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/media/gonic/app
   interval: 30m
   timeout: 3m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: longhorn
       namespace: longhorn-system

--- a/kubernetes/apps/media/immich-pet-tagger/ks.yaml
+++ b/kubernetes/apps/media/immich-pet-tagger/ks.yaml
@@ -12,11 +12,6 @@ spec:
   path: ./kubernetes/apps/media/immich-pet-tagger/app
   interval: 30m
   timeout: 3m
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: onepassword-connect
       namespace: external-secrets

--- a/kubernetes/apps/media/immich-power-tools/ks.yaml
+++ b/kubernetes/apps/media/immich-power-tools/ks.yaml
@@ -12,11 +12,6 @@ spec:
   path: ./kubernetes/apps/media/immich-power-tools/app
   interval: 30m
   timeout: 3m
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: onepassword-connect
       namespace: external-secrets

--- a/kubernetes/apps/media/immich/ks.yaml
+++ b/kubernetes/apps/media/immich/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/media/immich/app
   interval: 30m
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: dragonfly-cluster
       namespace: databases

--- a/kubernetes/apps/media/immichkiosk-party/ks.yaml
+++ b/kubernetes/apps/media/immichkiosk-party/ks.yaml
@@ -12,11 +12,6 @@ spec:
   path: ./kubernetes/apps/media/immichkiosk-party/app
   interval: 30m
   timeout: 3m
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: onepassword-connect
       namespace: external-secrets

--- a/kubernetes/apps/media/immichkiosk/ks.yaml
+++ b/kubernetes/apps/media/immichkiosk/ks.yaml
@@ -12,11 +12,6 @@ spec:
   path: ./kubernetes/apps/media/immichkiosk/app
   interval: 30m
   timeout: 3m
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: onepassword-connect
       namespace: external-secrets

--- a/kubernetes/apps/media/janitorr/ks.yaml
+++ b/kubernetes/apps/media/janitorr/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/media/janitorr/app
   interval: 30m
   timeout: 3m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: onepassword-connect
       namespace: external-secrets

--- a/kubernetes/apps/media/jellyfin/ks.yaml
+++ b/kubernetes/apps/media/jellyfin/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/media/jellyfin/app
   interval: 30m
   timeout: 3m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: longhorn
       namespace: longhorn-system

--- a/kubernetes/apps/media/kodi-playback-watcher/ks.yaml
+++ b/kubernetes/apps/media/kodi-playback-watcher/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/media/kodi-playback-watcher/secrets
   interval: 30m
   timeout: 5m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: onepassword-connect
       namespace: external-secrets
@@ -39,12 +34,7 @@ spec:
   path: ./kubernetes/apps/media/kodi-playback-watcher/app
   interval: 30m
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: kodi-playback-watcher-secrets
       namespace: media

--- a/kubernetes/apps/media/lidarr-bridge/ks.yaml
+++ b/kubernetes/apps/media/lidarr-bridge/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/media/lidarr-bridge/app
   interval: 1h
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: lidarr
       namespace: media

--- a/kubernetes/apps/media/lidarr-sab-autoimport/ks.yaml
+++ b/kubernetes/apps/media/lidarr-sab-autoimport/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/media/lidarr-sab-autoimport/app
   interval: 1h
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: lidarr
       namespace: media

--- a/kubernetes/apps/media/lidarr/ks.yaml
+++ b/kubernetes/apps/media/lidarr/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/media/lidarr/app
   interval: 30m
   timeout: 3m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: authelia
       namespace: auth

--- a/kubernetes/apps/media/medialyze/ks.yaml
+++ b/kubernetes/apps/media/medialyze/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/media/medialyze/app
   interval: 30m
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: authelia
       namespace: auth

--- a/kubernetes/apps/media/music-assistant/ks.yaml
+++ b/kubernetes/apps/media/music-assistant/ks.yaml
@@ -11,12 +11,7 @@ spec:
   targetNamespace: media
   path: ./kubernetes/apps/media/music-assistant/app
   interval: 30m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: longhorn
       namespace: longhorn-system
@@ -37,12 +32,7 @@ spec:
   targetNamespace: media
   path: ./kubernetes/apps/media/music-assistant/net-attach
   interval: 30m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: multus
       namespace: network

--- a/kubernetes/apps/media/radarr/ks.yaml
+++ b/kubernetes/apps/media/radarr/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/media/radarr/app
   interval: 30m
   timeout: 3m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: authelia
       namespace: auth

--- a/kubernetes/apps/media/recyclarr/ks.yaml
+++ b/kubernetes/apps/media/recyclarr/ks.yaml
@@ -14,11 +14,6 @@ spec:
   path: ./kubernetes/apps/media/recyclarr/app
   interval: 30m
   timeout: 3m
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: onepassword-connect
       namespace: external-secrets

--- a/kubernetes/apps/media/romm/ks.yaml
+++ b/kubernetes/apps/media/romm/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/media/romm/app
   interval: 1h
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: authelia
       namespace: auth

--- a/kubernetes/apps/media/seerr/ks.yaml
+++ b/kubernetes/apps/media/seerr/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/media/seerr/app
   interval: 1h
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: longhorn
       namespace: longhorn-system

--- a/kubernetes/apps/media/sonarr/ks.yaml
+++ b/kubernetes/apps/media/sonarr/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/media/sonarr/app
   interval: 30m
   timeout: 3m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: authelia
       namespace: auth

--- a/kubernetes/apps/media/soularr/ks.yaml
+++ b/kubernetes/apps/media/soularr/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/media/soularr/app
   interval: 30m
   timeout: 3m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: authelia
       namespace: auth

--- a/kubernetes/apps/media/stash/ks.yaml
+++ b/kubernetes/apps/media/stash/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/media/stash/app
   interval: 30m
   timeout: 3m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: longhorn
       namespace: longhorn-system

--- a/kubernetes/apps/media/suggestarr/ks.yaml
+++ b/kubernetes/apps/media/suggestarr/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/media/suggestarr/app
   interval: 30m
   timeout: 3m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: authelia
       namespace: auth

--- a/kubernetes/apps/media/theme-park/ks.yaml
+++ b/kubernetes/apps/media/theme-park/ks.yaml
@@ -12,9 +12,4 @@ spec:
   path: ./kubernetes/apps/media/theme-park/app
   interval: 30m
   timeout: 3m
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   retryInterval: 1m

--- a/kubernetes/apps/media/videodupfinder/ks.yaml
+++ b/kubernetes/apps/media/videodupfinder/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/media/videodupfinder/secrets
   interval: 30m
   timeout: 5m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: onepassword-connect
       namespace: external-secrets
@@ -39,12 +34,7 @@ spec:
   path: ./kubernetes/apps/media/videodupfinder/app
   interval: 30m
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: videodupfinder
       namespace: databases

--- a/kubernetes/apps/network/cloudflare-ddns/ks.yaml
+++ b/kubernetes/apps/network/cloudflare-ddns/ks.yaml
@@ -14,12 +14,7 @@ spec:
   path: ./kubernetes/apps/network/cloudflare-ddns/app
   interval: 30m
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: onepassword-connect
       namespace: external-secrets

--- a/kubernetes/apps/network/cloudflared/ks.yaml
+++ b/kubernetes/apps/network/cloudflared/ks.yaml
@@ -14,12 +14,7 @@ spec:
   path: ./kubernetes/apps/network/cloudflared/app
   interval: 30m
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: onepassword-connect
       namespace: external-secrets

--- a/kubernetes/apps/network/envoy-gateway/ks.yaml
+++ b/kubernetes/apps/network/envoy-gateway/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: "./kubernetes/apps/network/envoy-gateway/app"
   interval: 1h
   timeout: 5m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -32,12 +27,7 @@ spec:
   path: "./kubernetes/apps/network/envoy-gateway/config"
   interval: 1h
   timeout: 5m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: envoy-gateway
       namespace: network

--- a/kubernetes/apps/network/external-dns/ks.yaml
+++ b/kubernetes/apps/network/external-dns/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/network/external-dns/app
   interval: 30m
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: onepassword-connect
       namespace: external-secrets

--- a/kubernetes/apps/network/multus/ks.yaml
+++ b/kubernetes/apps/network/multus/ks.yaml
@@ -14,9 +14,4 @@ spec:
   path: ./kubernetes/apps/network/multus/app
   interval: 30m
   timeout: 3m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system

--- a/kubernetes/apps/network/omada-cert-sync/ks.yaml
+++ b/kubernetes/apps/network/omada-cert-sync/ks.yaml
@@ -14,9 +14,4 @@ spec:
   path: ./kubernetes/apps/network/omada-cert-sync/app
   interval: 30m
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system

--- a/kubernetes/apps/network/wg-easy/ks.yaml
+++ b/kubernetes/apps/network/wg-easy/ks.yaml
@@ -14,12 +14,7 @@ spec:
   path: ./kubernetes/apps/network/wg-easy/app
   interval: 30m
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: onepassword-connect
       namespace: external-secrets

--- a/kubernetes/apps/network/whoami/ks.yaml
+++ b/kubernetes/apps/network/whoami/ks.yaml
@@ -12,8 +12,3 @@ spec:
   path: ./kubernetes/apps/network/whoami/app
   interval: 30m
   timeout: 3m
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system

--- a/kubernetes/apps/observability/exporters/blackbox-exporter/ks.yaml
+++ b/kubernetes/apps/observability/exporters/blackbox-exporter/ks.yaml
@@ -12,11 +12,6 @@ spec:
   path: ./kubernetes/apps/observability/exporters/blackbox-exporter/app
   interval: 30m
   timeout: 3m
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: kube-prometheus-stack
       namespace: observability

--- a/kubernetes/apps/observability/exporters/mqtt-exporter/ks.yaml
+++ b/kubernetes/apps/observability/exporters/mqtt-exporter/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/observability/exporters/mqtt-exporter/app
   interval: 30m
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: emqx
       namespace: home

--- a/kubernetes/apps/observability/exporters/node-exporter/ks.yaml
+++ b/kubernetes/apps/observability/exporters/node-exporter/ks.yaml
@@ -11,12 +11,7 @@ spec:
   targetNamespace: observability
   path: "./kubernetes/apps/observability/exporters/node-exporter/app"
   interval: 30m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: kube-prometheus-stack
       namespace: observability

--- a/kubernetes/apps/observability/exporters/omada-exporter/ks.yaml
+++ b/kubernetes/apps/observability/exporters/omada-exporter/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/observability/exporters/omada-exporter/app
   interval: 30m
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: onepassword-connect
       namespace: external-secrets

--- a/kubernetes/apps/observability/exporters/pushgateway/ks.yaml
+++ b/kubernetes/apps/observability/exporters/pushgateway/ks.yaml
@@ -12,11 +12,6 @@ spec:
   path: ./kubernetes/apps/observability/exporters/pushgateway/app
   interval: 30m
   timeout: 3m
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: kube-prometheus-stack
       namespace: observability

--- a/kubernetes/apps/observability/exporters/smartctl-exporter/ks.yaml
+++ b/kubernetes/apps/observability/exporters/smartctl-exporter/ks.yaml
@@ -12,9 +12,4 @@ spec:
   path: ./kubernetes/apps/observability/exporters/smartctl-exporter/app
   interval: 30m
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system

--- a/kubernetes/apps/observability/exporters/snmp-exporter/ks.yaml
+++ b/kubernetes/apps/observability/exporters/snmp-exporter/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/observability/exporters/snmp-exporter/app
   interval: 30m
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: kube-prometheus-stack
       namespace: observability

--- a/kubernetes/apps/observability/goldilocks/ks.yaml
+++ b/kubernetes/apps/observability/goldilocks/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/observability/goldilocks/app
   interval: 30m
   timeout: 3m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: authelia
       namespace: auth

--- a/kubernetes/apps/observability/grafana/ks.yaml
+++ b/kubernetes/apps/observability/grafana/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/observability/grafana/app
   interval: 30m
   timeout: 3m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: home-assistant
       namespace: databases

--- a/kubernetes/apps/observability/holmesgpt/ks.yaml
+++ b/kubernetes/apps/observability/holmesgpt/ks.yaml
@@ -11,12 +11,7 @@ spec:
   targetNamespace: observability
   path: ./kubernetes/apps/observability/holmesgpt/app
   interval: 30m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: authelia
       namespace: auth

--- a/kubernetes/apps/observability/kromgo/ks.yaml
+++ b/kubernetes/apps/observability/kromgo/ks.yaml
@@ -11,9 +11,4 @@ spec:
   targetNamespace: observability
   path: "./kubernetes/apps/observability/kromgo/app"
   interval: 30m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system

--- a/kubernetes/apps/observability/kube-ops-view/ks.yaml
+++ b/kubernetes/apps/observability/kube-ops-view/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/observability/kube-ops-view/app
   interval: 30m
   timeout: 3m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   # extAuth SecurityPolicy backends on the authelia Service (#12767).
   dependsOn:
     - name: authelia

--- a/kubernetes/apps/observability/kube-prometheus-stack/ks.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/ks.yaml
@@ -11,12 +11,7 @@ spec:
   targetNamespace: observability
   path: ./kubernetes/apps/observability/kube-prometheus-stack/app/
   interval: 30m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: rook-ceph-cluster
       namespace: rook-ceph
@@ -37,12 +32,7 @@ spec:
   targetNamespace: observability
   path: ./kubernetes/apps/observability/kube-prometheus-stack/addons/
   interval: 30m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: kube-prometheus-stack
       namespace: observability

--- a/kubernetes/apps/observability/kube-state-metrics/ks.yaml
+++ b/kubernetes/apps/observability/kube-state-metrics/ks.yaml
@@ -12,9 +12,4 @@ spec:
   path: ./kubernetes/apps/observability/kube-state-metrics/app
   interval: 30m
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system

--- a/kubernetes/apps/observability/loki/ks.yaml
+++ b/kubernetes/apps/observability/loki/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/observability/loki/app
   interval: 30m
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: kube-prometheus-stack
       namespace: observability

--- a/kubernetes/apps/observability/netdata/ks.yaml
+++ b/kubernetes/apps/observability/netdata/ks.yaml
@@ -12,11 +12,6 @@ spec:
   path: ./kubernetes/apps/observability/netdata/app
   interval: 30m
   timeout: 3m
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: rook-ceph-cluster
       namespace: rook-ceph

--- a/kubernetes/apps/observability/opentelemetry-collector/ks.yaml
+++ b/kubernetes/apps/observability/opentelemetry-collector/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/observability/opentelemetry-collector/app
   interval: 30m
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: kube-prometheus-stack
       namespace: observability

--- a/kubernetes/apps/observability/prometheus-operator-crds/ks.yaml
+++ b/kubernetes/apps/observability/prometheus-operator-crds/ks.yaml
@@ -12,9 +12,4 @@ spec:
   path: ./kubernetes/apps/observability/prometheus-operator-crds/crds
   interval: 30m
   timeout: 5m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system

--- a/kubernetes/apps/observability/silence-operator/ks.yaml
+++ b/kubernetes/apps/observability/silence-operator/ks.yaml
@@ -11,12 +11,7 @@ spec:
   targetNamespace: observability
   path: "./kubernetes/apps/observability/silence-operator/app"
   interval: 10m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -30,12 +25,7 @@ spec:
   targetNamespace: observability
   path: "./kubernetes/apps/observability/silence-operator/silences"
   interval: 10m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: silence-operator
       namespace: observability

--- a/kubernetes/apps/observability/tempo/ks.yaml
+++ b/kubernetes/apps/observability/tempo/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/observability/tempo/app
   interval: 30m
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: kube-prometheus-stack
       namespace: observability

--- a/kubernetes/apps/observability/vector/ks.yaml
+++ b/kubernetes/apps/observability/vector/ks.yaml
@@ -11,12 +11,7 @@ spec:
   targetNamespace: observability
   path: ./kubernetes/apps/observability/vector/aggregator
   interval: 30m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: onepassword-connect
       namespace: external-secrets
@@ -33,12 +28,7 @@ spec:
   targetNamespace: observability
   path: ./kubernetes/apps/observability/vector/agent
   interval: 30m
-  prune: true
   wait: false # no flux ks dependents
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: vector-aggregator
       namespace: observability

--- a/kubernetes/apps/renovate/renovate-operator/ks.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/ks.yaml
@@ -12,11 +12,6 @@ spec:
   path: "./kubernetes/apps/renovate/renovate-operator/app"
   interval: 1h
   timeout: 5m
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease
@@ -37,12 +32,7 @@ spec:
   path: "./kubernetes/apps/renovate/renovate-operator/auth"
   interval: 1h
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: renovate-operator
 
@@ -60,12 +50,7 @@ spec:
   path: "./kubernetes/apps/renovate/renovate-operator/jobs"
   interval: 1h
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: renovate-operator
     - name: renovate-github-auth

--- a/kubernetes/apps/rook-ceph/rook-ceph/ks.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/rook-ceph/rook-ceph/app
   interval: 30m
   timeout: 3m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -32,12 +27,7 @@ spec:
   path: ./kubernetes/apps/rook-ceph/rook-ceph/csi-drivers
   interval: 30m
   timeout: 5m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: rook-ceph
       namespace: rook-ceph
@@ -55,12 +45,7 @@ spec:
   path: ./kubernetes/apps/rook-ceph/rook-ceph/cluster
   interval: 30m
   timeout: 5m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: rook-ceph
       namespace: rook-ceph

--- a/kubernetes/apps/selfhosted/konflate/ks.yaml
+++ b/kubernetes/apps/selfhosted/konflate/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/selfhosted/konflate/app
   interval: 1h
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: authelia
       namespace: auth

--- a/kubernetes/apps/selfhosted/webhook/ks.yaml
+++ b/kubernetes/apps/selfhosted/webhook/ks.yaml
@@ -12,9 +12,4 @@ spec:
   path: "./kubernetes/apps/selfhosted/webhook/app"
   interval: 1h
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system

--- a/kubernetes/apps/storage/garage/ks.yaml
+++ b/kubernetes/apps/storage/garage/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/storage/garage/app
   interval: 1h
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: onepassword-connect
       namespace: external-secrets
@@ -39,12 +34,7 @@ spec:
   path: ./kubernetes/apps/storage/garage/webui
   interval: 1h
   timeout: 5m
-  prune: true
   wait: false
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: authelia
       namespace: auth

--- a/kubernetes/apps/storage/openebs/ks.yaml
+++ b/kubernetes/apps/storage/openebs/ks.yaml
@@ -12,8 +12,3 @@ spec:
   path: ./kubernetes/apps/storage/openebs/app
   interval: 1h
   timeout: 5m
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system

--- a/kubernetes/apps/vpn/downloads-gateway/ks.yaml
+++ b/kubernetes/apps/vpn/downloads-gateway/ks.yaml
@@ -12,12 +12,7 @@ spec:
   path: ./kubernetes/apps/vpn/downloads-gateway/app
   interval: 30m
   timeout: 5m
-  prune: true
   wait: true
-  sourceRef:
-    kind: GitRepository
-    name: home-ops-kubernetes
-    namespace: flux-system
   dependsOn:
     - name: cert-manager
       namespace: cert-manager


### PR DESCRIPTION
## Summary

- Removes 239 redundant \`sourceRef\` blocks and 237 \`prune: true\` lines from 164 per-app \`ks.yaml\` files
- These fields are now injected by the \`cluster-apps\` strategic-merge defaults patch (merged in #12803)
- \`prune: false\` overrides in \`coredns\` and \`kubelet-csr-approver\` are intentional and left untouched
- Net: −1,192 lines, zero functional change to cluster behavior

## Test plan

- [ ] All 7 required CI contexts pass (Lint, Image, Flux Local, Webhook Validate, Secret Scan, Inline Credential Scan, Analyze)
- [ ] Post-merge: \`flux get ks -A --status-selector ready=false\` returns empty