### PR TITLE
feat(pump): bump to v0.0.105 (weight-ingest plausibility guard)

### DIFF
--- a/kubernetes/apps/collab/pump/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump/app/helmrelease.yaml
@@ -49,7 +49,7 @@ spec:
           pump:
             image:
               repository: ghcr.io/rwlove/pump
-              tag: v0.0.104@sha256:6b23acdbbbd73f51c2737af7af7c194c524e2ee8b01c03542311da54c66d2dcc
+              tag: v0.0.105@sha256:939c5fe794d90d49544a21e64ae35edb9d87c9e5bddd623f34c94a1c17f265fc
 
             env:
               # Activates the /api/cv/* proxy in pump (see internal/web/exercise.go).


### PR DESCRIPTION
Deploys rwlove/PUMP#70: `POST /api/weight` now rejects physically-impossible body weights (**422** + warn log) before storing, instead of accepting any value. Env-configurable `WEIGHT_MIN_LBS`/`WEIGHT_MAX_LBS` (default 50–500 lb). Backend-only — no schema/migration.

Image: `ghcr.io/rwlove/pump:v0.0.105@sha256:939c5fe…`

🤖 Generated with [Claude Code](https://claude.com/claude-code)