### PR TITLE
feat(security): securityContext backfill — open-webui, paperless

### DIFF
--- a/kubernetes/apps/collab/open-webui/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/open-webui/app/helmrelease.yaml
@@ -25,13 +25,56 @@ spec:
 
         type: statefulset
 
+        # runAsNonRoot: live-verified 2026-07-04. Data PVC top level was
+        # 0:0 (subdirs/db already writable by any owner); fsGroup below
+        # handles the one-time kubelet chown on next mount (standard
+        # k8s mechanism, not a manual migration). Two real blockers
+        # found and fixed:
+        #   1. start.sh writes ./.webui_secret_key relative to the
+        #      image's /app/backend cwd (root-owned, unwritable as
+        #      1000) — WEBUI_SECRET_KEY_FILE below redirects it onto
+        #      the PVC. Bonus: this also fixes a pre-existing bug where
+        #      every pod restart silently regenerated the secret key
+        #      and force-logged-out all users (the file was never
+        #      persisted before).
+        #   2. Startup tries to overlay custom static assets onto
+        #      /app/backend/open_webui/static (image-baked, read-only
+        #      to 1000) — these raise caught "Permission denied"
+        #      errors in the log but are non-fatal; app boots and
+        #      serves normally past them.
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            fsGroupChangePolicy: OnRootMismatch
+
         containers:
           app:
             image:
               repository: ghcr.io/open-webui/open-webui
               tag: v0.9.6
 
+            securityContext:
+              allowPrivilegeEscalation: false
+              # RO rootfs stays off: Python app writes to /tmp and may
+              # pip-install extras at runtime.
+              readOnlyRootFilesystem: false
+              capabilities:
+                drop:
+                  - ALL
+              seccompProfile:
+                type: RuntimeDefault
+
             env:
+              # HOME=/root is unwritable as UID 1000; several deps
+              # (huggingface/langchain caches, matplotlib config) fall
+              # back to $HOME for scratch/config dirs.
+              HOME: /tmp
+              # See pod-level comment above — persists the secret key
+              # on the PVC instead of the unwritable image cwd.
+              WEBUI_SECRET_KEY_FILE: /app/backend/data/.webui_secret_key
               # Multi-endpoint: Spark (qwen3-next:80b-a3b-instruct-q4_K_M) is the new default,
               # P40 (qwen2.5:7b) remains user-selectable per
               # conversation. Open WebUI parses this as `;`-separated

--- a/kubernetes/apps/collab/paperless/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/paperless/app/helmrelease.yaml
@@ -18,6 +18,29 @@ spec:
 
         type: statefulset
 
+        # runAsNonRoot: live-verified 2026-07-04 against the real
+        # image+tag (not just docs). paperless-ngx is s6-overlay based
+        # (same family as the wyoming-services whisper deferral above)
+        # but its entrypoint has first-class non-root support: it
+        # detects a non-zero start UID and logs "Running as non-root
+        # user (1000:1000), skipping UID/GID remapping" — no PUID/PGID
+        # dance needed. USERMAP_UID/GID below are a documented no-op in
+        # that mode (upstream logs a warning) but kept for clarity/
+        # back-compat if non-root is ever reverted. The PVC's actual
+        # document subdirs (consume/data/media) were ALREADY 1000:1000
+        # owned in prod before this change — only the /library mount
+        # root itself was 0:0, so fsGroup's OnRootMismatch does a one-
+        # time recursive chown (standard k8s mechanism, not a manual
+        # migration) rather than a bulk ownership flip on already-
+        # correct data.
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            fsGroupChangePolicy: OnRootMismatch
+
         initContainers:
           init-db:
             image:
@@ -32,7 +55,22 @@ spec:
             image:
               repository: ghcr.io/paperless-ngx/paperless-ngx
               tag: 2.20.15
+
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+              seccompProfile:
+                type: RuntimeDefault
+
             env:
+              # USERMAP_UID/GID are a no-op once the pod runs fully
+              # non-root (upstream skips remapping and warns) — kept
+              # for documentation/back-compat.
+              USERMAP_UID: "1000"
+              USERMAP_GID: "1000"
               # Configure application
               PAPERLESS_URL: "https://paperless.${SECRET_DOMAIN}"
               PAPERLESS_PORT: "8000"
