### PR TITLE
fix(observability): drop mislabeled water-softener blackbox target

### DIFF
--- a/kubernetes/apps/observability/exporters/blackbox-exporter/app/probes.yaml
+++ b/kubernetes/apps/observability/exporters/blackbox-exporter/app/probes.yaml
@@ -65,7 +65,6 @@ spec:
         # IOT VLAN 20 smart devices — ICMP reachability. HTTP servers are
         # probed via ICMP here (not the http_2xx probe) because most don't
         # return a clean 2xx on `/`; ICMP avoids false-down alerts.
-        - water-softener
         - refoss
         - droplet
         - shelly-radon


### PR DESCRIPTION
## What
Removes `water-softener` from the blackbox-exporter `devices` (ICMP) probe.

## Why
`10.10.20.9` (Omada client `espressif`) was labeled `water-softener` in DNS/NetBox, but it is **not** the water softener. HA monitors the real softener via a **Zooz ZEN15 Z-Wave plug** (zwavejs2mqtt → MQTT, no IP address) — power-draw + a threshold helper. The `.9` ESP is an old decommissioned device that never answered ICMP (`probe_success=0`, `rtt=0`, resolves fine). It was the one target from #12932 that wouldn't go green.

Its NetBox IP record and bind9 A/PTR are being removed out-of-band (network-operator), and the stale Omada known-client entry forgotten. Follow-up to #12932.

## Verification
- `probe_success{job="probe/observability/devices"}` no longer lists `water-softener`.
- No `BlackboxIoTDeviceUnreachable` warning for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)