### PR TITLE
feat(observability): re-introduce BackupStale CNPG alert via KSM CRSM

### DIFF
--- a/kubernetes/apps/databases/cloudnative-pg/app/prometheusrule.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/app/prometheusrule.yaml
@@ -74,12 +74,35 @@ spec:
           for: 5m
           labels:
             severity: warning
-        # TODO: re-introduce BackupStale once a CustomResourceStateMetrics config
-        # exposes Cluster.status.conditions[type=LastBackupSucceeded] as a metric.
-        # cnpg_collector_last_available_backup_timestamp is unreliable for plugin-method
-        # clusters — it freezes at the migration timestamp instead of advancing on each
-        # successful backup (verified 2026-05-25, all 6 "stale" clusters are actually
-        # healthy). Tracking: https://github.com/rwlove/home-ops/issues/12075
+        # BackupStale — no successful backup in too long, complementary to
+        # BackupFailed (which catches recent explicit failures). Signal is
+        # kube-state-metrics CRSM over Cluster.status.conditions: the metric
+        # cnpg_cluster_condition_last_transition_time carries lastTransitionTime
+        # (epoch seconds) labeled by condition type+status. We watch the
+        # LastBackupSucceeded condition. cnpg_collector_last_available_backup_timestamp
+        # is unreliable for plugin-method clusters — it freezes at the migration
+        # timestamp instead of advancing per successful backup (verified 2026-05-25,
+        # all 6 "stale" clusters were actually healthy). See #12075.
+        #
+        # No-data-on-failure edge case: CRSM emits one series per condition
+        # reflecting its CURRENT status, so the {status="True"} series DISAPPEARS
+        # the moment a backup is failing. A naive `time() - max(...{status="True"})`
+        # would then go empty and silently miss a stuck-failing cluster. We instead
+        # alert on staleness of the LastBackupSucceeded transition REGARDLESS of
+        # status (drop the status label with max by), so a cluster stuck at
+        # status="False" whose last success is >26h old still trips. Once a backup
+        # succeeds again the transition time advances and the alert clears.
+        - alert: BackupStale
+          annotations:
+            description: Cluster {{ $labels.cluster }} in {{ $labels.namespace }} has had no successful backup in over 26 hours.
+            summary: CNPG cluster backup is stale.
+          expr: |-
+            time() - max by (cluster, namespace) (
+              cnpg_cluster_condition_last_transition_time{type="LastBackupSucceeded"}
+            ) > 26 * 3600
+          for: 30m
+          labels:
+            severity: warning
         # changes()[25h] false-fires when the gauge is re-emitted after a CNPG
         # pod restart, even when the last failure is weeks old (same gauge
         # re-emission problem documented for BackupStale above). Gate on the

--- a/kubernetes/apps/observability/kube-state-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-state-metrics/app/helmrelease.yaml
@@ -12,10 +12,46 @@ spec:
   values:
     fullnameOverride: kube-state-metrics
 
+    # Expose CNPG Cluster.status.conditions as metrics. plugin-method
+    # barman-cloud clusters make cnpg_collector_last_available_backup_timestamp
+    # unreliable (freezes at the migration timestamp), so the reliable
+    # backup-recency signal is the LastBackupSucceeded condition's
+    # lastTransitionTime, which advances on every successful backup.
+    # Consumed by the BackupStale alert (cloudnative-pg-rules). See #12075.
+    customResourceState:
+      enabled: true
+      config:
+        spec:
+          resources:
+            - groupVersionKind:
+                group: postgresql.cnpg.io
+                kind: Cluster
+                version: v1
+              labelsFromPath:
+                cluster: [metadata, name]
+                namespace: [metadata, namespace]
+              metricNamePrefix: cnpg_cluster
+              metrics:
+                - name: condition_last_transition_time
+                  help: Unix timestamp of the last transition of a CNPG Cluster status condition
+                  each:
+                    type: Gauge
+                    gauge:
+                      path: [status, conditions]
+                      labelsFromPath:
+                        status: [status]
+                        type: [type]
+                      valueFrom: [lastTransitionTime]
     prometheus:
       monitor:
         enabled: true
         honorLabels: true
+    rbac:
+      # CRSM needs read access to the CNPG Cluster CR (see customResourceState).
+      extraRules:
+        - apiGroups: [postgresql.cnpg.io]
+          resources: [clusters]
+          verbs: [list, watch]
     resources:
       requests:
         cpu: 10m


### PR DESCRIPTION
Closes #12075.

Re-introduces the `BackupStale` alert deleted when both `cnpg_collector_last_*_backup_timestamp` metrics proved unreliable for barman-cloud plugin-method clusters (they freeze at the ~2026-02-15 migration timestamp — all 6 clusters read ~99d "stale" while healthy, verified 2026-05-25).

## Reliable signal
CNPG `Cluster.status.conditions[type=LastBackupSucceeded].lastTransitionTime` advances on every successful plugin-method backup (verified live: all clusters show todays staggered 04:00–04:10 backup window). Exposed as a metric via kube-state-metrics CustomResourceStateMetrics.

## Changes
1. **kube-state-metrics HR** — `customResourceState` config emitting `cnpg_cluster_condition_last_transition_time{cluster,namespace,type,status}` (KSM v2.19.1 Gauge auto-parses the RFC3339 timestamp → epoch seconds), plus `rbac.extraRules` for `list`/`watch` on `postgresql.cnpg.io/clusters`.
2. **cloudnative-pg PrometheusRule** — the `BackupStale` alert (replaces the `#12075` TODO placeholder), `for: 30m`, `severity: warning`.

## Alert expr + edge-case handling
```
time() - max by (cluster, namespace) (
  cnpg_cluster_condition_last_transition_time{type="LastBackupSucceeded"}
) > 26 * 3600
```
CRSM emits one series per condition reflecting its *current* status, so filtering on `{status="True"}` would make the series vanish the instant a backup fails — silently missing a stuck cluster. Instead it filters only on `type="LastBackupSucceeded"` and drops the status label via `max by`, so a cluster stuck at `status="False"` whose last success is >26h old **still trips**. Complementary to the existing `BackupFailed` (recent explicit failure).

## Post-merge validation (metric does not emit until KSM redeploys)
```promql
cnpg_cluster_condition_last_transition_time{type="LastBackupSucceeded"}   # expect 6 series
time() - max by (cluster, namespace) (cnpg_cluster_condition_last_transition_time{type="LastBackupSucceeded"})  # << 93600 for all
```
Also confirm RBAC bound: `kubectl auth can-i list clusters.postgresql.cnpg.io --as=system:serviceaccount:observability:kube-state-metrics`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)