### PR TITLE
fix(immichkiosk): bump to 0.41.0 for Immich v3 compatibility

### DIFF
--- a/kubernetes/apps/media/immichkiosk-party/app/helmrelease.yaml
+++ b/kubernetes/apps/media/immichkiosk-party/app/helmrelease.yaml
@@ -27,7 +27,7 @@ spec:
           app:
             image:
               repository: ghcr.io/damongolding/immich-kiosk
-              tag: 0.39.3@sha256:b65371b9fbe93cde8355c06ba095fb4801bbb5d7c8c51065a5bfa02183536771
+              tag: 0.41.0@sha256:ee6145ac6bd5a5492a746d019bf01bbe25559def1cbc2e79f61b0871b8933cf6
 
             env:
               # Required settings

--- a/kubernetes/apps/media/immichkiosk/app/helmrelease.yaml
+++ b/kubernetes/apps/media/immichkiosk/app/helmrelease.yaml
@@ -27,7 +27,7 @@ spec:
           app:
             image:
               repository: ghcr.io/damongolding/immich-kiosk
-              tag: 0.39.3@sha256:b65371b9fbe93cde8355c06ba095fb4801bbb5d7c8c51065a5bfa02183536771
+              tag: 0.41.0@sha256:ee6145ac6bd5a5492a746d019bf01bbe25559def1cbc2e79f61b0871b8933cf6
 
             env:
               # Required settings


### PR DESCRIPTION
## Why

Follow-up to the Immich v3.0.2 upgrade (#12956). **immich-kiosk 0.39.3 does not support Immich v3** — upstream made v3 support a breaking change in **v0.40.0** ("v0.40.0 and above will only support Immich V3").

After v3 went live, kiosk's album/excluded-tags query returns **no assets**, matching upstream issue [damongolding/immich-kiosk#797](https://github.com/damongolding/immich-kiosk/issues/797) ("no asset found when specifying an AlbumID" on v3).

## Evidence

- **immichkiosk-party** surfaced it immediately: its `KIOSK_EXCLUDED_TAGS=kiosk-party-shown` churn exhausted its asset cache, and the refresh query returned 0 despite **191 untagged assets available** in the party album (verified in the immich DB: 251 total − 60 tagged = 191). Hard retry-loop from 15:57 EDT (the instant v3 became Ready); zero errors the day before.
- **base immichkiosk** appeared fine only because it was still rotating through its **pre-upgrade cached** 747 assets — it would hit the same wall on next refresh.

## Change

Bump both instances `0.39.3` → `0.41.0` (digest-pinned). 0.40.0+ is Immich-v3-only, which matches the cluster now (both instances point at the v3 server).

## Post-merge verification

Watch immichkiosk-party recover — the album query should return the 191 available assets and the retry-loop should stop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)