### PR TITLE
fix(windmill): make lightrag-rag-ingest idempotent on 409

### DIFF
--- a/kubernetes/apps/home/windmill/workflows/lightrag-rag-ingest.ts
+++ b/kubernetes/apps/home/windmill/workflows/lightrag-rag-ingest.ts
@@ -57,7 +57,7 @@ export async function main() {
     const existing = await lightragSourceMap(apiKey); // "paperless:<id>" -> [docId]
     console.log(`[lightrag-ingest] watermark=${watermark} known_sources=${existing.size}`);
 
-    let submitted = 0, replaced = 0, skipped = 0;
+    let submitted = 0, replaced = 0, skipped = 0, already = 0;
     let maxModified = watermark;
     let page = 1;
     let capped = false;
@@ -77,8 +77,8 @@ export async function main() {
             }
             const prior = existing.get(src);
             if (prior?.length) { await lightragDelete(apiKey, prior); replaced++; }
-            await lightragInsert(apiKey, text, src);
-            submitted++;
+            const inserted = await lightragInsert(apiKey, text, src);
+            if (inserted) submitted++; else already++;
             if (doc.modified > maxModified) maxModified = doc.modified;
         }
         if (!list.next) break;
@@ -97,6 +97,7 @@ export async function main() {
         submitted,
         replaced,
         skipped,
+        already,
         capped,
     };
 }
@@ -120,14 +121,23 @@ async function lightragSourceMap(apiKey: string): Promise<Map<string, string[]>>
     return map;
 }
 
-async function lightragInsert(apiKey: string, text: string, source: string): Promise<void> {
+async function lightragInsert(apiKey: string, text: string, source: string): Promise<boolean> {
     const r = await fetch(`${LIGHTRAG}/documents/text`, {
         method: "POST",
         headers: { "Content-Type": "application/json", "X-API-Key": apiKey },
         body: JSON.stringify({ text, file_source: source }),
         signal: AbortSignal.timeout(60_000),
     });
+    // 409 = LightRAG already has this source but our dedup map missed it
+    // (GET /documents returns a capped subset). Treat as already-ingested,
+    // NOT fatal — otherwise one duplicate aborts the run before the watermark
+    // advances (line ~90), and every subsequent run re-scans from EPOCH and
+    // re-hits the same doc forever. Returns false so the caller counts it as
+    // `already` rather than a fresh submit. Follow-up: paginate
+    // lightragSourceMap so modified docs still refresh cleanly.
+    if (r.status === 409) return false;
     if (!r.ok) throw new Error(`lightrag insert ${source} ${r.status}: ${await r.text()}`);
+    return true;
 }
 
 async function lightragDelete(apiKey: string, docIds: string[]): Promise<void> {


### PR DESCRIPTION
## Problem

The `lightrag-rag-ingest` Windmill schedule (every 30m) has been **failing on every run** — a permanent deadlock, not a transient error.

Live evidence: every run logs the same `watermark=1970-01-01T00:00:00Z known_sources=19`, and the last failure returned:

```
lightrag insert paperless:8 409:
{"detail":"Document storage already contains 'paperless:8' (Status: processed)."}
```

### Mechanism

1. `lightragInsert` threw on **any** non-OK response.
2. The dedup map (`lightragSourceMap`) is built from a single, capped `GET /documents` — it only sees 19 sources and misses docs LightRAG actually has (e.g. `paperless:8`).
3. On a missed doc, the blind insert gets a **409**, throws, and aborts the run **before** `setState(maxModified)` can advance the watermark.
4. State stays pinned at EPOCH → next run re-scans from 1970 → re-hits the same duplicate → dies again. Forever.

## Fix

Tolerate 409 (already-ingested) the same way `lightragDelete` already tolerates 404: return `false` instead of throwing, and count it as `already` rather than a fresh submit. The run now completes, the watermark advances past already-present docs, and the pipeline un-wedges.

## Impact / scope

- This is the experimental **graph-RAG** pipeline (LightRAG), run alongside the healthy **vector** pipeline (`paperless-rag-ingest` → Qdrant). The vector side was unaffected; only the LightRAG graph corpus was frozen.
- Not user-facing.

## Follow-up (not in this PR)

Paginate `lightragSourceMap` so *modified* docs still refresh cleanly instead of silently 409-skipping.

## ⚠️ Deploy note

These workflows are git-backed but there is **no live git→Windmill auto-sync**. Merging this PR does **not** change runtime — the live schedule still needs a `wmill sync push` / UI Save+Deploy to pick up the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)