### PR TITLE
fix(music-assistant): target the MCP broker pod in the gateway CNP holes

### DIFF
--- a/kubernetes/apps/mcp-system/music-assistant-mcp/app/cnp-allow.yaml
+++ b/kubernetes/apps/mcp-system/music-assistant-mcp/app/cnp-allow.yaml
@@ -6,17 +6,16 @@ metadata:
   name: music-assistant-mcp-gateway-egress
 spec:
   endpointSelector:
-    # The istio data-plane pod is what actually opens the upstream
-    # connection to a registered backend Service (the broker reaches
-    # backends via privateHost = mcp-gateway-istio:8080, which then
-    # applies this HTTPRoute). Every other backend lives in mcp-system,
-    # so that hop is intra-namespace (baseline allow-intra-namespace).
-    # MA lives in `media`, so the gateway needs an explicit cross-ns
-    # egress hole. Paired with the ingress rule in music-assistant-allow
-    # (media) and the ReferenceGrant there.
+    # The broker (MCPRouter) pod dials the backend Service directly —
+    # confirmed from its logs: `POST http://music-assistant.media.svc:8095/mcp`
+    # to MA's ClusterIP. It does NOT proxy backend calls through the istio
+    # data-plane pod. Every other backend lives in mcp-system, so that hop
+    # is intra-namespace (baseline allow-intra-namespace). MA lives in
+    # `media`, so the broker needs an explicit cross-ns egress hole. Paired
+    # with the ingress rule in music-assistant-allow (media) and the
+    # ReferenceGrant there.
     matchLabels:
-      gateway.networking.k8s.io/gateway-name: mcp-gateway
-      gateway.istio.io/managed: istio.io-gateway-controller
+      app.kubernetes.io/name: mcp-gateway
   # Additive — default-deny is enabled by the namespace component.
   enableDefaultDeny:
     egress: false

--- a/kubernetes/apps/media/music-assistant/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/music-assistant/app/cnp-allow.yaml
@@ -55,18 +55,18 @@ spec:
         - ports:
             - port: "8095"
               protocol: TCP
-    # In-cluster MCP gateway: the Kuadrant mcp-gateway (istio data-plane
-    # pod in mcp-system) proxies aggregated MCP tool calls to MA's
-    # FastMCP mount at :8095/mcp. MA is the first gateway backend that
-    # lives outside mcp-system, so this cross-namespace ingress hole is
-    # needed (the other backends run in mcp-system and are covered there
-    # by allow-intra-namespace). Paired with the egress allow in
+    # In-cluster MCP gateway: the Kuadrant broker (MCPRouter) pod in
+    # mcp-system dials MA's FastMCP mount at :8095/mcp directly (not via
+    # the istio data-plane). MA is the first gateway backend that lives
+    # outside mcp-system, so this cross-namespace ingress hole is needed
+    # (the other backends run in mcp-system and are covered there by
+    # allow-intra-namespace). Paired with the egress allow in
     # kubernetes/apps/mcp-system/music-assistant-mcp/app/cnp-allow.yaml
     # and the ReferenceGrant in this namespace.
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: mcp-system
-            gateway.networking.k8s.io/gateway-name: mcp-gateway
+            app.kubernetes.io/name: mcp-gateway
       toPorts:
         - ports:
             - port: "8095"


### PR DESCRIPTION
Follow-up to #12839. The `music_assistant_` backend registered but came up **NotReady** — the broker's connection to `music-assistant.media.svc:8095/mcp` timed out (`dial tcp 10.43.22.228:8095: i/o timeout`), i.e. a CNP drop.

**Root cause:** #12839 assumed the istio data-plane pod (`mcp-gateway-istio`) makes the backend connection. It doesn't — the broker log shows the **broker** (`app.kubernetes.io/name: mcp-gateway`) POSTing directly to MA's ClusterIP. So both cross-namespace holes targeted the wrong pod.

**Fix:** point both holes at the broker:
- egress CNP (`mcp-system/music-assistant-mcp`): `mcp-gateway-istio` → `app.kubernetes.io/name: mcp-gateway`
- ingress rule (`media/music-assistant`): same.

The FastMCP endpoint itself is verified healthy (`POST /mcp` → 200); this is purely the two network-policy selectors. Verified post-merge: broker connects, registration Ready, `music_assistant_` tools appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)