### PR TITLE
fix(media): raise memory limits on two media-stack apps to stop OOMKill loop

### DIFF
--- a/kubernetes/apps/media/radarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/radarr/app/helmrelease.yaml
@@ -74,9 +74,9 @@ spec:
             resources:
               requests:
                 cpu: 15m
-                memory: 800M
+                memory: 1Gi
               limits:
-                memory: 800M
+                memory: 1.5Gi
 
             securityContext:
               allowPrivilegeEscalation: false

--- a/kubernetes/apps/media/sonarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sonarr/app/helmrelease.yaml
@@ -75,7 +75,7 @@ spec:
                 cpu: 15m
                 memory: 1G
               limits:
-                memory: 1.25G
+                memory: 1.5Gi
 
             securityContext:
               allowPrivilegeEscalation: false


### PR DESCRIPTION
## Problem

A media-stack app returned HTTP 503 — its pod was stuck `Pending` on a
`FailedMount`: the Longhorn XFS config volume refused to mount with a
dirty-journal error (`Metadata has LSN ahead of current LSN`). Cleared
in-place with `xfs_repair -L` (dirty log only, no corruption, no data
loss; pre-repair Longhorn snapshot taken).

Root cause of the *ungraceful* death that dirtied the journal: the app
was **OOMKilled**. Its memory limit equalled its request (a hard cap)
and sat at/below the real working-set peak, so the kernel SIGKILLed it
under load. SIGKILL skips graceful shutdown → dirty XFS log → next
mount fails. `terminationGracePeriodSeconds` cannot help an OOMKill.

A sibling app was on the same trajectory (limit exceeded by a recent
peak), so both are bumped here.

## Change

| App | req before → after | lim before → after | Observed peak |
|-----|--------------------|--------------------|---------------|
| A | 800M → 1Gi | 800M → 1.5Gi | ~740 MiB |
| B | 1G (unchanged) | 1.25G → 1.5Gi | ~1168 MiB |

Limits set with headroom above observed peaks so library scans and
imports don't clip the cap. Flux rolls this out with one clean restart
per app.

## Test

- `xfs_repair -n` classified the failure as dirty-log only (Phases
  1–7 clean, no Phase 5/6 AG/btree/superblock damage).
- Post-repair pod bounce: mount succeeded, app `1/1 Ready`, 503 cleared.
- OOMKill confirmed via `kube_pod_container_status_last_terminated_reason{reason="OOMKilled"}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)