### PR TITLE
chore(container): pin missing image digests

### DIFF
--- a/kubernetes/apps/ai/khoj/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/khoj/app/helmrelease.yaml
@@ -45,7 +45,7 @@ spec:
           app:
             image:
               repository: ghcr.io/khoj-ai/khoj
-              tag: 2.0.0-beta.28
+              tag: 2.0.0-beta.28@sha256:eb2e44669df44b51cb206b394dc0a00c782ac152dda02c97c9e3dac3d643dbb4
             # First-run superuser bootstrap is automatic when KHOJ_ADMIN_EMAIL
             # + KHOJ_ADMIN_PASSWORD are set; --non-interactive skips the
             # TTY prompt that would otherwise CrashLoop the pod.

--- a/kubernetes/apps/ai/lightrag/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/lightrag/app/helmrelease.yaml
@@ -40,7 +40,7 @@ spec:
           app:
             image:
               repository: ghcr.io/hkuds/lightrag
-              tag: v1.5.4
+              tag: v1.5.4@sha256:de09cd75e32b6b45b104625a9fb229f84f3dec4827ecffc825aa4438b196cbe6
             env:
               HOST: "0.0.0.0"
               PORT: "9621"

--- a/kubernetes/apps/ai/paperless-ai/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/paperless-ai/app/helmrelease.yaml
@@ -25,7 +25,7 @@ spec:
           app:
             image:
               repository: ghcr.io/clusterzx/paperless-ai
-              tag: 3.0.9
+              tag: 3.0.9@sha256:2b65888163fd59716f1c8285b31c5bd0b30c9c3c192c42b516688e3887d4ba60
 
             resources:
               requests:

--- a/kubernetes/apps/collab/it-tools/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/it-tools/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
           app:
             image:
               repository: ghcr.io/corentinth/it-tools
-              tag: 2024.10.22-7ca5933
+              tag: 2024.10.22-7ca5933@sha256:8b8128748339583ca951af03dfe02a9a4d7363f61a216226fc28030731a5a61f
             # TODO: add securityContext once upstream ships an unprivileged (non-:80) image variant
 
             probes:

--- a/kubernetes/apps/collab/open-webui/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/open-webui/app/helmrelease.yaml
@@ -54,7 +54,7 @@ spec:
           app:
             image:
               repository: ghcr.io/open-webui/open-webui
-              tag: v0.10.2
+              tag: v0.10.2@sha256:9fcea9c6e32ab60b0498f3986c6cdf651ddbe61db48d2213a3d28048ddd673d4
 
             securityContext:
               allowPrivilegeEscalation: false

--- a/kubernetes/apps/collab/paperless/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/paperless/app/helmrelease.yaml
@@ -35,7 +35,7 @@ spec:
           chown-runtime-dirs:
             image:
               repository: public.ecr.aws/docker/library/busybox
-              tag: "1.38"
+              tag: "1.38@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d"
             command:
               - sh
               - -c
@@ -60,7 +60,7 @@ spec:
           app:
             image:
               repository: ghcr.io/paperless-ngx/paperless-ngx
-              tag: 2.20.15
+              tag: 2.20.15@sha256:6c86cad803970ea782683a8e80e7403444c5bf3cf70de63b4d3c8e87500db92f
             env:
               # Configure application
               PAPERLESS_URL: "https://paperless.${SECRET_DOMAIN}"

--- a/kubernetes/apps/collab/pump-cv/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump-cv/app/helmrelease.yaml
@@ -65,7 +65,7 @@ spec:
           config-render:
             image:
               repository: docker.io/library/alpine
-              tag: "3.24"
+              tag: "3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b"
             command:
               - sh
               - -c

--- a/kubernetes/apps/collab/zulip/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/zulip/app/helmrelease.yaml
@@ -106,7 +106,7 @@ spec:
   values:
     image:
       repository: ghcr.io/zulip/zulip-server
-      tag: 12.1-0
+      tag: 12.1-0@sha256:1e9235b345ac86ff97168055d5c7e35e314dd9aa96e343be28583ab2b61b1bb0
 
     service:
       type: ClusterIP

