### PR TITLE
fix(home): remove duplicate /config mount that broke the venv-reset fix

### DIFF
--- a/kubernetes/apps/home/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/home/home-assistant/app/helmrelease.yaml
@@ -163,10 +163,6 @@ spec:
         existingClaim: home-assistant-config-pvc
         globalMounts:
           - path: /config
-        advancedMounts:
-          home-assistant:
-            venv-reset:
-              - path: /config
 
       config-cache:
         accessMode: ReadWriteOnce


### PR DESCRIPTION
## Summary

- Follow-up to #12898, which is still causing the HA outage — the `venv-reset` init container's explicit `advancedMounts` entry for `/config` duplicated the mount already applied by `config`'s `globalMounts`, so Helm upgrade failed 3x with `spec.template.spec.initContainers[1].volumeMounts[1].mountPath: Invalid value: "/config": must be unique` and Flux rolled back to the pre-fix release. Confirmed live: HA is still throwing the same `decode_text` WebSocket TypeError, unchanged since before #12898 merged.
- Drops the redundant `advancedMounts.home-assistant.venv-reset` entry under the `config` persistence block. `globalMounts: - path: /config` already covers every container in the controller, including `venv-reset`. The `config-cache` volume's `advancedMounts` for `venv-reset` at `/config/.venv` is untouched — that volume has no competing `globalMounts`.

## Test plan

- [x] `yamllint` passes
- [x] pre-commit hooks pass locally
- [ ] CI green
- [ ] Post-merge: Flux HelmRelease reconciles past `RetriesExceeded`, StatefulSet rolls with `venv-reset` present, its logs show the wipe, app container comes up clean, WebSocket connects