### PR TITLE
fix(rook-ceph): disable unused leaky mgr restful module to stop OOMKill

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -79,15 +79,25 @@ spec:
       mgr:
         modules:
           - enabled: true
-
             name: rook
+          # restful is a legacy mgr module (standalone REST API on :8003) with
+          # no consumer in this cluster — nothing routes to it. It is also a
+          # known ceph-mgr memory leaker proportional to PG count
+          # (https://tracker.ceph.com/issues/40260). The active mgr grows
+          # ~300Mi/hr and OOMKills every ~5h under the 1536Mi limit; disabling
+          # unused leaky modules is the root-cause fix rather than re-raising
+          # the ceiling. dashboard + prometheus stay (both are used).
+          - enabled: false
+            name: restful
       resources:
         mgr:
           limits:
-            # Active mgr's memory creeps with enabled modules (prometheus,
-            # pg_autoscaler, balancer, devicehealth). 940Mi was too tight —
-            # the active mgr peaked at 938Mi and OOMKilled. 1.5Gi gives
-            # ~60% headroom over that peak.
+            # The active mgr leaks memory linearly (~300Mi/hr) — not a stable
+            # "creep" — driven by enabled modules (prometheus/dashboard, and
+            # formerly restful, now disabled above). 940Mi→1536Mi (#12513) only
+            # extended the OOMKill period; the real fix is cutting leak sources.
+            # Keep 1536Mi as headroom while we confirm the leak plateaus after
+            # dropping restful. Guaranteed QoS (req == limit).
             memory: 1536Mi
           requests:
             cpu: 100m


### PR DESCRIPTION
## Problem

The active ceph-mgr (`mgr.b`) **leaks memory linearly (~300 MiB/hr)** and OOMKills every ~5h — **11 restarts in 2.5 days**. The alertmanager `OOMKilled` critical latches on it.

The prior fix ([#12513](https://github.com/rwlove/home-ops/pull/12513), 940Mi→1536Mi) treated it as memory "creep" and added headroom. But there's no stable peak — the growth is unbounded, so bumping the ceiling only extends the OOMKill *period* (was ~hourly at 940Mi, now ~5-hourly at 1536Mi). The standby `mgr.a` sits dead-flat at ~144 MiB, confirming only the *active* mgr leaks.

This is a well-documented ceph-mgr leak class ([tracker #40260](https://tracker.ceph.com/issues/40260)), and three of the worst-known leaking modules are all enabled: `dashboard`, `prometheus`, `restful`.

## Fix

Disable **`restful`** — the only one of the three we don't use:
- No route, no consumer anywhere in the repo (legacy standalone REST API on :8003).
- Known heavy leaker, proportional to PG count.

`dashboard` (exposed + on the glance homepage) and `prometheus` (feeds kube-prometheus-stack) stay enabled.

Root-cause-aligned per HOMELAB-SPEC: remove an unused leaky component rather than re-raise the ceiling or add a restart-cron. GitOps-clean — rook runs `ceph mgr module disable restful` live; no mgr restart required.

## Blast radius / risk

None to data — mgr failover is clean (mons/OSDs/IO unaffected). Single-file change.

## Verification (post-merge)

Watch `mgr.b` working-set for a plateau under 1536 MiB over ~24h:
- **Plateaus** → restful was the dominant leaker; follow up by right-sizing the limit back down.
- **Still climbs** → leak is in dashboard/prometheus; escalate to a dashboard-module tune or formally workaround-track the raised limit against an upstream fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)