### PR TITLE
fix(home): matter-server memory right-size + attestation egress

### DIFF
--- a/kubernetes/apps/home/matter-server/README.md
+++ b/kubernetes/apps/home/matter-server/README.md
@@ -1,0 +1,30 @@
+# matter-server
+
+[python-matter-server](https://github.com/home-assistant-libs/python-matter-server)
+— the Matter controller Home Assistant's Matter integration talks to.
+
+## Networking
+
+Runs with a Multus macvlan secondary NIC (`net1`) on the IoT VLAN (20,
+`matter-server-iot-static`) and `--primary-interface=net1`, so Matter device
+traffic (mDNS / IPv6 multicast / commissioning) reaches the IoT segment and
+bypasses Cilium. The pod's primary `eth0` stays on the cluster network for the
+WebSocket API, the LoadBalancer VIP, and startup egress (PAA certs / DCL vendor
+info — see the `egress` block in `app/cnp-allow.yaml`).
+
+## Dashboard UI
+
+The image bundles the matter-server dashboard, served on port `5580` and exposed
+at `https://matter.${SECRET_DOMAIN}/` (internal HTTPRoute) and on the
+LoadBalancer VIP (`${SVC_MATTER_ADDR}`).
+
+On first visit the dashboard prompts **"Enter Websocket URL to a running Matter
+Server"** and defaults to `ws://localhost:5580/ws` — that default does **not**
+work from a browser (localhost = your machine). Enter:
+
+```text
+wss://matter.${SECRET_DOMAIN}/ws
+```
+
+The value is stored in the browser's localStorage, so it's a one-time step per
+browser. Envoy proxies the `/ws` WebSocket upgrade to the backend over HTTP/1.1.

--- a/kubernetes/apps/home/matter-server/app/cnp-allow.yaml
+++ b/kubernetes/apps/home/matter-server/app/cnp-allow.yaml
@@ -33,7 +33,22 @@ spec:
         - ports:
             - port: "5580"
               protocol: TCP
-    # NOTE: Matter devices live on the IoT VLAN and are reached via
-    # the multus-attached secondary NIC (matter-server-iot-static,
-    # --primary-interface=net1). All device traffic bypasses Cilium
-    # entirely.
+  # NOTE: Matter devices live on the IoT VLAN and are reached via
+  # the multus-attached secondary NIC (matter-server-iot-static,
+  # --primary-interface=net1). All device traffic bypasses Cilium
+  # entirely.
+  egress:
+    # PAA root-cert bootstrap (device attestation) + vendor info (DCL),
+    # both fetched at startup over the primary (eth0) NIC. Without them
+    # the server fetches 0 PAA certs and commissioning CERTIFIED Matter
+    # devices fails attestation. The namespace default-deny blocks this
+    # by default; the baseline allow-dns L7 rule populates Cilium's FQDN
+    # cache so these toFQDNs entries resolve. Widen to toEntities:world
+    # on 443 (node-red pattern) only if PAA fetch still reports 0.
+    - toFQDNs:
+        - matchName: api.github.com
+        - matchName: on.dcl.csa-iot.org
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/home/matter-server/app/helmrelease.yaml
+++ b/kubernetes/apps/home/matter-server/app/helmrelease.yaml
@@ -75,9 +75,11 @@ spec:
             resources:
               requests:
                 cpu: 50m
-                memory: 100M
+                memory: 256Mi
               limits:
-                memory: 100M
+                # req≠lim on purpose: the CHIP SDK working set peaks well
+                # above idle; 100M req==lim OOMKilled (137) under load.
+                memory: 512Mi
 
     service:
       *app :


### PR DESCRIPTION
## What

Two small fixes so `matter-server` is fully functional (it ran, but was only partially working). Diagnosed live 2026-07-08.

### 1. Memory right-size (OOMKilled)
The container had `requests.memory == limits.memory == 100M` — the hard-cap-at-working-set trap. Confirmed `lastState: terminated exitCode 137 reason OOMKilled`; it survived at idle but OOMed under any load. Decoupled to `requests 256Mi` / `limits 512Mi` (reference deployments use 256–512Mi).

### 2. Attestation egress (0 PAA certs)
The `home` namespace `default-deny` blocks egress and `matter-server-allow` had **only ingress rules**, so the server fetched **0 PAA root certificates** (timeout to `api.github.com`) and no DCL vendor info — commissioning certified Matter devices would fail device-attestation. Added a least-privilege `toFQDNs` egress allow to `api.github.com` + `on.dcl.csa-iot.org` on 443 (the `allow-dns` baseline populates Cilium's FQDN cache).

### 3. UI (docs only)
The bundled dashboard was already served and reachable via the internal HTTPRoute + LoadBalancer VIP (verified `101 Switching Protocols` on the `/ws` upgrade through envoy). Its first-run prompt just needs `wss://matter.${SECRET_DOMAIN}/ws` instead of the default `ws://localhost:5580/ws`; documented in a new co-located `README.md`.

## Risk
Low. `matter-server` has **0 commissioned nodes**, so the rolling restart has no user-facing impact. Both manifest changes are additive/widening (more memory, one egress hole) — no reduction of existing guarantees.

## Verify after merge
- `kubectl -n home get pod -l app.kubernetes.io/name=matter-server` → `RESTARTS` stops climbing, no `OOMKilled`.
- `kubectl -n home logs deploy/matter-server | grep -i "PAA root certificates"` → non-zero (was 0).
- Open `https://matter.${SECRET_DOMAIN}/`, enter `wss://matter.${SECRET_DOMAIN}/ws` → dashboard connects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)