### PR TITLE
feat(resources): resources backfill — stash + openebs

### DIFF
--- a/kubernetes/apps/media/stash/app/helmrelease.yaml
+++ b/kubernetes/apps/media/stash/app/helmrelease.yaml
@@ -92,6 +92,13 @@ spec:
               - secretRef:
                   name: stash-secret
 
+            resources:
+              requests:
+                cpu: 100m
+                memory: 256Mi
+              limits:
+                memory: 512Mi
+
     service:
       app:
         controller: stash

--- a/kubernetes/apps/storage/openebs/app/helmrelease.yaml
+++ b/kubernetes/apps/storage/openebs/app/helmrelease.yaml
@@ -36,6 +36,12 @@ spec:
         basePath: *hostPath
         image:
           registry: quay.io/
+        resources:
+          requests:
+            cpu: 25m
+            memory: 128Mi
+          limits:
+            memory: 256Mi
       rbac:
         create: true
     loki:


### PR DESCRIPTION
## Summary
- Adds `resources:` blocks to the final 2 HRs from the #12772 audit still missing them
- Everything else in that plan (31 HRs) was already covered by PR #12803, confirmed by direct audit
- No CPU limits (repo convention); memory limit set to ~2x request per PR #12803 precedent

## Test plan
- [ ] Post-merge: `kubectl describe pod -n media -l app.kubernetes.io/name=stash` shows QoS Class: Burstable
- [ ] Post-merge: openebs provisioner pods show QoS Class: Burstable
- [ ] No Evicted events in the following 24h