### PR TITLE
fix(frigate): give snapshot sidecar git; strip model-history comments

### DIFF
--- a/kubernetes/apps/home/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/home/frigate/app/helmrelease.yaml
@@ -50,8 +50,11 @@ spec:
           # the moment they happen. The daily CronJob handles ongoing UI edits.
           snapshot:
             image:
-              repository: docker.io/library/alpine
-              tag: "3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b"
+              # Must be an image WITH git (matches the snapshot CronJob).
+              # Plain alpine has no git → the startup snapshot silently
+              # failed `git: not found` (only the daily CronJob committed).
+              repository: docker.io/alpine/git
+              tag: "v2.54.0@sha256:77418e6e7c7f434c4a98eaff04ef16840cf03649c881c03948e3e213923e3136"
             command: ["/bin/sh", "/opt/snapshot/snapshot.sh"]
             env:
               # Wait for Frigate to finish auto-migration before snapshotting.

--- a/kubernetes/apps/home/frigate/snapshots/config.yml
+++ b/kubernetes/apps/home/frigate/snapshots/config.yml
@@ -30,17 +30,6 @@ ui:
 
 model:
   path: plus://REDACTED
-  #3e711036dc2003b0afdbfd8fa61de75e
-  #c68fb5900938a9cccddfbc637ce535f2
-  #18258fc4c00729ee12287b1adc2ed763
-  #a316bbbf0da5b12c0548bf475f534bde
-  #46287cf8d9e18ad374ab2d1acdaa8de8
-  #63e775900371c6f8d7b55d6d42facea8
-  #182461734fdb111413d4c7e83a3e3034
-  #6edeacefa958d51e89a961ed5b418b8f
-  #b5abb723a0db7a6bb581b71552774e81
-  #a9fc8d0fdc35df282fd3911f9b2a6f5b
-  #6514830311b1b8f1fb45cbc2702ef369
 
 auth:
   enabled: false


### PR DESCRIPTION
Two small follow-ups to the Frigate model/redaction work:

1. **Sidecar image** — the snapshot **sidecar** ran `docker.io/library/alpine:3.24` (no git), so its startup snapshot silently failed `git: not found`; only the daily CronJob (`docker.io/alpine/git`) ever committed. Point the sidecar at the same `alpine/git:v2.54.0` image so startup snapshots work.
2. **History cleanup** — remove the stale `#<old-model-id>` breadcrumb comments from `snapshots/config.yml`. The active id is redacted (`plus://REDACTED`) and the real value lives in 1Password. The live PVC config is cleaned in lockstep so snapshots stay clean. (Old ids remain in git *history* — not rewriting that.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)