### PR TITLE
fix(rook-ceph): mitigate mgr OOMKill via active-mgr recycle + revert #13086

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/app/kustomization.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/app/kustomization.yaml
@@ -4,4 +4,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./cnp-allow.yaml
+  - ./mgr-recycle-cronjob.yaml
+  - ./mgr-recycle-rbac.yaml
   - operator

--- a/kubernetes/apps/rook-ceph/rook-ceph/app/mgr-recycle-cronjob.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/app/mgr-recycle-cronjob.yaml
@@ -1,0 +1,75 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/cronjob-batch-v1.json
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: rook-ceph-mgr-recycle
+  # workaround: https://tracker.ceph.com/issues/40260 — remove when the ceph-mgr
+  # prometheus-module memory leak is fixed upstream and the active-mgr
+  # working-set trend stays flat without recycling.
+spec:
+  # The active ceph-mgr leaks ~330Mi/hr — isolated 2026-07-17 to the
+  # `prometheus` module (see cluster/helmrelease.yaml) — and OOMKills at the
+  # 1536Mi limit every ~4h, an involuntary restart that fires OOMKilled
+  # criticals. Recycling the active mgr every 3h reclaims the heap *before*
+  # the ceiling (fresh ~160Mi + 3h × 330Mi/hr ≈ 1150Mi, ~75% of limit): ceph
+  # promotes the standby in seconds and the deleted pod returns as a fresh
+  # standby. Graceful, keeps the prometheus metrics + ceph_default alerts, and
+  # eliminates the OOMKill. k8tz injects timeZone America/New_York; every-3h
+  # cadence is timezone-agnostic anyway.
+  schedule: "17 */3 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: rook-ceph-mgr-recycle
+        spec:
+          serviceAccountName: rook-ceph-mgr-recycle
+          restartPolicy: OnFailure
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+          containers:
+            - name: recycle
+              image: docker.io/alpine/k8s:1.36.2@sha256:44ef4942e171939b9c665a4a84beb80e2dcdb9a24330d4651cfdfd2e9deecc47
+              env:
+                - name: KUBECACHEDIR
+                  value: /tmp/.kube-cache
+              command:
+                - /bin/sh
+                - -ceu
+                - |
+                  # Delete the active mgr pod by its rook-set role label; the
+                  # operator recreates it and ceph promotes the standby. No
+                  # spec mutation → GitOps-clean. --wait=false so the Job
+                  # returns immediately (the failover is async).
+                  kubectl -n rook-ceph delete pod \
+                    -l app=rook-ceph-mgr,mgr_role=active --wait=false
+                  echo "Requested recycle of the active rook-ceph mgr"
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 64Mi
+                limits:
+                  memory: 128Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop:
+                    - ALL
+                seccompProfile:
+                  type: RuntimeDefault
+              volumeMounts:
+                - name: tmp
+                  mountPath: /tmp
+          volumes:
+            - name: tmp
+              emptyDir: {}

--- a/kubernetes/apps/rook-ceph/rook-ceph/app/mgr-recycle-rbac.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/app/mgr-recycle-rbac.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rook-ceph-mgr-recycle
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: rook-ceph-mgr-recycle
+rules:
+  # The active mgr pod name is non-deterministic
+  # (rook-ceph-mgr-<a|b>-<hash>-<rand>), so it must be selected by the
+  # rook-set `mgr_role=active` label — which requires `list` (a
+  # resourceNames-scoped Role cannot match a label selector). Scope stays
+  # namespace-local (rook-ceph) via the RoleBinding below. The operator
+  # recreates the deleted pod, so no Deployment spec mutation / Flux drift.
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rook-ceph-mgr-recycle
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rook-ceph-mgr-recycle
+subjects:
+  - kind: ServiceAccount
+    name: rook-ceph-mgr-recycle

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -68,18 +68,23 @@ spec:
       crashCollector:
         disable: false
 
-      # workaround: https://tracker.ceph.com/issues/48792 — remove when the ceph
-      # dashboard-module perf_schema memory leak is fixed upstream (still open as
-      # of v20.2.2 Tentacle). The dashboard mgr module leaks ~330Mi/hr on the
-      # ACTIVE mgr (standby stays flat), OOMKilling mgr.b every ~4h at the 1536Mi
-      # limit. Confirmed 2026-07-16 by the tracker's signature toggle test:
-      # `ceph mgr module disable dashboard && enable dashboard` on mgr.b dropped
-      # working-set 642->270Mi (-58%) instantly. Disabling restful (#13029) did
-      # NOT fix it — dashboard is the real leaker. Grafana (via the prometheus
-      # module, still enabled) covers observability; only Ceph's embedded UI is
-      # lost. Re-enable by flipping this back to true + restoring the route below.
+      # The ~330Mi/hr active-mgr memory leak (OOMKill every ~4h at the 1536Mi
+      # limit) was isolated 2026-07-17 to the `prometheus` mgr module — NOT the
+      # dashboard. A disable-and-leave test flatlined the active mgr at ~210Mi
+      # with prometheus off, while the dashboard made no difference (the earlier
+      # 642->270Mi "dashboard" result was a Python-heap reload artifact that any
+      # module toggle reproduces; #13086 disabled dashboard for zero benefit).
+      # prometheus stays enabled (it feeds kube-prometheus-stack and the
+      # ceph_default alerts; the module's tunables are already at their
+      # memory-safe defaults, so the leak is a genuine upstream bug on 20.2.2).
+      # The leak is instead mitigated by a periodic active-mgr recycle CronJob
+      # (see app/mgr-recycle-*). So the dashboard has no reason to stay off —
+      # re-enabled here (reverts #13086).
       dashboard:
