### PR TITLE
chore(flux): drop wait:true from leaf-config Kustomizations

### DIFF
--- a/kubernetes/apps/cert-manager/cert-manager/ks.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/ks.yaml
@@ -32,7 +32,6 @@ spec:
   targetNamespace: cert-manager
   path: ./kubernetes/apps/cert-manager/cert-manager/issuers
   interval: 1h
-  wait: true
   dependsOn:
     - name: cert-manager
       namespace: cert-manager

--- a/kubernetes/apps/kube-system/cilium/ks.yaml
+++ b/kubernetes/apps/kube-system/cilium/ks.yaml
@@ -32,7 +32,6 @@ spec:
   path: "./kubernetes/apps/kube-system/cilium/config"
   interval: 1h
   timeout: 5m
-  wait: true
   # CiliumBGPAdvertisement + CiliumLoadBalancerIPPool here use CRDs
   # the cilium chart provides. Without dependsOn, fresh deploys /
   # full reconciles race the chart's CRD install (chicken-and-egg).

--- a/kubernetes/apps/kube-system/intel-device-plugin/ks.yaml
+++ b/kubernetes/apps/kube-system/intel-device-plugin/ks.yaml
@@ -31,7 +31,6 @@ spec:
   path: ./kubernetes/apps/kube-system/intel-device-plugin/gpu
   interval: 30m
   timeout: 3m
-  wait: true
   dependsOn:
     - name: intel-device-plugin-operator
       namespace: kube-system

--- a/kubernetes/apps/kube-system/node-feature-discovery/ks.yaml
+++ b/kubernetes/apps/kube-system/node-feature-discovery/ks.yaml
@@ -31,7 +31,6 @@ spec:
   path: ./kubernetes/apps/kube-system/node-feature-discovery/rules
   interval: 30m
   timeout: 3m
-  wait: true
   dependsOn:
     - name: node-feature-discovery
       namespace: kube-system

--- a/kubernetes/apps/kube-system/node-problem-detector/ks.yaml
+++ b/kubernetes/apps/kube-system/node-problem-detector/ks.yaml
@@ -14,4 +14,3 @@ spec:
   path: ./kubernetes/apps/kube-system/node-problem-detector/app
   interval: 30m
   timeout: 3m
-  wait: true

--- a/kubernetes/apps/kyverno/kyverno/ks.yaml
+++ b/kubernetes/apps/kyverno/kyverno/ks.yaml
@@ -27,7 +27,6 @@ spec:
   path: ./kubernetes/apps/kyverno/kyverno/policies
   interval: 30m
   timeout: 5m
-  wait: true
   dependsOn:
     - name: kyverno
       namespace: kyverno

--- a/kubernetes/apps/kyverno/policy-reporter/ks.yaml
+++ b/kubernetes/apps/kyverno/policy-reporter/ks.yaml
@@ -12,7 +12,6 @@ spec:
   path: ./kubernetes/apps/kyverno/policy-reporter/app
   interval: 30m
   timeout: 5m
-  wait: true
   dependsOn:
     - name: kyverno
       namespace: kyverno


### PR DESCRIPTION
## Summary
- Removes `wait: true` from 7 leaf-config Kustomizations: cilium-config, node-feature-rules, intel-device-plugin-gpu, node-problem-detector, kyverno-policies, policy-reporter, cert-manager-issuers
- These KSes apply config objects or DaemonSets after the operator is ready; no external KS has a `dependsOn` on any of them
- Operator KSes (cilium, node-feature-discovery, intel-device-plugin-operator, kyverno, cert-manager) retain `wait: true`

## Test plan
- [ ] All CI checks pass
- [ ] Post-merge: cluster policies and device plugins function normally