### PR TITLE
chore(renovate): revert two temporary rules (soak bypass + upgrade hold)

### DIFF
--- a/.github/renovate/autoMerge.json5
+++ b/.github/renovate/autoMerge.json5
@@ -86,33 +86,5 @@
       ],
       ignoreTests: true,
     },
-    {
-      // TEMPORARY — Rob asked to force this specific backlog through today
-      // (2026-07-06) despite not having soaked the standing 3-day
-      // minimumReleaseAge. Scoped to these exact packages only; revert this
-      // rule once the corresponding PRs have been created and merged.
-      description: "TEMPORARY: bypass minimumReleaseAge soak for 2026-07-09 dashboard backlog — revert after merge",
-      matchPackageNames: [
-        "docker.io/grafana/mcp-grafana",
-        "docker.io/ollama/ollama",
-        "docker.io/binwiederhier/ntfy",
-        "docker.io/cloudflare/cloudflared",
-        "docker.io/rclone/rclone",
-        "ghcr.io/frederikemmer/medialyze",
-        "ghcr.io/home-operations/qbittorrent",
-        "ghcr.io/tedornitier/immich-pet-tagger",
-        "ghcr.io/rook/rook-ceph",
-        "ghcr.io/rook/rook-ceph-cluster",
-        "ceph-csi-drivers",
-        "ghcr.io/atuinsh/atuin",
-        "ghcr.io/deliveryhero/helm-charts/node-problem-detector",
-        "ghcr.io/homeassistant-ai/ha-mcp",
-        "ghcr.io/jlesage/jdownloader-2",
-        "ghcr.io/kyverno/charts/policy-reporter",
-        "quay.io/jetstack/charts/cert-manager",
-        "lycheeverse/lychee-action",
-      ],
-      minimumReleaseAge: "0 minutes",
-    },
   ],
 }

--- a/.github/renovate/packageRules.json5
+++ b/.github/renovate/packageRules.json5
@@ -8,24 +8,6 @@
       "automerge": false
     },
     {
-      // Hold three multi-version chart jumps for manual review (2026-07-09).
-      // These accumulated large non-major gaps while stuck on HTTP
-      // HelmRepositories before the OCIRepository migration: kyverno
-      // 3.3->3.8 (admission controller — a bad minor can block cluster-wide
-      // pod admission), opentelemetry-collector 0.118->0.164 (pre-1.0, minor
-      // = routinely breaking), tempo 1.18->1.24. They are non-major so the
-      // blanket automerge rule would otherwise land them unattended; force
-      // a PR + manual changelog review instead. Remove this rule once the
-      // three are caught up.
-      "description": "Hold kyverno/otel-collector/tempo backlog jumps for manual review (2026-07-09)",
-      "matchPackageNames": [
-        "ghcr.io/kyverno/charts/kyverno",
-        "ghcr.io/open-telemetry/opentelemetry-helm-charts/opentelemetry-collector",
-        "ghcr.io/grafana/helm-charts/tempo"
-      ],
-      "automerge": false
-    },
-    {
       // Freeze jlesage/jdownloader-2 at v26.03.1 (last baseimage 4.11 build).
       // v26.07.1 moved onto baseimage-gui 4.12.x, which symlinks /run ->
       // /tmp/run; under CRI-O the container can't create /run/.containerenv


### PR DESCRIPTION
Reverts two temporary Renovate rules added 2026-07-09; both have served their purpose.

## `autoMerge.json5` — drop the `minimumReleaseAge: 0` bypass
Forced the 2026-07-09 dashboard backlog through without the standing 3-day soak. Those PRs are merged, so this restores the soak safety belt for the listed packages.

## `packageRules.json5` — drop the `automerge: false` HOLD on kyverno/otel/tempo
- otel-collector (#12970) and tempo (#12971) are upgraded.
- The **kyverno entry is dead** — kyverno was removed from the cluster (#13003 / #13004).

Non-major bumps for the remaining charts resume normal automerge.

Net: `46 deletions`, restores normal Renovate behavior. renovate-config-validator confirms both files still parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)