### PR TITLE
feat(security): drop privileged on comfyui, use granular caps (#12769)

### DIFF
--- a/kubernetes/apps/ai/comfyui/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/comfyui/app/helmrelease.yaml
@@ -59,7 +59,22 @@ spec:
                 nvidia.com/gpu: 1 # requesting 1 GPU
 
             securityContext:
-              privileged: true
+              # ai-dock's init.sh calls chown/useradd/usermod on first
+              # start to remap the in-image user. Granular caps for
+              # that init phase; privileged dropped. Verified live
+              # (2026-07-05): no permission errors during init, GPU
+              # detected, inference API responds normally.
+              privileged: false
+              allowPrivilegeEscalation: true # needed for setuid useradd
+              capabilities:
+                drop:
+                  - ALL
+                add:
+                  - CHOWN
+                  - SETUID
+                  - SETGID
+                  - DAC_OVERRIDE
+                  - FOWNER
 
     service:
       app:


### PR DESCRIPTION
## Summary

- Replaces `privileged: true` on `ai/comfyui` with the specific capabilities its init phase needs: `CHOWN`, `SETUID`, `SETGID`, `DAC_OVERRIDE`, `FOWNER`
- ai-dock's `init.sh` does `chown`/`useradd`/`usermod` at container startup to remap the in-image user — these are the caps that operation actually requires, not full privileged escalation
- `comfyui-spark` (different image, sudo-based remap) is a deliberate follow-up, not included here — different failure modes per the roadmap plan

## Live verification (done before this PR, against the running P40 pod)

Phased test per `.claude-personal/plans/roadmap/12769-comfyui-granular-caps.md`:

1. **Phase 1** — caps added, `privileged: true` kept: pod restarted clean, GPU detected, API responded with JSON (`system_stats`).
2. **Phase 2** — `privileged: false`, caps only: pod restarted clean, **zero permission errors** in `chown`/`useradd`/`usermod` during init, GPU still detected (Tesla P40, 24GB VRAM), API fully responsive.
3. **Phase 3** — inference smoke test: `/queue` returned empty running/pending, `/prompt` returned the expected `prompt_no_outputs` validation error for an empty graph — proof the endpoint is live and processing, not crashed.

This PR's diff matches exactly what was live-tested; no untested changes.

## Test plan

- [ ] CI green
- [ ] Post-merge: `kubectl get pod -n ai comfyui-0 -o jsonpath='{.spec.containers[?(@.name=="app")].securityContext.privileged}'` → `false`
- [ ] Post-merge: `kubectl exec -n ai comfyui-0 -c app -- nvidia-smi -L` → Tesla P40
- [ ] Post-merge: submit a real workflow via the ComfyUI UI, confirm image generation completes