--- a/kubernetes/apps/databases/dragonfly/cluster/cluster.yaml
+++ b/kubernetes/apps/databases/dragonfly/cluster/cluster.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   labels:
     dragonflydb.io/cluster: dragonfly
-  image: ghcr.io/dragonflydb/dragonfly:v1.39.0
+  image: ghcr.io/dragonflydb/dragonfly:v1.39.0@sha256:f406dc580bf3b289cc9f8e98b83077403180aeffcd39e3aeb580293a4ba4c8bd
   replicas: 3
   resources:
     requests:

--- a/kubernetes/apps/databases/qdrant/app/helmrelease.yaml
+++ b/kubernetes/apps/databases/qdrant/app/helmrelease.yaml
@@ -31,7 +31,7 @@ spec:
           app:
             image:
               repository: docker.io/qdrant/qdrant
-              tag: v1.18.2
+              tag: v1.18.2@sha256:75eab8c4ba42096724fdcfde8b4de0b5713d529dde32f285a1f86fdcb2c9e50c
             env:
               # Default snapshots path is ./snapshots (qdrant's WORKDIR
               # /qdrant), which the non-root user can't create. Redirect

--- a/kubernetes/apps/home/aquapured/app/helmrelease.yaml
+++ b/kubernetes/apps/home/aquapured/app/helmrelease.yaml
@@ -103,7 +103,7 @@ spec:
           mosquitto:
             image:
               repository: public.ecr.aws/docker/library/eclipse-mosquitto
-              tag: "2.0.22"
+              tag: "2.0.22@sha256:212f89e1eaeb2c322d6441b64396e3346026674db8fa9c27beac293405c32b3c"
             command: ["/usr/sbin/mosquitto", "-c", "/mosquitto/config/mosquitto.conf"]
             securityContext:
               # Start AS the mosquitto user (1883) so it never tries to drop

--- a/kubernetes/apps/home/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/home/frigate/app/helmrelease.yaml
@@ -51,7 +51,7 @@ spec:
           snapshot:
             image:
               repository: docker.io/library/alpine
-              tag: "3.24"
+              tag: "3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b"
             command: ["/bin/sh", "/opt/snapshot/snapshot.sh"]
             env:
               # Wait for Frigate to finish auto-migration before snapshotting.

--- a/kubernetes/apps/home/frigate/app/restart-cronjob.yaml
+++ b/kubernetes/apps/home/frigate/app/restart-cronjob.yaml
@@ -34,7 +34,7 @@ spec:
             fsGroup: 1000
           containers:
             - name: restart
-              image: docker.io/alpine/k8s:1.36.2
+              image: docker.io/alpine/k8s:1.36.2@sha256:44ef4942e171939b9c665a4a84beb80e2dcdb9a24330d4651cfdfd2e9deecc47
               command:
                 - /bin/sh
                 - -ceu

--- a/kubernetes/apps/home/frigate/app/snapshot-cronjob.yaml
+++ b/kubernetes/apps/home/frigate/app/snapshot-cronjob.yaml
@@ -52,7 +52,7 @@ spec:
               # `apk add git openssh-client` at runtime, which fails
               # under home-ns default-deny (no egress to dl-cdn.alpine
               # linux.org). Same pattern as ha-config-sync (PR #11710).
-              image: docker.io/alpine/git:v2.54.0
+              image: docker.io/alpine/git:v2.54.0@sha256:697cb1c85aefc5724febaec2202a974e0d66f6abb6be91a9a86d0c8757af692a
               command: ["/bin/sh", "/opt/snapshot/snapshot.sh"]
               env:
                 - name: CONFIG_FILE

--- a/kubernetes/apps/home/home-assistant/app/sync-cronjob.yaml
+++ b/kubernetes/apps/home/home-assistant/app/sync-cronjob.yaml
@@ -28,7 +28,7 @@ spec:
               # `apk add` (which fails under home/default-deny since
               # 2026-05-18 — alpine repos aren't reachable from this
               # pod's egress slice).
