### PR TITLE
fix(descheduler): exclude Cilium CNI-rollout taint from eviction sweeps

### DIFF
--- a/kubernetes/apps/kube-system/descheduler/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/descheduler/app/helmrelease.yaml
@@ -59,7 +59,17 @@ spec:
                 nodeAffinityType:
                   - requiredDuringSchedulingIgnoredDuringExecution
               name: RemovePodsViolatingNodeAffinity
-            - name: RemovePodsViolatingNodeTaints
+            - args:
+                # Ignore Cilium's transient CNI-rollout taint. During a
+                # cilium-agent restart (every chart upgrade) the node carries
+                # `node.cilium.io/agent-not-ready:NoSchedule` until the new
+                # agent is Ready; without this exclusion the descheduler
+                # evicts every non-tolerating pod on that node, producing a
+                # cluster-wide eviction storm (2026-07-18: 50-64 pods/tick,
+                # blacked out Immich during the 1.19.6 rollout).
+                excludedTaints:
+                  - node.cilium.io/agent-not-ready
+              name: RemovePodsViolatingNodeTaints
             - name: RemovePodsViolatingTopologySpreadConstraint
           plugins:
             balance:


### PR DESCRIPTION
## Problem

On 2026-07-18 the `descheduler` threw eviction storms of **50–64 pods per 5-min tick** (15:10/15:14/15:29 EDT), which blacked out both Immich photo frames: `immich-server-0` kept getting evicted before it could finish its own image pull, so `immichkiosk` returned HTTP 503 for every asset.

## Root cause

The `#13107` Cilium **1.19.5 → 1.19.6** upgrade rolled the `cilium-agent` DaemonSet. While each node's agent restarts, Cilium taints the node `node.cilium.io/agent-not-ready:NoSchedule` until the new agent is Ready. The agent image pull ran long (cold pull-through cache), so nodes stayed tainted across descheduler ticks. `RemovePodsViolatingNodeTaints` then evicted every pod not tolerating that taint — a cluster-wide storm (also caused `Multi-Attach` volume churn across `databases`/`home`/`media`).

`nodeFit: true` + the disabled `PodsWithLocalStorage` protection made the blast radius nearly every pod (most carry the k8tz emptyDir sidecar).

## Fix

Add `excludedTaints: [node.cilium.io/agent-not-ready]` to `RemovePodsViolatingNodeTaints` so CNI rollouts (Cilium restarts on every chart upgrade) no longer trigger eviction sweeps. Supported by chart 0.36.0 (descheduler v0.33).

## Operational note

The descheduler was **suspended + scaled to 0** as the incident mitigation. After this merges, un-suspend the `descheduler` Flux Kustomization in `kube-system` to bring it back with the safe config. The Cilium rollout has completed and no taints are present, so it is safe to un-suspend once this fix is in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)