### PR TITLE
fix(media): add tmpfs /tmp for per-app-UID Tier-1 writers

### DIFF
--- a/kubernetes/apps/media/radarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/radarr/app/helmrelease.yaml
@@ -120,3 +120,11 @@ spec:
 
       sabnzbd:
         existingClaim: sonarr-sabnzbd-downloads
+
+      # Writable scratch for readOnlyRootFilesystem: true. DataProtection's
+      # atomic key-store writes a temp file via Path.GetTempFileName() (/tmp);
+      # without this it fails "Read-only file system" on every boot. Mirrors
+      # the lidarr tmpfs mount.
+      tmp:
+        type: emptyDir
+        medium: Memory

--- a/kubernetes/apps/media/sonarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sonarr/app/helmrelease.yaml
@@ -119,3 +119,11 @@ spec:
 
       sabnzbd:
         existingClaim: sonarr-sabnzbd-downloads
+
+      # Writable scratch for readOnlyRootFilesystem: true. DataProtection's
+      # atomic key-store writes a temp file via Path.GetTempFileName() (/tmp);
+      # without this it fails "Read-only file system" on every boot. Mirrors
+      # the lidarr tmpfs mount.
+      tmp:
+        type: emptyDir
+        medium: Memory


### PR DESCRIPTION
## Problem

Follow-up to the per-app-UID `/config` ownership fix. With `readOnlyRootFilesystem: true` and no writable `/tmp`, the ASP.NET DataProtection key-store fails `System.IO.IOException: Read-only file system` at `Path.GetTempFileName()` on every boot — so it can't persist a freshly-minted key (existing keys are expired) and logs an `[Error]` each start.

Functionally minor — auth is `External` (gateway-side), so these keys don't gate access — but it's log noise and leaves the controllers without a stable data-protection key. The third sibling writer already has a tmpfs `/tmp` and is clean.

## Fix

Add a memory-backed `emptyDir` at `/tmp` to both, mirroring the sibling's mount. Standard remedy for `readOnlyRootFilesystem` apps needing scratch (per `.agents/instructions/helmrelease.security.md`).

## Impact

One brief rolling restart each on reconcile (admin-only, not Renee-facing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)