-              image: docker.io/alpine/git:v2.54.0
+              image: docker.io/alpine/git:v2.54.0@sha256:697cb1c85aefc5724febaec2202a974e0d66f6abb6be91a9a86d0c8757af692a
               command:
                 - /bin/sh
                 - -c

--- a/kubernetes/apps/home/netbox/app/helmrelease.yaml
+++ b/kubernetes/apps/home/netbox/app/helmrelease.yaml
@@ -61,7 +61,7 @@ spec:
       - envFrom:
           - secretRef:
               name: *secret
-        image: ghcr.io/home-operations/postgres-init:18
+        image: ghcr.io/home-operations/postgres-init:18@sha256:ebd9d30add17acdf935d73eb004758c7dfd9388aaa605fda70ad74378ab92aec
         name: init-db
     livenessProbe:
       enabled: true

--- a/kubernetes/apps/home/ntfy/app/helmrelease.yaml
+++ b/kubernetes/apps/home/ntfy/app/helmrelease.yaml
@@ -32,7 +32,7 @@ spec:
               # ntfy is published to Docker Hub only — no GHCR mirror.
               # If/when ZOT container-image pull-through lands, route here.
               repository: docker.io/binwiederhier/ntfy
-              tag: v2.26.0
+              tag: v2.26.0@sha256:a6d335064ae927c4dbef118e1fa39656b3d2e01472b2a82af5915d5cebfe815f
             args: ["serve"]
             resources:
               requests:

--- a/kubernetes/apps/home/wyoming-services/app/helmrelease.yaml
+++ b/kubernetes/apps/home/wyoming-services/app/helmrelease.yaml
@@ -31,7 +31,7 @@ spec:
           main:
             image:
               repository: ghcr.io/nordwestt/kokoro-wyoming
-              tag: 1.0.2
+              tag: 1.0.2@sha256:953b1487f06e1a7df89e80248996c7277dac448526031df31d293f00fadfa89b
             args:
               - --uri
               - tcp://0.0.0.0:10200
@@ -67,7 +67,7 @@ spec:
           main:
             image:
               repository: docker.io/rhasspy/wyoming-openwakeword
-              tag: 2.1.0
+              tag: 2.1.0@sha256:52cb1168731a1849fc28cf339c935fde58746bbabc94226668a40ef6ddf5d42b
             args:
               - --preload-model
               - "ok_nabu"
@@ -131,7 +131,7 @@ spec:
           main:
             image:
               repository: ghcr.io/linuxserver/faster-whisper
-              tag: gpu-legacy-v3.1.0-ls40
+              tag: gpu-legacy-v3.1.0-ls40@sha256:1bbe03a5c77c91a1e9493866220177132fd7938f20d2aba3df314946501e433e
             env:
               PUID: "1000"
               PGID: "1000"

--- a/kubernetes/apps/home/zwave-js-ui/app/helmrelease.yaml
+++ b/kubernetes/apps/home/zwave-js-ui/app/helmrelease.yaml
@@ -37,7 +37,7 @@ spec:
           app:
             image:
               repository: ghcr.io/zwave-js/zwave-js-ui
-              tag: 11.21.1
+              tag: 11.21.1@sha256:1193b96b31488e5a6c7895f16a27b2ead38f8a0c3d1bec335bb10b6d9f9e2905
 
             probes:
               liveness: &probes

--- a/kubernetes/apps/kube-system/etcd-defrag/cron-job.yaml
+++ b/kubernetes/apps/kube-system/etcd-defrag/cron-job.yaml
@@ -12,7 +12,7 @@ spec:
         spec:
           containers:
           - name: etcd-defrag
-            image: ghcr.io/ahrtr/etcd-defrag:v0.42.0 # Please replace the version with the latest version.
+            image: ghcr.io/ahrtr/etcd-defrag:v0.42.0@sha256:5138a12eda39067dabcf1d420d66f54f29f1e9297109a6b36574e010b45d58cc  # Please replace the version with the latest version.
             args:
             - --endpoints=https://127.0.0.1:2379
             - --cacert=/ca.crt

