### PR TITLE
fix(paperless): revert non-root hardening from #12846 — restore service

### DIFF
--- a/kubernetes/apps/collab/paperless/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/paperless/app/helmrelease.yaml
@@ -18,29 +18,6 @@ spec:
 
         type: statefulset
 
-        # runAsNonRoot: live-verified 2026-07-04 against the real
-        # image+tag (not just docs). paperless-ngx is s6-overlay based
-        # (same family as the wyoming-services whisper deferral above)
-        # but its entrypoint has first-class non-root support: it
-        # detects a non-zero start UID and logs "Running as non-root
-        # user (1000:1000), skipping UID/GID remapping" — no PUID/PGID
-        # dance needed. USERMAP_UID/GID below are a documented no-op in
-        # that mode (upstream logs a warning) but kept for clarity/
-        # back-compat if non-root is ever reverted. The PVC's actual
-        # document subdirs (consume/data/media) were ALREADY 1000:1000
-        # owned in prod before this change — only the /library mount
-        # root itself was 0:0, so fsGroup's OnRootMismatch does a one-
-        # time recursive chown (standard k8s mechanism, not a manual
-        # migration) rather than a bulk ownership flip on already-
-        # correct data.
-        pod:
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 1000
-            runAsGroup: 1000
-            fsGroup: 1000
-            fsGroupChangePolicy: OnRootMismatch
-
         initContainers:
           init-db:
             image:
@@ -55,22 +32,7 @@ spec:
             image:
               repository: ghcr.io/paperless-ngx/paperless-ngx
               tag: 2.20.15
-
-            securityContext:
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: true
-              capabilities:
-                drop:
-                  - ALL
-              seccompProfile:
-                type: RuntimeDefault
-
             env:
-              # USERMAP_UID/GID are a no-op once the pod runs fully
-              # non-root (upstream skips remapping and warns) — kept
-              # for documentation/back-compat.
-              USERMAP_UID: "1000"
-              USERMAP_GID: "1000"
               # Configure application
               PAPERLESS_URL: "https://paperless.${SECRET_DOMAIN}"
               PAPERLESS_PORT: "8000"
@@ -136,20 +98,3 @@ spec:
     persistence:
       library:
         existingClaim: paperless-library-pvc
-
-      tmp:
-        type: emptyDir
-        advancedMounts:
-          paperless:
-            app:
-              - path: /tmp
-
-      run:
-        # s6-overlay preinit wants to own /run; under readOnlyRootFilesystem
-        # this needs an explicit writable (tmpfs) mount or the container
-        # can't even get through its init stage. Live-verified 2026-07-04.
-        type: emptyDir
-        advancedMounts:
-          paperless:
-            app:
-              - path: /run


### PR DESCRIPTION
## Problem

`paperless-0` (collab) has been **CrashLoopBackOff since #12846 merged** (Jul-4 13:45) — exit code 100, 187 restarts, ~16h of downtime on Tier-1 scanned-document data.

## Root cause

paperless-ngx is s6-overlay based. Its preinit requires `/run` owned by **uid 1000**:

```
/package/admin/s6-overlay/libexec/preinit: fatal: /run belongs to uid 0 instead of 1000,
has insecure and/or unworkable permissions, and we're lacking the privileges to fix it.
s6-overlay-suexec: fatal: child failed with exit code 100
```

#12846 added a tmpfs `/run` emptyDir + `fsGroup: 1000`, but **`fsGroup` only sets the gid** — the emptyDir root stays **uid 0**. preinit can't self-chown as a non-root process, so it aborts before the app ever starts. The scratch-pod "live verification" in #12846 didn't reproduce the StatefulSet's real emptyDir ownership semantics.

## Fix

Reverts paperless's portion of #12846 to its **byte-identical pre-hardening (root) state** to restore service now. Verified `git diff 876dc98245^` is empty.

`open-webui`'s portion of #12846 is untouched and healthy (not s6-based).

## Follow-up

Redo paperless non-root hardening properly — a root init-container that `chown 1000:1000` the `/run` and `/tmp` emptyDirs, iterated in a scratch pod against the real StatefulSet — as a separate tracked change. Will file a `workaround`/follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)