### PR TITLE
feat(immich): persist ML model cache on ceph-block

### DIFF
--- a/kubernetes/apps/media/immich/app/helmrelease.yaml
+++ b/kubernetes/apps/media/immich/app/helmrelease.yaml
@@ -135,6 +135,18 @@ spec:
           replicas: 1
           strategy: RollingUpdate
           type: statefulset
+
+      # Persist the HuggingFace model cache (chart mounts this at /cache)
+      # so CLIP + face models don't re-download on every ML pod restart.
+      # Regenerable data → ceph-block per storage-class rule 2. RWO: the
+      # ML controller is a single statefulset replica. No fsGroup needed —
+      # the ML container runs as root.
+      persistence:
+        cache:
+          type: persistentVolumeClaim
+          accessMode: ReadWriteOnce
+          size: 20Gi
+          storageClass: ceph-block
     server:
       controllers:
         main:


### PR DESCRIPTION
## Why

Follow-up to the Immich v3 upgrade. The ML model cache is chart-default `emptyDir`, so CLIP (SigLIP2) + face-recognition models re-download (~339 files) on **every** ML pod restart — as just observed during the v3 rollout.

(A prior `storageClassName` override was a no-op — wrong bjw-s key — and was removed in #12956.)

## Change

Add a **20Gi ceph-block** PVC for the ML cache. The chart mounts it at `/cache` and points the HuggingFace/matplotlib cache env there automatically (render-verified: creates PVC `immich-machine-learning`, `ReadWriteOnce`, `storageClassName: ceph-block`, `mountPath: /cache`).

- **ceph-block** per storage-class rule 2 (regenerable data — in-cluster-durable default).
- **RWO** — the ML controller is a single statefulset replica.
- **No `fsGroup`** — the ML container runs as root (uid=0, verified live), so it can write to a fresh PVC.

## Rollout note

The ML pod restarts and re-downloads models **once** into the persistent cache; subsequent restarts reuse it. Brief ML background-inference unavailability during that first preload (covered by the existing 10-min startup probe budget).

🤖 Generated with [Claude Code](https://claude.com/claude-code)