--- a/kubernetes/apps/kube-system/gpu-operator/app/crio-cdi-setup.yaml
+++ b/kubernetes/apps/kube-system/gpu-operator/app/crio-cdi-setup.yaml
@@ -62,7 +62,7 @@ spec:
           # Alpine provides a shell + nsenter (via util-linux).
           # hostPID=true exposes host /proc/1 so nsenter can enter the
           # host mount namespace where the glibc-linked nvidia-ctk lives.
-          image: docker.io/alpine:3.24
+          image: docker.io/alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
           command:
             - sh
             - -c

--- a/kubernetes/apps/kube-system/kube-vip/daemon-set.yaml
+++ b/kubernetes/apps/kube-system/kube-vip/daemon-set.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: kube-vip
-          image: ghcr.io/kube-vip/kube-vip:v1.2.1
+          image: ghcr.io/kube-vip/kube-vip:v1.2.1@sha256:49b77655f9f109bedc5eb25723bb0e4c57d8513ba33cc69c31be3f243eb2386d
           imagePullPolicy: IfNotPresent
           args:
             - manager
@@ -88,7 +88,7 @@ spec:
     spec:
       containers:
         - name: kube-vip
-          image: ghcr.io/kube-vip/kube-vip:v1.2.1
+          image: ghcr.io/kube-vip/kube-vip:v1.2.1@sha256:49b77655f9f109bedc5eb25723bb0e4c57d8513ba33cc69c31be3f243eb2386d
           imagePullPolicy: IfNotPresent
           args:
             - manager

--- a/kubernetes/apps/kube-system/node-problem-detector/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/node-problem-detector/app/helmrelease.yaml
@@ -12,7 +12,7 @@ spec:
   values:
     image:
       repository: registry.k8s.io/node-problem-detector/node-problem-detector
-      tag: v1.36.0
+      tag: v1.36.0@sha256:b4db5a168c5f6192c3fb3d650920d192d83776598fcdfcc092d16ca8dc9213ff
 
     metrics:
       serviceMonitor:

--- a/kubernetes/apps/kube-system/node-tuning/daemonset.yaml
+++ b/kubernetes/apps/kube-system/node-tuning/daemonset.yaml
@@ -30,7 +30,7 @@ spec:
         app.kubernetes.io/name: node-tuning
     spec:
       containers:
-        - image: registry.k8s.io/pause:3.10
+        - image: registry.k8s.io/pause:3.10@sha256:68e08199906d1c90399a2d35db0cc4cab616b112e300851e66be11b4291dc95c
           name: pause
           resources:
             limits:

--- a/kubernetes/apps/kube-system/zot/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/zot/app/helmrelease.yaml
@@ -37,7 +37,7 @@ spec:
           app:
             image:
               repository: ghcr.io/project-zot/zot-linux-amd64
-              tag: v2.1.18
+              tag: v2.1.18@sha256:34f18f783037f967dba10df02f9d4086c4d626f5643ef9f5e51e4a4547280a0b
             probes:
               liveness: &probe
                 enabled: true

--- a/kubernetes/apps/mcp-system/comfyui-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/comfyui-mcp/app/helmrelease.yaml
@@ -28,7 +28,7 @@ spec:
               repository: ghcr.io/rwlove/comfyui-mcp
               # Pinned to the first release built from rwlove/containers
               # PR #32; Renovate manages bumps after the image lands.
-              tag: v0.24.1
+              tag: v0.24.1@sha256:0db5af07f525e884d44152195106298bda214f90e53798450879f092678ed24d
             env:
               # Streamable-HTTP transport (artokun added 2026-05-21).
               # See: rwlove/containers/comfyui-mcp/README.md

--- a/kubernetes/apps/mcp-system/grafana-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/grafana-mcp/app/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
           app:
             image:
               repository: docker.io/grafana/mcp-grafana
-              tag: 0.17.2-alpine
+              tag: 0.17.2-alpine@sha256:50f92a0d3413f4420ae73ee9a670bfc9e425d4db433d3242886b16139f186d0b
             args:
               - -t
               - streamable-http

