### PR TITLE
ci(renovate): add 2.10.0 GA watch for music-assistant

### DIFF
--- a/.github/renovate/packageRules.json5
+++ b/.github/renovate/packageRules.json5
@@ -44,17 +44,25 @@
       ],
     },
     {
-      // Beta-channel versioning for music-assistant server. We are held on
-      // the 2.10.0 beta line because it wrote a schema-52 library DB that
-      // stable 2.9.9 cannot read (a downgrade attempt cleared the DB and
-      // crashed, 2026-07-18). This regex matches the bN prerelease tags so
-      // Renovate carries us FORWARD to the beta where the Settings → Players
-      // refactor is complete. Revisit switching to stable once 2.10.0 GAs.
-      description: 'Custom versioning for music-assistant server',
+      // Versioning for music-assistant server + built-in GA watch. We are
+      // held on the 2.10.0 beta line because it wrote a schema-52 library DB
+      // that stable 2.9.9 cannot read (a downgrade attempt cleared the DB and
+      // crashed, 2026-07-18). The `bN` suffix is captured as `prerelease`
+      // (NOT `build`) on purpose: that makes the eventual plain `2.10.0` GA
+      // sort ABOVE `2.10.0bN`, so Renovate auto-opens a PR the moment 2.10.0
+      // leaves beta — the path back to a stable channel with no schema
+      // downgrade (2.10.0 GA reads schema 52 natively). Meanwhile, because
+      // the pinned version is itself a prerelease, Renovate still offers
+      // newer TAGGED betas (bN) — carrying us toward the build where the
+      // Settings → Players refactor is complete — while the `.dev` nightlies
+      // are excluded by the `$` anchor. It never offers 2.9.x (lower than
+      // 2.10.0bN, so not an upgrade). Once we land on 2.10.0 GA, ignoreUnstable
+      // keeps us on the stable line. See memory: project_ma_schema52_stable_path.
+      description: 'Custom versioning for music-assistant server (beta + GA watch)',
       matchDatasources: [
         'docker',
       ],
-      versioning: 'regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)b(?<build>\\d+)$',
+      versioning: 'regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(b(?<prerelease>\\d+))?$',
       matchPackageNames: [
         'ghcr.io/music-assistant/server',
       ],


### PR DESCRIPTION
## What
Capture the music-assistant `bN` suffix as **`prerelease`** instead of `build` in the custom regex versioning.

## Why
This is the durable "GA watch" for the path back to a stable channel. It makes the eventual plain `2.10.0` GA tag sort **above** `2.10.0bN`, so Renovate auto-opens a PR the moment 2.10.0 leaves beta.

That matters because 2.10.0b6 wrote a **schema-52** library DB. Stable 2.9.x cannot read it — downgrading clears the DB and crashes (2026-07-18 incident, reverted in #13116). `2.10.0` GA reads schema 52 natively, so `2.10.0bX → 2.10.0` is a forward, zero-data-loss move.

## Behavior (all intended)
- ✅ Auto-PRs `2.10.0` GA when it publishes, ranked above the betas.
- ✅ Still offers newer **tagged** betas meanwhile (pinned version is a prerelease), carrying us toward the build where the Settings → Players refactor is complete.
- ✅ Excludes `.dev` nightlies (the `$` anchor rejects the `.devYYYYMMDDHH` suffix).
- ✅ Never offers 2.9.x (lower than `2.10.0bN`, so not an upgrade).
- ✅ Once on `2.10.0` GA, `ignoreUnstable` (default) keeps us on the stable line.

Config-only — **no image bump, no pod restart.**

Fallback if Renovate's prerelease ranking doesn't behave as expected: flip the rule to stable-only (`^X.Y.Z$`) at GA, which deterministically surfaces the forward upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)