### PR TITLE
fix(observability): widen CNPG BackupStale threshold 26h → 8d for weekly cadence

### DIFF
--- a/kubernetes/apps/databases/cloudnative-pg/app/prometheusrule.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/app/prometheusrule.yaml
@@ -90,16 +90,24 @@ spec:
         # would then go empty and silently miss a stuck-failing cluster. We instead
         # alert on staleness of the LastBackupSucceeded transition REGARDLESS of
         # status (drop the status label with max by), so a cluster stuck at
-        # status="False" whose last success is >26h old still trips. Once a backup
+        # status="False" whose last success is >8d old still trips. Once a backup
         # succeeds again the transition time advances and the alert clears.
+        #
+        # Threshold is 8 days, not 26h: every cluster backs up @weekly (168h) via
+        # the shared cnpg-app-database component's ScheduledBackup — no cluster is
+        # on a daily cadence. A 26h threshold false-fires ~6 of every 7 days on a
+        # healthy weekly cluster. 8d = one full week + 24h grace, so it only trips
+        # on a genuinely missed cycle. Fast detection of a backup that RAN AND
+        # FAILED is already covered by BackupFailed below (<24h on the failure
+        # timestamp); BackupStale is the backstop for "nothing happened at all".
         - alert: BackupStale
           annotations:
-            description: Cluster {{ $labels.cluster }} in {{ $labels.namespace }} has had no successful backup in over 26 hours.
+            description: Cluster {{ $labels.cluster }} in {{ $labels.namespace }} has had no successful backup in over 8 days.
             summary: CNPG cluster backup is stale.
           expr: |-
             time() - max by (cluster, namespace) (
               cnpg_cluster_condition_last_transition_time{type="LastBackupSucceeded"}
-            ) > 26 * 3600
+            ) > 8 * 24 * 3600
           for: 30m
           labels:
             severity: warning


### PR DESCRIPTION
## Problem

All 20 CNPG clusters back up `@weekly` (168h) via the shared `cnpg-app-database` ScheduledBackup component — none are on a daily cadence. The `BackupStale` alert threshold of **26h** assumes daily backups, so on a healthy weekly cluster it false-fires roughly **6 of every 7 days**. This morning that was **20 simultaneous `BackupStale` pages** to Pushover for a non-problem (Garage backend verified healthy, live WAL PUTs in progress during triage).

That's the textbook flap that trains the recipient to ignore the notification surface.

## Fix

Widen the threshold to **8 days** (`8 * 24 * 3600`) — one full week + 24h grace — so it only trips on a genuinely missed backup cycle.

## Why this is safe (no detection gap)

Fast detection of a backup that **ran and failed** is already handled by the separate `BackupFailed` alert in the same rule file, which fires within 24h off `cnpg_collector_last_failed_backup_timestamp`. `BackupStale` is only the backstop for "no backup happened at all / stuck archiver" — widening it does not slow detection of active failures.

## Scope

- Single file: `kubernetes/apps/databases/cloudnative-pg/app/prometheusrule.yaml`
- Threshold + description + explanatory comment. No change to `BackupFailed` or any other rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)