### PR TITLE
fix(claude-config-lint): replace mapfile with portable read-loop

### DIFF
--- a/.agents/skills/claude-config-lint.md
+++ b/.agents/skills/claude-config-lint.md
@@ -43,11 +43,14 @@ test -f ~/.claude-personal/rules/persona-base.md \
 
 ```bash
 # Discover all CLAUDE.md files: workspace repos + user-global, exclude worktrees.
-# Use mapfile to avoid bash word-splitting on paths with spaces (e.g. "3532 Foxhall/CLAUDE.md").
-mapfile -t CLAUDE_MDs < <(
-  find ~/workspace/claude-workspace -maxdepth 2 -name 'CLAUDE.md' \
-      ! -path '*worktrees*' 2>/dev/null
-)
+# Use a read-loop (not `mapfile`, which is bash-only and absent in zsh — this
+# session's default shell) to avoid word-splitting on paths with spaces
+# (e.g. "3532 Foxhall/CLAUDE.md"). Portable across bash and zsh.
+CLAUDE_MDs=()
+while IFS= read -r line; do
+  CLAUDE_MDs+=("$line")
+done < <(find ~/workspace/claude-workspace -maxdepth 2 -name 'CLAUDE.md' \
+      ! -path '*worktrees*' 2>/dev/null)
 CLAUDE_MDs+=("$HOME/.claude-personal/CLAUDE.md")
 
 for claude_md in "${CLAUDE_MDs[@]}"; do


### PR DESCRIPTION
## Summary
- `claude-config-lint.md` Check 2 used `mapfile`, a bash-4+ builtin. Verified via `ps -p $$ -o comm=` that the Bash tool's actual interpreter in this environment is zsh, which has no `mapfile` — the check would fail with "command not found" the moment it's actually run.
- Replaced with a `while read -r ... done < <(find ...)` loop into an array, portable across bash and zsh, preserving the original word-splitting fix for paths with spaces (e.g. "3532 Foxhall/CLAUDE.md").

Found during post-merge verification of #12836 (same PF-05 instruction-refactor plan).

## Test plan
- [x] Manually ran the replacement loop in this environment's actual shell (zsh) against the live `~/workspace/claude-workspace` tree — correctly enumerated all 12 CLAUDE.md files including the space-containing "3532 Foxhall/CLAUDE.md" path as a single array element.
- [x] Doc-only change, no kubernetes manifests touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)