### PR TITLE
refactor(immich): migrate chart source HTTP HelmRepository → OCIRepository

### DIFF
--- a/kubernetes/apps/media/immich/app/helmrelease.yaml
+++ b/kubernetes/apps/media/immich/app/helmrelease.yaml
@@ -5,14 +5,9 @@ kind: HelmRelease
 metadata:
   name: immich
 spec:
-  chart:
-    spec:
-      # renovate: registryUrl=https://immich-app.github.io/immich-charts
-      chart: immich
-      sourceRef:
-        kind: HelmRepository
-        name: immich-charts
-      version: 0.12.0
+  chartRef:
+    kind: OCIRepository
+    name: immich-charts
   interval: 30m
 
   # disableWait — immich-machine-learning's CLIP+SigLIP2 preload blocks

--- a/kubernetes/apps/media/immich/app/helmrepository.yaml
+++ b/kubernetes/apps/media/immich/app/helmrepository.yaml
@@ -1,9 +1,0 @@
----
-# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/refs/heads/main/helmrepository-source-v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: HelmRepository
-metadata:
-  name: immich-charts
-spec:
-  interval: 2h
-  url: https://immich-app.github.io/immich-charts

--- a/kubernetes/apps/media/immich/app/kustomization.yaml
+++ b/kubernetes/apps/media/immich/app/kustomization.yaml
@@ -9,6 +9,6 @@ resources:
   - ./externalsecret-offsite-backup.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
-  - ./helmrepository.yaml
   - ./httproute.yaml
+  - ./ocirepository.yaml
   - ./nfs-pvc.yaml

--- a/kubernetes/apps/media/immich/app/ocirepository.yaml
+++ b/kubernetes/apps/media/immich/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/refs/heads/main/ocirepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: immich-charts
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.12.0
+  url: oci://ghcr.io/immich-app/immich-charts/immich


### PR DESCRIPTION
## What

Migrate the immich chart source from the HTTP `HelmRepository`
(`immich-app.github.io/immich-charts`) to the OCI registry
(`oci://ghcr.io/immich-app/immich-charts/immich`).

## Why

Upstream marked the HTTP helm repo **removed / no longer receiving
updates**. It's frozen at chart `0.12.0` (our current pin) while OCI has
already shipped `0.12.1`, `0.13.0`, `0.13.1`.

- Renovate reads `registryUrl=<HTTP repo>` → can never surface the newer
  charts. Chart bumps have gone silent.
- The HTTP index only *happens* to still respond `200`; if it 404s, Flux
  can't fetch and reconciliation breaks.

immich was the straggler missed by the #12692 direct-to-OCI chart sweep.

## Scope

Source migration **only** — stays pinned at chart `0.12.0`, no app
upgrade. Same chart version → no-op reconcile, no pod churn. A follow-up
Renovate PR will surface `0.13.1` (which re-enters the separate
downstream-consumer verification gate).

- `helmrepository.yaml` removed → `ocirepository.yaml` added
- `helmrelease.yaml`: `spec.chart` → `spec.chartRef` (OCIRepository)
- `kustomization.yaml`: resource list updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)