### PR TITLE
feat(monica): enable SMTP via the shared relay (verification/reminder mail)

### DIFF
--- a/kubernetes/apps/collab/monica/app/cnp-allow.yaml
+++ b/kubernetes/apps/collab/monica/app/cnp-allow.yaml
@@ -24,6 +24,17 @@ spec:
         - ports:
             - port: "5432"
               protocol: TCP
+    # Shared internal SMTP relay in home ns (Maddy → Mailgun, port 2525,
+    # no auth) for verification + reminder email. Same target as
+    # lldap/authelia/zulip.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: home
+            app.kubernetes.io/name: smtp-relay
+      toPorts:
+        - ports:
+            - port: "2525"
+              protocol: TCP
   ingress:
     # Internal Gateway (extAuth SecurityPolicy) → monica apache :80.
     # The chart's Service maps port 8080 → containerPort 80; the pod

--- a/kubernetes/apps/collab/monica/app/externalsecret.yaml
+++ b/kubernetes/apps/collab/monica/app/externalsecret.yaml
@@ -22,6 +22,12 @@ spec:
         # Laravel APP_KEY — must be a stable `base64:<32-bytes>` value.
         # Rotating it makes existing encrypted columns unreadable.
         appkey: "{{ .APP_KEY }}"
+        # The chart wires MAIL_USERNAME/MAIL_PASSWORD from this Secret
+        # (keys smtp-username/smtp-password) whenever monica.mail.enabled.
+        # The internal smtp-relay needs no auth, so these are empty — the
+        # keys must still exist or the container fails on a missing ref.
+        smtp-username: ""
+        smtp-password: ""
   dataFrom:
     - extract:
         key: monica

--- a/kubernetes/apps/collab/monica/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/monica/app/helmrelease.yaml
@@ -62,6 +62,20 @@ spec:
       # Laravel scheduler (reminders, cleanup, stats).
       cronjob:
         enabled: true
+      # SMTP via the cluster's shared internal relay (Maddy → Mailgun),
+      # the same target lldap/authelia/zulip use. The relay needs no auth
+      # and speaks plain SMTP on 2525, so MAIL_ENCRYPTION="". The chart
+      # always wires MAIL_USERNAME/PASSWORD from the monica secret when
+      # mail.enabled, so externalsecret.yaml supplies empty
+      # smtp-username/smtp-password keys. Egress opened in cnp-allow.yaml.
+      mail:
+        enabled: true
+        fromAddress: monica@${SECRET_DOMAIN}
+        replyToAddress: monica@${SECRET_DOMAIN}
+        smtp:
+          host: smtp-relay.home.svc.cluster.local
+          port: 2525
+          encryption: ""
 
     # SQLite off — Monica uses the dedicated CNPG postgres-monica cluster.
     internalDatabase:


### PR DESCRIPTION
Follow-up to #13146/#13147/#13148. After the blank-login fix, signup works but dead-ends at `/email/verify` — Monica asks you to click a verification link that never arrives, because it was deployed with **mail disabled**.

Point Monica at the cluster's internal **smtp-relay** (`smtp-relay.home.svc.cluster.local:2525`, Maddy → Mailgun, no auth, plain) — the same relay lldap/authelia/zulip use, verified actively delivering (recent `delivered attempt:1` in the relay logs).

Three coordinated changes:
- **helmrelease**: `monica.mail.enabled: true` + smtp host/port, `MAIL_ENCRYPTION=""` (relay is plain), from `monica@${SECRET_DOMAIN}`.
- **externalsecret**: empty `smtp-username`/`smtp-password` keys — the chart always sources `MAIL_USERNAME`/`MAIL_PASSWORD` from the `monica` Secret when mail is enabled, and the relay needs no auth, but the keys must exist or the container fails on a missing ref.
- **cnp-allow**: egress to `smtp-relay` in the `home` ns on 2525.

Verified via `helm template`: `MAIL_HOST=smtp-relay.home.svc.cluster.local`, `MAIL_PORT=2525`, `MAIL_USERNAME/PASSWORD`→`monica` secret keys, `MAIL_ENCRYPTION=""`.

After reconcile, "Resend verification email" delivers.

Generated with Claude Code