### PR TITLE
feat(frigate): update frigate+ model to 4fe4bbea

### DIFF
--- a/kubernetes/apps/home/frigate/snapshots/config.yml
+++ b/kubernetes/apps/home/frigate/snapshots/config.yml
@@ -29,7 +29,8 @@ ui:
   unit_system: imperial
 
 model:
-  path: plus://3e711036dc2003b0afdbfd8fa61de75e
+  path: plus://4fe4bbea669c7a966633023dd57a0aca
+  #3e711036dc2003b0afdbfd8fa61de75e
   #c68fb5900938a9cccddfbc637ce535f2
   #18258fc4c00729ee12287b1adc2ed763
   #a316bbbf0da5b12c0548bf475f534bde


### PR DESCRIPTION
Update the active Frigate+ model to `plus://4fe4bbea669c7a966633023dd57a0aca`. Prior model ID demoted to the commented history list, matching the existing convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)