--- a/kubernetes/apps/mcp-system/ha-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/ha-mcp/app/helmrelease.yaml
@@ -27,7 +27,7 @@ spec:
           app:
             image:
               repository: ghcr.io/homeassistant-ai/ha-mcp
-              tag: 7.12.1
+              tag: 7.12.1@sha256:fe32c119ce77d1806209648b294e2644d970255f3ae4c4acd1957707fcca811b
             command:
               - ha-mcp-web
             env:

--- a/kubernetes/apps/mcp-system/mcp-gateway/app/rotator-cronjob.yaml
+++ b/kubernetes/apps/mcp-system/mcp-gateway/app/rotator-cronjob.yaml
@@ -34,7 +34,7 @@ spec:
             fsGroup: 1000
           containers:
             - name: rotator
-              image: docker.io/alpine/k8s:1.36.2
+              image: docker.io/alpine/k8s:1.36.2@sha256:44ef4942e171939b9c665a4a84beb80e2dcdb9a24330d4651cfdfd2e9deecc47
               command:
                 - /bin/sh
                 - -ceu

--- a/kubernetes/apps/mcp-system/searxng-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/searxng-mcp/app/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
           app:
             image:
               repository: docker.io/isokoliuk/mcp-searxng
-              tag: "1.11.1"
+              tag: "1.11.1@sha256:b6727fc950cf1a7501d70f863b563d9fc689d6e33c773296ed845070c5646b48"
             env:
               SEARXNG_URL: http://searxng.collab.svc.cluster.local:8080
               # MCP_HTTP_HOST defaults to 127.0.0.1 (loopback-only), so the

--- a/kubernetes/apps/media/batocera-webdashboard-pro/app/helmrelease.yaml
+++ b/kubernetes/apps/media/batocera-webdashboard-pro/app/helmrelease.yaml
@@ -36,7 +36,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/batocera-webdashboard-pro
-              tag: v2.0.0
+              tag: v2.0.0@sha256:10ecea37752bf4f5079b918d4513ccfeb4af23814e75fc3beb55d279d252c81e
 
             env:
               MODE: remote

--- a/kubernetes/apps/media/beets/app/helmrelease.yaml
+++ b/kubernetes/apps/media/beets/app/helmrelease.yaml
@@ -34,7 +34,7 @@ spec:
           config-setup:
             image:
               repository: ghcr.io/dmfrey/bash
-              tag: 5.2.26-alpine3.20
+              tag: 5.2.26-alpine3.20@sha256:42c68bce7e307aa96882ce22365e04986b0d8185280afa1fa2141c2296c47d15
             command:
               - "/usr/local/bin/bash"
               - -c

--- a/kubernetes/apps/media/kodi-playback-watcher/app/helmrelease.yaml
+++ b/kubernetes/apps/media/kodi-playback-watcher/app/helmrelease.yaml
@@ -27,7 +27,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/kodi-playback-watcher
-              tag: v0.1.0
+              tag: v0.1.0@sha256:638b536873c767bbf4e79b53b6422c6f2ef69b2ad987a05d194d796515af8262
 
             env:
               KPW_KODI_HOST: kodi-familyroom

--- a/kubernetes/apps/media/lidarr-bridge/app/helmrelease.yaml
+++ b/kubernetes/apps/media/lidarr-bridge/app/helmrelease.yaml
@@ -34,7 +34,7 @@ spec:
           app:
             image:
               repository: python
-              tag: 3.14-alpine
+              tag: 3.14-alpine@sha256:26730869004e2b9c4b9ad09cab8625e81d256d1ce97e72df5520e806b1709f92
 
             # umask 0002 so created dirs are group-writable for shared-GID
             # writers (beets). See per-app-UIDs commit 152c67ef3a.

--- a/kubernetes/apps/media/lidarr-sab-autoimport/app/helmrelease.yaml
+++ b/kubernetes/apps/media/lidarr-sab-autoimport/app/helmrelease.yaml
@@ -40,7 +40,7 @@ spec:
           app:
             image:
               repository: python
