### PR TITLE
fix(container): pin music-assistant to 2.9.9 stable, off the beta channel

### DIFF
--- a/.github/renovate/packageRules.json5
+++ b/.github/renovate/packageRules.json5
@@ -44,11 +44,16 @@
       ],
     },
     {
-      description: 'Custom versioning for music-assistant server',
+      // Stable-only versioning for music-assistant server. MA publishes
+      // both stable (2.9.9) and beta (2.10.0b6) tags. This regex matches
+      // stable X.Y.Z only, so the bN prerelease tags are ignored entirely
+      // and Renovate stops auto-PRing beta bumps. The beta track put us on
+      // a mid-refactor 2.10.0 build that broke the Settings → Players page.
+      description: 'Stable-only versioning for music-assistant server (ignore bN prereleases)',
       matchDatasources: [
         'docker',
       ],
-      versioning: 'regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)b(?<build>\\d+)$',
+      versioning: 'regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$',
       matchPackageNames: [
         'ghcr.io/music-assistant/server',
       ],

--- a/kubernetes/apps/media/music-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/media/music-assistant/app/helmrelease.yaml
@@ -82,7 +82,12 @@ spec:
           app:
             image:
               repository: ghcr.io/music-assistant/server
-              tag: 2.10.0b6@sha256:02e0e2534d5d2d2ac094de637210af2ae3459ea9697a49d143fa1395f0157648
+              # Pinned to 2.9.9 stable. The 2.10.0 beta track shipped a
+              # mid-refactor build (b6) where Settings → Players fails to
+              # render (route resolves to the settings index). Renovate had
+              # been tracking the beta channel only; see the stable-only
+              # versioning rule in .github/renovate/packageRules.json5.
+              tag: 2.9.9@sha256:50666a6f8d7f87d53d993dc41860ab06dda11047f6e433bb5bdbcb6e309ac74c
 
             env:
               # Smart Fades' Beat This! beat-tracking model downloads its


### PR DESCRIPTION
## What

- Pin `ghcr.io/music-assistant/server` to **2.9.9** stable (digest-pinned), down from `2.10.0b6`.
- Change the Renovate versioning rule for MA from **beta-only** (`X.Y.ZbN`) to **stable-only** (`X.Y.Z`) so `bN` prereleases are ignored and the beta channel isn't re-selected.

## Why

Settings → Players wouldn't open — the `/#/settings/players` route resolved but rendered the settings index instead of the player list. `2.10.0b6` (published 2026-07-13, from the `dev` branch) is a mid-refactor beta where the player-protocol UI was being extracted into its own component. Server and players were healthy the whole time; only the settings frontend route was broken.

Root cause for being stuck on beta: the prior Renovate regex `^…\d+b(?<build>\d+)$` **only** matched beta tags, so stable releases were never visible and only `bN` bumps were ever offered.

`2.9.9` stable was published 2026-07-17.

## Rollout notes

- **Renee-facing** app. Per repo convention a normal bump waits for the Tuesday 02:00–04:00 ET window, but the Players settings page is broken *now* and this is a low-risk version pin — merge timing is Rob's call.
- **Downgrade across a minor beta boundary.** MA's library/config DB lives on `music-assistant-data-pvc` (Longhorn, `daily-snapshot` + `weekly-backup` labels). If 2.10 migrated the DB schema forward, 2.9.9 could reject it — worth a fresh Longhorn snapshot immediately before merge as a rollback anchor. Verify Settings → Players renders and players still resolve after reconcile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)