### PR TITLE
fix(ci): fully retire flux-local dependency, replace with flate

### DIFF
--- a/.github/renovate/autoMerge.json5
+++ b/.github/renovate/autoMerge.json5
@@ -10,7 +10,7 @@
   packageRules: [
     {
       // Auto-merge all container digest re-tags (same version, rebuilt
-      // content). flux-local can't meaningfully validate a re-tag, so
+      // content). flate can't meaningfully validate a re-tag, so
       // minimumReleaseAge is the real safety belt — a bad rebuild gets
       // 3 days to be caught upstream before it can land. ignoreTests
       // stays false so a red CI for any other reason still blocks.
@@ -26,7 +26,7 @@
       // Blanket non-major auto-merge for containers + helm charts.
       // patch/minor are non-breaking by the semver contract; majors
       // are firewalled to manual review in packageRules.json5. The
-      // flux-local CI gate (ignoreTests=false) still must pass, and
+      // flate CI gate (ignoreTests=false) still must pass, and
       // minimumReleaseAge gives a bad release 3 days to get yanked
       // upstream before it can land. Digests stay on the trusted-org
       // allowlist above — CI can't meaningfully validate a re-tag.
@@ -123,7 +123,6 @@
         "ghcr.io/renovatebot/renovate",
         "ghcr.io/rwlove/comfyui-mcp",
         "ghcr.io/zulip/helm-charts/zulip",
-        "ghcr.io/allenporter/flux-local",
       ],
       minimumReleaseAge: "0 minutes",
     },

--- a/.github/workflows/image-registry-check.yaml
+++ b/.github/workflows/image-registry-check.yaml
@@ -37,11 +37,9 @@ jobs:
   extract-images:
     if: ${{ needs.filter-changes.outputs.changed-files != '[]' }}
     name: Extract images
-    # Runs flux-local to extract images; charts resolve from public
-    # registries, so GitHub-hosted works (see flux-local.yaml).
+    # Runs flate to extract images; charts resolve from public registries,
+    # so GitHub-hosted works with no cluster access (see flux-local.yaml).
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/allenporter/flux-local:v8.4.0
     needs:
       - filter-changes
     strategy:
@@ -59,30 +57,33 @@ jobs:
         with:
           ref: "${{ matrix.branches == 'default' && github.event.repository.default_branch || '' }}"
 
-      # Retry mostly covers first-call cold-cache misses on ZOT — the
-      # underlying upstream-registry transients that motivated this on
-      # ubuntu-latest are largely absorbed by the in-cluster pull-through
-      # cache, but cold tags still occasionally 5xx on first reach.
+      - name: Setup flate
+        uses: home-operations/flate/action@0fc37fae10cf3c265294f6adebc6d6c100c74ea5 # v0.4.10
+
+      # Retry mostly covers first-call cold-cache misses on upstream
+      # registries when resolving chart/image refs.
       - name: Gather images
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        # FLATE_BASE="" overrides the setup action's FLATE_BASE=main — each
+        # matrix leg is a single-ref shallow checkout (no `main` to diff
+        # against), so this forces full-tree extraction on both legs instead
+        # of an implicit changed-only mode. Same override as
+        # flux-local.yaml's `test` job.
+        env:
+          FLATE_BASE: ""
         with:
           timeout_minutes: 10
           max_attempts: 3
           retry_wait_seconds: 30
           shell: sh
           command: |
-            flux-local get cluster \
-              --all-namespaces \
+            flate get images \
               --path "$GITHUB_WORKSPACE/kubernetes/flux" \
-              --enable-images \
-              --only-images \
-              --output json \
-              --output-file images.json
+              --output json > images.json
 
-      # Multi-line heredoc avoids needing jq inside the flux-local
-      # container (it isn't there) — file is already valid JSON, just
-      # plumb it through. printf ensures a trailing newline before the
-      # delimiter (flux-local doesn't write one), and the random-ish
+      # Multi-line heredoc avoids needing jq for this step — file is
+      # already valid JSON, just plumb it through. printf ensures a
+      # trailing newline before the delimiter, and the random-ish
       # delimiter guards against any image name literally containing
       # `EOF` on a line.
       - name: Emit images

--- a/tools/check-image-registry.sh
+++ b/tools/check-image-registry.sh
@@ -9,7 +9,7 @@
 #
 # Reads from stdin or the file given as the last positional arg.
 # Pass --json if the input is a JSON array of image strings (e.g. the
-# output of `flux-local get cluster --only-images --output json`).
+# output of `flate get images --output json`).
 #
 # Policy: Docker Hub (docker.io) is the only restricted registry — it
 # rate-limits anonymous/free pulls. Every other registry (ghcr.io,


### PR DESCRIPTION
## Summary
- `image-registry-check.yaml` was the last workflow pulling the real `ghcr.io/allenporter/flux-local` container. `flux-local.yaml` migrated to `flate` earlier (#12734) but this one was missed.
- Replaced `flux-local get cluster --enable-images --only-images` with `flate get images`. Verified locally (installed the `flate` binary, ran it against this repo's real `kubernetes/flux` tree) that the JSON output is a flat array of image strings — a drop-in match for the schema the downstream jq diff and `tools/check-image-registry.sh` already expect. No changes needed to either consumer.
- `FLATE_BASE=""` override on the extraction step, same pattern `flux-local.yaml`'s `test` job already uses — each matrix leg (`default`/`pull`) is a single-ref shallow checkout, so the setup action's default `FLATE_BASE=main` would otherwise put `get images` into changed-only mode instead of full-tree.
- Dropped the now-dead `ghcr.io/allenporter/flux-local` entry from the temporary `autoMerge.json5` packageRule (#12863) — nothing left in the tree for Renovate to match.
- Fixed two stale "flux-local CI gate" comments in `autoMerge.json5` to say `flate`.
- **Not touched on purpose**: `flux-local.yaml`'s file name and job names ("Flux Local Test", "Flux Local successful"). Its own header comment explains why — that literal status-check name is required by the "Require CI on main" branch-protection ruleset, so renaming it would silently block merges. That'd need a ruleset update first, which is a repo-settings change outside this PR's scope.
- Follow-up: PR #12892 (a Renovate version bump for the now-removed `flux-local` image) is obsolete once this merges — closing separately rather than merging it.

## Test plan
- [x] Validated `flate get images` output schema locally against this repo's real manifests before writing the workflow change
- [x] Simulated the full extract → jq diff → `check-image-registry.sh --json` pipeline locally with flate's output
- [ ] CI (this PR's own `Image Registry Check` run exercises the migration directly, self-testing)