### PR TITLE
fix(rook-ceph): retire ceph-csi null-resources {} padding (ceph-csi-operator#490 fixed)

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/csi-drivers/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/csi-drivers/helmrelease.yaml
@@ -94,15 +94,6 @@ spec:
             plugin:
               requests: {memory: 512Mi}
               limits: {memory: 1Gi}
-            # workaround: https://github.com/ceph/ceph-csi-operator/issues/490 — remove when
-            # the ceph-csi-drivers chart guards unset sidecar resources keys instead of
-            # emitting `null`. The chart force-emits EVERY sidecar key under resources; the
-            # ones we don't size render as `null`, which the live Driver CRD rejects on
-            # server-side apply ("must be of type object"). Pad them with {} until fixed.
-            # Tracking: home-ops#12302. (addons only runs with deployCsiAddons.)
-            liveness: {}
-            addons: {}
-            logRotator: {}
         nodePlugin:
           priorityClassName: "system-node-critical"
           kubeletDirPath: "/var/lib/kubelet"
@@ -125,9 +116,6 @@ spec:
             registrar:
               requests: {cpu: 50m, memory: 128Mi}
               limits: {memory: 256Mi}
-            liveness: {}
-            addons: {}
-            logRotator: {}
       cephfs:
         enabled: true
         name: "rook-ceph.cephfs.csi.ceph.com"
@@ -159,10 +147,6 @@ spec:
             plugin:
               requests: {cpu: 250m, memory: 512Mi}
               limits: {memory: 1Gi}
-            omapGenerator: {}
-            liveness: {}
-            addons: {}
-            logRotator: {}
         nodePlugin:
           priorityClassName: "system-node-critical"
           kubeletDirPath: "/var/lib/kubelet"
@@ -182,9 +166,6 @@ spec:
             registrar:
               requests: {cpu: 50m, memory: 128Mi}
               limits: {memory: 256Mi}
-            liveness: {}
-            addons: {}
-            logRotator: {}
       # Not used in this cluster — keep them off to match the current footprint
       # (the vendored RBAC only ever covered rbd + cephfs).
       nvmeof:


### PR DESCRIPTION
Retires the ceph-csi `{}` null-padding workaround now that upstream has fixed it.

## ceph-csi null-resources `{}` padding — closes #12302

`ceph/ceph-csi-operator#490` fixed upstream (PR #498, shipped in `ceph-csi-drivers` chart >=1.0.2; repo is on **1.0.3**). The chart no longer emits `null` for unset sidecar `resources` keys, so the `liveness`/`addons`/`logRotator`/`omapGenerator` `{}` padding is dead weight.

This defect is invisible to `helm template` / flux-local — it only surfaces on a real server-side apply — so removal was verified against the **live cluster**:

- Rendered chart 1.0.3 with the padding removed → **no `null`** under any `resources` block.
- `kubectl apply --server-side --force-conflicts --dry-run=server` → both `Driver` CRs (`rook-ceph.{rbd,cephfs}.csi.ceph.com`) accepted cleanly. These are the exact resources that previously rejected `null`.

Nothing was persisted (dry-run only).

---

**Note:** an earlier revision of this PR also dropped the Fairwinds digest-mismatch CI tolerance (#12758). Reverted — that workaround must stay. Fairwinds re-indexed the *superseded* versions (vpa 4.12.2 / goldilocks 10.4.0) but the *live* versions still mismatch (goldilocks 10.4.1 index≠tgz; vpa 4.12.3 intermittently mismatches at CloudFront edge). `FairwindsOps/charts#1879` is not resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)