### PR TITLE
docs(cnpg): scrub cutvideo references after LosslessCut migration

### DIFF
--- a/.agents/skills/add-cnpg-cluster.md
+++ b/.agents/skills/add-cnpg-cluster.md
@@ -18,7 +18,7 @@ app — its own ExternalSecret pointing at `postgres-<app>-rw` — lives in
 its own namespace under `kubernetes/apps/<ns>/<app>/app/`. This skill
 covers both.
 
-Canonical recent reference: `cloudnative-pg/config/cutvideo/`.
+Canonical recent reference: `cloudnative-pg/config/videodupfinder/`.
 
 ## Workflow
 
@@ -26,7 +26,7 @@ Canonical recent reference: `cloudnative-pg/config/cutvideo/`.
 
 Ask the user for:
 
-1. **App name** — e.g. `cutvideo`, `videodupfinder`. Used as the
+1. **App name** — e.g. `videodupfinder`, `sparkyfitness`. Used as the
    directory name and as `<app>` in every reference below.
 2. **App namespace** — where the consuming workload lives (e.g. `media`,
    `auth`). The DB always lives in `databases/`.
@@ -270,7 +270,7 @@ The `INIT_POSTGRES_*` block is consumed by an `initContainers:` entry
 in the consuming HelmRelease (typical pattern: a `mendhak/init-pg`-style
 container that creates the DB and grants it to the app user). If the
 app already exists and just needs DB env wiring, look at
-`media/cutvideo/app/helmrelease.yaml` for the canonical init-container
+`media/videodupfinder/app/helmrelease.yaml` for the canonical init-container
 shape.
 
 ### Step 6: Smoke test before declaring done

--- a/.agents/skills/dependency-mapper.md
+++ b/.agents/skills/dependency-mapper.md
@@ -329,7 +329,7 @@ This repository:
   recurses into.
 - Per-app Kustomizations live next to each app at
   `kubernetes/apps/<namespace>/<app>/ks.yaml`. The `metadata.name` is
-  just the app name (e.g., `nextcloud`, `cutvideo`); there is no
+  just the app name (e.g., `nextcloud`, `videodupfinder`); there is no
   `<system>-<app>` prefix.
 - The Flux source is `GitRepository/home-ops-kubernetes` in the
   `flux-system` namespace — every `ks.yaml` references it as

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Worker nodes attach to **iot** and **sec** VLANs via Multus for direct camera an
 | **Music Assistant** + **Gonic** | Multi-room music control + Subsonic API |
 | **RomM** | Retro game library (~10k ROMs) |
 | **Beets** | Music library tagging |
-| **cutVideo / av1corrector / videodupfinder / medialyze** | Custom video tooling |
+| **av1corrector / videodupfinder / medialyze** | Custom video tooling |
 | **Theme Park** | Consistent UI theming across apps |
 | **Batocera Webdashboard Pro** | Retro-gaming console dashboard |
 | **kodi-playback-watcher** | Bridge for Kodi playback state |

--- a/docs/src/cluster_rebuild.md
+++ b/docs/src/cluster_rebuild.md
@@ -174,7 +174,7 @@ done
 
 **Commented** — block exists in the file but is commented out. Uncomment before the relevant Flux Kustomization runs on rebuild:
 
-- `cutvideo`, `medikeep`, `netbox`, `pump`, `romm`, `sparkyfitness`, the media-pull-stack apps
+- `medikeep`, `netbox`, `pump`, `romm`, `sparkyfitness`, the media-pull-stack apps
 
 **No recovery block at all** — these clusters have never been wired for Barman recovery. **Add a `bootstrap.recovery` block (and confirm an `ObjectStore` + `ScheduledBackup` exist) before any rebuild that needs them to survive:**
 

--- a/docs/src/cnpg_restore.md
+++ b/docs/src/cnpg_restore.md
@@ -129,7 +129,7 @@ shipped offsite. App reconstruction depends on the app:
 - media-pull-stack apps — full data loss is non-recoverable beyond
   re-scraping from external sources
 - `medikeep` — full loss; manual reentry
-- `pump`, `sparkyfitness`, `videodupfinder`, `cutvideo` —
+- `pump`, `sparkyfitness`, `videodupfinder` —
   application-specific; mostly recoverable from source data
 - `nametag`, `medialyze`, `windmill` — workflow / metadata; full
   loss


### PR DESCRIPTION
## Summary

cutVideo was decommissioned in #11663 (LosslessCut migration). This session finished the cleanup by deleting its Garage backup bucket, GHCR image, and 1Password item. This PR scrubs the remaining stale references in docs and skills so nothing points at the removed app anymore.

## Changes

- **`.agents/skills/add-cnpg-cluster.md`** — the skill named `cloudnative-pg/config/cutvideo/` and `media/cutvideo/app/helmrelease.yaml` as its **canonical recent reference**; both paths were **deleted** in #11663. Repointed to the still-live **`videodupfinder`** (same custom-video-tooling family, same CNPG + init-container pattern). Also swapped the stale `cutvideo` example app name.
- **`README.md`** — dropped `cutVideo` from the custom-video-tooling app table (app no longer deployed).
- **`docs/src/cluster_rebuild.md`** / **`docs/src/cnpg_restore.md`** — removed `cutvideo` from the CNPG recovery/restore lists so a DR run doesn't attempt to restore a deleted cluster.

## Not touched (deliberate)

- `containers/cutVideo/` source stays on disk (separate repo; deliberate archive).

Doc-only; no manifest/cluster impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)