-              tag: 3.14-alpine
+              tag: 3.14-alpine@sha256:26730869004e2b9c4b9ad09cab8625e81d256d1ce97e72df5520e806b1709f92
 
             command:
               - python3

--- a/kubernetes/apps/media/music-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/media/music-assistant/app/helmrelease.yaml
@@ -67,7 +67,7 @@ spec:
           wait-for-gonic:
             image:
               repository: docker.io/library/alpine
-              tag: "3.24"
+              tag: "3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b"
             command:
               - sh
               - -c
@@ -82,7 +82,7 @@ spec:
           app:
             image:
               repository: ghcr.io/music-assistant/server
-              tag: 2.10.0b6
+              tag: 2.10.0b6@sha256:02e0e2534d5d2d2ac094de637210af2ae3459ea9697a49d143fa1395f0157648
 
             env:
               # Smart Fades' Beat This! beat-tracking model downloads its

--- a/kubernetes/apps/media/soularr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/soularr/app/helmrelease.yaml
@@ -29,7 +29,7 @@ spec:
           config-setup:
             image:
               repository: ghcr.io/dmfrey/bash
-              tag: 5.2.26-alpine3.20
+              tag: 5.2.26-alpine3.20@sha256:42c68bce7e307aa96882ce22365e04986b0d8185280afa1fa2141c2296c47d15
             command:
               - "/usr/local/bin/bash"
               - -c

--- a/kubernetes/apps/media/stash/app/helmrelease.yaml
+++ b/kubernetes/apps/media/stash/app/helmrelease.yaml
@@ -47,7 +47,7 @@ spec:
           fix-stash-perms:
             image:
               repository: docker.io/library/alpine
-              tag: "3.24"
+              tag: "3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b"
             command:
               - sh
               - -c

--- a/kubernetes/apps/media/videodupfinder/app/helmrelease.yaml
+++ b/kubernetes/apps/media/videodupfinder/app/helmrelease.yaml
@@ -36,7 +36,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/videodupfinder
-              tag: v0.3
+              tag: v0.3@sha256:a769866d3a6307869fd1a2172723bf27e1d3b0d3e6cfebb17a1db48597b97005
 
             env:
               VIDEODUPFINDER_BIN_DIR: /mnt/scan/.videodupfinder-bin

--- a/kubernetes/apps/network/cloudflare-ddns/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cloudflare-ddns/app/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
           app:
             image:
               repository: docker.io/favonia/cloudflare-ddns
-              tag: 1.16.2
+              tag: 1.16.2@sha256:bc53b40b13c8b2a84e9b93c21f65fcd7d574b741014fb93912eb9efd93015aa2
 
             env:
               DOMAINS: vpn.${SECRET_DOMAIN}

--- a/kubernetes/apps/network/wg-easy/app/helmrelease.yaml
+++ b/kubernetes/apps/network/wg-easy/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
           app:
             image:
               repository: ghcr.io/wg-easy/wg-easy
-              tag: "15"
+              tag: "15@sha256:93bbd593e07bab98d02807a28770ac87ab6c48818e319e68c1f66561feb99876"
 
             command:
               - /bin/sh

--- a/kubernetes/apps/observability/kromgo/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kromgo/app/helmrelease.yaml
@@ -37,7 +37,7 @@ spec:
           app:
             image:
               repository: ghcr.io/kashalls/kromgo
-              tag: v0.10.0
+              tag: v0.10.0@sha256:965ecc92d68dc1a4a969397855367bbc70da03227a941ea607b73bb7e0b78fd6
             env:
               PROMETHEUS_URL: http://kube-prometheus-stack-prometheus.observability.svc.cluster.local:9090
             resources:

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -143,7 +143,7 @@ spec:
         image:
           registry: docker.io
           repository: prompp/prompp
-          tag: 2.53.2-0.3.3
+          tag: 2.53.2-0.3.3@sha256:df67ff1dc7094940e9d62e9bc318b02e4e35f539893dec5cc6b72d4fee4d8f21
         podMonitorSelectorNilUsesHelmValues: false
         probeSelectorNilUsesHelmValues: false
         resources:

