### PR TITLE
feat(kyverno): upgrade kyverno 3.3.7 → 3.8.1

### DIFF
--- a/kubernetes/apps/kyverno/kyverno/app/ocirepository.yaml
+++ b/kubernetes/apps/kyverno/kyverno/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 3.3.7
+    tag: 3.8.1
   url: oci://ghcr.io/kyverno/charts/kyverno


### PR DESCRIPTION
Changelog-reviewed chart upgrade held off Renovate auto-merge. Deliberate one-at-a-time merge — do not enable auto-merge.

## Change
- `ocirepository.yaml`: `ref.tag` `3.3.7` → `3.8.1` (**TAG ONLY** — no values changes)

App-version span **v1.13.4 → v1.18.1 (5 minors)**. The v1.13 breaking changes are already behind us (we deployed on 3.3.7 = app v1.13.4). Chart 3.8.1 (app v1.18.1) ships `crds.migration.enabled: true`, which runs the `kyverno migrate` hook to advance stored CRD versions automatically. All our controller values keys are structurally unchanged.

## ⚠️ MAINTENANCE WINDOW REQUIRED — routine, any night 02:00–05:00 ET
The single-replica admission controller restart affects cluster-wide pod/namespace admission, and our namespace-delete policy is in live **Enforce**.

## Post-merge verify (IN ORDER)
1. All 4 kyverno controllers Ready, no CrashLoop from the CRD-migration hook Job.
2. `clusterpolicy disallow-namespace-deletion-without-approval` Ready under the new CRD.
3. **ENFORCE TEST:** creating and then deleting a throwaway `kyverno-upgrade-test` namespace must be **REJECTED** (missing the two-person-approval label), while a normal pod create must **SUCCEED**.
4. Record effective `failurePolicy` on the managed ValidatingWebhookConfiguration.

## Note (not part of this upgrade)
Our `config.webhooks.failurePolicy: Ignore` value is **inert** — it is not a real chart key, so it has no effect. Tracked as a separate cleanup, not part of this tag bump. No file edit here.
