### PR TITLE
chore: paperless securityContext hardening + drop stale Fairwinds flate tolerance

### DIFF
--- a/.github/workflows/flate.yaml
+++ b/.github/workflows/flate.yaml
@@ -82,32 +82,7 @@ jobs:
       - name: Run flate test
         env:
           FLATE_BASE: ""
-        # workaround: https://github.com/FairwindsOps/charts/issues/1879 — remove when Fairwinds re-indexes
-        # The Fairwinds Helm repo (charts.fairwinds.com, an S3/CloudFront-hosted
-        # index we can't PR) publishes an index.yaml whose `digest:` for
-        # vpa no longer matches the served .tgz, so flate correctly
-        # rejects the chart with "digest mismatch". flate has no digest-skip
-        # flag, so this wrapper tolerates ONLY that exact symptom — a
-        # `fairwinds-charts-*` HelmRelease failing with "digest mismatch" — and
-        # still fails the job on any other error (a real render error alongside
-        # it is not swallowed). When upstream re-indexes, the mismatch vanishes
-        # and this branch matches nothing, restoring normal fail-loud behavior.
-        run: |
-          set +e
-          out="$(flate test all --path "${GITHUB_WORKSPACE}/kubernetes/flux" 2>&1)"
-          rc=$?
-          set -e
-          printf '%s\n' "$out"
-          [ "$rc" -eq 0 ] && exit 0
-          clean="$(printf '%s\n' "$out" | sed 's/\x1b\[[0-9;]*m//g')"
-          failed="$(printf '%s\n' "$clean" | grep -oE '[0-9]+ failed' | grep -oE '[0-9]+' | tail -1)"
-          tolerated="$(printf '%s\n' "$clean" | grep -cE 'HelmRelease.*fairwinds-charts-.*digest mismatch' || true)"
-          if [ -n "$failed" ] && [ "$failed" -gt 0 ] && [ "$failed" -eq "$tolerated" ]; then
-            echo "::warning::flate test: tolerating ${tolerated} Fairwinds index digest mismatch(es) (vpa) — see FairwindsOps/charts#1879. All other resources passed."
-            exit 0
-          fi
-          echo "::error::flate test failed with untolerated errors (failed=${failed:-unknown}, tolerated Fairwinds digest mismatches=${tolerated})."
-          exit "$rc"
+        run: flate test all --path "${GITHUB_WORKSPACE}/kubernetes/flux"
 
   diff:
     # Diff-against-default-branch only makes sense on PRs.

--- a/kubernetes/apps/collab/paperless/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/paperless/app/helmrelease.yaml
@@ -13,12 +13,41 @@ spec:
   values:
     controllers:
       paperless:
+        pod:
+          # paperless-ngx is s6-overlay based: its preinit refuses to start
+          # unless /run is owned by uid 1000. fsGroup only sets the GID, so
+          # the chown-runtime-dirs initContainer (root + CAP_CHOWN) fixes the
+          # UID ownership of the /run and /tmp emptyDirs before app boot.
+          # See issue #12851 / #12846 (first attempt crashlooped ~16h).
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            fsGroupChangePolicy: OnRootMismatch
+
         annotations:
           reloader.stakater.com/auto: "true"
 
         type: statefulset
 
         initContainers:
+          chown-runtime-dirs:
+            image:
+              repository: public.ecr.aws/docker/library/busybox
+              tag: "1.37"
+            command:
+              - sh
+              - -c
+              - chown 1000:1000 /run /tmp
+            securityContext:
+              runAsNonRoot: false
+              runAsUser: 0
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop: ["ALL"]
+                add: ["CHOWN"]
           init-db:
             image:
               repository: ghcr.io/home-operations/postgres-init
@@ -70,6 +99,15 @@ spec:
                 # headroom bump for the rare large-document burst.
                 memory: 5Gi
 
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+              seccompProfile:
+                type: RuntimeDefault
+
     service:
       app:
         controller: paperless
@@ -98,3 +136,15 @@ spec:
     persistence:
       library:
         existingClaim: paperless-library-pvc
+      # s6-overlay writes supervision state to /run; readOnlyRootFilesystem
+      # forces these onto tmpfs. chown-runtime-dirs sets uid-1000 ownership.
+      run:
+        type: emptyDir
+        medium: Memory
+        globalMounts:
+          - path: /run
+      tmp:
+        type: emptyDir
+        medium: Memory
+        globalMounts:
+          - path: /tmp


### PR DESCRIPTION
Two verified housekeeping wins from the open-issue audit.

## 1. Harden paperless securityContext — Closes #12851

Re-does the non-root + \`readOnlyRootFilesystem\` hardening that #12846 attempted and #12850 reverted after a ~16h crashloop.

**Root cause of the original failure:** paperless-ngx is s6-overlay based — its \`preinit\` aborts unless \`/run\` is owned by **uid 1000**. \`fsGroup\` only sets the GID, so the tmpfs emptyDir root stayed uid 0 and preinit failed.

**Fix:** a root init-container (\`runAsUser: 0\` + \`CAP_CHOWN\`, otherwise fully locked down) chowns the \`/run\` and \`/tmp\` tmpfs emptyDirs to \`1000:1000\` before the app container starts.

**Validated in a scratch pod** mirroring the StatefulSet fsGroup/emptyDir semantics (the #12846 scratch test did not reproduce real ownership and passed a config that failed in prod). Under the full hardened context the boot cleared preinit:

```
[init-start] paperless-ngx docker container running under a user (1000:1000)
[init-folders] Running in non-root mode, checking directories
```

…and proceeded normally under \`readOnlyRootFilesystem\` (only stalling on the DB, which the scratch pod lacks).

Applied baseline: pod \`runAsNonRoot\`/1000 + \`fsGroup\` 1000; app container \`allowPrivilegeEscalation: false\`, \`readOnlyRootFilesystem: true\`, drop ALL caps, RuntimeDefault seccomp.

**Service impact:** paperless is a StatefulSet — merging triggers a pod restart. Routine/internal service; fits any-night 02:00–05:00 if you want to time it.

## 2. Drop Fairwinds digest-mismatch flate tolerance — Closes #12758

FairwindsOps/charts#1879 is resolved. Verified live that \`charts.fairwinds.com\` now serves an \`index.yaml\` whose digests **match** the served \`.tgz\` for both **vpa 4.12.2** and **goldilocks 10.4.0** (index digest == tgz sha256). The flate-test wrapper that tolerated the mismatch is obsolete; reverted to a plain \`flate test all\`, restoring fail-loud behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)