### PR TITLE
fix(home): bump netbox memory limit to 1.5Gi for headroom

### DIFF
--- a/kubernetes/apps/home/netbox/app/helmrelease.yaml
+++ b/kubernetes/apps/home/netbox/app/helmrelease.yaml
@@ -93,7 +93,7 @@ spec:
         cpu: 50m
         memory: 512Mi
       limits:
-        memory: 1Gi
+        memory: 1.5Gi
     service:
       annotations:
         teleport.dev/name: *app


### PR DESCRIPTION
## Summary
- Follow-up to #12894/#12896: 1Gi left the pod at 984Mi/1024Mi (~4% headroom) - stable but too tight to absorb a load spike.
- Bumping limit to 1.5Gi, matching what the pod ran at before #12803's blanket resource backfill.

## Test plan
- [ ] Flux reconciles the HelmRelease
- [ ] netbox pod stable with comfortable memory headroom, no OOMKilled