### PR TITLE
fix(network): allow mcp-system ingress to media-stack API services

### DIFF
--- a/kubernetes/apps/media/lidarr/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/lidarr/app/cnp-allow.yaml
@@ -35,6 +35,17 @@ spec:
         - ports:
             - port: "8686"
               protocol: TCP
+    # Cross-ns: arr-mcp MCP server queries this API via
+    # LIDARR_URL=http://lidarr.media.svc.cluster.local:8686. Mirrors the
+    # arr-mcp source already allowed in prowlarr-allow (downloads ns).
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: mcp-system
+            app.kubernetes.io/name: arr-mcp
+      toPorts:
+        - ports:
+            - port: "8686"
+              protocol: TCP
   egress:
     # CNPG: postgres-lidarr in databases ns (Pattern B).
     - toEndpoints:

--- a/kubernetes/apps/media/radarr/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/radarr/app/cnp-allow.yaml
@@ -34,6 +34,17 @@ spec:
         - ports:
             - port: "7878"
               protocol: TCP
+    # Cross-ns: arr-mcp MCP server queries this API via
+    # RADARR_URL=http://radarr.media.svc.cluster.local:7878. Mirrors the
+    # arr-mcp source already allowed in prowlarr-allow (downloads ns).
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: mcp-system
+            app.kubernetes.io/name: arr-mcp
+      toPorts:
+        - ports:
+            - port: "7878"
+              protocol: TCP
   egress:
     # CNPG: postgres-radarr in databases ns (Pattern B).
     - toEndpoints:

--- a/kubernetes/apps/media/sonarr/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/sonarr/app/cnp-allow.yaml
@@ -33,6 +33,17 @@ spec:
         - ports:
             - port: "8989"
               protocol: TCP
+    # Cross-ns: arr-mcp MCP server queries this API via
+    # SONARR_URL=http://sonarr.media.svc.cluster.local:8989. Mirrors the
+    # arr-mcp source already allowed in prowlarr-allow (downloads ns).
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: mcp-system
+            app.kubernetes.io/name: arr-mcp
+      toPorts:
+        - ports:
+            - port: "8989"
+              protocol: TCP
   egress:
     # CNPG: postgres-sonarr in databases ns (Pattern B).
     - toEndpoints:


### PR DESCRIPTION
## Problem

The mcp-system MCP integration reaches four media-stack API services by internal cluster DNS — three in the `media` namespace, one in `downloads`. Only the `downloads` service was reachable; the three `media` services returned connection-level failures (`fetch failed`) while their pods were healthy and their web UIs served normally.

## Root cause

The `media` namespace enforces default-deny ingress (`components/network-policy/default-deny`, re-enabled 2026-05-18). The three `media` ingress `CiliumNetworkPolicy`s allow the internal gateway (`network/envoy`) and the `downloads` sync source, but were **never updated to allow the mcp-system client**. The `downloads` service's ingress policy already allows it — which is why it was the only one reachable. A Cilium ingress drop surfaces to the caller as a connection timeout, not an HTTP error.

## Fix

Add `mcp-system/arr-mcp` as an allowed ingress source (each service's own port) to the three `media` ingress policies, mirroring the rule already present on the `downloads` service.

## Impact

Additive CNP rule only — Cilium applies policy changes to BPF maps live, so **no pod restart and no service downtime**. No maintenance window required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)