### PR TITLE
refactor(immich): drop dead :80 egress from immich-offsite-backup CNP

### DIFF
--- a/kubernetes/apps/media/immich/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/immich/app/cnp-allow.yaml
@@ -146,18 +146,13 @@ spec:
     ingress: false
   egress:
     # External: rclone sync to crypt:* on AWS S3 (encrypted backend
-    # over the public S3 endpoint) on :443. The :80 rule previously
-    # served immichkiosk-transcode's alpine apk pulls; that CronJob was
-    # removed, so :80 now has no known consumer and is a candidate to
-    # drop in a follow-up (left in place pending confirmation that the
-    # offsite-backup rclone path never falls back to HTTP).
+    # over the public S3 endpoint), HTTPS only. The rclone/rclone image
+    # pulls no packages and the S3 API is HTTPS, so no :80 is needed.
     - toEntities:
         - world
       toPorts:
         - ports:
             - port: "443"
-              protocol: TCP
-            - port: "80"
               protocol: TCP
     # In-cluster: rclone → garage S3 API via the cluster Service name
     # garage.storage.svc.cluster.local:3900 (rclone.conf points at


### PR DESCRIPTION
## What

Removes the `:80` world-egress port from the `immich-offsite-backup-allow` CiliumNetworkPolicy, leaving `:443` only.

## Why

That `:80` rule existed solely for the now-removed `immichkiosk-transcode` CronJob's alpine `apk add` pulls (#13006). The `immich-offsite-backup` job that actually owns this CNP is the `rclone/rclone` image:

- pulls no packages (no apk/apt),
- its external traffic is `rclone sync → AWS S3` via the `crypt:` remote (HTTPS/443),
- in-cluster Garage is covered by the separate `:3900` egress rule.

rclone does not fall back to HTTP for the S3 API, so `:80` has no remaining consumer. Completes the transcode-job removal cleanup started in #13006.

🤖 Generated with [Claude Code](https://claude.com/claude-code)