### PR TITLE
fix(descheduler): exclude zot + VPN gateway from eviction sweeps

### DIFF
--- a/kubernetes/apps/kube-system/descheduler/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/descheduler/app/helmrelease.yaml
@@ -18,6 +18,12 @@ spec:
           pluginConfig:
             - args:
                 nodeFit: true
+                # Honor `descheduler.alpha.kubernetes.io/prefer-no-eviction`
+                # as a hard exclusion (default is soft "Preferred"). Lets
+                # singletons that are expensive/disruptive to reschedule
+                # (zot pull-through cache, VPN gateway) opt out of the
+                # LowNodeUtilization balance sweep.
+                noEvictionPolicy: Mandatory
                 podProtections:
                   defaultDisabled:
                     - FailedBarePods

--- a/kubernetes/apps/kube-system/zot/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/zot/app/helmrelease.yaml
@@ -30,6 +30,10 @@ spec:
 
         annotations:
           reloader.stakater.com/auto: "true"
+          # Pull-through registry cache: a descheduler eviction takes ~4-5min
+          # to recover (startup repo-index scan) and 503s block image pulls
+          # cluster-wide while it's down. Opt out of the balance sweep.
+          descheduler.alpha.kubernetes.io/prefer-no-eviction: "true"
 
         type: statefulset
 

--- a/kubernetes/apps/vpn/downloads-gateway/app/helmrelease.yaml
+++ b/kubernetes/apps/vpn/downloads-gateway/app/helmrelease.yaml
@@ -17,6 +17,11 @@ spec:
       main:
         annotations:
           reloader.stakater.com/auto: "true"
+          # Shared VPN egress gateway: evicting it drops connectivity for
+          # every downstream pod routed through it. Opt out of the
+          # descheduler balance sweep (honored via noEvictionPolicy:
+          # Mandatory on the DefaultEvictor).
+          descheduler.alpha.kubernetes.io/prefer-no-eviction: "true"
         type: statefulset
         containers:
           main:


### PR DESCRIPTION
## Problem

The descheduler runs a `LowNodeUtilization` **balance** sweep every 30 min, evicting pods from any node above 30% utilization. When that sweep evicts `zot-0` (the pull-through registry cache), the cluster takes a **~4–5 min image-pull brownout**:

- ZOT's startup repo-index scan (302 repos) keeps it `NotReady` for minutes.
- Every mirrored image pull `503`s while it's down → `ImagePullBackOff` on anything rescheduling in the same window (observed today: dragonfly, frigate, wyoming voice, node-tuning all stalled behind it).

Same argument for the downloads **VPN egress gateway** — evicting it drops connectivity for every pod routed through it.

## Fix

1. **descheduler** — set the `DefaultEvictor` `noEvictionPolicy: Mandatory`. By default the `descheduler.alpha.kubernetes.io/prefer-no-eviction` annotation is only a *soft* preference the balancer can still override; `Mandatory` makes it a hard exclusion. This setting **only affects pods that carry the annotation** — un-annotated workloads keep their current balance behavior.
2. **zot** + **downloads-gateway** — add the `prefer-no-eviction` annotation to the pod.

Verified against descheduler `v0.36.0` source: `HaveNoEvictionAnnotation` checks annotation *presence*, and `DefaultEvictor` skips the pod when `NoEvictionPolicy == Mandatory`.

## Not addressed here

This stops the descheduler from *causing* the churn. It does not make ZOT faster to recover if it's evicted for another reason (node drain, OOM) — that's a separate hardening question (readiness-gated startup / warm cache).

🤖 Generated with [Claude Code](https://claude.com/claude-code)