### PR TITLE
fix(observability): rename blackbox voice-PE probe targets to match live DNS

### DIFF
--- a/kubernetes/apps/observability/exporters/blackbox-exporter/app/probes.yaml
+++ b/kubernetes/apps/observability/exporters/blackbox-exporter/app/probes.yaml
@@ -48,8 +48,8 @@ spec:
         - aquara-presense-office
         - aquara-presense-server-room
         - aquara-presense-kitchen
-        - hass-voice-1
-        - hass-voice-2
+        - hass-voice-familyroom
+        - hass-voice-bedroom
         - hass-voice-gym
         - ratgdo-primary
         - ratgdo-secondary


### PR DESCRIPTION
## What

The `devices` blackbox probe still targeted `hass-voice-1` / `hass-voice-2`, which are now **NXDOMAIN** — the two Home Assistant Voice PE units were renamed on brain's live DNS on 2026-07-09:

- `hass-voice-1` → `hass-voice-familyroom` (10.10.20.58)
- `hass-voice-2` → `hass-voice-bedroom` (10.10.20.60)
- `hass-voice-gym` (10.10.20.65) — unchanged

Verified live from in-cluster: old names resolve NXDOMAIN and were reporting `probe_success=0`; the new names resolve to .58/.60. IPs and MACs are unchanged (MAC-keyed reservations).

## Change

```diff
-        - hass-voice-1
-        - hass-voice-2
+        - hass-voice-familyroom
+        - hass-voice-bedroom
         - hass-voice-gym
```

## Related

Repo DNS snapshot (forward A, reverse PTR, dhcpd reservation) aligned in `lovenet-network-configuration` #40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)