### PR TITLE
feat(observability): upgrade tempo 1.18.3 → 1.24.4

### DIFF
--- a/kubernetes/apps/observability/tempo/app/cnp-allow.yaml
+++ b/kubernetes/apps/observability/tempo/app/cnp-allow.yaml
@@ -13,14 +13,14 @@ spec:
     egress: false
     ingress: false
   ingress:
-    # Grafana queries Tempo for trace data at port 3100 (HTTP).
+    # Grafana queries Tempo for trace data at port 3200 (HTTP).
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: observability
             app.kubernetes.io/name: grafana
       toPorts:
         - ports:
-            - port: "3100"
+            - port: "3200"
               protocol: TCP
     # OTel collector (also in observability ns) pushes spans via OTLP
     # gRPC 4317 and HTTP 4318. Cross-ns ingestion from ai/ namespace

--- a/kubernetes/apps/observability/tempo/app/configmap-grafana-datasource.yaml
+++ b/kubernetes/apps/observability/tempo/app/configmap-grafana-datasource.yaml
@@ -17,7 +17,7 @@ data:
         type: tempo
         uid: tempo
         access: proxy
-        url: http://tempo.observability.svc.cluster.local:3100
+        url: http://tempo.observability.svc.cluster.local:3200
         jsonData:
           # Link traces ↔ logs ↔ metrics via these data sources.
           tracesToLogsV2:

--- a/kubernetes/apps/observability/tempo/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/tempo/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 1.18.3
+    tag: 1.24.4
   url: oci://ghcr.io/grafana/helm-charts/tempo


### PR DESCRIPTION
Changelog-reviewed chart upgrade held off Renovate auto-merge. Deliberate one-at-a-time merge — do not enable auto-merge.

## Change
- `ocirepository.yaml`: `ref.tag` `1.18.3` → `1.24.4`
- `configmap-grafana-datasource.yaml`: Tempo datasource `url` port `:3100` → `:3200`
- `cnp-allow.yaml`: the Grafana→Tempo ingress rule `port: "3100"` → `"3200"` (OTLP `4317`/`4318` rules left untouched)

Bundled Tempo 2.7.1 → 2.9.0. The HTTP/metrics port moved 3100 → 3200 (chart `_ports.tpl`), so the Grafana datasource URL and the Cilium ingress rule are updated to match. No HelmRelease `values`-block change — we don't set `http_listen_port` (inherit the new 3200 default) and don't set `global_overrides`.

Stored data is safe (block format unchanged — vParquet4 both sides; 14-day retention). The port edits prevent a silent break where Tempo is healthy but Grafana/Cilium still target the dead 3100.

## Impact
Off-hours ideal (brief trace-query gap during the port cutover), not mandatory.

## Verify after merge
- HR Ready on image `tempo:2.9.0`.
- `svc/tempo` port `tempo-prom-metrics` = 3200.
- Grafana Tempo datasource Test + a TraceQL query succeed.
- OTLP ingest (4317/4318) still lands.
