### PR TITLE
docs: slim persona to shared base, expand claude-config-lint to all repos

### DIFF
--- a/.agents/instructions/persona.md
+++ b/.agents/instructions/persona.md
@@ -1,30 +1,10 @@
-# Claude persona for this repository
+# Claude persona for home-ops
 
-This file defines who Claude is acting as when working in `home-ops`, and
-how to communicate. It's auto-loaded via `CLAUDE.md` so every session in
-this repo starts from the same baseline.
-
-Fill in the sections below. Anything left as a placeholder (`TODO:`) is
-ignored in practice — Claude won't infer preferences from an empty stub.
-
-## Relationship to output styles
-
-Three mode-specific output styles live in `.claude/output-styles/`:
-
-- `optimizer.md` — perf / cost / resource efficiency focus
-- `architect.md` — design / tradeoffs / big-picture focus
-- `debugger.md` — root-cause / evidence-first focus
-
-Switch in-session with `/output-style <mode>`. Each style overrides the
-*mode-specific* dimensions (tone, lean-toward, output format) while this
-file keeps the *shared baseline* (role, decision bias) that applies
-regardless of which mode is active.
-
-Rule of thumb when deciding where a preference belongs:
-
-- "True regardless of what I'm working on" → here, in `persona.md`.
-- "Changes meaningfully when I'm in optimizer vs architect vs debugger
-  mode" → in the relevant output-style file.
+Home-ops-specific role, prime directive, and operating rules. The shared
+baseline — push-back-once, propose-then-execute, voice, output-styles
+pointer, data-classification check — loads automatically from
+`~/.claude-personal/rules/persona-base.md`. This file adds the
+home-ops overlay on top of that base.
 
 ## Role / framing
 
@@ -69,7 +49,7 @@ Git path), surface the gap and get explicit sign-off before acting.
 
 ## Pushback discipline
 
