### PR TITLE
fix(ci): tolerate Fairwinds digest mismatch in image-registry-check

### DIFF
--- a/.github/workflows/image-registry-check.yaml
+++ b/.github/workflows/image-registry-check.yaml
@@ -76,10 +76,33 @@ jobs:
           max_attempts: 3
           retry_wait_seconds: 30
           shell: sh
+          # workaround: https://github.com/FairwindsOps/charts/issues/1879 — remove when Fairwinds re-indexes
+          # The Fairwinds Helm repo (charts.fairwinds.com) publishes an
+          # index.yaml whose `digest:` for vpa/goldilocks no longer matches the
+          # served .tgz, so flate's strict reconcile exits non-zero. flate still
+          # writes the full image list to stdout, so we keep images.json and
+          # tolerate ONLY when every reconcile failure is a `fairwinds-charts-*
+          # … digest mismatch`; any other error (or a transient failure) exits
+          # non-zero so retry / the job still fails loud. Same tolerance as
+          # flux-local.yaml's `test` job.
           command: |
+            set +e
             flate get images \
               --path "$GITHUB_WORKSPACE/kubernetes/flux" \
-              --output json > images.json
+              --output json > images.json 2> flate.err
+            rc=$?
+            set -e
+            cat flate.err >&2
+            [ "$rc" -eq 0 ] && exit 0
+            clean="$(sed 's/\x1b\[[0-9;]*m//g' flate.err)"
+            total="$(printf '%s\n' "$clean" | grep -oE 'reconcile completed with [0-9]+ failure' | grep -oE '[0-9]+' | tail -1)"
+            tolerated="$(printf '%s\n' "$clean" | grep -cE 'fairwinds-charts-.*digest mismatch' || true)"
+            if [ -n "$total" ] && [ "$total" -gt 0 ] && [ "$total" -eq "$tolerated" ]; then
+              echo "::warning::flate get images: tolerating ${tolerated} Fairwinds index digest mismatch(es) (vpa/goldilocks) — see FairwindsOps/charts#1879. Image list still emitted."
+              exit 0
+            fi
+            echo "::error::flate get images failed with untolerated errors (failed=${total:-unknown}, tolerated Fairwinds digest mismatches=${tolerated})."
+            exit "$rc"
 
       # Multi-line heredoc avoids needing jq for this step — file is
       # already valid JSON, just plumb it through. printf ensures a


### PR DESCRIPTION
## Problem

The `Extract images` job in `image-registry-check.yaml` runs `flate get
images`, whose strict reconcile hits the Fairwinds `index.yaml` digest
mismatch for `vpa`/`goldilocks` and exits non-zero. This fails the
`Extract images (default)` and `Extract images (pull)` checks on **every**
PR that touches `kubernetes/**` (e.g. #12941) — unrelated to the PR's
actual change.

`Flux Local Test` passes on the same PRs because its `test` job already
wraps flate with a Fairwinds-digest-mismatch tolerance; the image-registry
job never got the same treatment.

## Fix

Port the identical tolerance into the `Gather images` step. flate still
writes the complete image list to stdout even when the reconcile reports
failures, so `images.json` stays valid; we only swallow the exit code when
**every** reconcile failure is a `fairwinds-charts-* … digest mismatch`.
Any other error (or a transient cold-cache failure) still exits non-zero,
so `nick-fields/retry` retries and the job fails loud.

Annotated with the same `# workaround:` pointer to
[FairwindsOps/charts#1879](https://github.com/FairwindsOps/charts/issues/1879)
as `flux-local.yaml`, so the upstream-watcher retires both together when
Fairwinds re-indexes.

## Verification

Reproduced locally with flate v0.4.10 (the CI-pinned version):
- Bare `flate get images` → rc=1, but stdout is a valid 245-element array.
- New wrapper → exits 0, emits the `::warning::` tolerating 4 Fairwinds
  mismatches, `images.json` intact (245 images).
- `yamllint` + pre-commit `actionlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)