### PR TITLE
fix(home): revert stale WS-breaking venv via reset init container

### DIFF
--- a/kubernetes/apps/home/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/home/home-assistant/app/helmrelease.yaml
@@ -57,11 +57,40 @@ spec:
               - secretRef:
                   name: *app
 
+          venv-reset:
+            image:
+              repository: ghcr.io/home-operations/home-assistant
+              tag: &hassImage 2026.7.1@sha256:77612bf97ff111c5517f708b7893e6d4400e0104db24cdd69e30105c95b7bfcc
+
+            args:
+              - |
+                set -eu
+                marker=/config/.hass-image-version
+                current="$(python3 -c 'from homeassistant.const import __version__; print(__version__)')"
+                previous="$(cat "$marker" 2>/dev/null || true)"
+                if [ "$current" != "$previous" ]; then
+                  echo "HA image changed ($previous -> $current); wiping /config/.venv"
+                  rm -rf /config/.venv/* /config/.venv/.[!.]* 2>/dev/null || true
+                  printf '%s' "$current" > "$marker"
+                else
+                  echo "HA image unchanged ($current); keeping /config/.venv cache"
+                fi
+            command: ["/bin/bash", "-c"]
+
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - ALL
+              readOnlyRootFilesystem: true
+              seccompProfile:
+                type: RuntimeDefault
+
         containers:
           app:
             image:
               repository: ghcr.io/home-operations/home-assistant
-              tag: 2026.7.1@sha256:77612bf97ff111c5517f708b7893e6d4400e0104db24cdd69e30105c95b7bfcc
+              tag: *hassImage
 
             env:
               POSTGRES_HOST: postgres-home-assistant-rw.databases.svc.cluster.local
@@ -70,12 +99,29 @@ spec:
             envFrom: *envFrom
 
             probes:
-              liveness:
-                enabled: false
-              readiness:
-                enabled: false
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: 8123
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness: *probes
               startup:
-                enabled: false
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: 8123
+                  initialDelaySeconds: 0
+                  periodSeconds: 5
+                  timeoutSeconds: 5
+                  failureThreshold: 60
 
             resources:
               requests:
@@ -117,6 +163,10 @@ spec:
         existingClaim: home-assistant-config-pvc
         globalMounts:
           - path: /config
+        advancedMounts:
+          home-assistant:
+            venv-reset:
+              - path: /config
 
       config-cache:
         accessMode: ReadWriteOnce
@@ -125,6 +175,8 @@ spec:
         advancedMounts:
           home-assistant:
             app:
+              - path: /config/.venv
+            venv-reset:
               - path: /config/.venv
 
       media:


### PR DESCRIPTION
## Summary

- Home Assistant went unreachable externally after the `2026.6.4` → `2026.7.1` image bump: every WebSocket handshake failed with `TypeError: WebSocketResponse.__init__() got an unexpected keyword argument 'decode_text'`, so Lovelace's REST auth succeeded but the live-state connection never came up ("Unable to connect to Home Assistant, retrying...").
- Root cause: HA core `2026.7.1` correctly requires `aiohttp>=3.14.1`, but the image's entrypoint reuses the persisted `/config/.venv` on every boot (`uv venv --system-site-packages --allow-existing`) instead of rebuilding it. Packages previously installed into that venv (via HACS/integrations) shadow the newer aiohttp baked into the image after a version bump. Same bug class as [home-operations/containers#794](https://github.com/home-operations/containers/issues/794); at least one other operator hit this exact upgrade path ([billimek/k8s-gitops#5891](https://github.com/billimek/k8s-gitops/pull/5891)).
- Adds a `venv-reset` init container (ported from billimek's fix) that reads HA's actual baked-in `__version__`, compares it to a marker file on the config PVC, and wipes `/config/.venv` only on a version change — normal restarts still reuse the cached venv.
- Re-enables liveness/readiness/startup probes on the `app` container (previously fully disabled), which would have masked this failure mode indefinitely — the pod stayed `Ready: True` the whole time while every WS request 500'd.

## Test plan

- [x] `yamllint` passes
- [x] pre-commit hooks pass locally
- [ ] CI (Flux Local Test / flate) green
- [ ] Post-merge: confirm HA pod restarts cleanly, `venv-reset` init container logs show the wipe on first run, WebSocket connects (Lovelace loads without "Unable to connect")