### PR TITLE
docs(agents): upstream-watcher — verify against deployed state before retiring a workaround

### DIFF
--- a/.agents/skills/upstream-watcher.md
+++ b/.agents/skills/upstream-watcher.md
@@ -38,6 +38,35 @@ Manually, ~weekly. Future: scheduled.
 4. Use the sweep pattern from `CLAUDE.md` "Blast radius" if multiple
    workarounds retire at once (label `sweep`).
 
+## Verification discipline
+
+"Upstream closed/merged" is necessary but NOT sufficient to remove a
+workaround. Confirm the fix reaches *this cluster's actual state*, not a
+stale reference in the annotation, before opening a removal PR.
+
+- **Check the DEPLOYED version, not the version named in the comment.**
+  Upstream may fix/re-index only the versions its issue mentions while
+  the version we actually run still breaks. For the Fairwinds digest
+  tolerance (2026-07-09), the comment named vpa 4.12.2 / goldilocks
+  10.4.0 — both re-indexed clean — but the repo runs 4.12.3 / 10.4.1,
+  which still mismatch. Removing the tolerance red the CI. Always
+  `grep` the live `version:`/`tag:` in the HelmRelease and verify
+  against THAT, not the annotation's example version.
+- **"Issue closed" ≠ "fix is in the version we pin."** Find the closing
+  PR, then confirm it shipped in a release `<=` our pinned version
+  (`gh release list`, check the PR's merge date vs release dates).
+- **For defects invisible to static rendering, verify against the live
+  cluster.** Some workarounds compensate for behavior that `helm
+  template` / flate never exercises (e.g. the ceph-csi `{}` padding —
+  a `null` the Driver CRD only rejects on server-side apply). Removal
+  is safe only if a real `helm template ... | kubectl apply
+  --server-side --dry-run=server -f -` accepts it. Dry-run is
+  read-only; nothing persists.
+- **Let the removal PR's own CI be the final proof.** For CI-tolerance
+  workarounds, the reverted wrapper runs against current versions in
+  the PR — a green run is the confirmation, a red run means the
+  workaround still earns its keep. Don't `--admin`-merge past it.
+
 ## What this is NOT
 
 - Not a general bug-watcher — only tracks code we've explicitly


### PR DESCRIPTION
Adds a **Verification discipline** section to the upstream-watcher skill, capturing two near-misses from the 2026-07-09 workaround-retirement pass (#12958).

- **Check the DEPLOYED version, not the version named in the comment.** The Fairwinds digest tolerance annotation named vpa 4.12.2 / goldilocks 10.4.0 — both re-indexed clean upstream — but the repo runs 4.12.3 / 10.4.1, which still mismatch. Removing the tolerance red the CI. Verify against the live `version:`/`tag:`, not the annotation's example.
- **"Issue closed" ≠ "fix is in the version we pin."** Find the closing PR; confirm it shipped in a release ≤ our pinned version.
- **For render-invisible defects, verify against the live cluster.** The ceph-csi `{}` padding compensates for a `null` the Driver CRD only rejects on server-side apply — invisible to `helm template` / flate. Removal is safe only after a real `--server-side --dry-run=server` accepts it.
- **Let the removal PR's own CI be the final proof** for CI-tolerance workarounds; don't `--admin`-merge past it.

Docs-only; no cluster impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)