--- a/kubernetes/apps/observability/netdata/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/netdata/app/helmrelease.yaml
@@ -21,7 +21,7 @@ spec:
 
     image:
       repository: ghcr.io/netdata/netdata
-      tag: "v2.10.4"
+      tag: "v2.10.4@sha256:54308650e16df962e759a783460cbf866e0b1d09de889c46055d171dc2814105"
 
     ingress:
       enabled: false

--- a/kubernetes/apps/renovate/renovate-operator/jobs/home-ops.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/jobs/home-ops.yaml
@@ -38,7 +38,7 @@ spec:
       value: enabled
     - name: RENOVATE_CACHE_PRIVATE_PACKAGES
       value: "true"
-  image: ghcr.io/renovatebot/renovate:43.265.0
+  image: ghcr.io/renovatebot/renovate:43.265.0@sha256:9df026a4a4de4eae52e9ca380dbc9276dedb4ac67b19d8fae875eaa7c20d0df2
   parallelism: 5
   provider:
     name: github

--- a/kubernetes/apps/renovate/renovate-operator/jobs/pump.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/jobs/pump.yaml
@@ -32,7 +32,7 @@ spec:
     # narrow run — the rwlove-home-ops job owns it.
     - name: RENOVATE_DEPENDENCY_DASHBOARD
       value: "false"
-  image: ghcr.io/renovatebot/renovate:43.265.0
+  image: ghcr.io/renovatebot/renovate:43.265.0@sha256:9df026a4a4de4eae52e9ca380dbc9276dedb4ac67b19d8fae875eaa7c20d0df2
   parallelism: 1
   provider:
     name: github

--- a/kubernetes/apps/vpn/downloads-gateway/app/helmrelease.yaml
+++ b/kubernetes/apps/vpn/downloads-gateway/app/helmrelease.yaml
@@ -95,7 +95,7 @@ spec:
           netshoot:
             image:
               repository: ghcr.io/nicolaka/netshoot
-              tag: v0.16
+              tag: v0.16@sha256:b09d9b21381f47a79b3cbcb30da25266dc17186ea00ae65e99fdc51396f48e70
             command:
               - sleep
               - infinity


### PR DESCRIPTION
Sha-pins every container image that carried a bare tag with no `@sha256:` digest, per the add-app convention ("preferably a sha-pinned tag `v1.76.0@sha256:…`"). **43 distinct images across 47 files.**

## How
- Digests resolved from each image's **current manifest index** (sha256 of the raw manifest, so multi-arch amd64/arm64 both resolve correctly).
- Every applied digest cross-checked against the resolved value — **0 mismatches** across 53 pinned refs.
- Registry and tag are unchanged; only a `@sha256:…` suffix is appended.

## Why
Completes the loop on the repo's existing `:automergeDigest` Renovate config: with a digest present, Renovate can now track and auto-merge upstream re-tags. Highest value on the **floating tags** — `alpine:3.24`, `python:3.14-alpine`, `busybox:1.38`, `ghcr.io/wg-easy/wg-easy:15` — which were previously mutable and untracked for rebuilds.

## Runtime impact
- **Precise semver tags** (most of the 43): no-op — the digest already equals what's deployed.
- **Floating tags**: the next Flux reconcile pulls the current resolved build (that's the point of pinning). Touches some Renee-facing apps (frigate, music-assistant, wg-easy, wyoming) — all routine, none are a Renee-facing serving change beyond a normal image pull. Merge in a maintenance window if you'd prefer the floating-tag pulls to happen off-hours.

## Scope
Excludes the four files touched by the in-flight registry-migration PRs (#13088 rclone, #13089 nginx-unprivileged + github-mcp-server) — those get digests folded into their own branches so there's no file overlap. Reflector (#13090) is chart-appVersion-driven with no explicit image tag, so it's intentionally left unpinned.

`sweep` label applied (repo-wide digest retrofit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)