### PR TITLE
fix(vector): raise aggregator HR timeout to 10m to unstick 0.57 upgrade

### DIFF
--- a/kubernetes/apps/observability/vector/aggregator/helmrelease.yaml
+++ b/kubernetes/apps/observability/vector/aggregator/helmrelease.yaml
@@ -13,6 +13,10 @@ spec:
     name: app-template
 
   interval: 30m
+  # Default 5m HR timeout clips the atomic --wait during the 0.57 roll
+  # (2-replica rollout + geoipupdate init pulls a fresh MaxMind DB),
+  # tripping the client rate-limiter context-deadline and rolling back.
+  timeout: 10m
   values:
     controllers:
       vector-aggregator:


### PR DESCRIPTION
## What

Add `spec.timeout: 10m` to the vector-aggregator HelmRelease.

## Why

The HR has been stalled (`RetriesExceeded`) since the default **5m** HR timeout clipped the atomic helm `--wait` during the aggregator roll — the 2-replica rollout plus the geoipupdate init pulling a fresh MaxMind DB ran **~5m4s**, tripping the client rate-limiter context deadline and rolling back to v48.

Consequence: the cluster is pinned to **vector 0.56.0** while git wants **0.57.0** (+ geoipupdate v7→v8). All aggregator/agent pods are running fine on 0.56.0 — the *upgrade* is what's wedged, not live service.

## After merge (Routine window, 02:00–05:00)

A forced HR reconcile re-attempts the upgrade with the 10m headroom, rolls the aggregator (agents buffer → no log loss), and lands 0.57.0. Verify the HR reports Ready at revision 5.0.1 and pods come up on `vector:0.57.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)