### PR TITLE
feat(jdownloader2): retire /run CRI-O workaround, bump to v26.07.2

### DIFF
--- a/.github/renovate/packageRules.json5
+++ b/.github/renovate/packageRules.json5
@@ -8,21 +8,6 @@
       "automerge": false
     },
     {
-      // Freeze jlesage/jdownloader-2 at v26.03.1 (last baseimage 4.11 build).
-      // v26.07.1 moved onto baseimage-gui 4.12.x, which symlinks /run ->
-      // /tmp/run; under CRI-O the container can't create /run/.containerenv
-      // at create time and never starts (CreateContainerError). No pod-level
-      // workaround exists (emptyDir at /run and /tmp/run both fail — the write
-      // happens before volumes mount); the fix must be image-level. Upstream:
-      // jlesage/docker-baseimage#18. Remove this rule once that lands and the
-      // new image is verified to start under CRI-O. Tracked:
-      // rwlove/home-ops#13010. (2026-07-10)
-      description: "Hold jlesage/jdownloader-2 at v26.03.1 — baseimage 4.12.x breaks /run under CRI-O (docker-baseimage#18)",
-      matchDatasources: ["docker"],
-      matchPackageNames: ["ghcr.io/jlesage/jdownloader-2"],
-      enabled: false,
-    },
-    {
       "matchDatasources": ["docker", "github-tags"],
       "matchPackageNames": ["ghcr.io/fluxcd/flux-manifests", "fluxcd/flux2"],
       "groupName": "fluxcd/flux2"

--- a/kubernetes/apps/downloads/jdownloader2/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/jdownloader2/app/helmrelease.yaml
@@ -44,8 +44,7 @@ spec:
           app:
             image:
               repository: ghcr.io/jlesage/jdownloader-2
-              # workaround: https://github.com/jlesage/docker-baseimage/issues/18 — remove when baseimage 4.12.x's /run->/tmp/run symlink is fixed and a newer jdownloader-2 tag is verified to start under CRI-O (tracked: rwlove/home-ops#13010)
-              tag: v26.03.1@sha256:3d6cb102bd9bacff12ab1ca5136a38cb8f93d6595a7ccf5bce60aac4df138ebd
+              tag: v26.07.2@sha256:47ee6c64917ca5326516ebe868714709c6bdd2e08ca0e33f6e80a943ef2019d2
 
             env:
               # jlesage's baseimage handles user creation/drop via these env vars.


### PR DESCRIPTION
## What

Retires workaround #13010. Upstream [jlesage/docker-baseimage#18](https://github.com/jlesage/docker-baseimage/issues/18) is fixed — baseimage restores `/run` as a real directory (commit `afc71c9`, shipped in baseimage v3.11.8 → baseimage-gui v4.12.6). jdownloader-2 `v26.07.2` builds `FROM jlesage/baseimage-gui:alpine-3.24-v4.12.6`, so the dangling `/run -> /tmp/run` symlink no longer breaks container-create under CRI-O.

## Changes

- **`helmrelease.yaml`** — bump `v26.03.1` → `v26.07.2` (index digest pinned), drop the `# workaround:` annotation.
- **`packageRules.json5`** — remove the Renovate hold; normal updates re-enabled.

## Verification

Ran a `v26.07.2` probe pod in `downloads` on **worker7 (CRI-O 1.35.2)** — the exact runtime that failed before:

- No `CreateContainerError` / `openat2 'run'` failure at container-create.
- `cont-init` completed clean (no EBUSY abort), all services started, nginx on 5800.
- `restarts=0`, `ready=true`. Probe torn down after.

This satisfies the workaround's own "remove when … verified to start under CRI-O" gate.

## Notes

- 2-major image jump (v26.03 → v26.07); JDownloader is backward-compatible on `/config`.
- The separate `init-users-fix` ConfigMap override (unrelated to #18) is left in place.
- Flux rolls the live pod on merge — `downloads` ns is Routine (not Renee-facing).

Closes #13010