### PR TITLE
feat(music-assistant): register FastMCP mount as an MCP gateway backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ _Production-grade Kubernetes for a household._
 
 <br/>
 
-![apps](https://img.shields.io/badge/apps-163-blue?style=for-the-badge)
+![apps](https://img.shields.io/badge/apps-164-blue?style=for-the-badge)
 ![helmreleases](https://img.shields.io/badge/HelmReleases-177-326CE5?style=for-the-badge&logo=helm&logoColor=white)
 ![nodes](https://img.shields.io/badge/k8s_nodes-11-326CE5?style=for-the-badge&logo=kubernetes&logoColor=white)
 ![cnpg](https://img.shields.io/badge/Postgres_clusters-24-336791?style=for-the-badge&logo=postgresql&logoColor=white)
@@ -277,7 +277,7 @@ Worker nodes attach to **iot** and **sec** VLANs via Multus for direct camera an
 </details>
 
 <details>
-<summary>🔌 <b>MCP Servers</b> — 19 Model Context Protocol servers behind an Authelia-gated gateway</summary>
+<summary>🔌 <b>MCP Servers</b> — 20 Model Context Protocol servers behind an Authelia-gated gateway</summary>
 
 | Server | Exposes |
 |--------|---------|

--- a/kubernetes/apps/mcp-system/kustomization.yaml
+++ b/kubernetes/apps/mcp-system/kustomization.yaml
@@ -26,6 +26,7 @@ resources:
   - ./kubectl-mcp/ks.yaml
   - ./mcp-gateway/ks.yaml
   - ./memory-mcp/ks.yaml
+  - ./music-assistant-mcp/ks.yaml
   - ./netbox-mcp/ks.yaml
   - ./observability/ks.yaml
   - ./omada-mcp/ks.yaml

--- a/kubernetes/apps/mcp-system/music-assistant-mcp/app/cnp-allow.yaml
+++ b/kubernetes/apps/mcp-system/music-assistant-mcp/app/cnp-allow.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: music-assistant-mcp-gateway-egress
+spec:
+  endpointSelector:
+    # The istio data-plane pod is what actually opens the upstream
+    # connection to a registered backend Service (the broker reaches
+    # backends via privateHost = mcp-gateway-istio:8080, which then
+    # applies this HTTPRoute). Every other backend lives in mcp-system,
+    # so that hop is intra-namespace (baseline allow-intra-namespace).
+    # MA lives in `media`, so the gateway needs an explicit cross-ns
+    # egress hole. Paired with the ingress rule in music-assistant-allow
+    # (media) and the ReferenceGrant there.
+    matchLabels:
+      gateway.networking.k8s.io/gateway-name: mcp-gateway
+      gateway.istio.io/managed: istio.io-gateway-controller
+  # Additive — default-deny is enabled by the namespace component.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: media
+            app.kubernetes.io/name: music-assistant
+      toPorts:
+        - ports:
+            - port: "8095"
+              protocol: TCP

--- a/kubernetes/apps/mcp-system/music-assistant-mcp/app/httproute.yaml
+++ b/kubernetes/apps/mcp-system/music-assistant-mcp/app/httproute.yaml
@@ -1,0 +1,40 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/gateway.networking.k8s.io/httproute_v1.json
+#
+# Registers Music Assistant's built-in FastMCP mount as a backend of the
+# in-cluster Kuadrant MCP gateway. Unlike every other backend, MA is not a
+# dedicated MCP-server Deployment in mcp-system — the FastMCP plugin mounts
+# straight onto MA's own webserver (media/music-assistant:8095/mcp). So this
+# route points cross-namespace into `media`, which requires the paired
+# ReferenceGrant (kubernetes/apps/media/music-assistant/app/referencegrant.yaml)
+# and the two CNP holes (cnp-allow.yaml here + the ingress rule in MA's own
+# music-assistant-allow policy). The FastMCP plugin runs with
+# require_auth=false and mount_path=/mcp to match the fleet path convention.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: music-assistant-mcp
+spec:
+  hostnames:
+    - music-assistant-mcp.mcp.local
+  parentRefs:
+    - name: mcp-gateway
+      namespace: mcp-system
+      sectionName: mcps
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /mcp
+      filters:
+        # Strip the broker-side Authorization before it reaches MA. With
+        # require_auth=false MA ignores it anyway, but stripping keeps this
+        # hop identical to the rest of the fleet (see paperless-mcp).
+        - type: RequestHeaderModifier
+          requestHeaderModifier:
+            remove:
+              - Authorization
+      backendRefs:
+        - name: music-assistant
+          namespace: media
+          port: 8095

--- a/kubernetes/apps/mcp-system/music-assistant-mcp/app/kustomization.yaml
+++ b/kubernetes/apps/mcp-system/music-assistant-mcp/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./cnp-allow.yaml
+  - ./httproute.yaml

--- a/kubernetes/apps/mcp-system/music-assistant-mcp/ks.yaml
+++ b/kubernetes/apps/mcp-system/music-assistant-mcp/ks.yaml
@@ -1,0 +1,38 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app music-assistant-mcp
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: mcp-system
+  path: ./kubernetes/apps/mcp-system/music-assistant-mcp/app
+  interval: 1h
+  timeout: 5m
+  wait: false
+  dependsOn:
+    - name: mcp-gateway
+      namespace: mcp-system
+  retryInterval: 2m
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app music-assistant-mcp-mcpserverregistration
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: mcp-system
+  path: ./kubernetes/apps/mcp-system/music-assistant-mcp/mcp
+  interval: 1h
+  timeout: 5m
+  wait: false
+  dependsOn:
+    - name: music-assistant-mcp
+      namespace: mcp-system
+  retryInterval: 2m

--- a/kubernetes/apps/mcp-system/music-assistant-mcp/mcp/kustomization.yaml
+++ b/kubernetes/apps/mcp-system/music-assistant-mcp/mcp/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./mcpserverregistration.yaml

--- a/kubernetes/apps/mcp-system/music-assistant-mcp/mcp/mcpserverregistration.yaml
+++ b/kubernetes/apps/mcp-system/music-assistant-mcp/mcp/mcpserverregistration.yaml
@@ -1,0 +1,14 @@
+---
+# TODO: apply schema
+apiVersion: mcp.kuadrant.io/v1alpha1
+kind: MCPServerRegistration
+metadata:
+  name: music-assistant-tools
+  labels:
+    mcp.kuadrant.io/managed: "true"
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: music-assistant-mcp
+  prefix: music_assistant_

--- a/kubernetes/apps/media/music-assistant/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/music-assistant/app/cnp-allow.yaml
@@ -55,6 +55,22 @@ spec:
         - ports:
             - port: "8095"
               protocol: TCP
+    # In-cluster MCP gateway: the Kuadrant mcp-gateway (istio data-plane
+    # pod in mcp-system) proxies aggregated MCP tool calls to MA's
+    # FastMCP mount at :8095/mcp. MA is the first gateway backend that
+    # lives outside mcp-system, so this cross-namespace ingress hole is
+    # needed (the other backends run in mcp-system and are covered there
+    # by allow-intra-namespace). Paired with the egress allow in
+    # kubernetes/apps/mcp-system/music-assistant-mcp/app/cnp-allow.yaml
+    # and the ReferenceGrant in this namespace.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: mcp-system
+            gateway.networking.k8s.io/gateway-name: mcp-gateway
+      toPorts:
+        - ports:
+            - port: "8095"
+              protocol: TCP
   egress:
     # External: Spotify, Tidal, Apple Music, Sonos cloud APIs, plus
     # mDNS-style LAN discovery to local devices (Sonos, Chromecast,

--- a/kubernetes/apps/media/music-assistant/app/kustomization.yaml
+++ b/kubernetes/apps/media/music-assistant/app/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - ./helmrelease.yaml
   - ./longhorn-pvc.yaml
   - ./nfs-pvc.yaml
+  - ./referencegrant.yaml
 commonLabels:
   app.kubernetes.io/instance: music-assistant
   app.kubernetes.io/name: music-assistant

--- a/kubernetes/apps/media/music-assistant/app/referencegrant.yaml
+++ b/kubernetes/apps/media/music-assistant/app/referencegrant.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/gateway.networking.k8s.io/referencegrant_v1beta1.json
+#
+# Permits the music-assistant-mcp HTTPRoute in mcp-system to use MA's
+# Service as a cross-namespace backend, so the in-cluster Kuadrant MCP
+# gateway can reach MA's FastMCP mount (:8095/mcp). Scoped to the one
+# Service; do NOT wildcard. Paired with the egress CNP in
+# kubernetes/apps/mcp-system/music-assistant-mcp/app/cnp-allow.yaml and
+# the ingress rule in music-assistant-allow (this namespace).
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: music-assistant-mcp-gateway
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      namespace: mcp-system
+  to:
+    - group: ""
+      kind: Service
+      name: music-assistant


### PR DESCRIPTION
## What

Registers Music Assistant's built-in **FastMCP** plugin as a backend of the in-cluster Kuadrant MCP gateway, so its tools join the aggregated fleet under the `music_assistant_` prefix.

Unlike every existing backend (each a dedicated MCP-server Deployment inside `mcp-system`), MA serves its MCP endpoint from its **own webserver** in the `media` namespace (`music-assistant:8095/mcp`). So this is the first gateway backend reached **cross-namespace**, which needs plumbing the intra-namespace backends don't:

- `mcp-system/music-assistant-mcp/` — `ks.yaml`, `app/httproute.yaml` (cross-ns backendRef → `media/music-assistant:8095`, path `/mcp`, broker `Authorization` stripped per fleet convention), `app/cnp-allow.yaml` (egress hole: `mcp-gateway-istio` → `media`), `mcp/mcpserverregistration.yaml` (`prefix: music_assistant_`).
- `media/music-assistant/app/referencegrant.yaml` — permits the mcp-system HTTPRoute to target MA's Service.
- `media/music-assistant/app/cnp-allow.yaml` — ingress hole: gateway → MA `:8095`.
- README apps badge 163→164, MCP-server count 19→20.

## Runtime dependency (not in this PR)

The FastMCP plugin is enabled in MA's own provider config (lives on its data PVC, the intended place for provider config — not GitOps). It must be configured with **`mount_path: /mcp`** and **`require_auth: false`** for this route to resolve. Until then the broker's backend ping to `/mcp` 404s and the registration shows not-ready (harmless).

## Note on exposure

`require_auth: false` means `/mcp` is also reachable unauthenticated on the MA LB VIP `:8095` from LAN/IoT — the same surface MA's web UI already exposes. Permissions are scoped to query + playback/volume/player control (no library/playlist edits, no deletes, no debug/config).

## Verify after Flux applies

- Broker backend ping succeeds; tools appear under `music_assistant_`.
- Confirm via Hubble that the egress originates from `mcp-gateway-istio` (the selected pod) — if a `POLICY_DENIED` shows the broker making the connection instead, add it to the egress CNP.
- Istio gateway → non-mesh cross-ns backend routing works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)