### PR TITLE
fix(immichkiosk): writable /tmp for 0.41.0 video manager

### DIFF
--- a/kubernetes/apps/media/immichkiosk-party/app/helmrelease.yaml
+++ b/kubernetes/apps/media/immichkiosk-party/app/helmrelease.yaml
@@ -146,6 +146,14 @@ spec:
               - path: /config/config.yaml
                 subPath: config.yaml
                 readOnly: true
+      # kiosk 0.41.0's video manager creates /tmp/immich-kiosk at startup;
+      # readOnlyRootFilesystem blocks it. Writable scratch for /tmp.
+      tmp:
+        type: emptyDir
+        advancedMounts:
+          immichkiosk-party:
+            app:
+              - path: /tmp
 
     route:
       app:

--- a/kubernetes/apps/media/immichkiosk/app/helmrelease.yaml
+++ b/kubernetes/apps/media/immichkiosk/app/helmrelease.yaml
@@ -149,3 +149,13 @@ spec:
           - backendRefs:
               - identifier: app
                 port: *httpPort
+
+    persistence:
+      # kiosk 0.41.0's video manager creates /tmp/immich-kiosk at startup;
+      # readOnlyRootFilesystem blocks it. Writable scratch for /tmp.
+      tmp:
+        type: emptyDir
+        advancedMounts:
+          immichkiosk:
+            app:
+              - path: /tmp


### PR DESCRIPTION
## Why

Follow-up to #12959 (kiosk → 0.41.0). kiosk 0.41.0's video manager creates `/tmp/immich-kiosk` at startup, but `readOnlyRootFilesystem: true` (from the securityContext baseline) blocks it:

```
ERRO Error creating custom temp directory err="mkdir /tmp/immich-kiosk: read-only file system"
ERRO Failed to initialize video manager err="mkdir /tmp/immich-kiosk: read-only file system"
```

Seen on **both** instances (both have `KIOSK_ALBUM_VIDEO` enabled). Images already serve fine; this only affects video playback.

## Change

Add a `tmp` `emptyDir` mounted at `/tmp` on both kiosks, per the `helmrelease.security.md` scratch-path pattern (keeps `readOnlyRootFilesystem: true`). Uses `advancedMounts` targeting the `app` container to avoid mounting into the injected k8tz init container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)