### PR TITLE
fix(smtp-relay): allow collab/monica ingress on 2525

### DIFF
--- a/kubernetes/apps/home/smtp-relay/app/cnp-allow.yaml
+++ b/kubernetes/apps/home/smtp-relay/app/cnp-allow.yaml
@@ -21,6 +21,7 @@ spec:
     #   home/netbox        — netbox email.server
     #   home/home-assistant — HA notify SMTP integration
     #   home/windmill      — watcher-workflow email notifications
+    #   collab/monica      — CRM verification + reminder email
     # Plus LoadBalancer VIP (SVC_SMTP_RELAY_ADDR) so LAN devices
     # / cron scripts on hosts can submit mail too.
     - fromEndpoints:
@@ -39,6 +40,9 @@ spec:
         - matchLabels:
             io.kubernetes.pod.namespace: home
             app.kubernetes.io/name: windmill-workers
+        - matchLabels:
+            io.kubernetes.pod.namespace: collab
+            app.kubernetes.io/name: monica
       toPorts:
         - ports:
             - port: "2525"


### PR DESCRIPTION
Completes the Monica mail path (#13150). Cilium enforces policy on both sides — #13150 opened Monica's *egress* to the relay, but the relay's own *ingress* allowlist didn't include `collab/monica`, so its SYN was dropped (a raw SMTP test from the Monica pod to `smtp-relay.home.svc.cluster.local:2525` timed out).

Adds `collab/monica` to the `smtp-relay` ingress `fromEndpoints` on 2525, alongside lldap/authelia/netbox/home-assistant/windmill-workers.

Generated with Claude Code