### PR TITLE
fix(home): bump netbox memory limit to stop OOMKill loop

### DIFF
--- a/kubernetes/apps/home/netbox/app/helmrelease.yaml
+++ b/kubernetes/apps/home/netbox/app/helmrelease.yaml
@@ -91,9 +91,9 @@ spec:
     resources:
       requests:
         cpu: 50m
-        memory: 256Mi
-      limits:
         memory: 512Mi
+      limits:
+        memory: 800Mi
     service:
       annotations:
         teleport.dev/name: *app


### PR DESCRIPTION
## Summary
- netbox is currently stuck mid-rollout: the new pod OOMKills immediately under the 512Mi limit set by #12803's blanket resource backfill, which didn't check netbox's actual usage.
- Bumps requests/limits to 512Mi/800Mi.

## Test plan
- [ ] Flux reconciles the HelmRelease
- [ ] New netbox pod stays up past startup probe, old ReplicaSet scales to 0
- [ ] No further `OOMKilled` alert for netbox