### PR TITLE
feat(network): tighten external-secrets egress to toFQDNs (#11851 stage 2)

### DIFF
--- a/kubernetes/apps/external-secrets/external-secrets/app/cnp-allow-controller.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/app/cnp-allow-controller.yaml
@@ -15,18 +15,22 @@ spec:
     egress: false
     ingress: false
   egress:
-    # workaround: https://github.com/cilium/cilium/issues/20191 — remove when canonical-FQDN matchPattern matches reliably through K8s DNS search-domain augmentation
-    # Tracking: home-ops#11851
     # GithubAccessToken generator (renovate/github-auth-token ES) runs
     # IN the controller process and POSTs to api.github.com for App
     # installation token minting. Without this, ExternalSecrets using
     # GithubAccessToken fail with "context deadline exceeded" — surfaced
     # 2026-05-18 as renovate/github-auth-token failing for ~90min after
     # the external-secrets ns default-deny landed (PR #11572).
-    # api.github.com is canonical FQDN (no CNAME chain) — matchPattern
-    # silently fails per memory cilium-matchpattern-fqdn-limits, so use
-    # toEntities:[world]:443.
-    - toEntities: [world]
+    #
+    # Tightened from toEntities:[world]:443 back to toFQDNs.matchName
+    # (home-ops#11851). The search-domain-augmentation bug (cilium#20191)
+    # that forced world:443 no longer fires: PR #12482 removed CoreDNS
+    # `autopath @kubernetes`, so Cilium's DNS proxy caches api.github.com
+    # under the bare name and matchName matches (verified on Cilium
+    # 1.19.5). L7 DNS proxy visibility is provided namespace-wide by the
+    # baseline allow-dns component. NB: regresses if autopath re-enabled.
+    - toFQDNs:
+        - matchName: api.github.com
       toPorts:
         - ports:
             - port: "443"

--- a/kubernetes/apps/external-secrets/onepassword-connect/app/cnp-allow.yaml
+++ b/kubernetes/apps/external-secrets/onepassword-connect/app/cnp-allow.yaml
@@ -16,19 +16,20 @@ spec:
     egress: false
     ingress: false
   egress:
-    # 1Password Cloud (sync container only). Was a toFQDNs allow-list
-    # for `my.1password.com`. Cilium 1.19 matchPattern's `.*` token
-    # expands to `[-a-zA-Z0-9_]*` (single DNS label) in the generated
-    # regex, so the dual-form `my.1password.com` + `my.1password.com.*`
-    # pattern doesn't match the search-domain-augmented form actually
-    # cached in this cluster:
-    #   `my.1password.com.external-secrets.svc.cluster.local.`
-    # (four trailing labels — see PR #11512 follow-up). Broadened to
-    # toEntities:world:443 so it actually works. Tighten when FQDN
-    # search-domain augmentation in Cilium policy is fixed upstream
-    # (track PR #11498 / mcp-system precedent).
-    - toEntities:
-        - world
+    # 1Password Cloud (sync container only) — my.1password.com.
+    #
+    # Tightened from toEntities:world:443 back to toFQDNs.matchName
+    # (home-ops#11851). The search-domain-augmentation bug that forced
+    # world:443 (pod queried `my.1password.com.external-secrets.svc.
+    # cluster.local.`; the augmented form was cached, not the bare name)
+    # no longer fires: PR #12482 removed CoreDNS `autopath @kubernetes`,
+    # so Cilium's DNS proxy caches my.1password.com under the bare name
+    # and matchName matches (verified on Cilium 1.19.5). matchName follows
+    # the CNAME chain, so it covers the resolved edge IPs. L7 DNS proxy
+    # visibility is provided namespace-wide by the baseline allow-dns
+    # component. NB: regresses if autopath is re-enabled.
+    - toFQDNs:
+        - matchName: my.1password.com
       toPorts:
         - ports:
             - port: "443"


### PR DESCRIPTION
Second stage of the #11851 CNP tightening — after the renovate-operator canary (#13041) validated clean on Cilium 1.19.5 (FQDN cache populated under bare name, zero DROPs, operator healthy).

## Change
Two CNPs in the `external-secrets` namespace swap `toEntities:[world]:443` → `toFQDNs.matchName`:
- `external-secrets` controller → `api.github.com` (GithubAccessToken minting)
- `onepassword-connect` sync → `my.1password.com` (matchName follows the CNAME chain)

## Why it now works
Both used `world:443` solely as the cilium#20191 workaround (search-domain augmentation broke `toFQDNs`). **PR #12482 removed CoreDNS `autopath @kubernetes`**, so Cilium caches these hosts under the bare name and `matchName` matches. L7 DNS proxy visibility is provided namespace-wide by the baseline `allow-dns` component.

## Blast radius + validation
`external-secrets` namespace enforces default-deny, and the controller path has a documented 90-min outage precedent (2026-05-18) when this egress was cut. **Post-merge validation before closing #11851:**
- Hubble: `external-secrets` egress to `api.github.com` and `my.1password.com` FORWARDED, zero DROPs.
- ExternalSecrets stay `SecretSynced` (esp. `renovate/github-auth-token` — the GithubAccessToken path).
- onepassword-connect sync healthy (no 1Password cloud reachability errors).

`world:443` is a one-line revert if anything regresses. Tripwire: re-enabling CoreDNS autopath regresses this.

Refs #11851

🤖 Generated with [Claude Code](https://claude.com/claude-code)
