### PR TITLE
fix(observability): unstick prometheus-operator (prompp digest → sha field)

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -143,7 +143,12 @@ spec:
         image:
           registry: docker.io
           repository: prompp/prompp
-          tag: 2.53.2-0.3.3@sha256:df67ff1dc7094940e9d62e9bc318b02e4e35f539893dec5cc6b72d4fee4d8f21
+          # digest MUST stay in a separate `sha` field, not appended to `tag`:
+          # prometheus-operator parses `tag` as the Prometheus semver `version`,
+          # and a `@sha256:` suffix fails that parse → PrometheusOperatorSyncFailed
+          # (all operator reconciliation stalls). See #13091 (bulk digest pin).
+          tag: 2.53.2-0.3.3
+          sha: df67ff1dc7094940e9d62e9bc318b02e4e35f539893dec5cc6b72d4fee4d8f21
         podMonitorSelectorNilUsesHelmValues: false
         probeSelectorNilUsesHelmValues: false
         resources:


### PR DESCRIPTION
## Problem

`PrometheusOperatorSyncFailed` firing since #13091 ("pin missing image digests"). The bulk digest-pin appended the digest onto the prompp image **tag**:

\`\`\`yaml
tag: 2.53.2-0.3.3@sha256:df67ff…   # breaks the operator
\`\`\`

prometheus-operator derives the Prometheus `version` from the image tag and can't parse a digest-laden semver:

\`\`\`
sync "observability/kube-prometheus-stack" failed: failed to parse Prometheus version:
Invalid character(s) found in prerelease "3@sha256:df67ff…"
\`\`\`

So it aborts **every** reconcile of the Prometheus StatefulSet. Existing scrape config keeps running, but ServiceMonitor / Probe / PrometheusRule changes silently stop applying — a monitoring blind spot.

## Fix

Move the digest into the chart's dedicated `image.sha` field. The tag stays a clean parseable version; the digest pin is preserved and still applied to the pod image ref. Only the Prometheus (prompp) image was affected — Alertmanager wasn't digest-pinned in a version-bearing field.

## Verification

- `kustomize build` clean; all pre-commit hooks pass.
- Live confirmation of root cause: the deployed `Prometheus` CR shows `spec.version: 2.53.2-0.3.3@sha256:df67ff…`.
- Full chart render validated by flate/flux-local CI on this PR.

## Follow-up

The pin script/Renovate produced the bad `tag@sha256` form — a guard to keep future digest bumps in the `sha` field would prevent recurrence. Not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)