### PR TITLE
feat(immich): enable real-time transcoding via system.json

### DIFF
--- a/kubernetes/apps/media/immich/app/externalsecret.yaml
+++ b/kubernetes/apps/media/immich/app/externalsecret.yaml
@@ -22,7 +22,12 @@ spec:
           {
             "ffmpeg": {
               "targetResolution": "1080",
-              "transcode": "disabled"
+              "transcode": "disabled",
+              "realtime": {
+                "enabled": true,
+                "videoCodecs": ["h264", "hevc"],
+                "resolutions": [480, 720, 1080]
+              }
             },
             "library": {
               "watch": {


### PR DESCRIPTION
## What

Enables Immich v3's on-the-fly (real-time) transcoding by adding `ffmpeg.realtime` to the git-managed `system.json` (immich ExternalSecret).

```json
"realtime": { "enabled": true, "videoCodecs": ["h264","hevc"], "resolutions": [480,720,1080] }
```

## Why

This is the native v3 replacement for the removed `immichkiosk-transcode` CronJob (#13006 / #13007) — frame videos transcode at playback instead of being pre-generated offline. Global offline transcode stays `disabled`.

This instance runs with `IMMICH_CONFIG_FILE`, so the admin UI is read-only ("Config is currently set by a config file"). The realtime toggle can only be set in git — hence this change rather than a UI flip.

## Notes / risk

- Real-time transcoding is **EXPERIMENTAL** upstream, and this server is CPU-transcode (`accel: disabled`). Fine for the handful of short frame clips; may stutter on heavier use.
- No UI off-switch under the config-file lock — reverting this PR is the way to disable it.
- After merge + reconcile, Immich needs to pick up the changed config file; verify realtime shows enabled and test playback on a frame. A pod restart may be required if the running server doesn't hot-reload the config file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)