### PR TITLE
fix(home): bump netbox memory limit to 1Gi

### DIFF
--- a/kubernetes/apps/home/netbox/app/helmrelease.yaml
+++ b/kubernetes/apps/home/netbox/app/helmrelease.yaml
@@ -93,7 +93,7 @@ spec:
         cpu: 50m
         memory: 512Mi
       limits:
-        memory: 800Mi
+        memory: 1Gi
     service:
       annotations:
         teleport.dev/name: *app


### PR DESCRIPTION
## Summary
- Follow-up to #12894: 800Mi wasn't enough. The new pod pegged at 799/800Mi within ~2 minutes of startup and OOMKilled once.
- Bumping limit to 1Gi (request stays 512Mi).

## Test plan
- [ ] Flux reconciles the HelmRelease
- [ ] New netbox pod stays up, no further OOMKilled restarts