-        enabled: false
+        enabled: true
+        prometheusEndpoint: http://kube-prometheus-stack-prometheus.observability.svc.cluster.local:9090
+        ssl: false
+        urlPrefix: /
 
       dataDirHostPath: /var/lib/rook
 
@@ -88,14 +93,12 @@ spec:
           - enabled: true
             name: rook
           # restful is a legacy mgr module (standalone REST API on :8003) with
-          # no consumer in this cluster — nothing routes to it. It is also a
-          # known ceph-mgr memory leaker proportional to PG count
-          # (https://tracker.ceph.com/issues/40260). The active mgr grows
-          # ~300Mi/hr and OOMKills every ~5h under the 1536Mi limit; disabling
-          # unused leaky modules is the root-cause fix rather than re-raising
-          # the ceiling. dashboard is ALSO disabled (above, cephClusterSpec) —
-          # it was the dominant leaker (ceph#48792), restful alone didn't fix it.
-          # prometheus stays (feeds kube-prometheus-stack / Grafana).
+          # no consumer in this cluster — nothing routes to it, and it is a
+          # known ceph-mgr memory leaker (https://tracker.ceph.com/issues/40260),
+          # so it stays disabled. It was NOT the dominant leaker, though: the
+          # ~330Mi/hr active-mgr leak was isolated 2026-07-17 to the `prometheus`
+          # module (kept enabled for metrics; mitigated by the recycle CronJob in
+          # app/mgr-recycle-*), and dashboard (ceph#48792) was ruled out entirely.
           - enabled: false
             name: restful
       resources:
@@ -247,8 +250,19 @@ spec:
       createPrometheusRules: true
       enabled: true
 
-  # route.dashboard removed with the dashboard module (disabled above,
-  # ceph#48792). Nothing serves rook.${SECRET_DOMAIN} now; the glance "Rook"
-  # Storage tile goes away with it. Restore this block if the dashboard is
-  # ever re-enabled.
+    route:
+      dashboard:
+        annotations:
+          glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/rook.svg"
+          glance/id: "Storage"
+          glance/name: "Rook"
+          glance/show: "true"
+        host:
+          name: "rook.${SECRET_DOMAIN}"
+          path: /
+          pathType: PathPrefix
+        parentRefs:
+          - name: internal
+            namespace: network
+            sectionName: https
   timeout: 15m


### PR DESCRIPTION
## Root cause (confirmed 2026-07-17)

The ~330Mi/hr active-mgr memory leak — OOMKill every ~4h at the 1536Mi limit — was isolated to the ceph-mgr **`prometheus` module** via a disable-and-leave test on the same process:

| t | mgr working-set | note |
|---|---|---|
| disable prometheus | 1517 → 98 Mi | heap unload |
| +51 min | 210 Mi | re-warm |
| +73 min | **210.8 Mi** | **flat** |

With the module off the active mgr flatlined; with it on it climbs to OOM. The module's memory tunables are already at their safe defaults (`exclude_perf_counters=true`, `rbd_stats_pools` empty), so this is a genuine upstream leak on Ceph 20.2.2 Tentacle, not a misconfig. Earlier dashboard/restful theories were both wrong — the dashboard "confirmation" was a Python-heap reload artifact that any module toggle reproduces.

## Why not just disable the module

`prometheus` feeds kube-prometheus-stack and the `ceph_default` alert rules. Disabling it blinds the cluster to OSD-down/full, mon quorum, and PG-health alerts (ceph-exporter only covers per-daemon perf counters, not cluster-level). Not acceptable for the storage layer.

## Fix: periodic active-mgr recycle

`mgr-recycle-cronjob.yaml` deletes the `mgr_role=active` mgr pod every 3h. Ceph promotes the standby in seconds; the deleted pod returns as a fresh standby. The heap is reclaimed **before** the ceiling (fresh ~160Mi + 3h × 330Mi/hr ≈ 1150Mi, ~75% of limit), so the OOMKilled critical and the ungraceful restart go away while metrics/alerting stay live.

- Same pattern as `frigate-restart` (alpine/k8s image + scoped SA/RBAC).
- GitOps-clean: no spec mutation — the operator recreates the pod.
- apiserver/DNS egress covered by the namespace baseline network-policy (`endpointSelector: {}`); no extra CNP.
- Non-disruptive (mgr isn't in the data path), so it runs any time, not gated to a maintenance window.

## Also: reverts #13086

Since prometheus (not dashboard) is the proven leaker, re-enable the Ceph dashboard module + its `rook.${SECRET_DOMAIN}` route and glance tile. Disabling it bought zero leak reduction.

## Verification

- `kustomize build` clean on the app dir and the full rook-ceph namespace; all pre-commit hooks pass.
- Live test log captured in memory (`reference_rook_mgr_restful_leak_disable.md`).
- Full render validated by flate/flux-local CI on this PR.

Workaround tracked vs https://tracker.ceph.com/issues/40260 (issue #13085).

🤖 Generated with [Claude Code](https://claude.com/claude-code)