### PR TITLE
fix(media): raise soularr memory 768Mi → 1536Mi to stop recurring OOMKill

### DIFF
--- a/kubernetes/apps/media/soularr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/soularr/app/helmrelease.yaml
@@ -55,9 +55,13 @@ spec:
             resources:
               requests:
                 cpu: 10m
-                memory: 512Mi
-              limits:
                 memory: 768Mi
+              limits:
+                # 768Mi limit OOMKilled 8× — soularr builds an in-memory
+                # user/directory cache while processing large Soulseek search
+                # results. 1536Mi gives 2× burst headroom; request/limit gap
+                # kept deliberately (req==lim invites OOMKill under spikes).
+                memory: 1536Mi
 
             securityContext:
               allowPrivilegeEscalation: false


### PR DESCRIPTION
## Problem

`soularr` has **8 lifetime OOMKill restarts** against its `768Mi` memory limit — surfaced in the last-12h alert triage (3 `OOMKilled` segments overnight, last ~1 AM ET). It builds an in-memory user/directory cache while processing large Soulseek search results and overruns the ceiling. This is a real, recurring resource-sizing bug, not a one-off spike.

## Fix

- `requests.memory`: `512Mi` → `768Mi` (reflects real baseline)
- `limits.memory`: `768Mi` → `1536Mi` (2× burst headroom)

Request/limit gap kept deliberately — `req==lim` makes a spike an immediate OOMKill (per prior cluster experience with req==lim traps).

## Scope

Single file: `kubernetes/apps/media/soularr/app/helmrelease.yaml`. No behavior change beyond the resource envelope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)