### PR TITLE
feat(observability): expand blackbox IOT coverage, remove Hue bridge, tune modules

### DIFF
--- a/kubernetes/apps/observability/exporters/blackbox-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/exporters/blackbox-exporter/app/helmrelease.yaml
@@ -25,15 +25,17 @@ spec:
         http_2xx:
           http:
             follow_redirects: true
+            ip_protocol_fallback: false
             preferred_ip_protocol: "ip4"
             valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
           prober: http
           timeout: 5s
         icmp:
           icmp:
+            ip_protocol_fallback: false
             preferred_ip_protocol: "ip4"
           prober: icmp
-          timeout: 30s
+          timeout: 4s
         # Synthetic embed prober for ollama-spark. POSTs a small input
         # against bge-m3 and validates a 200 with an "embeddings" key
         # in the body. 30 s timeout accommodates cold model load (bge-m3
@@ -77,22 +79,11 @@ spec:
         release: prometheus
       enabled: true
       rules:
-        - alert: BlackboxSslCertificateWillExpireSoon
-          annotations:
-            description: |-
-              The SSL certificate for {{ $labels.instance }} will expire in less than 3 days
-          expr: probe_ssl_earliest_cert_expiry - time() < 86400 * 3
-          for: 5m
-          labels:
-            severity: critical
-        - alert: BlackboxSslCertificateExpired
-          annotations:
-            description: |-
-              The SSL certificate for {{ $labels.instance }} has expired
-          expr: probe_ssl_earliest_cert_expiry - time() <= 0
-          for: 5m
-          labels:
-            severity: critical
+        # NB: the two BlackboxSslCertificate* alerts were removed — no
+        # probe uses an https module, so probe_ssl_earliest_cert_expiry
+        # was never populated and the rules could never fire. Cert
+        # expiry is handled by cert-manager. Re-add an https_2xx module
+        # + cert-bearing targets first if SSL monitoring is wanted here.
         # Infrastructure reachability — storage NFS path (brain/beast/
         # security-storage:2049) and the two ollama embed heartbeats.
         # These are genuinely page-worthy: a sustained failure means a
@@ -109,8 +100,9 @@ spec:
           labels:
             severity: critical
         # IoT / device reachability (the ICMP `devices` probe + the HTTP
-        # `http` probe — WLED, Hue, Kodi, presence sensors, ratgdo, frame
-        # displays, UPS/iDRAC ICMP, cameras). These targets legitimately
+        # `http` probe — WLED, Kodi, presence sensors, ratgdo, frame
+        # displays, UPS/iDRAC ICMP, cameras, pool/pump/water ESP devices,
+        # WiiM). These targets legitimately
         # sleep or power-cycle, so a critical/5m page floods the surface
         # (14 distinct devices fired criticals in one day). warning +
         # for:15m absorbs the transient blips and routes to Pushover

--- a/kubernetes/apps/observability/exporters/blackbox-exporter/app/probes.yaml
+++ b/kubernetes/apps/observability/exporters/blackbox-exporter/app/probes.yaml
@@ -5,6 +5,9 @@ kind: Probe
 metadata:
   name: devices
 spec:
+  # 2m cadence: the IoT unreachable alert is for:15m, so 1m granularity
+  # buys nothing and 2m halves ICMP + DNS load across the target set.
+  interval: 2m
   module: icmp
   prober:
     url: blackbox-exporter.observability.svc.cluster.local:9115
@@ -47,6 +50,7 @@ spec:
         - aquara-presense-kitchen
         - hass-voice-1
         - hass-voice-2
+        - hass-voice-gym
         - ratgdo-primary
         - ratgdo-secondary
         - bluetooth-proxy-wifi-1
@@ -58,6 +62,21 @@ spec:
         # - birdcam
         - frameo-familyroom
         - frameo-basement
