### PR TITLE
fix(home): allow matter-server egress to raw.githubusercontent.com

### DIFF
--- a/kubernetes/apps/home/matter-server/app/cnp-allow.yaml
+++ b/kubernetes/apps/home/matter-server/app/cnp-allow.yaml
@@ -45,8 +45,12 @@ spec:
     # by default; the baseline allow-dns L7 rule populates Cilium's FQDN
     # cache so these toFQDNs entries resolve. Widen to toEntities:world
     # on 443 (node-red pattern) only if PAA fetch still reports 0.
+    # The dev/test PAA set is listed via api.github.com then each cert is
+    # pulled from raw.githubusercontent.com — both are needed, and without
+    # the raw host startup stalls ~2min timing out before init completes.
     - toFQDNs:
         - matchName: api.github.com
+        - matchName: raw.githubusercontent.com
         - matchName: on.dcl.csa-iot.org
       toPorts:
         - ports:


### PR DESCRIPTION
Follow-up to #12934. After that merged, `matter-server` fetches production PAA certs + vendors from DCL fine (74 certs / 447 vendors), but the GitHub dev/test PAA set still returned 0.

Cause: matter-server *lists* the dev certs via `api.github.com` (allowed in #12934) then downloads each `.pem` from **`raw.githubusercontent.com`**, which was still blocked by the namespace default-deny. Confirmed live: `api.github.com` TCP443 OK, `raw.githubusercontent.com` → TimeoutError.

Effects fixed:
- 0 dev/test PAA certs fetched (needed to commission uncertified/DIY Matter devices).
- ~2 min startup stall on every restart, waiting for the blocked download to time out before init completes.

One-line change: add `raw.githubusercontent.com` to the existing `toFQDNs` egress allow.

## Verify after merge
`kubectl -n home logs deploy/matter-server | grep "certificates from Git"` → non-zero (was 0), and no `raw.githubusercontent.com` ConnectionTimeout; startup reaches "successfully initialized" without the ~2min stall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)