### PR TITLE
chore(flux): drop wait:true from arr CNPG clusters

### DIFF
--- a/kubernetes/apps/databases/cloudnative-pg/ks.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/ks.yaml
@@ -319,7 +319,6 @@ spec:
   path: ./kubernetes/apps/databases/cloudnative-pg/config/sparkyfitness
   interval: 30m
   timeout: 5m
-  wait: true
   dependsOn:
     - name: cloudnative-pg
       namespace: databases
@@ -519,7 +518,6 @@ spec:
   path: ./kubernetes/apps/databases/cloudnative-pg/config/lidarr
   interval: 30m
   timeout: 5m
-  wait: true
   dependsOn:
     - name: cloudnative-pg
       namespace: databases
@@ -552,7 +550,6 @@ spec:
   path: ./kubernetes/apps/databases/cloudnative-pg/config/sonarr
   interval: 30m
   timeout: 5m
-  wait: true
   dependsOn:
     - name: cloudnative-pg
       namespace: databases
@@ -585,7 +582,6 @@ spec:
   path: ./kubernetes/apps/databases/cloudnative-pg/config/radarr
   interval: 30m
   timeout: 5m
-  wait: true
   dependsOn:
     - name: cloudnative-pg
       namespace: databases
@@ -618,7 +614,6 @@ spec:
   path: ./kubernetes/apps/databases/cloudnative-pg/config/prowlarr
   interval: 30m
   timeout: 5m
-  wait: true
   dependsOn:
     - name: cloudnative-pg
       namespace: databases


### PR DESCRIPTION
## Summary
- Removes `wait: true` from 5 CNPG cluster Kustomizations (sparkyfitness, lidarr, sonarr, radarr, prowlarr)
- None of these clusters have a downstream KS with `dependsOn` referencing them — the arr apps connect to the DB at runtime and retry
- The 19 CNPG clusters that DO have downstream KS `dependsOn` consumers (immich, paperless, home-assistant, etc.) are left untouched

## Test plan
- [ ] All CI checks pass
- [ ] Post-merge: arr apps come up normally after next reconcile