### PR TITLE
feat(network): tighten renovate-operator egress to toFQDNs (canary)

### DIFF
--- a/kubernetes/apps/renovate/renovate-operator/app/cnp-allow.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/app/cnp-allow.yaml
@@ -34,16 +34,17 @@ spec:
     # spawned RenovateJob pods (covered by renovate-jobs-allow in
     # ../jobs/).
     #
-    # Was a toFQDNs allow-list (api.github.com, github.com — with
-    # matchPattern + `.*` variants per the search-domain hack from
-    # PR #11492). Even with that workaround Cilium 1.19 doesn't
-    # reliably match through Kubernetes pod DNS search-domain
-    # augmentation (pod queries
-    # `api.github.com.renovate.svc.cluster.local.`; FQDN cache stores
-    # the augmented name; matching is unreliable). Broadened to
-    # toEntities:world:443 so it actually works. Tighten when FQDN
-    # matching is fixed.
-    - toEntities: [world]
+    # Tightened from toEntities:[world]:443 back to a toFQDNs allow-list
+    # (home-ops#11851). The search-domain-augmentation bug (cilium#20191)
+    # that forced the world:443 workaround no longer fires: PR #12482
+    # removed CoreDNS `autopath @kubernetes`, so Cilium's DNS proxy sees
+    # the bare-name query and caches these canonical A-record hosts under
+    # the bare name. matchName works (verified on Cilium 1.19.5). L7 DNS
+    # proxy visibility is provided namespace-wide by the baseline
+    # allow-dns component. NB: regresses if autopath is re-enabled.
+    - toFQDNs:
+        - matchName: api.github.com
+        - matchName: github.com
       toPorts:
         - ports:
             - port: "443"


### PR DESCRIPTION
Canary for the #11851 CNP tightening sweep — renovate-operator first (low blast radius).

## Change
Replaces the renovate-operator `toEntities:[world]:443` egress with a `toFQDNs.matchName` allow-list for `api.github.com` + `github.com`.

## Why it now works
The `world:443` rule existed solely as the cilium#20191 workaround (K8s search-domain augmentation broke `toFQDNs` for canonical FQDNs). That bug stopped firing when **PR #12482 removed CoreDNS `autopath @kubernetes`** — Cilium's DNS proxy now sees the bare-name query and caches `api.github.com`/`github.com` under the bare name, so `matchName` matches. Verified on Cilium 1.19.5 via the #11851 scratch-ns test. L7 DNS proxy visibility is provided namespace-wide by the baseline `allow-dns` component.

## Post-merge validation (before proceeding to external-secrets)
- Hubble: confirm renovate-operator egress to GitHub is FORWARDED and matches the FQDN rule (not dropped).
- Confirm the operator still reaches `api.github.com` (repo discovery / PR state) — no `context deadline exceeded`.

Tripwire: regresses if CoreDNS autopath is ever re-enabled. `world:443` is a one-line revert if anything is off.

Refs #11851

🤖 Generated with [Claude Code](https://claude.com/claude-code)
