### PR TITLE
feat(monica): add Monica CRM to collab (CNPG postgres + Authelia SSO)

### DIFF
--- a/.github/image-registry-allowlist.txt
+++ b/.github/image-registry-allowlist.txt
@@ -23,6 +23,7 @@
 docker.io/ollama/ollama
 docker.io/glanceapp/glance
 docker.io/library/couchdb               # ghcr/apache/couchdb is devcontainer-only
+docker.io/library/monica                # Monica CRM canonical image; monica-next is ghcr but the moving :main dev tag
 docker.io/longhornio/                    # Longhorn canonical, no ghcr publication
 docker.io/alpine/k8s                    # alpine-based kubectl/helm; registry.k8s.io/kubectl is distroless
 docker.io/library/alpine

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ _Production-grade Kubernetes for a household._
 
 <br/>
 
-![apps](https://img.shields.io/badge/apps-155-blue?style=for-the-badge)
-![helmreleases](https://img.shields.io/badge/HelmReleases-167-326CE5?style=for-the-badge&logo=helm&logoColor=white)
+![apps](https://img.shields.io/badge/apps-156-blue?style=for-the-badge)
+![helmreleases](https://img.shields.io/badge/HelmReleases-168-326CE5?style=for-the-badge&logo=helm&logoColor=white)
 ![nodes](https://img.shields.io/badge/k8s_nodes-11-326CE5?style=for-the-badge&logo=kubernetes&logoColor=white)
-![cnpg](https://img.shields.io/badge/Postgres_clusters-21-336791?style=for-the-badge&logo=postgresql&logoColor=white)
-![secrets](https://img.shields.io/badge/secrets-87-0572EC?style=for-the-badge&logo=1password&logoColor=white)
+![cnpg](https://img.shields.io/badge/Postgres_clusters-22-336791?style=for-the-badge&logo=postgresql&logoColor=white)
+![secrets](https://img.shields.io/badge/secrets-88-0572EC?style=for-the-badge&logo=1password&logoColor=white)
 ![age](https://img.shields.io/badge/cluster_age-5%2B_years-success?style=for-the-badge)
 
 </div>

--- a/kubernetes/apps/auth/authelia/app/configmap.yaml
+++ b/kubernetes/apps/auth/authelia/app/configmap.yaml
@@ -84,6 +84,7 @@ data:
             - 'garage.${SECRET_DOMAIN}'
             - 'pump.${SECRET_DOMAIN}'
             - 'konflate.${SECRET_DOMAIN}'
+            - 'monica.${SECRET_DOMAIN}'
           policy: 'one_factor'
           subject: 'group:lldap_admin'
         # Household-tier (was authorization_policy: one_factor)

--- a/kubernetes/apps/collab/kustomization.yaml
+++ b/kubernetes/apps/collab/kustomization.yaml
@@ -21,6 +21,7 @@ resources:
   - ./it-tools/ks.yaml
   - ./kitchenowl/ks.yaml
   - ./medikeep/ks.yaml
+  - ./monica/ks.yaml
   - ./nametag/ks.yaml
   - ./obsidian-couchdb/ks.yaml
   - ./open-webui/ks.yaml

--- a/kubernetes/apps/collab/monica/app/cnp-allow.yaml
+++ b/kubernetes/apps/collab/monica/app/cnp-allow.yaml
@@ -1,0 +1,38 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: monica-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: monica
+  # Additive — default-deny (collab ns) is what triggers the lockdown;
+  # these rules punch holes through it. DNS + intra-namespace are
+  # covered by the baseline network-policy component.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  egress:
+    # CNPG cluster postgres-monica in databases ns.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: databases
+            cnpg.io/cluster: postgres-monica
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+  ingress:
+    # Internal Gateway (extAuth SecurityPolicy) → monica apache :80.
+    # The chart's Service maps port 8080 → containerPort 80; the pod
+    # listens on 80, so the policy allows 80.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "80"
+              protocol: TCP

--- a/kubernetes/apps/collab/monica/app/externalsecret.yaml
+++ b/kubernetes/apps/collab/monica/app/externalsecret.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: monica
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    # The chart hardcodes the APP_KEY env to secretKeyRef
+    # name={release fullname}=`monica`, key=`appkey` (it ignores
+    # monica.existingSecret.secretName/appKey). With
+    # monica.existingSecret.enabled: true the chart does NOT create this
+    # Secret, so this ExternalSecret owns it. Name/key must match exactly.
+    name: monica
+    creationPolicy: Owner
+    template:
+      data:
+        # Laravel APP_KEY — must be a stable `base64:<32-bytes>` value.
+        # Rotating it makes existing encrypted columns unreadable.
+        appkey: "{{ .APP_KEY }}"
+  dataFrom:
+    - extract:
+        key: monica

--- a/kubernetes/apps/collab/monica/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/monica/app/helmrelease.yaml
@@ -1,0 +1,91 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app monica
+spec:
+  chart:
+    spec:
+      # renovate: registryUrl=https://monicahq.github.io/helm chart=monica
+      chart: monica
+      sourceRef:
+        kind: HelmRepository
+        name: *app
+      version: 1.0.15
+  interval: 30m
+  values:
+    # Chart default is the unreleased monica-next:main (moving tag).
+    # Pinned to the classic, stable Monica v5 apache image by digest
+    # instead — Renovate tracks docker.io/library/monica.
+    image:
+      repository: docker.io/library/monica
+      tag: 5.0-apache@sha256:2a07a56474945d463da35617f7fe2f5d325880b307d8fab81a0d9d0239639453
+      pullPolicy: IfNotPresent
+
+    replicaCount: 1
+
+    # Auth + TLS are handled at the internal gateway (httproute.yaml +
+    # securitypolicy.yaml extAuth → Authelia). No in-chart ingress.
+    ingress:
+      enabled: false
+
+    monica:
+      host: monica.${SECRET_DOMAIN}
+      # enabled: true stops the chart from generating its own APP_KEY
+      # Secret. The chart then reads APP_KEY from a Secret hardcoded to
+      # name=`monica` (release fullname), key=`appkey` — supplied by the
+      # externalsecret.yaml ExternalSecret from 1Password. The
+      # secretName/appKey fields are ignored by the chart for APP_KEY,
+      # so they are intentionally omitted.
+      existingSecret:
+        enabled: true
+      # Laravel scheduler (reminders, cleanup, stats).
+      cronjob:
+        enabled: true
+
+    # SQLite off — Monica uses the dedicated CNPG postgres-monica cluster.
+    internalDatabase:
+      enabled: false
+
+    externalDatabase:
+      enabled: true
+      type: postgresql
+      host: postgres-monica-rw.databases.svc.cluster.local
+      database: monica
+      # username/password from CNPG's generated postgres-monica-app
+      # Secret, reflected into collab (see cluster.yaml inheritedMetadata).
+      existingSecret:
+        enabled: true
+        secretName: postgres-monica-app
+        usernameKey: username
+        passwordKey: password
+
+    # No bundled subcharts — DB is CNPG, no queue/cache/search backends.
+    mariadb:
+      enabled: false
+    postgresql:
+      enabled: false
+    redis:
+      enabled: false
+    memcached:
+      enabled: false
+    meilisearch:
+      enabled: false
+
+    # Uploaded files (avatars, contact documents) — irreplaceable, so
+    # Longhorn with recurring backups (longhorn-pvc.yaml), not ceph-block.
+    persistence:
+      enabled: true
+      existingClaim: monica-data-pvc
+
+    service:
+      type: ClusterIP
+      port: 8080
+
+    resources:
+      requests:
+        cpu: 50m
+        memory: 256Mi
+      limits:
+        memory: 1Gi

--- a/kubernetes/apps/collab/monica/app/helmrepository.yaml
+++ b/kubernetes/apps/collab/monica/app/helmrepository.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: monica
+spec:
+  interval: 2h
+  url: https://monicahq.github.io/helm
+  timeout: 3m

--- a/kubernetes/apps/collab/monica/app/httproute.yaml
+++ b/kubernetes/apps/collab/monica/app/httproute.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/gateway.networking.k8s.io/httproute_v1.json
+#
+# Auth is enforced by the extAuth SecurityPolicy (securitypolicy.yaml),
+# not by Monica alone. Internal gateway only — no public exposure.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: monica
+  annotations:
+    glance/icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/monica.png"
+    glance/id: "Collaboration"
+    glance/name: "Monica"
+    glance/show: "true"
+spec:
+  hostnames:
+    - monica.${SECRET_DOMAIN}
+  parentRefs:
+    - name: internal
+      namespace: network
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: monica
+          port: 8080

--- a/kubernetes/apps/collab/monica/app/kustomization.yaml
+++ b/kubernetes/apps/collab/monica/app/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./cnp-allow.yaml
+  - ./externalsecret.yaml
+  - ./helmrepository.yaml
+  - ./helmrelease.yaml
+  - ./httproute.yaml
+  - ./longhorn-pvc.yaml
+  - ./securitypolicy.yaml

--- a/kubernetes/apps/collab/monica/app/longhorn-pvc.yaml
+++ b/kubernetes/apps/collab/monica/app/longhorn-pvc.yaml
@@ -1,0 +1,41 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  namespace: collab
+  name: monica-data-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: 5Gi
+  volumeName: monica-data-pv
+  storageClassName: monica-data-storage-class
+
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: monica-data-pv
+  labels:
+    type: longhorn
+    recurring-job-group.longhorn.io/weekly-backup: enabled
+    recurring-job-group.longhorn.io/daily-snapshot: enabled
+spec:
+  capacity:
+    storage: 5Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: monica-data-storage-class
+  csi:
+    driver: driver.longhorn.io
+    fsType: xfs
+    volumeAttributes:
+      numberOfReplicas: "2"
+      staleReplicaTimeout: "2880"
+    volumeHandle: monica-data-xfs

--- a/kubernetes/apps/collab/monica/app/securitypolicy.yaml
+++ b/kubernetes/apps/collab/monica/app/securitypolicy.yaml
@@ -1,0 +1,34 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/gateway.envoyproxy.io/securitypolicy_v1alpha1.json
+#
+# extAuth via Authelia (#12767 pattern). failOpen stays false: Authelia
+# down means deny, not an open app. Authorization tier is set in the
+# Authelia access_control block (monica → admin-tier, group:lldap_admin).
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: monica-extauth
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: monica
+  extAuth:
+    failOpen: false
+    headersToExtAuth:
+      - accept
+      - cookie
+      - authorization
+      - proxy-authorization
+      - x-forwarded-proto
+    http:
+      backendRefs:
+        - name: authelia
+          namespace: auth
+          port: 9091
+      path: /api/authz/ext-authz/
+      headersToBackend:
+        - Remote-User
+        - Remote-Groups
+        - Remote-Name
+        - Remote-Email

--- a/kubernetes/apps/collab/monica/ks.yaml
+++ b/kubernetes/apps/collab/monica/ks.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app monica
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: collab
+  path: ./kubernetes/apps/collab/monica/app
+  interval: 30m
+  timeout: 5m
+  dependsOn:
+    - name: longhorn
+      namespace: longhorn-system
+    - name: onepassword-connect
+      namespace: external-secrets
+    - name: monica
+      namespace: databases
+  retryInterval: 1m

--- a/kubernetes/apps/databases/cloudnative-pg/config/monica/cluster.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/monica/cluster.yaml
@@ -1,0 +1,80 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/cluster_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgres-monica
+spec:
+  instances: 3
+
+  imageName: ghcr.io/cloudnative-pg/postgresql:17.7
+
+  primaryUpdateStrategy: unsupervised
+
+  failoverDelay: 30
+
+  replicationSlots:
+    highAvailability:
+      enabled: true
+
+  postgresql:
+    parameters:
+      timezone: "America/New_York"
+
+  storage:
+    size: 8Gi
+    storageClass: ceph-block
+
+  walStorage:
+    size: 8Gi
+    storageClass: ceph-block
+
+  resources:
+    requests:
+      cpu: 50m
+      memory: 512Mi
+    limits:
+      memory: 1Gi
+
+  enableSuperuserAccess: true
+  superuserSecret:
+    name: cloudnative-pg
+
+  bootstrap:
+    initdb:
+      database: monica
+      owner: monica
+
+  # CNPG generates the `postgres-monica-app` Secret (username/password/
+  # host/dbname) in this namespace. The Monica HelmRelease consumes it
+  # cross-namespace from `collab` via emberstack reflector — these
+  # annotations propagate to the generated Secret through
+  # inheritedMetadata so a future cluster rebuild re-establishes the
+  # mirror. Pattern: project_cnpg_cross_namespace_reflector.
+  inheritedMetadata:
+    annotations:
+      reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: collab
+      reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: collab
+
+  monitoring:
+    enablePodMonitor: true
+
+  plugins:
+    - enabled: true
+      isWALArchiver: true
+      name: barman-cloud.cloudnative-pg.io
+      parameters:
+        barmanObjectName: garage-monica
+        serverName: postgres-monica-backup
+
+  externalClusters:
+    - name: postgres-monica-backup
+      plugin:
+        enabled: true
+        isWALArchiver: false
+        name: barman-cloud.cloudnative-pg.io
+        parameters:
+          barmanObjectName: garage-monica
+          serverName: postgres-monica-backup

--- a/kubernetes/apps/databases/cloudnative-pg/config/monica/kustomization.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/monica/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../../components/cnpg-app-database
+resources:
+  - ./cluster.yaml

--- a/kubernetes/apps/databases/cloudnative-pg/ks.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/ks.yaml
@@ -729,3 +729,36 @@ spec:
     - apiVersion: postgresql.cnpg.io/v1
       kind: Cluster
       current: status.phase in ['Cluster in healthy state']
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app monica
+  labels:
+    substitution.flux.home.arpa/enabled: "true"
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: databases
+  path: ./kubernetes/apps/databases/cloudnative-pg/config/monica
+  interval: 30m
+  timeout: 5m
+  wait: true
+  dependsOn:
+    - name: cloudnative-pg
+      namespace: databases
+    - name: cloudnative-pg-plugin-barman-cloud
+      namespace: databases
+    - name: garage
+      namespace: storage
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  postBuild:
+    substitute:
+      APP: *app
+  healthCheckExprs:
+    - apiVersion: postgresql.cnpg.io/v1
+      kind: Cluster
+      current: status.phase in ['Cluster in healthy state']


### PR DESCRIPTION
Installs the [monicahq/helm](https://github.com/monicahq/helm) chart (`monica` 1.0.15) into the `collab` namespace, following the established collab-app + CNPG conventions.

## Design decisions
- **Image**: pinned to `docker.io/library/monica:5.0-apache` **by digest** — the chart defaults to the unreleased `monica-next:main` moving tag, which conflicts with the repo's stability/digest-pin conventions.
- **Database**: dedicated CNPG `postgres-monica` cluster on `ceph-block` (fresh `initdb`) with Garage Barman backups via the `cnpg-app-database` component. DB creds flow from CNPG's generated `postgres-monica-app` secret, reflected into `collab`.
- **APP_KEY**: from 1Password. The chart hardcodes the APP_KEY `secretKeyRef` to `name=monica`/`key=appkey` (it ignores `existingSecret.secretName/appKey`), and the ExternalSecret is shaped to match.
- **Storage**: uploaded files (avatars, contact documents) on Longhorn with daily-snapshot + weekly-backup labels — irreplaceable data.
- **Auth**: internal gateway + Authelia extAuth `SecurityPolicy`. `monica.${SECRET_DOMAIN}` added to the admin-tier `access_control` rule (`group:lldap_admin`).
- `docker.io/library/monica` added to the image-registry allowlist; README badge counts bumped.

## Out-of-band prerequisites (already provisioned)
- 1Password item `monica` (Kubernetes vault): `APP_KEY` + Garage keys.
- Garage bucket `postgres-monica-backup` with an RW-scoped key.

## Validation
- `kubectl kustomize` clean for `collab`, `databases`, `auth`.
- `helm template` renders correctly: `APP_KEY`→`monica`/`appkey`, `DB_CONNECTION=pgsql`→`postgres-monica-rw`, DB creds from `postgres-monica-app`, no competing chart-created secret.
- Full pre-commit pass (yamllint, gitleaks, literal-credentials, CNP rules, readme-drift).

## Blast radius
16 files, one logical app spanning `collab` + `databases`. New capacity only — no impact on existing services.

🤖 Generated with [Claude Code](https://claude.com/claude-code)