### PR TITLE
fix(frigate): redact Frigate+ model id in snapshot instead of env var

### DIFF
--- a/kubernetes/apps/home/frigate/app/externalsecret.yaml
+++ b/kubernetes/apps/home/frigate/app/externalsecret.yaml
@@ -21,7 +21,10 @@ spec:
         FRIGATE_REOLINK_RTSP_PASSWORD: "{{ .reolink_password }}"
         FRIGATE_LORYTA_RTSP_PASSWORD: "{{ .loryta_password }}"
         FRIGATE_BIRDCAM_RTSP_PASSWORD: "{{ .FRIGATE_BIRDCAM_RTSP_PASSWORD }}"
-        FRIGATE_PLUS_MODEL: "{{ .frigate_plus_custom_model }}"
+        # FRIGATE_PLUS_MODEL — intentionally NOT injected. Frigate can't
+        # env-substitute model.path (plain str, not EnvString), so the id
+        # stays literal in the live config and is redacted at snapshot time.
+        # # FRIGATE_PLUS_MODEL: "{{ .frigate_plus_custom_model }}"
         # go2rtc publish: target — substituted into rtmp://.../live2/{BIRDCAM_YOUTUBE_KEY}
         BIRDCAM_YOUTUBE_KEY: "{{ .BIRDCAM_STREAM_KEY }}"
         # EMQX

--- a/kubernetes/apps/home/frigate/app/snapshot-script-cm.yaml
+++ b/kubernetes/apps/home/frigate/app/snapshot-script-cm.yaml
@@ -106,13 +106,25 @@ data:
       # every regenerated snapshot trips ~30 lint errors. Kept inside the
       # script (not patched onto the file post-hoc) so it survives every
       # snapshot regeneration.
+      # Redact the Frigate+ model id (model.path `plus://<id>`) before commit.
+      # The id identifies Rob's Frigate+ account and this repo is public. It
+      # CANNOT be moved to a secret + env var: Frigate only substitutes env
+      # vars in `EnvString`-typed fields (mqtt/rtsp/onvif/genai/proxy);
+      # model.path is a plain `str` and is read verbatim, so a `{FRIGATE_*}`
+      # placeholder there just fails as `incorrect_id`. So keep the real id in
+      # the live PVC config and scrub only the committed snapshot. The sed
+      # matches `plus://<hex>` (the active path line only — the commented
+      # model-history lines are bare `#<hex>`, no `plus://`); the constant
+      # `plus://REDACTED` keeps the diff stable (no per-snapshot churn).
       {
         echo "# yamllint disable"
         echo "# This file is a snapshot of Frigate's live /config/config.yml,"
         echo "# written by Frigate itself via the UI / API config setter."
         echo "# Not hand-authored YAML; not Flux-reconciled. Lint rules around"
         echo "# quoted-strings / comment-spacing don't apply."
-        cat "$CONFIG_FILE"
+        echo "# model.path Frigate+ id is REDACTED; real value in 1Password"
+        echo "# (Kubernetes/frigate/frigate_plus_custom_model)."
+        sed -E 's#(plus://)[a-f0-9]{8,}#\1REDACTED#g' "$CONFIG_FILE"
       } > "$DEST"
 
       if git diff --quiet; then

--- a/kubernetes/apps/home/frigate/snapshots/config.yml
+++ b/kubernetes/apps/home/frigate/snapshots/config.yml
@@ -29,7 +29,7 @@ ui:
   unit_system: imperial
 
 model:
-  path: "plus://{FRIGATE_PLUS_MODEL}"
+  path: plus://REDACTED
   #3e711036dc2003b0afdbfd8fa61de75e
   #c68fb5900938a9cccddfbc637ce535f2
   #18258fc4c00729ee12287b1adc2ed763


### PR DESCRIPTION
## Context

#13126 tried to keep the Frigate+ model id out of this public repo by sourcing it from a secret and referencing `plus://{FRIGATE_PLUS_MODEL}` in the config. **That can't work** — verified against frigate `v0.17.2` source: env substitution only applies to fields typed `EnvString` (`mqtt.py`, `camera/ffmpeg.py`, `onvif.py`, `genai.py`, `proxy.py`). `detectors/detector_config.py`'s `model.path` is a plain `str`, read verbatim (`model_id = path[7:]`), so the placeholder reaches the Frigate+ API literally and returns `incorrect_id` → crashloop. (That's almost certainly why the plumbing was originally left commented out.)

## Fix

Keep the id literal in the **live PVC config** (Frigate requires it there) and redact only the **committed snapshot**:

- **snapshot script**: `sed 's#(plus://)[a-f0-9]{8,}#\1REDACTED#g'` before commit. The active `model.path` becomes `plus://REDACTED`; a constant so there's no per-snapshot churn. Model-history comment lines (`#<hex>`, no `plus://`) are untouched.
- **externalsecret**: revert the `FRIGATE_PLUS_MODEL` injection from #13126 (unused now).
- **snapshot config.yml**: `model.path` → `plus://REDACTED`.

## Not covered

The commented model-history ids in `snapshots/config.yml` are old, already-public ids left as breadcrumbs — not scrubbed here (they predate this and live in git history regardless). Say the word to strip them too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)