### PR TITLE
fix(lightrag): cap extraction concurrency + raise LLM timeout to stop Spark ReadTimeouts

### DIFF
--- a/kubernetes/apps/ai/lightrag/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/lightrag/app/helmrelease.yaml
@@ -66,7 +66,17 @@ spec:
               LLM_BINDING_HOST: http://ollama-spark.ai.svc.cluster.local:11434
               LLM_MODEL: qwen3-next:80b-a3b-instruct-q4_K_M
               OLLAMA_LLM_NUM_CTX: "32768"
-              LLM_TIMEOUT: "240"
+              LLM_TIMEOUT: "600"
+              # Single GB10 serves ~4 concurrent (ollama-spark
+              # OLLAMA_NUM_PARALLEL=4) and each 80b call runs at a fraction of
+              # GPU speed under load. LightRAG's defaults offer up to
+              # MAX_PARALLEL_INSERT(3) × MAX_ASYNC(4) = 12 concurrent extraction
+              # calls, which queue past the read timeout → extraction
+              # ReadTimeouts (docs stuck 'failed'). Cap concurrency so we stop
+              # over-subscribing the shared Spark GPU; ingest is slower but
+              # completes cleanly.
+              MAX_ASYNC: "2"
+              MAX_PARALLEL_INSERT: "1"
               # --- Embeddings: bge-m3 (1024-dim) on Ollama-Spark ---
               EMBEDDING_BINDING: ollama
               EMBEDDING_BINDING_HOST: http://ollama-spark.ai.svc.cluster.local:11434


### PR DESCRIPTION
## Problem

LightRAG entity-extraction was failing on several documents with `httpx.ReadTimeout` — **72** in recent logs, and multiple docs stuck in `failed` status (one reproducibly failing 7× on re-scan). The `error_msg` field was empty because `httpx.ReadTimeout` stringifies to nothing, which made it look like a silent failure.

## Root cause

The extraction LLM call to `ollama-spark` (`qwen3-next:80b-a3b`) times out under load. LightRAG's defaults offer up to `MAX_PARALLEL_INSERT(3) × MAX_ASYNC(4) = 12` concurrent 80b calls at a **single GB10** that serves `OLLAMA_NUM_PARALLEL=4`. The excess queues, and the in-flight calls each run at a fraction of GPU speed — so many exceed the 240 s client read timeout.

This is unrelated to the recent ingest-deadlock fix (#13125 / #13128), which is working correctly; the graph itself is healthy (~2,285 nodes / 2,944 edges).

## Fix

Contained entirely to the LightRAG HelmRelease (shared `ollama-spark` untouched):

- `LLM_TIMEOUT` 240 → 600
- `MAX_ASYNC` → 2, `MAX_PARALLEL_INSERT` → 1 (max 2 in-flight extraction calls)

Ingest drains slower but completes cleanly instead of bleeding timeouts. The pod restarts on reconcile; in-flight docs re-enter `pending` and reprocess safely under the idempotent re-scan path.

## Verification

- Backend confirmed healthy pre-change: `/graph/label/list` → 2,285 labels; `/graphs?label=*` → 1,000 nodes.
- After merge: watch the `failed` doc count drop as the backlog reprocesses, and confirm no new `ReadTimeout` entries in the lightrag logs.