### PR TITLE
revert(container): re-pin music-assistant to 2.10.0b6 (2.9.9 downgrade failed)

### DIFF
--- a/.github/renovate/packageRules.json5
+++ b/.github/renovate/packageRules.json5
@@ -44,16 +44,17 @@
       ],
     },
     {
-      // Stable-only versioning for music-assistant server. MA publishes
-      // both stable (2.9.9) and beta (2.10.0b6) tags. This regex matches
-      // stable X.Y.Z only, so the bN prerelease tags are ignored entirely
-      // and Renovate stops auto-PRing beta bumps. The beta track put us on
-      // a mid-refactor 2.10.0 build that broke the Settings → Players page.
-      description: 'Stable-only versioning for music-assistant server (ignore bN prereleases)',
+      // Beta-channel versioning for music-assistant server. We are held on
+      // the 2.10.0 beta line because it wrote a schema-52 library DB that
+      // stable 2.9.9 cannot read (a downgrade attempt cleared the DB and
+      // crashed, 2026-07-18). This regex matches the bN prerelease tags so
+      // Renovate carries us FORWARD to the beta where the Settings → Players
+      // refactor is complete. Revisit switching to stable once 2.10.0 GAs.
+      description: 'Custom versioning for music-assistant server',
       matchDatasources: [
         'docker',
       ],
-      versioning: 'regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$',
+      versioning: 'regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)b(?<build>\\d+)$',
       matchPackageNames: [
         'ghcr.io/music-assistant/server',
       ],

--- a/kubernetes/apps/media/music-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/media/music-assistant/app/helmrelease.yaml
@@ -82,12 +82,13 @@ spec:
           app:
             image:
               repository: ghcr.io/music-assistant/server
-              # Pinned to 2.9.9 stable. The 2.10.0 beta track shipped a
-              # mid-refactor build (b6) where Settings → Players fails to
-              # render (route resolves to the settings index). Renovate had
-              # been tracking the beta channel only; see the stable-only
-              # versioning rule in .github/renovate/packageRules.json5.
-              tag: 2.9.9@sha256:50666a6f8d7f87d53d993dc41860ab06dda11047f6e433bb5bdbcb6e309ac74c
+              # Held on the 2.10.0 beta line: it wrote a schema-52 library DB
+              # that stable 2.9.9 cannot read (downgrade to 2.9.9 cleared the
+              # DB and crashed — reverted 2026-07-18). Stay on 2.10 and roll
+              # FORWARD to the beta where the Settings → Players refactor is
+              # complete; do NOT downgrade to stable. Renovate tracks the beta
+              # channel (see packageRules.json5).
+              tag: 2.10.0b6@sha256:02e0e2534d5d2d2ac094de637210af2ae3459ea9697a49d143fa1395f0157648
 
             env:
               # Smart Fades' Beat This! beat-tracking model downloads its


### PR DESCRIPTION
## What
Reverts #13114 — re-pins `ghcr.io/music-assistant/server` back to **2.10.0b6** and returns the Renovate rule to beta-channel tracking.

## Why
The 2.9.9 downgrade failed. Stable 2.9.9 cannot read the **schema-52** library DB that 2.10.0b6 wrote. On startup 2.9.9 ran a 52→43 downgrade migration, logged `Clearing database DONE`, then crashed with `sqlite3.OperationalError: no such column: external_ids` and never started its API/streamserver. Music Assistant was down.

No stable release can read schema 52, so "get to stable" is not reachable without a data reset.

## Recovery (in progress alongside this PR)
- Reverted the Longhorn volume `music-assistant-data-xfs` to the pre-downgrade snapshot `pre-2.9.9-downgrade-20260718` (restores the schema-52 DB).
- Re-pin to 2.10.0b6 (this PR) so MA runs against a DB schema it can read.
- Renovate returned to beta tracking to carry us **forward** to the 2.10 beta where the Settings → Players refactor is complete — the right fix for the broken page, without a schema-forbidden downgrade.

## Follow-ups (separate)
- Identify the specific 2.10 build where Settings → Players renders again and move to it (no data risk — same schema line).
- Add `readinessProbe`/`livenessProbe` to this container: during the failed downgrade the crashed pod still reported `Running 1/1` because nothing was probing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)