### PR TITLE
fix(comfyui-mcp): satisfy 0.38.0 non-loopback auth guard

### DIFF
--- a/kubernetes/apps/mcp-system/comfyui-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/comfyui-mcp/app/helmrelease.yaml
@@ -35,6 +35,12 @@ spec:
               MCP_TRANSPORT: http
               MCP_HOST: 0.0.0.0
               MCP_PORT: "9100"
+              # 0.38.0 refuses to bind 0.0.0.0 without a token. The /mcp
+              # endpoint is not open — istio mTLS + the in-ns mcp-gateway
+              # broker + intra-ns CNP are the auth boundary, and the gateway
+              # route strips inbound Authorization (so COMFYUI_MCP_HTTP_TOKEN
+              # could never be presented). Opt into the non-loopback bind.
+              COMFYUI_MCP_ALLOW_UNAUTH: "1"
               # Skip auto-detection — point directly at the cluster's
               # ComfyUI Service. Cut over to the DGX Spark (GB10) backend
               # 2026-06-05; the P40 comfyui stays up as instant fallback


### PR DESCRIPTION
## Problem

comfyui-mcp has been crashlooping since the 0.24.1→0.38.0 bump. The 0.38.0 image finally surfaces a readable error instead of the opaque `Fatal error {}`:

> Refusing to start: HTTP MCP transport bound on non-loopback host 0.0.0.0 WITHOUT an auth token

0.38.0 added an opt-in auth guard that hard-refuses to bind a non-loopback host (`0.0.0.0`) with no token set. This was silently the same failure on 0.24.1 — **not an upstream bug**, so nothing to file.

## Why not a token

The guard's other fix is `COMFYUI_MCP_HTTP_TOKEN`, but token auth is incompatible with the current gateway route: the HTTPRoute strips inbound `Authorization` before forwarding (matching the arr-mcp pattern) and nothing injects `X-API-Key`, so a token could never be presented — every request would be rejected.

## Fix

The `/mcp` endpoint is not open: it's reachable only by the in-namespace `mcp-gateway` broker, behind istio mTLS + intra-ns CNP, never WAN-exposed. That mesh boundary is the auth layer (same posture as every other MCP backend here). Set `COMFYUI_MCP_ALLOW_UNAUTH=1` to opt into the non-loopback bind explicitly.

Non-destructive — fixes a crashlooping pod; no service currently up to disrupt.