### PR TITLE
chore(jdownloader2): annotate v26.03.1 pin as a tracked workaround

### DIFF
--- a/.github/renovate/packageRules.json5
+++ b/.github/renovate/packageRules.json5
@@ -15,7 +15,8 @@
       // workaround exists (emptyDir at /run and /tmp/run both fail — the write
       // happens before volumes mount); the fix must be image-level. Upstream:
       // jlesage/docker-baseimage#18. Remove this rule once that lands and the
-      // new image is verified to start under CRI-O. (2026-07-10)
+      // new image is verified to start under CRI-O. Tracked:
+      // rwlove/home-ops#13010. (2026-07-10)
       description: "Hold jlesage/jdownloader-2 at v26.03.1 — baseimage 4.12.x breaks /run under CRI-O (docker-baseimage#18)",
       matchDatasources: ["docker"],
       matchPackageNames: ["ghcr.io/jlesage/jdownloader-2"],

--- a/kubernetes/apps/downloads/jdownloader2/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/jdownloader2/app/helmrelease.yaml
@@ -44,6 +44,7 @@ spec:
           app:
             image:
               repository: ghcr.io/jlesage/jdownloader-2
+              # workaround: https://github.com/jlesage/docker-baseimage/issues/18 — remove when baseimage 4.12.x's /run->/tmp/run symlink is fixed and a newer jdownloader-2 tag is verified to start under CRI-O (tracked: rwlove/home-ops#13010)
               tag: v26.03.1@sha256:3d6cb102bd9bacff12ab1ca5136a38cb8f93d6595a7ccf5bce60aac4df138ebd
 
             env:


### PR DESCRIPTION
Follow-up to #13005 (the pin). Makes the pin discoverable to the upstream-watcher per `.agents/instructions/workarounds.md`:

- Adds the fixed-format `# workaround: <upstream-url> — remove when <condition>` annotation on the pinned image tag in the HelmRelease.
- Cross-references the tracking issue from the Renovate hold comment.

Tracking issue: #13010 (labeled `workaround`, links jlesage/docker-baseimage#18).

No behavior change — comments only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)