### PR TITLE
fix(vector): opt out of 0.57 template confinement on Loki sinks

### DIFF
--- a/kubernetes/apps/observability/vector/aggregator/resources/vector.yaml
+++ b/kubernetes/apps/observability/vector/aggregator/resources/vector.yaml
@@ -43,6 +43,11 @@ sinks:
     out_of_order_action: rewrite_timestamp
     remove_label_fields: true
     remove_timestamp: true
+    # vector 0.57 template confinement: Loki label values are legitimately
+    # fully dynamic; a literal prefix would mangle the indexed values and
+    # break Grafana queries. Opt out to preserve prior behavior.
+    # https://github.com/vectordotdev/vector/blob/master/website/content/en/highlights/2026-07-14-0-57-0-upgrade-guide.md
+    dangerously_allow_unconfined_template_resolution: true
     labels:
       app: "{{ custom_app_name }}"
       namespace: "{{ kubernetes.pod_namespace }}"
@@ -58,5 +63,7 @@ sinks:
     out_of_order_action: rewrite_timestamp
     remove_label_fields: true
     remove_timestamp: true
+    # vector 0.57 template confinement — see loki_kubernetes above.
+    dangerously_allow_unconfined_template_resolution: true
     labels:
       hostname: "{{ host }}"


### PR DESCRIPTION
## What

Set `dangerously_allow_unconfined_template_resolution: true` on the `loki_kubernetes` and `loki_journal` sinks in the aggregator config.

## Why

With the 5m→10m HR timeout (#13132) clearing the stall, Flux re-attempted the vector `0.56.0 → 0.57.0` upgrade and the **real** blocker surfaced: the new pods crashloop on config load with

```
Sink "loki_kubernetes": template references event fields (["kubernetes.pod_node_name"]) ...
Sink "loki_journal": template references event fields (["host"]) ...
```

vector **0.57 enforces template confinement** — sink routing templates with a fully dynamic `{{ field }}` value and no literal prefix are rejected at startup ([upstream 0.57 upgrade guide](https://github.com/vectordotdev/vector/blob/master/website/content/en/highlights/2026-07-14-0-57-0-upgrade-guide.md)). Our Loki sinks use bare-field **label values** (`custom_app_name`, `kubernetes.pod_namespace`, `kubernetes.pod_node_name`, `host`).

Adding a literal prefix is the "confined" fix, but for Loki **label values** that would mangle every indexed value and break Grafana queries. The documented behavior-preserving fix is the per-sink opt-out, used here.

No `${VAR}` interpolation in this config, so the other 0.57 breaking change (env-var interpolation off by default) does not apply.

## Impact

No outage during the failed roll — the old `0.56.0` pod kept serving 1/1 (RollingUpdate). This lands `0.57.0` cleanly.

## After merge (Routine window)

A forced HR reconcile rolls the aggregator; the reloader picks up the ConfigMap change. Verify the HR reports Ready at 5.0.1, pods come up `1/1` on `vector:0.57.0`, and `component_errors_total{error_type="confinement_failed"}` stays at 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)