### PR TITLE
chore(ci): drop dead docker.io allowlist entries

### DIFF
--- a/.github/image-registry-allowlist.txt
+++ b/.github/image-registry-allowlist.txt
@@ -21,7 +21,6 @@
 
 # --- No suitable non-docker equivalent (verified 2026-05) -----------
 docker.io/ollama/ollama
-docker.io/kanidm/server                 # ghcr is `devel`-only, no stable tags
 docker.io/glanceapp/glance
 docker.io/library/couchdb               # ghcr/apache/couchdb is devcontainer-only
 docker.io/longhornio/                    # Longhorn canonical, no ghcr publication
@@ -30,8 +29,6 @@ docker.io/library/alpine
 docker.io/library/busybox               # uclibc variant not on home-operations mirror
 docker.io/library/python                # Python language image, no ghcr publication
 docker.io/rhasspy/wyoming-openwakeword
-docker.io/rhasspy/wyoming-piper
-docker.io/rhasspy/wyoming-whisper
 docker.io/grafana/grafana-image-renderer  # Grafana project canonical; no ghcr publication
 docker.io/grafana/mcp-grafana
 docker.io/mmartial/comfyui-nvidia-docker  # DGX Spark arm64+GB10 ComfyUI; Docker Hub only, no ghcr
@@ -44,7 +41,6 @@ docker.io/ciuse99/suggestarr
 docker.io/cloudflare/cloudflared        # tracked by cloudflare/cloudflared#1533
 docker.io/favonia/cloudflare-ddns
 docker.io/dpage/pgadmin4                # no ghcr.io publication (verified 2026-05)
-docker.io/langfuse/                     # no ghcr.io publication; Docker Hub is primary (verified 2026-05)
 docker.io/dxflrs/garage
 docker.io/khairul169/garage-webui
 docker.io/hjacobs/kube-ops-view         # upstream archived 2020
@@ -52,7 +48,6 @@ docker.io/prompp/prompp                 # Prom++ Docker Hub only
 docker.io/rclone/rclone                 # ghcr.io/rclone/rclone has no stable semver tags
 docker.io/emberstack/kubernetes-reflector  # chart on ghcr.io but image is docker.io
 docker.io/qdrant/qdrant                 # ghcr.io/qdrant/qdrant ships only dev-*/master-* tags
-docker.io/robustadev/holmes             # no ghcr.io publication (ghcr.io/robusta-dev/holmes 403)
 docker.io/binwiederhier/ntfy            # no ghcr.io publication (verified 2026-05)
 docker.io/nginxinc/nginx-unprivileged   # nginx project canonical; no ghcr.io publication
 docker.io/hertzg/rtl_433               # no ghcr.io publication; Docker Hub is primary (verified 2026-05)


### PR DESCRIPTION
Removes five Docker Hub exceptions from `.github/image-registry-allowlist.txt` for images no longer used anywhere in the cluster.

| Entry | Why it's dead |
|---|---|
| `kanidm/server` | kanidm is not deployed — zero manifest references |
| `robustadev/holmes` | HolmesGPT decommissioned 2026-07-07 (only decommission-residue text remains) |
| `rhasspy/wyoming-piper` | wyoming-services migrated TTS → `ghcr.io/nordwestt/kokoro-wyoming` |
| `rhasspy/wyoming-whisper` | wyoming-services migrated STT → `ghcr.io/linuxserver/faster-whisper` |
| `langfuse/` | not deployed — only a stale dated comment in the external-dns bind HelmRelease references it |

## Notes
- Pure allowlist cleanup — **no workloads change**.
- The image-registry CI check cannot regress: none of these images are pulled by the cluster, so removing their allowlist lines can't create a docker.io violation.
- Found during a full audit of the allowlist (`skopeo list-tags` per entry + repo usage grep). Follow-up PRs migrate four *live* entries that now have a viable ghcr.io home (reflector, nginx-unprivileged, rclone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)