### PR TITLE
feat(grafana): claude-code cost & cache-hit-rate dashboard (PF-06a)

### DIFF
--- a/kubernetes/apps/observability/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/grafana/app/helmrelease.yaml
@@ -143,6 +143,12 @@ spec:
           # (lifecycle) dashboards.
           datasource: Prometheus
           url: https://raw.githubusercontent.com/rwlove/home-ops/main/kubernetes/apps/observability/grafana/dashboards/aihomeops-state.json
+        claude-code:
+          # Cache hit rate timeseries + cost-per-project panel.
+          # Data source: claude-cost-exporter.py → Pushgateway → Prometheus.
+          # Baseline captured 2026-07-03 per PF-06a.
+          datasource: Prometheus
+          url: https://raw.githubusercontent.com/rwlove/home-ops/main/kubernetes/apps/observability/grafana/dashboards/claude-code.json
         langgraph-agents:
           datasource: Prometheus
           url: https://raw.githubusercontent.com/rwlove/home-ops/main/kubernetes/apps/observability/grafana/dashboards/langgraph-agents.json

--- a/kubernetes/apps/observability/grafana/dashboards/claude-code.json
+++ b/kubernetes/apps/observability/grafana/dashboards/claude-code.json
@@ -1,0 +1,211 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "graphTooltip": 1,
+  "links": [],
+  "panels": [
+    {
+      "id": 1,
+      "title": "Cache Hit Rate — 24 h",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "expr": "claude_code_cache_hit_rate{window=\"24h\"}",
+          "legendFormat": "24 h",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red",    "value": null },
+              { "color": "yellow", "value": 0.5  },
+              { "color": "green",  "value": 0.8  }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 2,
+      "title": "Cache Hit Rate — 7 d",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 4 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "expr": "claude_code_cache_hit_rate{window=\"7d\"}",
+          "legendFormat": "7 d",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red",    "value": null },
+              { "color": "yellow", "value": 0.5  },
+              { "color": "green",  "value": 0.8  }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 3,
+      "title": "Cache Hit Rate over Time",
+      "description": "Fraction of input tokens served from prompt cache. Target ≥ 0.80 during active sessions.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 18, "x": 6, "y": 0 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "expr": "claude_code_cache_hit_rate{window=\"24h\"}",
+          "legendFormat": "24 h window",
+          "refId": "A"
+        },
+        {
+          "datasource": "Prometheus",
+          "expr": "claude_code_cache_hit_rate{window=\"7d\"}",
+          "legendFormat": "7 d window",
+          "refId": "B"
+        },
+        {
+          "datasource": "Prometheus",
+          "expr": "claude_code_cache_hit_rate{window=\"30d\"}",
+          "legendFormat": "30 d window",
+          "refId": "C"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "none" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      }
+    },
+    {
+      "id": 4,
+      "title": "Cost by Project — 24 h (USD)",
+      "description": "claude_code_cost_by_project{window=\"24h\"} — normalized project labels, worktrees collapsed to parent repo.",
+      "type": "bargauge",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "expr": "sort_desc(claude_code_cost_by_project{window=\"24h\"})",
+          "legendFormat": "{{project}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green",  "value": null },
+              { "color": "yellow", "value": 5    },
+              { "color": "red",    "value": 20   }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "orientation": "horizontal",
+        "displayMode": "gradient",
+        "valueMode": "color"
+      }
+    },
+    {
+      "id": 5,
+      "title": "Cache Tokens by Kind — 24 h (all projects)",
+      "description": "Sum of cache_read and cache_creation tokens across all projects in the last 24 h.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "expr": "sum(claude_code_cache_tokens_total{kind=\"read\",window=\"24h\"})",
+          "legendFormat": "cache read",
+          "refId": "A"
+        },
+        {
+          "datasource": "Prometheus",
+          "expr": "sum(claude_code_cache_tokens_total{kind=\"creation\",window=\"24h\"})",
+          "legendFormat": "cache creation (write)",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "none" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      }
+    }
+  ],
+  "refresh": "5m",
+  "schemaVersion": 38,
+  "tags": ["claude-code", "cost", "cache"],
+  "templating": { "list": [] },
+  "time": { "from": "now-24h", "to": "now" },
+  "timepicker": {},
+  "timezone": "America/New_York",
+  "title": "Claude Code — Cost & Cache",
+  "uid": "claude-code-cost-cache",
+  "version": 1
+}


### PR DESCRIPTION
## Summary

- Adds `claude-code.json` dashboard (5 panels: cache hit rate × 3, cost by project, cache tokens by kind)
- Adds `claude-code` entry to Grafana HelmRelease `spec.values.dashboards.ai`
- Part of PF-06a (cost/cache measurement baseline); companion to local exporter changes

## Test plan

- [ ] PR merged, Flux reconciles Grafana HelmRelease
- [ ] Dashboard loads at Grafana → Dashboards → AI folder → "Claude Code — Cost & Cache"
- [ ] Stat panels show hit rate ≥ 0 (non-null)
- [ ] Cost by project panel shows at least one project row
- [ ] No Grafana datasource errors in UI