-(Inherits global terse defaults from the system prompt — this section
+(Inherits from `~/.claude-personal/rules/persona-base.md` — this section
 is the home-ops overlay.)
 
 - Brief acknowledgment of being wrong is fine ("OK, that's not it").

--- a/.agents/skills/claude-config-lint.md
+++ b/.agents/skills/claude-config-lint.md
@@ -1,7 +1,7 @@
 ---
 name: claude-config-lint
-description: Audit Claude config health — verify @-import targets exist, symlinks are intact, skill frontmatter is complete, and MEMORY.md is within its load budget.
-last_verified: 2026-05-25
+description: Audit Claude config health across all repos — verify @-import targets exist, check skill frontmatter completeness in every repo with .agents/skills/, verify MEMORY.md load budget across all non-worktree namespaces, and confirm shared persona base exists.
+last_verified: 2026-07-03
 ---
 
 # Claude config lint
@@ -12,8 +12,8 @@ baseline, and again after to confirm nothing broke.
 
 ## When to use
 
-- Before and after modifying any `.claude.md`, `.agents/instructions/`,
-  `.agents/skills/`, or `~/.claude-personal/agents/` files.
+- Before and after modifying any `CLAUDE.md`, `.agents/instructions/`,
+  `.agents/skills/`, or `~/.claude-personal/` files.
 - When a session seems to be missing context (instructions not firing,
   operator behavior unexpected).
 - Weekly, as part of upstream-watcher hygiene.
@@ -22,56 +22,74 @@ baseline, and again after to confirm nothing broke.
 
 Run each check block in order. Failures are printed; silence = pass.
 
-### 1. Symlink integrity
+### 1. Symlink and shared-base integrity
 
 ```bash
-# Global CLAUDE.md symlinks
+# Global CLAUDE.md symlink chain
 ls -la ~/.claude-personal/CLAUDE.md ~/.claude-personal/HOMELAB-SPEC.md ~/.claude-personal/memory
 
-# Vault backing exists
-test -f ~/vaults/claude/user/CLAUDE.md && echo "vault CLAUDE.md OK" || echo "FAIL: vault CLAUDE.md missing"
-test -f ~/vaults/claude/user/HOMELAB-SPEC.md && echo "vault HOMELAB-SPEC.md OK" || echo "FAIL: vault HOMELAB-SPEC.md missing"
+# Vault backing
+test -f ~/vaults/claude/user/CLAUDE.md \
+  && echo "vault CLAUDE.md OK" || echo "FAIL: vault CLAUDE.md missing"
+test -f ~/vaults/claude/user/HOMELAB-SPEC.md \
+  && echo "vault HOMELAB-SPEC.md OK" || echo "FAIL: vault HOMELAB-SPEC.md missing"
+
+# Shared persona base (created by PF-05)
+test -f ~/.claude-personal/rules/persona-base.md \
+  && echo "persona-base.md OK" || echo "FAIL: ~/.claude-personal/rules/persona-base.md missing"
 ```
 
-### 2. `@`-import targets in CLAUDE.md files
+### 2. @-import targets — auto-discovered across all repos
 
 ```bash
-# For each CLAUDE.md in the workspace, verify every @-import resolves
-for claude_md in \
-    ~/.claude-personal/CLAUDE.md \
-    ~/workspace/claude-workspace/home-ops/CLAUDE.md \
-    ~/workspace/claude-workspace/home-assistant-config/CLAUDE.md \
-    ~/workspace/claude-workspace/langgraph-agents/CLAUDE.md; do
+# Discover all CLAUDE.md files: workspace repos + user-global, exclude worktrees.
+# Use mapfile to avoid bash word-splitting on paths with spaces (e.g. "3532 Foxhall/CLAUDE.md").
+mapfile -t CLAUDE_MDs < <(
+  find ~/workspace/claude-workspace -maxdepth 2 -name 'CLAUDE.md' \
+      ! -path '*worktrees*' 2>/dev/null
+)
+CLAUDE_MDs+=("$HOME/.claude-personal/CLAUDE.md")
+
+for claude_md in "${CLAUDE_MDs[@]}"; do
   [ -f "$claude_md" ] || continue
   dir=$(dirname "$claude_md")
-  # Resolve symlinks for the dir
   real_dir=$(readlink -f "$dir")
   echo "=== $claude_md ==="
   grep -E '^@' "$claude_md" | while read -r import_line; do
     target="${import_line#@}"
-    # Expand relative path
-    full="$real_dir/$target"
-    [ -f "$full" ] || echo "  MISSING: $target"
+    # expand leading ~
+    target="${target/#\~/$HOME}"
+    # relative → absolute
+    [[ "$target" != /* ]] && target="$real_dir/$target"
+    [ -f "$target" ] || echo "  MISSING: ${import_line#@}"
   done
 done
 ```
 
-### 3. Skill frontmatter completeness
+### 3. Skill frontmatter completeness — all repos with .agents/skills/
 
 ```bash
-# Every skill in home-ops .agents/skills/ must have name: and description:
-for f in ~/workspace/claude-workspace/home-ops/.agents/skills/*.md; do
-  name=$(grep -m1 '^name:' "$f")
-  desc=$(grep -m1 '^description:' "$f")
-  [ -z "$name" ] && echo "MISSING name: in $f"
-  [ -z "$desc" ] && echo "MISSING description: in $f"
+# Repo skills
+for skills_dir in ~/workspace/claude-workspace/*/.agents/skills; do
+  [ -d "$skills_dir" ] || continue
+  for f in "$skills_dir"/*.md; do
+    [ -f "$f" ] || continue
+    grep -q '^name:'        "$f" || echo "MISSING name:        in $f"
+    grep -q '^description:' "$f" || echo "MISSING description: in $f"
+  done
 done
+
+# User-global skills (PF-03 creates this dir; skip gracefully if absent)
+[ -d ~/.claude-personal/skills ] && \
+  find ~/.claude-personal/skills -name '*.md' | while read -r f; do
+    grep -q '^name:'        "$f" || echo "MISSING name:        in $f"
+    grep -q '^description:' "$f" || echo "MISSING description: in $f"
+  done
 ```
 
 ### 4. Operator persona frontmatter
 
 ```bash
-# Every operator must have name:, model:, description:, tools:
 for f in ~/.claude-personal/agents/*.md; do
   [[ "$f" == */_shared/* ]] && continue
   for field in name model description tools; do
@@ -80,26 +98,29 @@ for f in ~/.claude-personal/agents/*.md; do
 done
 ```
 
-### 5. MEMORY.md load budget
+### 5. MEMORY.md load budget — all non-worktree project namespaces
 
 ```bash
-MEM=~/.claude-personal/projects/-home-rwlove-workspace-claude-workspace-home-ops/memory/MEMORY.md
-lines=$(wc -l < "$MEM")
-maxlen=$(awk 'length > max {max=length} END {print max}' "$MEM")
-long=$(awk 'length > 150' "$MEM" | wc -l)
-echo "MEMORY.md: $lines lines (budget: 200) | max line: $maxlen chars | over-150: $long"
-[ "$lines" -gt 200 ] && echo "WARN: MEMORY.md exceeds 200-line load budget"
-[ "$long" -gt 10 ] && echo "WARN: $long entries exceed 150-char line length"
+echo "--- MEMORY.md line counts (budget: 200 lines each) ---"
+find ~/.claude-personal/projects -name 'MEMORY.md' \
+  | grep -v 'worktrees' \
+  | sort \
+  | while read -r mem; do
+    lines=$(wc -l < "$mem")
+    maxlen=$(awk 'length > max {max = length} END {print max}' "$mem")
+    printf "%-80s %4d lines (max line: %d chars)\n" "$mem" "$lines" "$maxlen"
+    [ "$lines" -gt 200 ] && echo "  WARN: exceeds 200-line load budget → archive overflow"
+    [ "$maxlen" -gt 150 ] && echo "  WARN: line(s) > 150 chars → trim for scan-ability"
+  done
 ```
 
-### 6. Shared MCP reference exists
+### 6. Shared MCP reference in all operators
 
 ```bash
 test -f ~/.claude-personal/agents/_shared/mcp-tool-loading.md \
   && echo "shared mcp-tool-loading.md OK" \
   || echo "FAIL: ~/.claude-personal/agents/_shared/mcp-tool-loading.md missing"
 
-# Verify all operators reference it (not the old inline pattern)
 for f in ~/.claude-personal/agents/*.md; do
   [[ "$f" == */_shared/* ]] && continue
   grep -q "mcp-tool-loading.md\|reference_lovenet_gateway_mcp_tool_prefixes" "$f" \
@@ -107,19 +128,33 @@ for f in ~/.claude-personal/agents/*.md; do
 done
 ```
 
+### 7. Per-repo persona.md references shared base (post-PF-05)
+
+```bash
+echo "--- persona.md shared-base pointer check ---"
+for persona in ~/workspace/claude-workspace/*/.agents/instructions/persona.md; do
+  [ -f "$persona" ] || continue
+  grep -q 'persona-base.md' "$persona" \
+    || echo "WARN: no shared-base reference in $persona"
+done
+```
+
 ## Interpreting results
 
 | Output | Meaning | Fix |
 |---|---|---|
+| `FAIL: vault CLAUDE.md missing` | Symlink broken | Restore vault file or fix symlink |
+| `FAIL: persona-base.md missing` | PF-05 not executed | Run PF-05 Change 1 |
 | `MISSING: <path>` | `@`-import target doesn't exist | Restore the file or remove the import |
-| `MISSING name: in <file>` | Frontmatter incomplete | Add the missing frontmatter field |
-| `WARN: MEMORY.md exceeds 200-line` | Index too long; older entries invisible | Archive overflow to `MEMORY-archive-*.md` |
-| `WARN: N entries exceed 150-char` | Entries too verbose for clean scanning | Trim descriptions to one-line hooks |
-| `WARN: <file> has no MCP loading reference` | Operator still has inline MCP prose | Replace with pointer to `_shared/mcp-tool-loading.md` |
+| `MISSING name: in <file>` | Skill frontmatter incomplete | Add the missing frontmatter field |
+| `WARN: exceeds 200-line load budget` | MEMORY.md too long; older entries invisible | Archive overflow to `MEMORY-archive-*.md`; run PF-04 for home-ops |
+| `WARN: line(s) > 150 chars` | Entries too verbose for clean scanning | Trim to one-line hooks |
+| `WARN: no MCP loading reference` | Operator still has inline MCP prose | Replace with pointer to `_shared/mcp-tool-loading.md` |
+| `WARN: no shared-base reference` | Persona not yet slimmed down (PF-05 pending) | Apply persona slim-down from PF-05 |
 
 ## What this is NOT
 
-- Not a runtime test — it doesn't invoke any tool or verify MCP
-  connectivity. It only checks the config files on disk.
+- Not a runtime test — it doesn't invoke any tool or verify MCP connectivity.
+  It only checks the config files on disk.
 - Not a substitute for reading the files — it catches structural gaps,
   not semantic ones (e.g. stale content in an operator).


### PR DESCRIPTION
## Summary
- persona.md's output-styles boilerplate now loads from the shared `~/.claude-personal/rules/persona-base.md` instead of being duplicated inline; home-ops-specific role/prime-directive/pushback overlay stays.
- claude-config-lint.md: replace the 4 hardcoded CLAUDE.md paths with an auto-discovering mapfile-based scan (handles paths with spaces, e.g. "3532 Foxhall/CLAUDE.md"); extend skill-frontmatter and MEMORY.md budget checks to every repo, not just home-ops; add checks for persona-base.md existence and per-repo persona.md shared-base references.

Part of the workflow-supercharge PF-05 instruction-architecture refactor.

## Test plan
- [x] Doc/skill-only change, no kubernetes manifests touched.
- [x] Pre-commit hooks passed (yamllint/markdownlint-cli2/secrets scan — all Passed/Skipped as appropriate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)