+        # IOT VLAN 20 smart devices — ICMP reachability. HTTP servers are
+        # probed via ICMP here (not the http_2xx probe) because most don't
+        # return a clean 2xx on `/`; ICMP avoids false-down alerts.
+        - water-softener
+        - refoss
+        - droplet
+        - shelly-radon
+        - elfin-salt
+        - pool-light
+        - konnected
+        - whisperflo-pool-pump
+        - wiim-pool
+        - wiim-deck
+        - wiim-yard
+        - bathroom-mmwave
 
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/probe_v1.json
@@ -83,13 +102,14 @@ kind: Probe
 metadata:
   name: http
 spec:
+  # 2m cadence — same rationale as the `devices` probe above.
+  interval: 2m
   module: http_2xx
   prober:
     url: blackbox-exporter.observability.svc.cluster.local:9115
   targets:
     staticConfig:
       static:
-        - hue
         - wled-nightlight
         - wled-gym-1
         - wled-gym-3
@@ -101,6 +121,7 @@ spec:
         - wled-cabinet-1
         - wled-cabinet-2
         - wled-bar
+        - wled-bush
 
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/probe_v1.json


### PR DESCRIPTION
## What

Reconciles the blackbox-exporter probe list against the live **IOT VLAN 20** inventory (Omada) and NetBox, decommissions the retired Philips Hue bridge, and does a correctness/optimization pass on the exporter config.

### Device coverage (`probes.yaml`)
- **Add 13 unmonitored live IOT devices** — `water-softener`, `refoss`, `droplet`, `shelly-radon`, `elfin-salt`, `pool-light`, `konnected`, `whisperflo-pool-pump`, `wiim-pool`/`wiim-deck`/`wiim-yard`, `bathroom-mmwave`, `hass-voice-gym` on the ICMP `devices` probe; `wled-bush` on the `http` probe.
- Uncertain HTTP servers go on **ICMP, not http_2xx** — most IOT devices don't return a clean 2xx on `/`, so ICMP avoids false-down alerts. Only WLED (known-good UI) uses the http probe.
- **Remove the Philips Hue bridge** (`hue`) from the `http` probe — offline since 2026-07-03, being decommissioned. Its NetBox + bind9 records are removed out-of-band.

### Module / alert tuning (`helmrelease.yaml`)
- **Remove 2 dead `BlackboxSslCertificate*` alerts** — no probe uses an https module, so `probe_ssl_earliest_cert_expiry` was never populated and they could never fire. Cert expiry is handled by cert-manager.
- **icmp timeout 30s → 4s** (was dead-capped by the 10s scrapeTimeout anyway).
- **`ip_protocol_fallback: false`** on icmp + http_2xx (ip4-only LAN; skips a slow ip6 attempt on a miss). The `tcp_connect` critical-NFS probe is intentionally left untouched.
- **Relax `devices` + `http` cadence to `interval: 2m`** — the IoT alert is `for: 15m`, so 1m granularity bought nothing at 2× the ICMP/DNS load.

## Why
The probe list had drifted from what's actually on the VLAN. Three sources of truth (blackbox / Omada / NetBox) are now aligned for VLAN 20.

## Companion out-of-band changes (not in this PR)
- **bind9 (brain):** add `pool-light` A record, confirm the WiiM forward records, remove the `hue` record, drop stale records for 6 decommissioned devices, then restart brain DHCP/DNS to persist.
- **NetBox:** delete Hue + 6 decommissioned IPs; add WiiM×3, whisperflo-pool-pump, and the matter-server/aquapured/music-assistant macvlan NICs.

## Merge gate
⚠️ **Do not merge until the bind9 write pass confirms `pool-light` and the 3 WiiM names resolve.** New targets probe by bare hostname (in-pod search domain verified); a missing A record → NXDOMAIN → probe-fail. All other 11 new names already resolve.

## Verification
- `probe_success{job=~"probe/observability/(devices|http)"}` — all new targets present and `== 1`; `hue` absent.
- Confirm the `BlackboxSslCertificate*` alerts are gone and `BlackboxIoTDeviceUnreachable` enumerates the new targets.
- No flapping-red rows from unresolved names over the first ~30m.

🤖 Generated with [Claude Code](https://claude.com/claude-code)