### PR TITLE
ci: rename Flux Local workflow → flate

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -28,7 +28,7 @@ jobs:
     # Self-hosted to stay off GitHub-hosted quota. Runs on the bare ARC
     # runner (not a container:) so the runner-provided node satisfies the
     # JS actions (setup-python, gh-pages deploy); a python container would
-    # lack node — same gotcha documented in flux-local.yaml's diff/comment
+    # lack node — same gotcha documented in flate.yaml's diff/comment
     # split. setup-python self-downloads CPython; pip reaches PyPI via the
     # runner CNP's wildcard 443 egress.
     runs-on: arc-runner-set-home-ops

--- a/.github/workflows/flate.yaml
+++ b/.github/workflows/flate.yaml
@@ -1,11 +1,13 @@
 ---
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
-name: Flux Local
+name: flate
 
 # Engine: flate (https://github.com/home-operations/flate), a Go
-# reimplementation of flux-local. The workflow + job names are intentionally
-# unchanged — "Flux Local successful" is a required status check in the
-# "Require CI on main" ruleset, so renaming would silently block merges.
+# reimplementation of flux-local. The workflow + job names track the engine.
+# "flate successful" is a required status check in the "Require CI on main"
+# ruleset — renaming this job means updating that ruleset's required-check
+# context in the same change, or merges silently block. (Renamed from
+# "Flux Local successful" in lockstep with the ruleset; see home-ops#12958.)
 #
 # flate ships as a static binary installed by its setup action and runs
 # directly on a GitHub-hosted runner. Charts are pulled direct from public
@@ -45,11 +47,11 @@ jobs:
         with:
           patterns: |-
             kubernetes/**/*
-            .github/workflows/flux-local.yaml
+            .github/workflows/flate.yaml
 
   test:
     if: ${{ needs.filter-changes.outputs.changed-files != '[]' }}
-    name: Flux Local Test
+    name: flate test
     runs-on: ubuntu-latest
     needs:
       - filter-changes
@@ -110,7 +112,7 @@ jobs:
   diff:
     # Diff-against-default-branch only makes sense on PRs.
     if: ${{ github.event_name == 'pull_request' && needs.filter-changes.outputs.changed-files != '[]' }}
-    name: Flux Local Diff
+    name: flate diff
     runs-on: ubuntu-latest
     needs:
       - filter-changes
@@ -163,7 +165,7 @@ jobs:
       - name: Upload diff artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: flux-local-diff
+          name: flate-diff
           path: diff-full.patch
           retention-days: 1
           if-no-files-found: ignore
@@ -196,12 +198,12 @@ jobs:
             ${{ steps.diff.outputs.content }}
             ```
 
-  flux-local-success:
+  flate-success:
     needs:
       - test
       - diff
     if: ${{ !cancelled() }}
-    name: Flux Local successful
+    name: flate successful
     runs-on: ubuntu-latest
     steps:
       - name: Check job status

--- a/.github/workflows/image-registry-check.yaml
+++ b/.github/workflows/image-registry-check.yaml
@@ -38,7 +38,7 @@ jobs:
     if: ${{ needs.filter-changes.outputs.changed-files != '[]' }}
     name: Extract images
     # Runs flate to extract images; charts resolve from public registries,
-    # so GitHub-hosted works with no cluster access (see flux-local.yaml).
+    # so GitHub-hosted works with no cluster access (see flate.yaml).
     runs-on: ubuntu-latest
     needs:
       - filter-changes
@@ -68,7 +68,7 @@ jobs:
         # matrix leg is a single-ref shallow checkout (no `main` to diff
         # against), so this forces full-tree extraction on both legs instead
         # of an implicit changed-only mode. Same override as
-        # flux-local.yaml's `test` job.
+        # flate.yaml's `test` job.
         env:
           FLATE_BASE: ""
         with:
@@ -84,7 +84,7 @@ jobs:
           # tolerate ONLY when every reconcile failure is a `fairwinds-charts-*
           # … digest mismatch`; any other error (or a transient failure) exits
           # non-zero so retry / the job still fails loud. Same tolerance as
-          # flux-local.yaml's `test` job.
+          # flate.yaml's `test` job.
           command: |
             set +e
             flate get images \


### PR DESCRIPTION
The CI engine has been [flate](https://github.com/home-operations/flate) for a while; only the "Flux Local" labels lagged. This renames the workflow, its three jobs, the file, and internal ids so the check names read flate end to end.

| before | after |
|---|---|
| workflow `Flux Local` | `flate` |
| job `Flux Local Test` | `flate test` |
| job `Flux Local Diff` | `flate diff` |
| job `Flux Local successful` (required) | `flate successful` |
| file `flux-local.yaml` | `flate.yaml` |

Plus stale `flux-local.yaml` path refs in `image-registry-check.yaml` and `docs.yaml`. (References to the *old tool* flux-local — the `flux-local test` command flate replaced, the flux-local image — are left intact as history.)

## Ruleset coordination

`flate successful` is a **required status check** in the "Require CI on main" ruleset. Renaming the job means the old `Flux Local successful` context is never produced again, so the ruleset's required-context string is updated in lockstep with this merge. Done in a **zero-open-PR window** so no in-flight PR is caught waiting on the old context.

Sequence:
1. This PR's CI produces `flate successful` (new name) — under the current ruleset it shows as blocked (old context never appears).
2. Ruleset required check `Flux Local successful` → `flate successful`.
3. This PR then satisfies the ruleset and merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)