### PR TITLE
docs(ci): drop goldilocks from Fairwinds flate-tolerance note

### DIFF
--- a/.github/workflows/flate.yaml
+++ b/.github/workflows/flate.yaml
@@ -85,7 +85,7 @@ jobs:
         # workaround: https://github.com/FairwindsOps/charts/issues/1879 — remove when Fairwinds re-indexes
         # The Fairwinds Helm repo (charts.fairwinds.com, an S3/CloudFront-hosted
         # index we can't PR) publishes an index.yaml whose `digest:` for
-        # vpa/goldilocks no longer matches the served .tgz, so flate correctly
+        # vpa no longer matches the served .tgz, so flate correctly
         # rejects the chart with "digest mismatch". flate has no digest-skip
         # flag, so this wrapper tolerates ONLY that exact symptom — a
         # `fairwinds-charts-*` HelmRelease failing with "digest mismatch" — and
@@ -103,7 +103,7 @@ jobs:
           failed="$(printf '%s\n' "$clean" | grep -oE '[0-9]+ failed' | grep -oE '[0-9]+' | tail -1)"
           tolerated="$(printf '%s\n' "$clean" | grep -cE 'HelmRelease.*fairwinds-charts-.*digest mismatch' || true)"
           if [ -n "$failed" ] && [ "$failed" -gt 0 ] && [ "$failed" -eq "$tolerated" ]; then
-            echo "::warning::flate test: tolerating ${tolerated} Fairwinds index digest mismatch(es) (vpa/goldilocks) — see FairwindsOps/charts#1879. All other resources passed."
+            echo "::warning::flate test: tolerating ${tolerated} Fairwinds index digest mismatch(es) (vpa) — see FairwindsOps/charts#1879. All other resources passed."
             exit 0
           fi
           echo "::error::flate test failed with untolerated errors (failed=${failed:-unknown}, tolerated Fairwinds digest mismatches=${tolerated})."

--- a/.github/workflows/image-registry-check.yaml
+++ b/.github/workflows/image-registry-check.yaml
@@ -78,7 +78,7 @@ jobs:
           shell: sh
           # workaround: https://github.com/FairwindsOps/charts/issues/1879 — remove when Fairwinds re-indexes
           # The Fairwinds Helm repo (charts.fairwinds.com) publishes an
-          # index.yaml whose `digest:` for vpa/goldilocks no longer matches the
+          # index.yaml whose `digest:` for vpa no longer matches the
           # served .tgz, so flate's strict reconcile exits non-zero. flate still
           # writes the full image list to stdout, so we keep images.json and
           # tolerate ONLY when every reconcile failure is a `fairwinds-charts-*
@@ -98,7 +98,7 @@ jobs:
             total="$(printf '%s\n' "$clean" | grep -oE 'reconcile completed with [0-9]+ failure' | grep -oE '[0-9]+' | tail -1)"
             tolerated="$(printf '%s\n' "$clean" | grep -cE 'fairwinds-charts-.*digest mismatch' || true)"
             if [ -n "$total" ] && [ "$total" -gt 0 ] && [ "$total" -eq "$tolerated" ]; then
-              echo "::warning::flate get images: tolerating ${tolerated} Fairwinds index digest mismatch(es) (vpa/goldilocks) — see FairwindsOps/charts#1879. Image list still emitted."
+              echo "::warning::flate get images: tolerating ${tolerated} Fairwinds index digest mismatch(es) (vpa) — see FairwindsOps/charts#1879. Image list still emitted."
               exit 0
             fi
             echo "::error::flate get images failed with untolerated errors (failed=${total:-unknown}, tolerated Fairwinds digest mismatches=${tolerated})."


### PR DESCRIPTION
goldilocks now sources from the OCI mirror (#12967), leaving only vpa on the `charts.fairwinds.com` HTTP index that triggers flate's digest-mismatch tolerance. Updates the stale `(vpa/goldilocks)` comment + warning text in `flate.yaml` and `image-registry-check.yaml` to `(vpa)`.

Comment/warning strings only — the `fairwinds-charts-*` match pattern and dynamic tolerated-count logic are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)