### PR TITLE
refactor(container): pull rclone from ghcr.io instead of Docker Hub

### DIFF
--- a/.github/image-registry-allowlist.txt
+++ b/.github/image-registry-allowlist.txt
@@ -45,7 +45,6 @@ docker.io/dxflrs/garage
 docker.io/khairul169/garage-webui
 docker.io/hjacobs/kube-ops-view         # upstream archived 2020
 docker.io/prompp/prompp                 # Prom++ Docker Hub only
-docker.io/rclone/rclone                 # ghcr.io/rclone/rclone has no stable semver tags
 docker.io/qdrant/qdrant                 # ghcr.io/qdrant/qdrant ships only dev-*/master-* tags
 docker.io/binwiederhier/ntfy            # no ghcr.io publication (verified 2026-05)
 docker.io/hertzg/rtl_433               # no ghcr.io publication; Docker Hub is primary (verified 2026-05)

--- a/kubernetes/apps/collab/paperless/app/cronjob-offsite-backup.yaml
+++ b/kubernetes/apps/collab/paperless/app/cronjob-offsite-backup.yaml
@@ -34,7 +34,7 @@ spec:
             fsGroup: 65534
           containers:
             - name: rclone
-              image: rclone/rclone:1.74.4
+              image: ghcr.io/rclone/rclone:1.74.4
               command: ["/bin/sh", "-c"]
               args:
                 - |

--- a/kubernetes/apps/collab/paperless/app/cronjob-offsite-backup.yaml
+++ b/kubernetes/apps/collab/paperless/app/cronjob-offsite-backup.yaml
@@ -34,7 +34,7 @@ spec:
             fsGroup: 65534
           containers:
             - name: rclone
-              image: ghcr.io/rclone/rclone:1.74.4
+              image: ghcr.io/rclone/rclone:1.74.4@sha256:c61954aaa32328a5486715dd063a81c7879f5195ad3505cd362deddd509dc4a1
               command: ["/bin/sh", "-c"]
               args:
                 - |

--- a/kubernetes/apps/media/immich/app/cronjob-offsite-backup.yaml
+++ b/kubernetes/apps/media/immich/app/cronjob-offsite-backup.yaml
@@ -21,7 +21,7 @@ spec:
             fsGroup: 65534
           containers:
             - name: rclone
-              image: rclone/rclone:1.74.4
+              image: ghcr.io/rclone/rclone:1.74.4
               command: ["/bin/sh", "-c"]
               args:
                 - |

--- a/kubernetes/apps/media/immich/app/cronjob-offsite-backup.yaml
+++ b/kubernetes/apps/media/immich/app/cronjob-offsite-backup.yaml
@@ -21,7 +21,7 @@ spec:
             fsGroup: 65534
           containers:
             - name: rclone
-              image: ghcr.io/rclone/rclone:1.74.4
+              image: ghcr.io/rclone/rclone:1.74.4@sha256:c61954aaa32328a5486715dd063a81c7879f5195ad3505cd362deddd509dc4a1
               command: ["/bin/sh", "-c"]
               args:
                 - |


### PR DESCRIPTION
`ghcr.io/rclone/rclone` now ships clean semver tags (`1.74.4` verified 2026-07-16), so the two offsite-backup CronJobs no longer need their Docker Hub exception. The on-file rationale ("ghcr.io/rclone/rclone has no stable semver tags") is stale.

## Changes
- `kubernetes/apps/media/immich/app/cronjob-offsite-backup.yaml` — `rclone/rclone:1.74.4` → `ghcr.io/rclone/rclone:1.74.4`
- `kubernetes/apps/collab/paperless/app/cronjob-offsite-backup.yaml` — same
- Drop `docker.io/rclone/rclone` from `.github/image-registry-allowlist.txt`

## Notes
- Same image content and tag — **registry only**.
- Only affects the next scheduled backup run; no serving path, no downtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)