### PR TITLE
fix(monica): pin image to immutable tag (chart stamps tag into a label)

### DIFF
--- a/kubernetes/apps/collab/monica/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/monica/app/helmrelease.yaml
@@ -16,11 +16,21 @@ spec:
   interval: 30m
   values:
     # Chart default is the unreleased monica-next:main (moving tag).
-    # Pinned to the classic, stable Monica v5 apache image by digest
-    # instead — Renovate tracks docker.io/library/monica.
+    # Pinned to the classic Monica v5 apache image instead. NOTE: v5 is
+    # still pre-GA upstream — the only immutable v5 apache tags are
+    # betas, and `5.0-apache` is a MOVING pointer over them. Pinning the
+    # explicit `5.0.0-beta.5-apache` (identical bits to `5.0-apache`
+    # today) so the tag can't drift under us. Renovate tracks
+    # docker.io/library/monica and will bump beta.N → GA when it lands.
+    #
+    # NOT digest-pinned: this chart stamps image.tag verbatim into the
+    # `app.kubernetes.io/version` label (_helpers.tpl), and a
+    # `<tag>@sha256:...` value is both >63 bytes and contains illegal
+    # label characters, which fails server-side apply. Immutable tag is
+    # the best available substitute for a digest here.
     image:
       repository: docker.io/library/monica
-      tag: 5.0-apache@sha256:2a07a56474945d463da35617f7fe2f5d325880b307d8fab81a0d9d0239639453
+      tag: 5.0.0-beta.5-apache
       pullPolicy: IfNotPresent
 
     replicaCount: 1


### PR DESCRIPTION
Follow-up to #13146. The Monica HelmRelease failed to install:

`ServiceAccount "monica" is invalid: metadata.labels: Invalid value "5.0-apache@sha256:2a07a564...": must be no more than 63 bytes / illegal label chars`

The `monica` chart stamps `image.tag` verbatim into `app.kubernetes.io/version` (`_helpers.tpl`), so a digest-in-tag value is an illegal label. Digest-pinning is therefore impossible with this chart.

**Fix:** pin the immutable `5.0.0-beta.5-apache` tag (identical digest to the `5.0-apache` moving pointer today). v5 apache is still pre-GA upstream — the only immutable v5 tags are betas — so this avoids a moving tag without a digest. No global pinDigests in Renovate, so it won't be re-digested.

The CNPG `postgres-monica` cluster from #13146 is already healthy (3/3); this only fixes the app image.

Generated with Claude Code