### PR TITLE
fix(network): revert onepassword-connect egress to world:443

### DIFF
--- a/kubernetes/apps/external-secrets/onepassword-connect/app/cnp-allow.yaml
+++ b/kubernetes/apps/external-secrets/onepassword-connect/app/cnp-allow.yaml
@@ -16,20 +16,20 @@ spec:
     egress: false
     ingress: false
   egress:
-    # 1Password Cloud (sync container only) — my.1password.com.
-    #
-    # Tightened from toEntities:world:443 back to toFQDNs.matchName
-    # (home-ops#11851). The search-domain-augmentation bug that forced
-    # world:443 (pod queried `my.1password.com.external-secrets.svc.
-    # cluster.local.`; the augmented form was cached, not the bare name)
-    # no longer fires: PR #12482 removed CoreDNS `autopath @kubernetes`,
-    # so Cilium's DNS proxy caches my.1password.com under the bare name
-    # and matchName matches (verified on Cilium 1.19.5). matchName follows
-    # the CNAME chain, so it covers the resolved edge IPs. L7 DNS proxy
-    # visibility is provided namespace-wide by the baseline allow-dns
-    # component. NB: regresses if autopath is re-enabled.
-    - toFQDNs:
-        - matchName: my.1password.com
+    # 1Password Cloud (sync container only). Stays on toEntities:world:443
+    # — it is NOT a single-canonical-host case. The sync container talks to
+    # BOTH `my.1password.com` (direct A-records) AND `b5n.1password.com`,
+    # the real-time sync/events backend, which is CloudFront-fronted
+    # (CNAME → 13.35.x / 2600:9000). A matchName:my.1password.com tightening
+    # (attempted under home-ops#11851, verified-broken 2026-07-12: b5n
+    # SYNs Policy-denied DROPPED in Hubble) severs the events channel;
+    # matchName:b5n is fragile (1Password rotates the sync-backend host),
+    # and matchPattern:*.1password.com hits Cilium's matchPattern CNAME-
+    # following gap (project_cilium_matchpattern_fqdn_limits) since b5n is
+    # CNAME-fronted. So world:443 is the correct tier here — same class as
+    # the other CNAME/wildcard-fronted egress rules that keep world:443.
+    - toEntities:
+        - world
       toPorts:
         - ports:
             - port: "443"


### PR DESCRIPTION
Reverts the onepassword-connect half of #13042. **Active-degradation fix.**

## What broke
The `matchName: my.1password.com` tightening severed onepassword-connect's **second** egress host — `b5n.1password.com`, the real-time sync/events backend (CloudFront-fronted, `13.35.x`). Hubble confirmed the b5n SYNs were `Policy denied DROPPED`. Cached secrets still served (ESO reads OK), but the events channel was down.

## Why onepassword-connect keeps world:443
Not a single-canonical-host case:
- `b5n.1password.com` is **CNAME-fronted** → Cilium's matchPattern CNAME-following gap (`project_cilium_matchpattern_fqdn_limits`).
- 1Password **rotates** the sync-backend host → `matchName:b5n` is fragile.

So `world:443` is the correct tier — same class as the other CNAME/wildcard-fronted rules that keep it. The **external-secrets controller** (`api.github.com`, single canonical host) stays tightened — that half is validated working.

## Lesson
The #11851 classification was too optimistic for onepassword-connect: the in-file comment named only `my.1password.com`, but the app also hits the b5n sync backend. Caught by the post-merge Hubble validation; `world:443` restored.

Refs #11851

🤖 Generated with [Claude Code](https://claude.com/claude-code)
