### PR TITLE
fix(observability): correct pushgateway-allow CNP endpointSelector label

### DIFF
--- a/kubernetes/apps/observability/exporters/pushgateway/app/cnp-allow.yaml
+++ b/kubernetes/apps/observability/exporters/pushgateway/app/cnp-allow.yaml
@@ -7,7 +7,10 @@ metadata:
 spec:
   endpointSelector:
     matchLabels:
-      app.kubernetes.io/name: pushgateway
+      # chart labels the pod `prometheus-pushgateway`, not `pushgateway` —
+      # the bare name selected zero pods, so this allow-CNP was inert and
+      # default-deny dropped the internal-gateway Envoy → 503 on exporter push.
+      app.kubernetes.io/name: prometheus-pushgateway
   enableDefaultDeny:
     egress: false
     ingress: false


### PR DESCRIPTION
## Problem

The Claude Code cost/cache Grafana dashboard (merged in #12828, PF-06a) renders empty: **no `claude_code_*` metrics reach Prometheus**. Root cause is a label typo in the pushgateway allow-CNP, not the exporter.

- Pushgateway pod label: `app.kubernetes.io/name: **prometheus-pushgateway**` (the chart's name)
- `pushgateway-allow` CNP `endpointSelector`: `app.kubernetes.io/name: **pushgateway**` → **matches zero pods** (`kubectl get pods -l app.kubernetes.io/name=pushgateway` = No resources found)

With the allow-CNP inert, namespace `default-deny` drops the internal-gateway Envoy's forward to `pushgateway:9091`. The laptop cost exporter's `PUT /metrics/job/…` therefore gets **HTTP 503 after a ~10 s connect-timeout**, and every timer push fails silently.

In-namespace Prometheus scrape kept working (covered by `allow-intra-namespace` + `allow-monitoring-scrape`), which masked the gap.

## Evidence

| Check | Result |
|---|---|
| In-cluster GET from `observability` ns | 200 in 15 ms |
| GET via `internal` gateway (`pushgateway.thesteamedcrab.com`) | **503** after 10 s |
| pushgateway pod | healthy, Running 1/1, 0 restarts, 8 d |
| CNP selector `app.kubernetes.io/name=pushgateway` | matches **0 pods** |
| pushgateway-allow HTTPRoute backendRef / ext-authz | correct / none — ruled out |

## Fix

One-line `endpointSelector` correction to the actual pod label, so the existing (correct-in-intent) `fromEndpoints: envoy@network` ingress rule actually applies. Additive — opens the intended path, removes nothing.

## Test plan

- [ ] Merge → Flux reconciles the CNP
- [ ] `kubectl get pods -n observability -l app.kubernetes.io/name=prometheus-pushgateway` selected by CNP
- [ ] `curl https://pushgateway.thesteamedcrab.com/metrics` → 200
- [ ] exporter push succeeds; `claude_code_cache_hit_rate` / `claude_code_cost_by_project` series appear
- [ ] Grafana "Claude Code — Cost & Cache" panels populate

🤖 Generated with [Claude Code](https://claude.com/claude-code)