### PR TITLE
fix(esphome): pin to last-good 2026.6.5, drop libusb fork

### DIFF
--- a/.github/renovate/packageRules.json5
+++ b/.github/renovate/packageRules.json5
@@ -2,6 +2,19 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "packageRules": [
     {
+      // workaround: https://github.com/home-operations/containers/issues/1620
+      // esphome 2026.7.0 switched to a native ESP-IDF installer that verifies
+      // openocd by executing it; the upstream image ships no libusb-1.0-0, so the
+      // check fails and ALL ESP-IDF device firmware compiles abort
+      // (esphome/esphome#17685). Held at the last-good 2026.6.x pin in
+      // kubernetes/apps/home/esphome/app/helmrelease.yaml. REMOVE this rule (and
+      // unpin the helmrelease) when the upstream esphome image ships libusb-1.0-0.
+      "description": "WORKAROUND: hold esphome at 2026.6.x until upstream image ships libusb (containers#1620)",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["ghcr.io/home-operations/esphome"],
+      "enabled": false
+    },
+    {
       "description": "Major updates: always open a PR, never auto-merge — manual review",
       "matchUpdateTypes": ["major"],
       "dependencyDashboardApproval": false,

--- a/kubernetes/apps/home/esphome/app/helmrelease.yaml
+++ b/kubernetes/apps/home/esphome/app/helmrelease.yaml
@@ -44,13 +44,15 @@ spec:
 
         containers:
           app:
-            # Fork of ghcr.io/home-operations/esphome adding libusb-1.0-0, without
-            # which ESPHome's ESP-IDF openocd verification fails and every device
-            # firmware compile aborts. Repoint at upstream when it ships libusb.
-            # workaround: https://github.com/home-operations/containers/issues/1620 — remove when upstream esphome ships libusb-1.0-0
+            # Pinned to the last-good 2026.6.x series. esphome 2026.7.0 switched to
+            # a native ESP-IDF installer that verifies openocd by executing it; the
+            # upstream image ships no libusb-1.0-0, so the check fails and every
+            # ESP-IDF device firmware compile aborts (esphome/esphome#17685). Renovate
+            # is held at this series in .github/renovate/packageRules.json5.
+            # workaround: https://github.com/home-operations/containers/issues/1620 — remove (unpin here + in packageRules.json5) when the upstream esphome image ships libusb-1.0-0
             image:
-              repository: ghcr.io/rwlove/esphome
-              tag: 2026.7.0@sha256:d314bf1e082da6eef4ea26438c64430905b92a2f699206a7aeb119b020b2a73b
+              repository: ghcr.io/home-operations/esphome
+              tag: 2026.6.5@sha256:dafe50b4923d2d4ff48199ac23ea389e40082c60b2c35f6c9e52a86b30e5dedb
 
 
             env:


### PR DESCRIPTION
## Why

esphome **2026.7.0** (bumped 2026-07-18, #13110) switched to a native ESP-IDF installer that verifies `openocd` by executing it. The upstream image ships **no `libusb-1.0-0`**, so the check fails and **every ESP-IDF device firmware compile aborts** (`RuntimeError: ESP-IDF 5.5.4 framework installation failure`). 2026.6.4 compiled + flashed fine on 2026-07-07; the 2026.7.0 bump is what broke it.

Upstream confirms this is an image-packaging gap, not a revertable esphome bug (maintainer fix = `apt install libusb-1.0-0`): esphome/esphome#17616 (closed), esphome/esphome#17685 (open).

## What

Instead of carrying a fork image, **roll back to the last-good upstream tag** and hold renovate there:
- app image `ghcr.io/rwlove/esphome:2026.7.0` → `ghcr.io/home-operations/esphome:2026.6.5` (reverts #13133).
- `packageRules.json5`: `enabled: false` hold on `ghcr.io/home-operations/esphome` so renovate can't bump back to 2026.7.x.

Both carry a `# workaround:` annotation. **Unpin (here + packageRules) when the upstream esphome image ships libusb** — tracked at home-operations/containers#1620.

Rendered via `kubectl kustomize`; image resolves to 2026.6.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)