### PR TITLE
chore(blackbox): retarget pool-pump ICMP probe to new controller

### DIFF
--- a/kubernetes/apps/observability/exporters/blackbox-exporter/app/probes.yaml
+++ b/kubernetes/apps/observability/exporters/blackbox-exporter/app/probes.yaml
@@ -71,7 +71,7 @@ spec:
         - elfin-salt
         - pool-light
         - konnected
-        - whisperflo-pool-pump
+        - pool-controller
         - wiim-pool
         - wiim-deck
         - wiim-yard


### PR DESCRIPTION
## What

Swap the blackbox-exporter ICMP probe target `whisperflo-pool-pump` → `pool-controller`.

## Why

The custom WhisperFlo ESP32 board (`whisperflo-pool-pump` @ `10.10.20.25`) was replaced by a Waveshare ESP32-S3-Relay-6CH (`pool-controller` @ `10.10.20.68`) during the pool-pump controller migration. The old board is physically removed, so its ICMP probe was failing (stale down alert). This retargets the probe to the live replacement (resolves at `pool-controller.thesteamedcrab.com`) and closes the deferred Stage-1 TODO to add a reachability probe for the new board.

## Scope / follow-up

Single-line change to `probes.yaml`. The old device's DNS/DHCP/NetBox records are decommissioned separately (held pending an MCP-gateway reconnect + explicit approval); this blackbox change is sequenced first so removing the old DNS record later doesn't briefly NXDOMAIN a still-probed target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)