### PR TITLE
docs(agents): make gpu-routing.md self-sufficient (langgraph-agents repo pointer removed)

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -15,7 +15,7 @@ context window space on every turn.
 | `configmap.resources.instructions.md` | ConfigMap source files live under `app/resources/`; file names match the in-container basename. |
 | `data-classification.md` | Public / Internal / Restricted tiers for narrative artifacts (PR text, docs, summaries, prompts to remote models). |
 | `flux.sorting.instructions.md` | Field ordering for Flux-managed YAML (Kustomization, dependsOn, sourceRef). |
-| `gpu-routing.md` | Pointer to langgraph-agents' canonical `hardware-routing.md` plus home-ops-local GPU facts (P40, GB10, runtime split). |
+| `gpu-routing.md` | GPU inventory + model-to-GPU routing rule of thumb (P40, GB10, runtime split). |
 | `helmfile.sorting.instructions.md` | Field ordering for HelmRelease YAML, especially app-template-based releases. |
 | `helmrelease.security.md` | Pod-securityContext defaults (runAsNonRoot, readOnlyRootFilesystem, etc.) for new HelmReleases. |
 | `kustomize.config.sorting.instructions.md` | Field ordering for kustomize `kustomization.yaml` files. |

--- a/.agents/instructions/gpu-routing.md
+++ b/.agents/instructions/gpu-routing.md
@@ -1,13 +1,12 @@
 # GPU routing
 
-This file is a pointer plus a small set of home-ops-local facts.
-Model-to-GPU routing decisions don't live here.
-
-## Canonical source
-
-The cross-repo authority lives in
-`~/workspace/claude-workspace/langgraph-agents/.agents/instructions/hardware-routing.md`.
-Read that before scheduling model work in this cluster.
+This file is the source of truth for model-to-GPU routing in this
+cluster. It used to defer to a canonical doc in the `langgraph-agents`
+repo (`hardware-routing.md`), but that doc described langgraph-agents'
+own internal per-agent routing factory — machinery that no longer
+exists (the fleet was decommissioned 2026-07-06, no value delivered).
+There was no cluster-wide routing content there beyond what's already
+below; nothing was migrated because there was nothing left to migrate.
 
 ## Local cluster GPU inventory
 
@@ -17,8 +16,7 @@ Read that before scheduling model work in this cluster.
 - **DGX Spark** (NVIDIA GB10, Grace-Blackwell) — on its own host
   running Ubuntu 24.04 / containerd (the lone non-CRI-O node — see
   `reference_cluster_runtime_inventory` in memory). Used for larger
-  inference; the Spark migration is in progress and specific model
-  assignments live in `hardware-routing.md` upstream.
+  inference; the Spark migration is in progress.
 
 ## Runtime split matters for gpu-operator
 
@@ -41,13 +39,10 @@ Read that before scheduling model work in this cluster.
 
 ## Routing decisions
 
-- Defer to `hardware-routing.md` in langgraph-agents — don't replicate
-  model-to-GPU mappings here.
-- Local rule of thumb: ≤8b → P40; larger → Spark (until the Spark
-  migration is documented as complete).
+- Rule of thumb: ≤8b → P40; larger → Spark (until the Spark migration
+  is documented as complete).
 
 ## What this is NOT
 
