### PR TITLE
fix(esphome): repoint to libusb fork so device firmware compiles

### DIFF
--- a/kubernetes/apps/home/esphome/app/helmrelease.yaml
+++ b/kubernetes/apps/home/esphome/app/helmrelease.yaml
@@ -44,9 +44,13 @@ spec:
 
         containers:
           app:
+            # Fork of ghcr.io/home-operations/esphome adding libusb-1.0-0, without
+            # which ESPHome's ESP-IDF openocd verification fails and every device
+            # firmware compile aborts. Repoint at upstream when it ships libusb.
+            # workaround: https://github.com/home-operations/containers/issues/1620 — remove when upstream esphome ships libusb-1.0-0
             image:
-              repository: ghcr.io/home-operations/esphome
-              tag: 2026.7.0@sha256:02e4805250f466dcead3f3d7f2491b10cc9b0819407dedd61474f3383f8420ce
+              repository: ghcr.io/rwlove/esphome
+              tag: 2026.7.0@sha256:d314bf1e082da6eef4ea26438c64430905b92a2f699206a7aeb119b020b2a73b
 
 
             env:


### PR DESCRIPTION
## Why

The upstream `ghcr.io/home-operations/esphome:2026.7.0` image ships **no libusb**. ESPHome's ESP-IDF toolchain installer downloads Espressif's `openocd-esp32` and verifies it by running it — that fails (`libusb-1.0.so.0: cannot open shared object file`), so ESPHome aborts the **entire** ESP-IDF framework install. Net effect: **no ESP-IDF device in the esphome pod can compile firmware** (surfaced when a bt-scale firmware change couldn't be flashed).

## What

Repoint the esphome app image from `ghcr.io/home-operations/esphome` → `ghcr.io/rwlove/esphome` — same 2026.7.0 base + `libusb-1.0-0` (rwlove/containers#159, published as `ghcr.io/rwlove/esphome:2026.7.0@sha256:d314bf1e…`).

Rendered via `kubectl kustomize`; image/digest resolve correctly.

## Tracking

`# workaround:` annotated. Drop the fork and repoint upstream once it ships libusb: home-operations/containers#1620

🤖 Generated with [Claude Code](https://claude.com/claude-code)