### PR TITLE
feat(security): drop privileged on comfyui-spark, use granular caps (#12769)

### DIFF
--- a/kubernetes/apps/ai/comfyui-spark/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/comfyui-spark/app/helmrelease.yaml
@@ -99,11 +99,25 @@ spec:
                 nvidia.com/gpu: 1
 
             securityContext:
-              # mmartial's init starts as the in-image user and uses sudo to
-              # usermod/chown to WANTED_UID/GID; matches ollama-spark + the
-              # existing comfyui (both privileged). Deviates from
-              # helmrelease.security.md by design — documented here.
-              privileged: true
+              # mmartial's init starts as the in-image user and uses sudo
+              # for groupmod/usermod/chown/su to remap to WANTED_UID/GID.
+              # Granular caps for that sudo chain; AUDIT_WRITE is needed
+              # because sudo logs to audit on each invocation. Privileged
+              # dropped. Verified live (2026-07-05): sudo chain succeeded
+              # (uid/gid matched WANTED_UID/GID, no error_exit), GPU
+              # detected, inference API responded normally.
+              privileged: false
+              allowPrivilegeEscalation: true # needed for setuid sudo/su
+              capabilities:
+                drop:
+                  - ALL
+                add:
+                  - CHOWN
+                  - SETUID
+                  - SETGID
+                  - DAC_OVERRIDE
+                  - FOWNER
+                  - AUDIT_WRITE
 
     service:
       app:


### PR DESCRIPTION
## Summary

- Replaces `privileged: true` on `ai/comfyui-spark` with the specific capabilities its sudo-based remap chain needs: `CHOWN`, `SETUID`, `SETGID`, `DAC_OVERRIDE`, `FOWNER`, `AUDIT_WRITE`
- mmartial's init script uses `sudo groupmod`/`usermod`/`chown`/`su` to remap the in-image user to `WANTED_UID`/`WANTED_GID` — `AUDIT_WRITE` is included because sudo logs to audit on each invocation
- Companion to #12854 (comfyui itself, merged) — different image, different remap mechanism, tested and shipped separately per the roadmap plan's guidance not to assume the same caps apply

## Live verification (done before this PR, against the running Spark/GB10 pod)

Phased test per `.claude-personal/plans/roadmap/12769-comfyui-granular-caps.md`:

1. **Phase 1** — caps added, `privileged: true` kept: pod restarted clean, GPU (GB10) detected, `WANTED_UID`/`GID` remap confirmed in logs.
2. **Phase 2** — `privileged: false`, caps only: pod restarted clean. The init script self-validates the remap and calls `error_exit` on mismatch — logs show `uid: 1000 / WANTED_UID: 1000` with **no error_exit anywhere**, confirming the sudo chain succeeded with caps alone.
3. **Phase 3** — inference verification: ComfyUI server process (`main.py`) came up under the remapped UID, `/system_stats` API responded with full JSON including the GB10 device and correct VRAM.

This PR's diff matches exactly what was live-tested; no untested changes.

## Test plan

- [ ] CI green
- [ ] Post-merge: `kubectl get pod -n ai comfyui-spark-0 -o jsonpath='{.spec.containers[?(@.name=="app")].securityContext.privileged}'` → `false`
- [ ] Post-merge: `kubectl exec -n ai comfyui-spark-0 -c app -- nvidia-smi -L` → GB10
- [ ] Post-merge: submit a real workflow via the ComfyUI UI, confirm image generation completes on Spark