### PR TITLE
fix(theme-park): add /tmp tmpfs so hardened nginx can start

### DIFF
--- a/kubernetes/apps/media/theme-park/app/helmrelease.yaml
+++ b/kubernetes/apps/media/theme-park/app/helmrelease.yaml
@@ -72,3 +72,15 @@ spec:
           - backendRefs:
               - identifier: app
                 port: *httpPort
+
+    persistence:
+      # nginx (UID 101) writes its pid + all *_temp_path dirs under /tmp;
+      # required scratch under readOnlyRootFilesystem: true. Logs symlink
+      # to stdout/stderr and no proxy_cache is configured, so /tmp is the
+      # only writable path needed.
+      tmp:
+        type: emptyDir
+        advancedMounts:
+          theme-park:
+            app:
+              - path: /tmp


### PR DESCRIPTION
## What

Add a tmpfs (`emptyDir`) mount at `/tmp` to the theme-park HelmRelease.

## Why

The securityContext backfill (#12792) set `readOnlyRootFilesystem: true` on theme-park but added **no writable scratch volume**. theme-park is nginx (UID 101), and its pid + all temp paths live under `/tmp`:

```
pid /tmp/nginx.pid;
proxy_temp_path /tmp/proxy_temp;  client_body_temp_path /tmp/client_temp;
fastcgi_temp_path /tmp/fastcgi_temp;  uwsgi_temp_path /tmp/uwsgi_temp;
scgi_temp_path /tmp/scgi_temp;
```

With a read-only rootfs and no writable `/tmp`, the hardened pod can't start → the StatefulSet rollout stalls → helm reports the resource `'Failed'` → Flux auto-rolls back to the pre-hardening release. The HR has been **stalled (`RetriesExceeded`) since 2026-07-02**; the live pods run the un-hardened rolled-back spec (2/2, so no service impact — just wedged reconciliation).

Logs symlink to `/dev/stdout` / `/dev/stderr` and no `proxy_cache` is configured, so `/tmp` is the **only** writable path nginx needs — this keeps `readOnlyRootFilesystem: true` intact rather than disabling it. Per `.agents/instructions/helmrelease.security.md`.

## Impact

Rolls both theme-park pods once (cosmetic *arr login theming — not Renee-facing). After merge the stalled upgrade converges; verify the HR reports `Ready=True` @ 5.0.1 and pods come up `1/1` with the `/tmp` emptyDir mounted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)