### PR TITLE
feat(home): point matter-server Glance tile at :5580 auto-connect URL

### DIFF
--- a/kubernetes/apps/home/matter-server/README.md
+++ b/kubernetes/apps/home/matter-server/README.md
@@ -18,13 +18,16 @@ The image bundles the matter-server dashboard, served on port `5580` and exposed
 at `https://matter.${SECRET_DOMAIN}/` (internal HTTPRoute) and on the
 LoadBalancer VIP (`${SVC_MATTER_ADDR}`).
 
-On first visit the dashboard prompts **"Enter Websocket URL to a running Matter
-Server"** and defaults to `ws://localhost:5580/ws` — that default does **not**
-work from a browser (localhost = your machine). Enter:
+The bundled dashboard auto-connects its WebSocket **only** when the page URL
+contains `:5580` (or an HA add-on ingress path); otherwise it prompts for a WS
+URL. So there are two ways in:
 
-```text
-wss://matter.${SECRET_DOMAIN}/ws
-```
-
-The value is stored in the browser's localStorage, so it's a one-time step per
-browser. Envoy proxies the `/ws` WebSocket upgrade to the backend over HTTP/1.1.
+- **Zero-prompt (recommended):** hit the LoadBalancer VIP on 5580 —
+  `http://${SVC_MATTER_ADDR}:5580/`. The `:5580` in the URL makes the dashboard
+  self-connect to `ws://${SVC_MATTER_ADDR}:5580/ws`, no prompt. This is what the
+  Glance tile links to (`glance/url` on the HTTPRoute in `helmrelease.yaml`).
+- **Pretty HTTPS host:** `https://matter.${SECRET_DOMAIN}/` (internal HTTPRoute).
+  Because the URL has no `:5580`, the dashboard prompts once — enter
+  `wss://matter.${SECRET_DOMAIN}/ws` (envoy proxies the `/ws` upgrade over
+  HTTP/1.1). The value is stored in that browser's localStorage, so it's a
+  one-time step per browser.

--- a/kubernetes/apps/home/matter-server/app/helmrelease.yaml
+++ b/kubernetes/apps/home/matter-server/app/helmrelease.yaml
@@ -99,6 +99,12 @@ spec:
           glance/show: "true"
           glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/matter.png"
           glance/id: "Home Automation"
+          # Point the Glance tile at the LoadBalancer VIP:5580 rather than
+          # the https://matter route. The bundled dashboard auto-connects
+          # its WebSocket only when the page URL contains ":5580" (or an HA
+          # ingress path); on the plain https host it prompts for a WS URL.
+          # Hitting the VIP on 5580 makes it self-connect — no prompt.
+          glance/url: "http://${SVC_MATTER_ADDR}:5580/"
 
         hostnames:
           - "matter.${SECRET_DOMAIN}"


### PR DESCRIPTION
## What

Makes the Glance tile for matter-server open the dashboard **without** the "Enter Websocket URL" prompt.

## Why

The python-matter-server dashboard's own JS only auto-connects its WebSocket when the page URL contains `:5580` (or an HA add-on ingress path):

```js
const auto = location.href.includes(":5580") || location.href.includes("hassio_ingress") || location.href.includes("/api/ingress/");
```

On the plain `https://matter.${SECRET_DOMAIN}/` route that check is false, so it prompts (and its default `ws://localhost:5580/ws` is useless from a browser). There is no env var to hardcode the WS URL.

## How

Add a `glance/url` override (a supported glance-k8s v0.5.3 annotation) on the HTTPRoute pointing at the LoadBalancer VIP on 5580: `http://${SVC_MATTER_ADDR}:5580/`. The `:5580` in the address makes the dashboard self-connect to `ws://${SVC_MATTER_ADDR}:5580/ws` — no prompt, zero client-side setup, works on any browser/device.

- VIP is BGP-advertised; the existing ingress CNP already allows LAN (`world`/`host`/`remote-node`) → 5580.
- Verified the VIP serves the dashboard: `curl http://10.45.0.4:5580/` → `HTTP 200 text/html`.
- The pretty `https://matter.${SECRET_DOMAIN}/` route still works (one-time prompt); README documents both paths.

## Verify after merge

Open the Glance dashboard → click the Matter Server tile → dashboard loads and connects with no prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)