### PR TITLE
fix(janitorr-sonarr): flip dry-run off

### DIFF
--- a/kubernetes/apps/media/janitorr-sonarr/app/resources/application.yml
+++ b/kubernetes/apps/media/janitorr-sonarr/app/resources/application.yml
@@ -13,7 +13,7 @@ file-system:
   free-space-check-dir: "/data"
 
 application:
-  dry-run: true
+  dry-run: false
   run-once: false
   whole-tv-show: false
   whole-show-seeding-check: false


### PR DESCRIPTION
## Summary
- Flips `janitorr-sonarr`'s `application.dry-run` from `true` to `false`.
- Audited real tag coverage first: pulled every series' tags + actual episode-file `dateAdded` directly from the Sonarr API (not the lenient `previousAiring`/`lastAired` proxy the 2026-05-16 tagging pass fell back to when its per-series loop hung).
  - 270 series total, 36 tagged `janitorr-keep`.
  - **103 series are true-stale (>365d since last file added) and untagged (~3.22 TiB)** — this is what's actually exposed once the 20% free-space threshold trips.
  - Of those, 23 (~551 GiB) are series the old lenient proxy would have wrongly called "fresh" (no recent `previousAiring`, but genuinely untouched files) — mostly older docs/dramas (Our Planet, Schitt's Creek, Band of Brothers, Silicon Valley, etc).
- Reviewed with Rob; decision was to go live now with the existing 36-series tag set, accepting the ~3.22 TiB untagged exposure rather than doing a full re-tagging pass first.
- `sonarr-media` currently reads 32.9% free (threshold is 20%), so this doesn't trigger an immediate cleanup pass.

## Test plan
- [ ] Watch `janitorr-sonarr`'s first live cycle logs for unwanted removals
- [ ] Confirm the app's Kustomization and HelmRelease both reconcile cleanly after the ConfigMap change (Reloader should restart the pod)

🤖 Generated with [Claude Code](https://claude.com/claude-code)