### PR TITLE
chore(flux): drop wait:true from home leaf-app Kustomizations

### DIFF
--- a/kubernetes/apps/home/emqx/ks.yaml
+++ b/kubernetes/apps/home/emqx/ks.yaml
@@ -12,7 +12,6 @@ spec:
   path: ./kubernetes/apps/home/emqx/app
   interval: 30m
   timeout: 5m
-  wait: true
   dependsOn:
     - name: rook-ceph-cluster
       namespace: rook-ceph

--- a/kubernetes/apps/home/ntfy/ks.yaml
+++ b/kubernetes/apps/home/ntfy/ks.yaml
@@ -12,7 +12,6 @@ spec:
   path: ./kubernetes/apps/home/ntfy/app
   interval: 30m
   timeout: 3m
-  wait: true
   dependsOn:
     - name: onepassword-connect
       namespace: external-secrets

--- a/kubernetes/apps/home/windmill/ks.yaml
+++ b/kubernetes/apps/home/windmill/ks.yaml
@@ -12,7 +12,6 @@ spec:
   path: ./kubernetes/apps/home/windmill/app
   interval: 30m
   timeout: 10m
-  wait: true
   dependsOn:
     - name: authelia
       namespace: auth

--- a/kubernetes/apps/home/wyoming-services/ks.yaml
+++ b/kubernetes/apps/home/wyoming-services/ks.yaml
@@ -11,7 +11,6 @@ spec:
   targetNamespace: home
   path: "./kubernetes/apps/home/wyoming-services/app"
   interval: 30m
-  wait: true
   dependsOn:
     - name: gpu-operator
       namespace: kube-system


### PR DESCRIPTION
## Summary
- Removes \`wait: true\` from 4 leaf-app Kustomizations: emqx, ntfy, windmill, wyoming-services
- All are leaf nodes — either nothing depends on them, or downstream consumers (MQTT clients, windmill-mcp) have built-in reconnect/retry
- No ordering change: \`dependsOn\` chains are preserved

## Test plan
- [ ] All CI checks pass
- [ ] Post-merge: apps start normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)