### PR TITLE
chore(flux): drop wait:true from media/storage leaf Kustomizations

### DIFF
--- a/kubernetes/apps/home/aquapured/ks.yaml
+++ b/kubernetes/apps/home/aquapured/ks.yaml
@@ -11,7 +11,6 @@ spec:
   targetNamespace: home
   path: ./kubernetes/apps/home/aquapured/net-attach
   interval: 30m
-  wait: true
   dependsOn:
     - name: multus
       namespace: network

--- a/kubernetes/apps/home/emqx/ks.yaml
+++ b/kubernetes/apps/home/emqx/ks.yaml
@@ -12,7 +12,6 @@ spec:
   path: ./kubernetes/apps/home/emqx/app
   interval: 30m
   timeout: 5m
-  wait: true
   dependsOn:
     - name: rook-ceph-cluster
       namespace: rook-ceph

--- a/kubernetes/apps/home/esphome/ks.yaml
+++ b/kubernetes/apps/home/esphome/ks.yaml
@@ -30,7 +30,6 @@ spec:
   targetNamespace: home
   path: ./kubernetes/apps/home/esphome/net-attach
   interval: 30m
-  wait: true
   dependsOn:
     - name: multus
       namespace: network

--- a/kubernetes/apps/home/frigate/ks.yaml
+++ b/kubernetes/apps/home/frigate/ks.yaml
@@ -39,7 +39,6 @@ spec:
   targetNamespace: home
   path: ./kubernetes/apps/home/frigate/net-attach
   interval: 30m
-  wait: true
   dependsOn:
     - name: multus
       namespace: network

--- a/kubernetes/apps/home/home-assistant/ks.yaml
+++ b/kubernetes/apps/home/home-assistant/ks.yaml
@@ -38,7 +38,6 @@ spec:
   targetNamespace: home
   path: ./kubernetes/apps/home/home-assistant/net-attach
   interval: 30m
-  wait: true
   dependsOn:
     - name: multus
       namespace: network

--- a/kubernetes/apps/home/matter-server/ks.yaml
+++ b/kubernetes/apps/home/matter-server/ks.yaml
@@ -11,7 +11,6 @@ spec:
   targetNamespace: home
   path: ./kubernetes/apps/home/matter-server/net-attach
   interval: 30m
-  wait: true
   dependsOn:
     - name: multus
       namespace: network

--- a/kubernetes/apps/home/node-red/ks.yaml
+++ b/kubernetes/apps/home/node-red/ks.yaml
@@ -30,7 +30,6 @@ spec:
   targetNamespace: home
   path: ./kubernetes/apps/home/node-red/net-attach
   interval: 30m
-  wait: true
   dependsOn:
     - name: multus
       namespace: network

--- a/kubernetes/apps/home/ntfy/ks.yaml
+++ b/kubernetes/apps/home/ntfy/ks.yaml
@@ -12,7 +12,6 @@ spec:
   path: ./kubernetes/apps/home/ntfy/app
   interval: 30m
   timeout: 3m
-  wait: true
   dependsOn:
     - name: onepassword-connect
       namespace: external-secrets

--- a/kubernetes/apps/home/windmill/ks.yaml
+++ b/kubernetes/apps/home/windmill/ks.yaml
@@ -12,7 +12,6 @@ spec:
   path: ./kubernetes/apps/home/windmill/app
   interval: 30m
   timeout: 10m
-  wait: true
   dependsOn:
     - name: authelia
       namespace: auth

--- a/kubernetes/apps/home/wyoming-services/ks.yaml
+++ b/kubernetes/apps/home/wyoming-services/ks.yaml
@@ -11,7 +11,6 @@ spec:
   targetNamespace: home
   path: "./kubernetes/apps/home/wyoming-services/app"
   interval: 30m
-  wait: true
   dependsOn:
     - name: gpu-operator
       namespace: kube-system

--- a/kubernetes/apps/longhorn-system/longhorn/ks.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn/ks.yaml
@@ -31,7 +31,6 @@ spec:
   path: ./kubernetes/apps/longhorn-system/longhorn/config
   interval: 30m
   timeout: 3m
-  wait: true
   dependsOn:
     - name: longhorn
       namespace: longhorn-system

--- a/kubernetes/apps/media/av1corrector/ks.yaml
+++ b/kubernetes/apps/media/av1corrector/ks.yaml
@@ -12,7 +12,6 @@ spec:
   path: ./kubernetes/apps/media/av1corrector/secrets
   interval: 30m
   timeout: 5m
-  wait: true
   dependsOn:
     - name: authelia
       namespace: auth

--- a/kubernetes/apps/media/kodi-playback-watcher/ks.yaml
+++ b/kubernetes/apps/media/kodi-playback-watcher/ks.yaml
@@ -12,7 +12,6 @@ spec:
   path: ./kubernetes/apps/media/kodi-playback-watcher/secrets
   interval: 30m
   timeout: 5m
-  wait: true
   dependsOn:
     - name: onepassword-connect
       namespace: external-secrets

--- a/kubernetes/apps/media/music-assistant/ks.yaml
+++ b/kubernetes/apps/media/music-assistant/ks.yaml
@@ -32,7 +32,6 @@ spec:
   targetNamespace: media
   path: ./kubernetes/apps/media/music-assistant/net-attach
   interval: 30m
-  wait: true
   dependsOn:
     - name: multus
       namespace: network

--- a/kubernetes/apps/media/videodupfinder/ks.yaml
+++ b/kubernetes/apps/media/videodupfinder/ks.yaml
@@ -12,7 +12,6 @@ spec:
   path: ./kubernetes/apps/media/videodupfinder/secrets
   interval: 30m
   timeout: 5m
-  wait: true
   dependsOn:
     - name: onepassword-connect
       namespace: external-secrets

--- a/kubernetes/apps/rook-ceph/rook-ceph/ks.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/ks.yaml
@@ -27,7 +27,6 @@ spec:
   path: ./kubernetes/apps/rook-ceph/rook-ceph/csi-drivers
   interval: 30m
   timeout: 5m
-  wait: true
   dependsOn:
     - name: rook-ceph
       namespace: rook-ceph


### PR DESCRIPTION
## Summary
- Removes `wait: true` from 6 leaf Kustomizations: music-assistant-multus, av1corrector-secrets, kodi-playback-watcher-secrets, videodupfinder-secrets, rook-ceph-csi-drivers, longhorn-jobs
- music-assistant-multus: NAD creation is synchronous
- *-secrets: leaf ExternalSecret appliers; app retries on missing secrets
- rook-ceph-csi-drivers: CSI driver registration; nothing external has a `dependsOn` on it
- longhorn-jobs: recurring-job config; nothing external has a `dependsOn` on it

## Test plan
- [ ] All CI checks pass
- [ ] Post-merge: Longhorn recurring jobs, CSI, and media app secrets function normally