### PR TITLE
fix(music-assistant): allow both gateway pods to reach the MA MCP backend

### DIFF
--- a/kubernetes/apps/mcp-system/music-assistant-mcp/app/cnp-allow.yaml
+++ b/kubernetes/apps/mcp-system/music-assistant-mcp/app/cnp-allow.yaml
@@ -1,21 +1,49 @@
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+#
+# MA is the only gateway backend outside mcp-system, and BOTH gateway pods
+# open connections to it — for an in-namespace backend, allow-intra-namespace
+# would cover both, so this cross-namespace pair is unique to MA:
+#   - the broker (app.kubernetes.io/name=mcp-gateway) dials MA's ClusterIP
+#     directly for registration + the 60s health ping;
+#   - the istio data-plane pod (gateway.networking.k8s.io/gateway-name=
+#     mcp-gateway) reaches MA via this app's HTTPRoute on every tool
+#     invocation (confirmed by a Hubble policy-DROP of its SYN to
+#     media/music-assistant:8095 when only the broker was allowed).
+# Both need the egress hole. Paired with the two ingress rules in
+# music-assistant-allow (media) and the ReferenceGrant there.
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
-  name: music-assistant-mcp-gateway-egress
+  name: music-assistant-mcp-broker-egress
 spec:
   endpointSelector:
-    # The broker (MCPRouter) pod dials the backend Service directly —
-    # confirmed from its logs: `POST http://music-assistant.media.svc:8095/mcp`
-    # to MA's ClusterIP. It does NOT proxy backend calls through the istio
-    # data-plane pod. Every other backend lives in mcp-system, so that hop
-    # is intra-namespace (baseline allow-intra-namespace). MA lives in
-    # `media`, so the broker needs an explicit cross-ns egress hole. Paired
-    # with the ingress rule in music-assistant-allow (media) and the
-    # ReferenceGrant there.
     matchLabels:
       app.kubernetes.io/name: mcp-gateway
+  # Additive — default-deny is enabled by the namespace component.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: media
+            app.kubernetes.io/name: music-assistant
+      toPorts:
+        - ports:
+            - port: "8095"
+              protocol: TCP
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: music-assistant-mcp-istio-egress
+spec:
+  endpointSelector:
+    matchLabels:
+      gateway.networking.k8s.io/gateway-name: mcp-gateway
+      gateway.istio.io/managed: istio.io-gateway-controller
   # Additive — default-deny is enabled by the namespace component.
   enableDefaultDeny:
     egress: false

--- a/kubernetes/apps/media/music-assistant/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/music-assistant/app/cnp-allow.yaml
@@ -55,18 +55,23 @@ spec:
         - ports:
             - port: "8095"
               protocol: TCP
-    # In-cluster MCP gateway: the Kuadrant broker (MCPRouter) pod in
-    # mcp-system dials MA's FastMCP mount at :8095/mcp directly (not via
-    # the istio data-plane). MA is the first gateway backend that lives
-    # outside mcp-system, so this cross-namespace ingress hole is needed
-    # (the other backends run in mcp-system and are covered there by
-    # allow-intra-namespace). Paired with the egress allow in
-    # kubernetes/apps/mcp-system/music-assistant-mcp/app/cnp-allow.yaml
+    # In-cluster MCP gateway: BOTH Kuadrant gateway pods reach MA's FastMCP
+    # mount at :8095/mcp — the broker (app.kubernetes.io/name=mcp-gateway)
+    # dials directly for registration + the 60s health ping, and the istio
+    # data-plane pod (gateway.networking.k8s.io/gateway-name=mcp-gateway)
+    # reaches it via the music-assistant-mcp HTTPRoute on every tool
+    # invocation. MA is the first gateway backend outside mcp-system, so it
+    # needs this cross-namespace ingress hole for both (in-ns backends are
+    # covered there by allow-intra-namespace). Paired with the two egress
+    # allows in kubernetes/apps/mcp-system/music-assistant-mcp/app/cnp-allow.yaml
     # and the ReferenceGrant in this namespace.
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: mcp-system
             app.kubernetes.io/name: mcp-gateway
+        - matchLabels:
+            io.kubernetes.pod.namespace: mcp-system
+            gateway.networking.k8s.io/gateway-name: mcp-gateway
       toPorts:
         - ports:
             - port: "8095"


### PR DESCRIPTION
Second follow-up to #12839 / #12842. The `music_assistant_` backend registered **Ready**, but tool *invocations* failed (`context canceled`; MA never received the call).

**Root cause:** two different gateway pods connect to the backend, and for a cross-namespace backend each needs its own hole:
- **broker** (`app.kubernetes.io/name: mcp-gateway`) — dials MA's ClusterIP directly for registration + the 60s health ping.
- **istio data-plane** (`gateway.networking.k8s.io/gateway-name: mcp-gateway`) — reaches MA via this app's HTTPRoute on **every tool invocation**. Hubble caught its SYN to `media/music-assistant:8095` as `Policy denied DROPPED`.

#12839 allowed only the istio pod → registration failed. #12842 swapped to only the broker → registration worked, invocation failed. This allows **both**, on the egress (mcp-system, now two CNPs) and ingress (MA, two `fromEndpoints`) sides.

In-namespace backends never hit this because `allow-intra-namespace` covers both pods — MA is the only cross-namespace backend, so it's the only one that needs the pair spelled out.

Verified after merge: `music_assistant_players_list_players` returns real players end-to-end through the gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)