### PR TITLE
docs(gpu-routing): GB10 power/clock gotcha + community model picks

### DIFF
--- a/.agents/instructions/gpu-routing.md
+++ b/.agents/instructions/gpu-routing.md
@@ -37,6 +37,50 @@ below; nothing was migrated because there was nothing left to migrate.
 - Only `POWER_USAGE` and `SM_CLOCK` report.
 - Use power draw as proxy for "is GB10 busy" in dashboards and alerts.
 
+## GB10 power-delivery / clock-limit gotcha
+
+Community-reported (NVIDIA DGX Spark GB10 forum + r/LocalLLM), not yet
+independently reproduced on our unit — treat as a lead, not gospel:
+
+- There's a **power-delivery bug** that sneakily degrades throughput.
+  A reboot does **not** clear it; check the NVIDIA dev forum GB10
+  category if the Spark feels slow with no obvious cause. Pairs with
+  the DCGM caveat above — since `POWER_USAGE` is one of the few live
+  counters, watch it for anomalies.
+- Two operational levers users run to keep it stable:
+
+  ```sh
+  # drop page-cache remnants periodically
+  sudo sh -c 'sync; echo 3 > /proc/sys/vm/drop_caches'
+  # cap GPU clocks if you hit crashes under load
+  sudo nvidia-smi -lgc 200,2300
+  ```
+
+  The clock cap trades a little peak throughput for stability; only
+  reach for it if the Spark is crashing under inference load.
+
+## Community model picks for a single GB10 (reference)
+
+External signal from r/LocalLLM DGX Spark owners — anchors for what
+"larger → Spark" means in practice. Not a mandate; we haven't
+benchmarked these on our unit:
+
+- **Qwen 3.5 122B-A10B** — the common single-Spark top pick; users
+  report comfortable 192k-token context.
+- **Qwen 3.6 27B (with MTP) / 35B-A3B** — faster MoE option; the
+  35B-A3B reportedly follows the Claude/opencode/codex agentic-coding
+  loop better.
+- **MiniMax M2.7 AWQ 4-bit** — favored on 2× Spark clusters (~25 tok/s
+  on a 110k-token session, ~2K tok/s prompt-processing); too big for a
+  single node.
+- Utility models people co-locate until capacity-bound: **bge-m3**
+  (embeddings, which we already run), **Parakeet** / **Qwen TTS**
+  (speech).
+- Serving consensus is **vLLM over Ollama** for the Spark (headless
+  inference server), vs the P40's current Ollama serving.
+
+Benchmarks aggregator: <https://spark-arena.com>.
+
 ## Routing decisions
 
 - Rule of thumb: ≤8b → P40; larger → Spark (until the Spark migration


### PR DESCRIPTION
## What

Adds two sections to `.agents/instructions/gpu-routing.md` capturing external signal from the r/LocalLLM DGX Spark thread and the NVIDIA GB10 forum:

1. **GB10 power-delivery / clock-limit gotcha** — the power-delivery bug (reboot doesn't clear it), plus the `drop_caches` and `nvidia-smi -lgc 200,2300` stability levers. Cross-linked to the existing DCGM `POWER_USAGE` caveat.
2. **Community model picks for a single GB10** — Qwen 3.5 122B-A10B, Qwen 3.6 27B/35B-A3B, MiniMax M2.7 AWQ (2× cluster only), co-located utility models, and the vLLM-over-Ollama serving consensus.

## Why

Concrete anchors for what "larger → Spark" means in practice, and operational gotchas worth knowing before/during the Spark migration.

## Notes

- Flagged explicitly as **community-reported / not yet reproduced on our unit** — not verified cluster facts.
- Routing rule of thumb (`≤8b → P40; larger → Spark`) **unchanged** pending a real GB10 benchmark.
- Docs-only; no manifest or runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)