### PR TITLE
feat(observability): upgrade opentelemetry-collector 0.118.0 → 0.164.1

### DIFF
--- a/kubernetes/apps/observability/opentelemetry-collector/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/opentelemetry-collector/app/helmrelease.yaml
@@ -61,7 +61,7 @@ spec:
       processors:
         # `kubernetesAttributes` preset injects this; declared
         # explicitly so the pipeline reference is unambiguous.
-        k8sattributes: {}
+        k8s_attributes: {}
 
         memory_limiter:
           check_interval: 1s
@@ -89,7 +89,7 @@ spec:
         pipelines:
           traces:
             receivers: [otlp]
-            processors: [memory_limiter, k8sattributes, batch]
+            processors: [memory_limiter, k8s_attributes, batch]
             exporters: [otlp/tempo]
         telemetry:
           logs:

--- a/kubernetes/apps/observability/opentelemetry-collector/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/opentelemetry-collector/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 0.118.0
+    tag: 0.164.1
   url: oci://ghcr.io/open-telemetry/opentelemetry-helm-charts/opentelemetry-collector


### PR DESCRIPTION
Changelog-reviewed chart upgrade held off Renovate auto-merge. Deliberate one-at-a-time merge — do not enable auto-merge.

## Change
- `ocirepository.yaml`: `ref.tag` `0.118.0` → `0.164.1`
- `helmrelease.yaml`: rename the deprecated `k8sattributes` processor → `k8s_attributes` in **both** the `config.processors` map and the traces-pipeline `processors:` list (kept between `memory_limiter` and `batch`).

Bundled collector 0.116 → 0.155. All our components (otlp, k8s_attributes, memory_limiter, batch, otlp/tempo exporter, health_check) are stable across the span.

**Why the rename ships with the bump:** the collector renamed the processor at core v0.146.0 (bundled in this chart). On the old chart the new name fails; on the new chart the old name only survives via a deprecation shim slated for removal — so bump + rename together.

## Impact
No maintenance window (routine internal, traces-only pipeline).

## Verify after merge
- Collector pod Ready + no config-parse error in logs.
- `health_check` on :13133 responds.
- Traces land in Tempo (Grafana → Tempo datasource).
- ServiceMonitor still scrapes :8888.
