### PR TITLE
fix(media): reclaim /config ownership for per-app-UID Tier-1 writers

### DIFF
--- a/kubernetes/apps/media/radarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/radarr/app/helmrelease.yaml
@@ -25,6 +25,32 @@ spec:
           reloader.stakater.com/auto: "true"
 
         type: statefulset
+
+        # The config PVC was populated when this controller ran as uid 1000;
+        # runAsUser is now 1102 (per-app-UIDs commit 152c67ef3a) and
+        # fsGroupChangePolicy:OnRootMismatch skips the recursive fsGroup chown
+        # (the PVC root already matches gid 1001), so the stale uid-1000 files
+        # (/config/asp DataProtection keyring, MediaCover/**, logs) aren't
+        # readable/writable by 1102 — DataProtection keys regenerate every boot
+        # and cover-art/log writes throw "Permission denied". Reclaim /config
+        # ownership on startup; idempotent + self-heals. Scoped to /config only —
+        # the media/downloads NFS mounts are owned correctly and must not be
+        # touched. Mirrors the lidarr init-perms pattern.
+        initContainers:
+          init-perms:
+            image:
+              repository: ghcr.io/home-operations/radarr
+              tag: rolling@sha256:a566e7d364b96ce8ffb1b582266e656c69f3a12dec289d72bb0daa647ed4725e
+            command:
+              - chown
+              - -R
+              - 1102:1001
+              - /config
+            securityContext:
+              runAsUser: 0
+              runAsGroup: 0
+              runAsNonRoot: false
+
         containers:
           app:
             image:

--- a/kubernetes/apps/media/sonarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sonarr/app/helmrelease.yaml
@@ -24,6 +24,32 @@ spec:
           reloader.stakater.com/auto: "true"
 
         type: statefulset
+
+        # The config PVC was populated when this controller ran as uid 1000;
+        # runAsUser is now 1101 (per-app-UIDs commit 152c67ef3a) and
+        # fsGroupChangePolicy:OnRootMismatch skips the recursive fsGroup chown
+        # (the PVC root already matches gid 1001), so the stale uid-1000 files
+        # (/config/asp DataProtection keyring, MediaCover/**, logs) aren't
+        # readable/writable by 1101 — DataProtection keys regenerate every boot
+        # and cover-art/log writes throw "Permission denied". Reclaim /config
+        # ownership on startup; idempotent + self-heals. Scoped to /config only —
+        # the media/downloads NFS mounts are owned correctly and must not be
+        # touched. Mirrors the lidarr init-perms pattern.
+        initContainers:
+          init-perms:
+            image:
+              repository: ghcr.io/home-operations/sonarr
+              tag: rolling@sha256:2cd77fb3d81909a734d61bb8f71462044cb9d2f187e626a28a05a5c4e4be8fd2
+            command:
+              - chown
+              - -R
+              - 1101:1001
+              - /config
+            securityContext:
+              runAsUser: 0
+              runAsGroup: 0
+              runAsNonRoot: false
+
         containers:
           app:
             image:


### PR DESCRIPTION
## Problem

Two media-stack controllers were moved to dedicated per-app UIDs (commit `152c67ef3a`, *per-app UIDs for Tier 1 writers*), but their config PVCs were populated years earlier under uid **1000**. `fsGroupChangePolicy: OnRootMismatch` skips the recursive `fsGroup` chown because the PVC root group already matches gid 1001, so stale **uid-1000** files persist and aren't readable/writable by the new UID:

- ASP.NET **DataProtection keyring** under `/config/asp` (mode 0600, owner 1000) → keys silently **regenerate every boot**.
- **NLog file target** → file logging silently dead since the UID switch.
- **MediaCover/** cover-art overwrites → `Permission denied`.

Non-fatal (auth is `External`/gateway-side, console logging still works), but it's real drift and degraded behavior. The third sibling writer already carries the fix; these two were missed.

## Fix

Add a root `init-perms` initContainer (mirrors the already-merged sibling pattern) that `chown -R <uid>:1001 /config` on startup — **idempotent, self-healing, scoped to `/config` only**. The media/downloads NFS mounts are correctly owned and are **not** touched.

## Impact

Pod-spec change → each controller does a one-time rolling restart on reconcile (brief admin-tool downtime; **not** Renee-facing). The initContainer adds a few seconds to startup while it reconciles ownership, then no-ops thereafter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)