### PR TITLE
refactor(container): pull kubernetes-reflector from ghcr.io

### DIFF
--- a/.github/image-registry-allowlist.txt
+++ b/.github/image-registry-allowlist.txt
@@ -50,7 +50,6 @@ docker.io/khairul169/garage-webui
 docker.io/hjacobs/kube-ops-view         # upstream archived 2020
 docker.io/prompp/prompp                 # Prom++ Docker Hub only
 docker.io/rclone/rclone                 # ghcr.io/rclone/rclone has no stable semver tags
-docker.io/emberstack/kubernetes-reflector  # chart on ghcr.io but image is docker.io
 docker.io/qdrant/qdrant                 # ghcr.io/qdrant/qdrant ships only dev-*/master-* tags
 docker.io/robustadev/holmes             # no ghcr.io publication (ghcr.io/robusta-dev/holmes 403)
 docker.io/binwiederhier/ntfy            # no ghcr.io publication (verified 2026-05)

--- a/kubernetes/apps/kube-system/reflector/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/reflector/helmrelease.yaml
@@ -48,6 +48,10 @@ spec:
     configuration:
       logging:
         minimumLevel: Information
+    # Chart default is docker.io/emberstack/kubernetes-reflector; the same
+    # image is published to ghcr.io, so pull it there and stay off Docker Hub.
+    image:
+      repository: ghcr.io/emberstack/kubernetes-reflector
     resources:
       requests:
         cpu: 10m


### PR DESCRIPTION
emberstack now publishes the reflector *image* to ghcr.io alongside its chart (the chart's own default still points at Docker Hub). Overrides `image.repository` to the ghcr copy and drops the allowlist entry. The on-file rationale ("chart on ghcr.io but image is docker.io") is stale.

## Changes
- `kubernetes/apps/kube-system/reflector/helmrelease.yaml` — add `values.image.repository: ghcr.io/emberstack/kubernetes-reflector`
- Drop `docker.io/emberstack/kubernetes-reflector` from `.github/image-registry-allowlist.txt`

## Notes
- Tag left to the chart appVersion. `helm template … --version 10.0.60` renders `ghcr.io/emberstack/kubernetes-reflector:10.0.60` (verified locally).
- Registry only; HelmRelease reconcile rolls the single reflector pod once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)