@@ -98,3 +136,20 @@ spec:
     persistence:
       library:
         existingClaim: paperless-library-pvc
+
+      tmp:
+        type: emptyDir
+        advancedMounts:
+          paperless:
+            app:
+              - path: /tmp
+
+      run:
+        # s6-overlay preinit wants to own /run; under readOnlyRootFilesystem
+        # this needs an explicit writable (tmpfs) mount or the container
+        # can't even get through its init stage. Live-verified 2026-07-04.
+        type: emptyDir
+        advancedMounts:
+          paperless:
+            app:
+              - path: /run


### PR DESCRIPTION
## Summary

Confirmed true remainder of the #12770 securityContext-backfill plan. This is the higher-risk half — both apps run as root today and hold real Tier-1 user data (chat history, scanned documents), which is exactly why they were deferred originally.

Per instructions, I did **not** blind-flip ownership. Both PVCs were live-probed first, and the proposed hardening was live-tested in scratch pods against the real images (not the live StatefulSets) before writing any YAML:

- **paperless**: `USERMAP_UID`/`USERMAP_GID` added per upstream convention (confirmed a documented no-op once the pod is fully non-root — upstream's entrypoint auto-detects and skips remapping — kept for clarity/back-compat). The volume's actual document subdirs (`consume`/`data`/`media`) were **already** `1000:1000` owned in prod; only the `/library` mount root itself was `0:0`. `fsGroup: 1000` + `fsGroupChangePolicy: OnRootMismatch` triggers the standard one-time kubelet ownership fixup — not a manual data migration. Full baseline hardening applied (`readOnlyRootFilesystem: true` + tmpfs `/tmp` and `/run`, capabilities drop ALL, seccomp default) — live-verified boots clean.

- **open-webui**: `/app/backend/data` volume top level was `0:0`; `fsGroup: 1000` handles it via the same standard mechanism. Live-testing surfaced two real blockers that would have broken the live pod, both fixed before shipping:
  1. `start.sh` writes its secret-key file relative to `/app/backend` (image-baked, root-owned, unwritable as 1000) → redirected via `WEBUI_SECRET_KEY_FILE` onto the persistent volume. This is also a **bonus fix** for a pre-existing bug: without persistence, every pod restart silently regenerated the secret key and force-logged-out every user.
  2. A startup attempt to overlay custom static assets onto the image's `open_webui/static/` dir throws a caught `Permission denied` (logged as ERROR, non-fatal) — app boots and serves normally past it.
  `readOnlyRootFilesystem: false` kept per plan guidance (Python app writes `/tmp`, may pip-install extras).

## What still needs review before merge

- Both volumes will get a one-time kubelet `fsGroup` ownership fixup on next pod restart after this merges (not run by me — happens automatically when Flux reconciles the new pod spec). This is the standard, supported k8s mechanism (documented in `.agents/instructions/helmrelease.security.md`), not a manual migration, but it **does touch every file's ownership metadata** on both volumes. Flagging explicitly per the "propose then execute" rule for anything touching live user data — recommend merging in a low-traffic window and watching the first restart.
- I left several scratch test pods running in the cluster from live-verification (namespace `collab`: `paperless-nonroot-test`, `paperless-nonroot-test2`, `paperless-nonroot-test3`, `openwebui-nonroot-test`, `openwebui-nonroot-test2`; namespace `home`: `whisper-nonroot-test`, `whisper-nonroot-test2`, `whisper-partial-test`, `kokoro-partial-test`) — all ephemeral (emptyDir only, no persistent volume touched), but I did not tear them down myself since this session's guardrail blocks that action type for me. Please clean these up manually when convenient.

## Test plan

- [x] `kubectl kustomize kubernetes/apps/collab` renders clean
- [x] `pre-commit run check-yaml` passes
- [x] Live-probed current UID + volume ownership on both pods before writing YAML
- [x] Live-tested proposed hardening (UID, fsGroup, RO rootfs, capability drop) in scratch pods against the real images — found and fixed the open-webui secret-key-path blocker before it could hit prod
- [ ] Post-merge: confirm the one-time fsGroup ownership fixup completes cleanly on first restart, both apps come up with 0 restarts after a 5m soak, and open-webui login/chat history + paperless document list are intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)