### PR TITLE
fix(flux): exempt secret-placeholder CMs from strict postBuild substitution

### DIFF
--- a/kubernetes/apps/home/aquapured/app/configmap.yaml
+++ b/kubernetes/apps/home/aquapured/app/configmap.yaml
@@ -8,6 +8,11 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: aquapured-config
+  annotations:
+    # Flux 2.9 makes postBuild substitution strict; exempt this ConfigMap so
+    # the literal ${MQTT_USER}/${MQTT_PASSWD} placeholders pass through for the
+    # container entrypoint's envsubst to fill from the aquapured Secret.
+    kustomize.toolkit.fluxcd.io/substitute: disabled
 data:
   aquapured.conf.tmpl: |
     [AQUACONTROLD]
@@ -30,10 +35,11 @@ data:
     # parser silently drops. Mosquitto is lenient, accepts it, and bridges
     # aquapured/# to EMQX. (Address still kept short for the [20] buffer.)
     MQTT_ADDRESS = 127.0.0.1:1883
-    # $$ escapes Flux post-build substitution so the literal ${MQTT_USER}
-    # placeholder survives into the cluster for the container's envsubst to fill.
-    MQTT_USER = $${MQTT_USER}
-    MQTT_PASSWD = $${MQTT_PASSWD}
+    # Flux substitution is disabled on this ConfigMap (metadata annotation), so
+    # these literal placeholders survive for the container entrypoint's envsubst
+    # to fill from the aquapured Secret.
+    MQTT_USER = ${MQTT_USER}
+    MQTT_PASSWD = ${MQTT_PASSWD}
     MQTT_TOPIC = aquapured
 
     # Disable Domoticz integration (no DZIDX_SWG_STATUS_ALERT_SENSOR needed).

--- a/kubernetes/apps/mcp-system/github-mcp/app/kustomization.yaml
+++ b/kubernetes/apps/mcp-system/github-mcp/app/kustomization.yaml
@@ -14,3 +14,8 @@ configMapGenerator:
       - default.conf.template=./resources/default.conf.template
 generatorOptions:
   disableNameSuffixHash: true
+  annotations:
+    # Flux 2.9 makes postBuild substitution strict; exempt the generated CM so
+    # the literal ${GITHUB_PERSONAL_ACCESS_TOKEN} placeholder passes through for
+    # nginx's envsubst to fill from the env var at startup.
+    kustomize.toolkit.fluxcd.io/substitute: disabled

--- a/kubernetes/apps/mcp-system/github-mcp/app/resources/default.conf.template
+++ b/kubernetes/apps/mcp-system/github-mcp/app/resources/default.conf.template
@@ -33,11 +33,11 @@ server {
 
         proxy_http_version 1.1;
         proxy_set_header Connection "";
-        # `$${GITHUB_PERSONAL_ACCESS_TOKEN}` (double-$) escapes Flux
-        # postBuild substitution — Flux renders it back to
-        # `${GITHUB_PERSONAL_ACCESS_TOKEN}`, which nginx's envsubst then
-        # expands from the env var at startup.
-        proxy_set_header Authorization "Bearer $${GITHUB_PERSONAL_ACCESS_TOKEN}";
+        # Flux postBuild substitution is disabled on this generated CM (see the
+        # kustomization's generatorOptions.annotations), so `${GITHUB_PERSONAL_ACCESS_TOKEN}`
+        # passes through literally for nginx's envsubst to expand from the env
+        # var at startup.
+        proxy_set_header Authorization "Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}";
 
         # SSE / streamable-HTTP friendliness — the MCP transport streams.
         proxy_buffering off;

--- a/kubernetes/apps/mcp-system/windmill-mcp/app/kustomization.yaml
+++ b/kubernetes/apps/mcp-system/windmill-mcp/app/kustomization.yaml
@@ -14,3 +14,8 @@ configMapGenerator:
       - default.conf.template=./resources/default.conf.template
 generatorOptions:
   disableNameSuffixHash: true
+  annotations:
+    # Flux 2.9 makes postBuild substitution strict; exempt the generated CM so
+    # the literal ${WINDMILL_TOKEN} placeholder passes through for nginx's
+    # envsubst to fill from the env var at startup.
+    kustomize.toolkit.fluxcd.io/substitute: disabled

--- a/kubernetes/apps/mcp-system/windmill-mcp/app/resources/default.conf.template
+++ b/kubernetes/apps/mcp-system/windmill-mcp/app/resources/default.conf.template
@@ -28,10 +28,11 @@ server {
         proxy_http_version 1.1;
         proxy_set_header Host windmill-app.home.svc.cluster.local;
         proxy_set_header Connection "";
-        # `$${WINDMILL_TOKEN}` (double-$) escapes Flux postBuild substitution
-        # — Flux renders it back to `${WINDMILL_TOKEN}`, which nginx's
-        # envsubst then expands from the WINDMILL_TOKEN env var at startup.
-        proxy_set_header Authorization "Bearer $${WINDMILL_TOKEN}";
+        # Flux postBuild substitution is disabled on this generated CM (see the
+        # kustomization's generatorOptions.annotations), so `${WINDMILL_TOKEN}`
+        # passes through literally for nginx's envsubst to expand from the
+        # WINDMILL_TOKEN env var at startup.
+        proxy_set_header Authorization "Bearer ${WINDMILL_TOKEN}";
 
         # SSE / streamable-HTTP friendliness — Windmill MCP streams.
         proxy_buffering off;


### PR DESCRIPTION
## Problem

Flux `kustomize-controller` 2.9 (bumped 2.8.8 → 2.9.0 → 2.9.1 in #12881/#12919, after the last clean apply at `aedcc89` on 2026-07-06) makes postBuild substitution **strict**: an undefined `${VAR}` now hard-errors instead of blanking. Three Kustomizations have been stuck `Ready=False` since:

| App | Kustomization error |
| --- | --- |
| `home/aquapured` | `variable not set (strict mode): "MQTT_USER"` |
| `mcp-system/github-mcp` | `variable not set (strict mode): "GITHUB_PERSONAL_ACCESS_TOKEN"` |
| `mcp-system/windmill-mcp` | `variable not set (strict mode): "WINDMILL_TOKEN"` |

All three used a `$${VAR}` double-dollar "escape" to pass a literal placeholder through to their **own** runtime `envsubst` (container entrypoint / nginx). That escape never actually suppressed drone/envsubst — pre-2.9 the unset var blanked silently, so it *looked* fine. 2.9 turned the latent bug into a hard reconcile failure.

## Fix

Adopt the repo's proven pattern — the `kustomize.toolkit.fluxcd.io/substitute: disabled` annotation (already used by jdownloader2, frigate, glance, zot, obsidian-couchdb, …) — on the placeholder-bearing ConfigMaps, and revert `$${VAR}` → clean `${VAR}` so the app's own `envsubst` fills them. Flux skips substitution on the annotated resource entirely, so the literal placeholder survives to runtime.

- **aquapured** — annotation on the inline `aquapured-config` CM.
- **github-mcp / windmill-mcp** — annotation via `configMapGenerator` `generatorOptions.annotations` on the generated `*-nginx-config` CM.

Verified the templates carry no *other* `${VAR}` that needs Flux substitution, so disabling it on these CMs is safe. `flate` CI exercises the substitution path.

## Notes

- No secret values touched; these are placeholder-only changes. Tokens are supplied at runtime from the apps' Secrets/env.
- `rtl-433` and `mcp-gateway` also use `$${...}` but currently reconcile green; leaving them untouched — if they're silently mis-rendering (stray `$`), that's a separate follow-up.