### PR TITLE
fix(media): penalize Scene releases in TV WEB quality profiles

### DIFF
--- a/kubernetes/apps/media/recyclarr/app/resources/recyclarr.yml
+++ b/kubernetes/apps/media/recyclarr/app/resources/recyclarr.yml
@@ -50,6 +50,7 @@ sonarr:
           - 82d40da2bc6923f41e14394075dd4b03 # No-RlsGroup
           - e1a997ddb54e3ecbfe06341ad323c458 # Obfuscated
           - 06d66ab109d4d2eddb2794d21526d140 # Retags
+          - 1b3994c551cbb92a2c781af061f4ab44 # Scene
         assign_scores_to:
           - name: WEB-1080p
           - name: WEB-2160p (Combined)


### PR DESCRIPTION
## What

Adds the Scene custom format (TRaSH default score **-10000**) to the TV WEB-1080p / WEB-2160p / Bluray+WEB-2160p quality profiles, mirroring the movie-profile config which already penalizes Scene.

## Why

The Scene CF previously scored **0** — at or above the profiles' `minFormatScore` of 0 — so a Scene release could be grabbed on a fresh episode. When a better source landed moments later and imported first, the Scene download would complete afterward, fail to import (not an upgrade), and wedge the import queue with no time-left.

Observed case: a season-premiere episode grabbed a Scene release, then grabbed + imported a proper WEB-DL ~13h later; the Scene download then sat stuck until manually removed. Scoring Scene below the floor stops the initial grab so the better source is used from the start.

## Effect

Takes effect on the next recyclarr sync after merge (`reset_unmatched_scores` manages the score). Reversible by dropping the line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)