-- Not the canonical GPU routing doc — that's in langgraph-agents.
 - Not a snapshot of every node's hardware — `kubectl get nodes -o yaml
   | grep nvidia` is the source of truth.

--- a/docs/src/ai_architecture.md
+++ b/docs/src/ai_architecture.md
@@ -126,9 +126,12 @@ fleet scripts plus `smoke-approval-flow.ts` and
 caps enforced in `langgraph-agents` code) — deleted along with the
 fleet. There is no automated in-cluster path to the Claude API today.
 
-Routing decisions belong in `langgraph-agents/.agents/instructions/hardware-routing.md`
-(canonical) and `.agents/instructions/gpu-routing.md` in this repo
-(local pointer + cluster-specific facts).
+Routing decisions belong in `.agents/instructions/gpu-routing.md` in
+this repo. It used to defer to a "canonical" doc in the
+`langgraph-agents` source repo, but that doc described langgraph's own
+now-decommissioned per-agent routing factory — nothing was actually
+cluster-wide there worth deferring to, so `gpu-routing.md` is now
+self-sufficient.
 
 ## RAG paths
 

--- a/docs/src/routing_policy.md
+++ b/docs/src/routing_policy.md
@@ -20,10 +20,11 @@ design that was drafted for HomeAIOps Stage 3. None of the `kubectl
 exec -n ai deploy/langgraph-agents` commands, file paths, or "current"
 framing below are still valid against the live cluster. For live
 model-routing policy (which model/GPU handles which class of work),
-see `langgraph-agents/.agents/instructions/hardware-routing.md` in the
-separate `rwlove/langgraph-agents` source repo — that repo itself is
-**not** decommissioned, only the in-cluster deployment is gone — and
-`.agents/instructions/gpu-routing.md` in this repo.
+see `.agents/instructions/gpu-routing.md` in this repo — it used to
+defer to `hardware-routing.md` in the separate `rwlove/langgraph-agents`
+source repo, but that doc described langgraph's own now-decommissioned
+per-agent routing factory, not cluster-wide policy, so `gpu-routing.md`
+was made self-sufficient instead.
 
 ## What this was
 


### PR DESCRIPTION
## Summary
Follow-up to the langgraph fleet decommission — the last remaining blocker on evaluating whether to decommission the `langgraph-agents` source repo itself.

`gpu-routing.md` pointed at `langgraph-agents/.agents/instructions/hardware-routing.md` as the "canonical" cross-repo authority for model-to-GPU routing. Read that doc directly: it's 100% about langgraph-agents' own internal per-agent routing factory (`AGENT_GROUP` table for triager/note-maker/errand-runner/etc., `escalate=True` rules keyed on `ANTHROPIC_API_KEY`, `health-tracker`'s local-only pin) — machinery that no longer exists, since the fleet was decommissioned 2026-07-06. **There was no cluster-wide GPU policy content there to migrate**; `gpu-routing.md`'s own "Local cluster GPU inventory" section already covered the real facts (P40/Spark hardware, DCGM quirks, containerd/CRI-O split) independently. Removed the dead pointer, made the file self-sufficient.

Also fixed two docs that still described `hardware-routing.md` as live "canonical" guidance (`ai_architecture.md`, `routing_policy.md`) — updated both to point at the now-self-sufficient `gpu-routing.md` instead. `docs/src/stage2_gap_analysis.md`'s mention was left alone — it's inside an already-established historical design-record table from an earlier pass, correctly citing what the original design pointed to.

Also updated the five Claude Code operator persona files (`~/.claude-personal/agents/*.md`, not part of this repo — local dotfiles) to scrub extensive stale HolmesGPT/langgraph-agents content: `ml-operator.md` had a whole "Spark-gated langgraph-agents activation" framework and a HolmesGPT-timeout-workaround section; `observability-operator.md` had an entire "AI triage" duty area for HolmesGPT prompt tuning; the other three had scattered hand-off mentions. All scrubbed to reflect that neither system exists in the cluster anymore.

**This does NOT decommission the `langgraph-agents` repo itself** — that's a separate, more consequential decision (archive vs. delete vs. leave as-is) not resolved here.

## Test plan
- [x] `flate test ks --allow-missing-secrets` — 236 pass (unchanged; docs-only + persona-only change, no manifest edits), the 1 failure is the known pre-existing Fairwinds/VPA digest-mismatch flake
- [x] `python3 tools/lint-readme-drift.py` — passes
- [x] Repo-wide grep for `hardware-routing` confirms no remaining "live canonical doc" claims outside the one deliberately-preserved historical table
- [x] Pre-commit hooks pass (markdownlint, readme-drift)