### PR TITLE
fix(monica): trust Envoy proxy so asset URLs render https (blank login)

### DIFF
--- a/kubernetes/apps/collab/monica/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/monica/app/helmrelease.yaml
@@ -50,6 +50,15 @@ spec:
       # so they are intentionally omitted.
       existingSecret:
         enabled: true
+      # Trust the Envoy gateway as a reverse proxy so Laravel honors its
+      # X-Forwarded-Proto: https and emits https:// asset/redirect URLs.
+      # Without this, Monica falls back to the plain-http pod request
+      # scheme and the Vite bundle URLs render as http:// — the browser
+      # blocks them as mixed content on the https page → blank login.
+      # `*` is safe: the CNP only admits the Envoy pod to this container.
+      extraEnv:
+        - name: APP_TRUSTED_PROXIES
+          value: "*"
       # Laravel scheduler (reminders, cleanup, stats).
       cronjob:
         enabled: true


### PR DESCRIPTION
Follow-up to #13146/#13147. Monica's login page loaded (HTTP 200, 150 KB HTML) but rendered a **blank white page**.

**Cause:** the Vite asset URLs were emitted as `http://monica.${SECRET_DOMAIN}/build/assets/...` on an HTTPS page. Brave/Chrome block that as **mixed active content**, so the Vue SPA bundles never load and nothing mounts.

Laravel generated the plain-`http` pod request scheme because it trusts no proxy — `config/trustedproxy.php` reads `APP_TRUSTED_PROXIES`, which was unset. Envoy Gateway already sends `X-Forwarded-Proto: https`; a test request proved Monica ignored it until the proxy is trusted.

**Fix:** `monica.extraEnv: APP_TRUSTED_PROXIES=*` → Laravel honors `X-Forwarded-Proto` and emits `https://` asset/redirect URLs. `*` is safe here — the CiliumNetworkPolicy only admits the Envoy pod to this container.

Verified via `helm template`: `APP_TRUSTED_PROXIES: '*'` renders into both the Deployment and the scheduler CronJob.

Generated with Claude Code