### PR TITLE
feat(container): add health probes to music-assistant

### DIFF
--- a/kubernetes/apps/media/music-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/media/music-assistant/app/helmrelease.yaml
@@ -101,6 +101,39 @@ spec:
               # model downloads once and survives restarts.
               XDG_CACHE_HOME: /data/.cache
 
+            # Probe the unauthenticated /info webserver endpoint (returns
+            # 200 with {"status": "running"}). During the 2026-07-18 failed
+            # 2.9.9 downgrade the app crashed in DB setup and never bound
+            # :8095, yet the pod still reported Running 1/1 because nothing
+            # was probing it — /info would have caught that (connection
+            # refused). Startup probe is generous: the ~2.5 GB image can
+            # cold-boot slowly, and we don't want liveness killing a healthy
+            # slow start.
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /info
+                    port: 8095
+                  initialDelaySeconds: 0
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness: *probes
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /info
+                    port: 8095
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                  timeoutSeconds: 5
+                  failureThreshold: 60
+
             resources:
               requests:
                 cpu: 15m


### PR DESCRIPTION
## What
Adds `liveness` + `readiness` (shared spec) and a `startup` probe to the Music Assistant container, all hitting the unauthenticated `GET /info` webserver endpoint (returns 200 with `{"status": "running"}`).

## Why
The container had **no probes**. During the 2026-07-18 failed 2.9.9 downgrade, MA crashed during DB setup and never bound `:8095`, yet the pod reported `Running 1/1` the entire time — nothing was probing it, so a fully-broken app looked green to Kubernetes and to dashboards. `/info` would have caught it (connection refused).

## Details
- **liveness/readiness:** `httpGet /info :8095`, `periodSeconds: 30`, `failureThreshold: 3` -> detects a hung/crashed server within ~90s and pulls the pod from Service endpoints.
- **startup:** `failureThreshold: 60 x periodSeconds: 5 = 300s` grace, so the ~2.5 GB image's slow cold boot isn't liveness-killed during a legitimate slow start.
- Verified `/info` returns `200` on the live pod before writing the probes.

## Rollout note
Merging re-renders the StatefulSet pod template -> a **rolling restart** of the single MA replica (~30s-2 min blip). MA is **Renee-facing**, so per repo convention this belongs in the **Tuesday 02:00-04:00 ET** window - merge timing is Rob's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)