### PR TITLE
fix(janitorr): flip dry-run off, split into per-library instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ _Production-grade Kubernetes for a household._
 
 <br/>
 
-![apps](https://img.shields.io/badge/apps-164-blue?style=for-the-badge)
-![helmreleases](https://img.shields.io/badge/HelmReleases-177-326CE5?style=for-the-badge&logo=helm&logoColor=white)
+![apps](https://img.shields.io/badge/apps-165-blue?style=for-the-badge)
+![helmreleases](https://img.shields.io/badge/HelmReleases-178-326CE5?style=for-the-badge&logo=helm&logoColor=white)
 ![nodes](https://img.shields.io/badge/k8s_nodes-11-326CE5?style=for-the-badge&logo=kubernetes&logoColor=white)
 ![cnpg](https://img.shields.io/badge/Postgres_clusters-24-336791?style=for-the-badge&logo=postgresql&logoColor=white)
-![secrets](https://img.shields.io/badge/secrets-94-0572EC?style=for-the-badge&logo=1password&logoColor=white)
+![secrets](https://img.shields.io/badge/secrets-95-0572EC?style=for-the-badge&logo=1password&logoColor=white)
 ![age](https://img.shields.io/badge/cluster_age-5%2B_years-success?style=for-the-badge)
 
 </div>

--- a/kubernetes/apps/media/janitorr-radarr/app/externalsecret.yaml
+++ b/kubernetes/apps/media/janitorr-radarr/app/externalsecret.yaml
@@ -1,0 +1,37 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: janitorr-radarr
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: janitorr-radarr
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        CLIENTS_RADARR_APIKEY: "{{ .RADARR__API_KEY }}"
+        CLIENTS_JELLYFIN_APIKEY: "{{ .JELLYFIN__API_KEY }}"
+        CLIENTS_JELLYFIN_USERNAME: "{{ .JELLYFIN__USERNAME }}"
+        CLIENTS_JELLYFIN_PASSWORD: "{{ .JELLYFIN__PASSWORD }}"
+        CLIENTS_JELLYSEERR_APIKEY: "{{ .SEERR__API_KEY }}"
+  dataFrom:
+    - extract:
+        key: radarr
+        property: RADARR__API_KEY
+    - extract:
+        key: jellyfin
+        property: JELLYFIN__API_KEY
+    - extract:
+        key: jellyfin
+        property: JELLYFIN__USERNAME
+    - extract:
+        key: jellyfin
+        property: JELLYFIN__PASSWORD
+    - extract:
+        key: seerr
+        property: SEERR__API_KEY

--- a/kubernetes/apps/media/janitorr-radarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/janitorr-radarr/app/helmrelease.yaml
@@ -3,7 +3,7 @@
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: &app janitorr
+  name: &app janitorr-radarr
 spec:
   chartRef:
     kind: OCIRepository
@@ -23,7 +23,7 @@ spec:
         runAsUser: 1000
 
     controllers:
-      janitorr:
+      janitorr-radarr:
         annotations:
           reloader.stakater.com/auto: "true"
 
@@ -35,7 +35,7 @@ spec:
 
             envFrom:
               - secretRef:
-                  name: janitorr
+                  name: janitorr-radarr
 
             resources:
               requests:
@@ -54,13 +54,13 @@ spec:
         size: 1Gi
         storageClass: ceph-block
         advancedMounts:
-          janitorr:
+          janitorr-radarr:
             app:
               - path: /config
 
       config-file:
         type: configMap
-        name: janitorr
+        name: janitorr-radarr
         globalMounts:
           - path: /config/application.yml
             subPath: application.yml

--- a/kubernetes/apps/media/janitorr-radarr/app/kustomization.yaml
+++ b/kubernetes/apps/media/janitorr-radarr/app/kustomization.yaml
@@ -11,7 +11,7 @@ resources:
 configMapGenerator:
   - files:
       - application.yml=./resources/application.yml
-    name: janitorr
+    name: janitorr-radarr
 generatorOptions:
   annotations:
     kustomize.toolkit.fluxcd.io/substitute: disabled

--- a/kubernetes/apps/media/janitorr-radarr/app/resources/application.yml
+++ b/kubernetes/apps/media/janitorr-radarr/app/resources/application.yml
@@ -15,8 +15,6 @@ file-system:
 application:
   dry-run: false
   run-once: false
-  whole-tv-show: false
-  whole-show-seeding-check: false
   leaving-soon: 14d
   leaving-soon-threshold-offset-percent: 5
   exclusion-tags:
@@ -25,8 +23,6 @@ application:
   media-deletion:
     enabled: true
     movie-expiration:
-      20: 365d
-    season-expiration:
       20: 365d
 
   tag-based-deletion:
@@ -42,11 +38,7 @@ clients:
     level: NONE
 
   sonarr:
-    enabled: true
-    url: "http://sonarr.media.svc.cluster.local:8989"
-    delete-empty-shows: true
-    determine-age-by: MOST_RECENT
-    import-exclusions: false
+    enabled: false
 
   radarr:
     enabled: true
@@ -60,7 +52,6 @@ clients:
     url: "http://jellyfin.media.svc.cluster.local:8096"
     delete: true
     exclude-favorited: false
-    leaving-soon-tv: "Shows (Leaving Soon)"
     leaving-soon-movies: "Movies (Leaving Soon)"
     leaving-soon-type: NONE
 

--- a/kubernetes/apps/media/janitorr-radarr/ks.yaml
+++ b/kubernetes/apps/media/janitorr-radarr/ks.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app janitorr-radarr
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: media
+  path: ./kubernetes/apps/media/janitorr-radarr/app
+  interval: 30m
+  timeout: 3m
+  wait: false
+  dependsOn:
+    - name: onepassword-connect
+      namespace: external-secrets
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  postBuild:
+    substitute:
+      APP: *app

--- a/kubernetes/apps/media/janitorr-sonarr/app/externalsecret.yaml
+++ b/kubernetes/apps/media/janitorr-sonarr/app/externalsecret.yaml
@@ -3,19 +3,18 @@
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
-  name: janitorr
+  name: janitorr-sonarr
 spec:
   secretStoreRef:
     kind: ClusterSecretStore
     name: onepassword-connect
   target:
-    name: janitorr
+    name: janitorr-sonarr
     creationPolicy: Owner
     template:
       engineVersion: v2
       data:
         CLIENTS_SONARR_APIKEY: "{{ .SONARR__API_KEY }}"
-        CLIENTS_RADARR_APIKEY: "{{ .RADARR__API_KEY }}"
         CLIENTS_JELLYFIN_APIKEY: "{{ .JELLYFIN__API_KEY }}"
         CLIENTS_JELLYFIN_USERNAME: "{{ .JELLYFIN__USERNAME }}"
         CLIENTS_JELLYFIN_PASSWORD: "{{ .JELLYFIN__PASSWORD }}"
@@ -24,9 +23,6 @@ spec:
     - extract:
         key: sonarr
         property: SONARR__API_KEY
-    - extract:
-        key: radarr
-        property: RADARR__API_KEY
     - extract:
         key: jellyfin
         property: JELLYFIN__API_KEY

--- a/kubernetes/apps/media/janitorr-sonarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/janitorr-sonarr/app/helmrelease.yaml
@@ -1,0 +1,86 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app janitorr-sonarr
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 30m
+  install:
+    disableWait: true
+  upgrade:
+    disableWait: true
+  values:
+    defaultPodOptions:
+      securityContext:
+        fsGroup: 1001
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 1001
+        runAsNonRoot: true
+        runAsUser: 1000
+
+    controllers:
+      janitorr-sonarr:
+        annotations:
+          reloader.stakater.com/auto: "true"
+
+        containers:
+          app:
+            image:
+              repository: ghcr.io/schaka/janitorr
+              tag: jvm-stable@sha256:270e9113c71182d30929f253ff6ff49c63078f4556487a668602c4114c7d665a
+
+            envFrom:
+              - secretRef:
+                  name: janitorr-sonarr
+
+            resources:
+              requests:
+                cpu: 50m
+                memory: 512Mi
+              limits:
+                memory: 1Gi
+
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: {drop: ["ALL"]}
+    persistence:
+      config:
+        accessMode: ReadWriteOnce
+        size: 1Gi
+        storageClass: ceph-block
+        advancedMounts:
+          janitorr-sonarr:
+            app:
+              - path: /config
+
+      config-file:
+        type: configMap
+        name: janitorr-sonarr
+        globalMounts:
+          - path: /config/application.yml
+            subPath: application.yml
+            readOnly: true
+
+      data:
+        existingClaim: sonarr-media
+        globalMounts:
+          - path: /data
+            readOnly: true
+
+      leaving-soon:
+        type: emptyDir
+        globalMounts:
+          - path: /leaving-soon
+
+      logs:
+        type: emptyDir
+        globalMounts:
+          - path: /logs
+
+      tmp:
+        type: emptyDir

--- a/kubernetes/apps/media/janitorr-sonarr/app/kustomization.yaml
+++ b/kubernetes/apps/media/janitorr-sonarr/app/kustomization.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: media
+components:
+  - ../../../../components/repos/app-template
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+configMapGenerator:
+  - files:
+      - application.yml=./resources/application.yml
+    name: janitorr-sonarr
+generatorOptions:
+  annotations:
+    kustomize.toolkit.fluxcd.io/substitute: disabled
+  disableNameSuffixHash: true

--- a/kubernetes/apps/media/janitorr-sonarr/app/resources/application.yml
+++ b/kubernetes/apps/media/janitorr-sonarr/app/resources/application.yml
@@ -1,0 +1,63 @@
+logging:
+  level:
+    com.github.schaka: INFO
+  file:
+    name: "/logs/janitorr.log"
+
+file-system:
+  access: true
+  validate-seeding: false
+  leaving-soon-dir: "/leaving-soon"
+  media-server-leaving-soon-dir: "/leaving-soon"
+  from-scratch: true
+  free-space-check-dir: "/data"
+
+application:
+  dry-run: true
+  run-once: false
+  whole-tv-show: false
+  whole-show-seeding-check: false
+  leaving-soon: 14d
+  leaving-soon-threshold-offset-percent: 5
+  exclusion-tags:
+    - "janitorr-keep"
+
+  media-deletion:
+    enabled: true
+    season-expiration:
+      20: 365d
+
+  tag-based-deletion:
+    enabled: false
+
+  episode-deletion:
+    enabled: false
+
+clients:
+  default:
+    connect-timeout: 60s
+    read-timeout: 60s
+    level: NONE
+
+  sonarr:
+    enabled: true
+    url: "http://sonarr.media.svc.cluster.local:8989"
+    delete-empty-shows: true
+    determine-age-by: MOST_RECENT
+    import-exclusions: false
+
+  radarr:
+    enabled: false
+
+  jellyfin:
+    enabled: true
+    url: "http://jellyfin.media.svc.cluster.local:8096"
+    delete: true
+    exclude-favorited: false
+    leaving-soon-tv: "Shows (Leaving Soon)"
+    leaving-soon-type: NONE
+
+  jellyseerr:
+    enabled: true
+    url: "http://seerr.media.svc.cluster.local:5055"
+    match-server: false

--- a/kubernetes/apps/media/janitorr-sonarr/ks.yaml
+++ b/kubernetes/apps/media/janitorr-sonarr/ks.yaml
@@ -3,13 +3,13 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app janitorr
+  name: &app janitorr-sonarr
 spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
   targetNamespace: media
-  path: ./kubernetes/apps/media/janitorr/app
+  path: ./kubernetes/apps/media/janitorr-sonarr/app
   interval: 30m
   timeout: 3m
   wait: false

--- a/kubernetes/apps/media/janitorr/app/resources/application.yml
+++ b/kubernetes/apps/media/janitorr/app/resources/application.yml
@@ -13,7 +13,7 @@ file-system:
   free-space-check-dir: "/data"
 
 application:
-  dry-run: true
+  dry-run: false
   run-once: false
   whole-tv-show: false
   whole-show-seeding-check: false

--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -25,7 +25,8 @@ resources:
   - ./immich/ks.yaml
   - ./immichkiosk/ks.yaml
   - ./immichkiosk-party/ks.yaml
-  - ./janitorr/ks.yaml
+  - ./janitorr-radarr/ks.yaml
+  - ./janitorr-sonarr/ks.yaml
   - ./jellyfin/ks.yaml
   - ./kodi-playback-watcher/ks.yaml
   - ./lidarr/ks.yaml


### PR DESCRIPTION
## Summary
- Flips `janitorr-radarr`'s (formerly `janitorr`) `application.dry-run` from `true` to `false`, per the plan set 2026-05-15 (target date 2026-07-01, executed 2026-07-05). Tagging pass complete: Radarr 377 titles tagged `janitorr-keep`, Sonarr 36 tagged.
- **Split into two instances**, discovered while verifying the flip: janitorr's `free-space-check-dir` only ever measures one mounted filesystem. The single instance mounted only the movies volume, so the 20% disk threshold gating *all* deletion — including TV season-expiration — was evaluated against movies' free space, never the TV library's (separate NFS export, separate host). Per upstream, running a second instance is the supported fix for this ("Janitorr cannot handle multiple instances of Sonarr/Radarr directly; you need to run another instance of Janitorr" — schaka/janitorr wiki FAQ).
  - `janitorr-radarr`: movies-only now, dry-run off (validated).
  - `janitorr-sonarr` (new): TV-only, dry-run **on** — this is a brand-new, never-run config path and hasn't been through a tagging/validation pass the way the movies instance has.
- Known accepted risk on the movies side: Sonarr's tagging pass used a lenient proxy (`previousAiring`/`lastAired`) instead of janitorr's true "most recent episode file added" rule, so ongoing-but-stalled shows may be under-tagged in `janitorr-sonarr`'s scope once that instance goes live.
- Verified both `radarr-media` and `sonarr-media` PVCs are at ~32% free (threshold is 20%), so neither the flip nor the split changes near-term behavior — this only matters once one library's usage diverges from the other's.

## Test plan
- [ ] Watch `janitorr-radarr`'s first live cycle logs for unexpected deletions
- [ ] Confirm seerr is healthy before/during the run (janitorr crash-loops on `Connection refused` to seerr at startup)
- [ ] Before flipping `janitorr-sonarr` to live, re-check `janitorr-keep` tag coverage in Sonarr using the true episode-file-added criterion
- [ ] Confirm `flux get ks -n media janitorr-radarr janitorr-sonarr` both reconcile cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)