### PR TITLE
chore(pump): bump pump to v0.0.104

### DIFF
--- a/kubernetes/apps/collab/pump/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump/app/helmrelease.yaml
@@ -49,7 +49,7 @@ spec:
           pump:
             image:
               repository: ghcr.io/rwlove/pump
-              tag: v0.0.103@sha256:0bb8e6ecd9a8bd08dba88ebaa5af3606b4d2d1113a6504c398473015b05c163a
+              tag: v0.0.104@sha256:6b23acdbbbd73f51c2737af7af7c194c524e2ee8b01c03542311da54c66d2dcc
 
             env:
               # Activates the /api/cv/* proxy in pump (see internal/web/exercise.go).


### PR DESCRIPTION
Bumps `ghcr.io/rwlove/pump` v0.0.103 → **v0.0.104**.

Ships PUMP [#69](https://github.com/rwlove/PUMP/pull/69):
- Bedtime / wake-time on the Sleep stats tab (tiles + per-night tooltip)
- Fix pre-existing sleep-duration over-count (cumulative snapshots were summed; a night now reflects the final reading)

Digest: `sha256:6b23acdbbbd73f51c2737af7af7c194c524e2ee8b01c03542311da54c66d2dcc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)