### PR TITLE
fix(esphome): unpin to 2026.7.0 now upstream image ships libusb (Closes #13143)

### DIFF
--- a/.github/renovate/packageRules.json5
+++ b/.github/renovate/packageRules.json5
@@ -2,19 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "packageRules": [
     {
-      // workaround: https://github.com/home-operations/containers/issues/1620
-      // esphome 2026.7.0 switched to a native ESP-IDF installer that verifies
-      // openocd by executing it; the upstream image ships no libusb-1.0-0, so the
-      // check fails and ALL ESP-IDF device firmware compiles abort
-      // (esphome/esphome#17685). Held at the last-good 2026.6.x pin in
-      // kubernetes/apps/home/esphome/app/helmrelease.yaml. REMOVE this rule (and
-      // unpin the helmrelease) when the upstream esphome image ships libusb-1.0-0.
-      "description": "WORKAROUND: hold esphome at 2026.6.x until upstream image ships libusb (containers#1620)",
-      "matchDatasources": ["docker"],
-      "matchPackageNames": ["ghcr.io/home-operations/esphome"],
-      "enabled": false
-    },
-    {
       "description": "Major updates: always open a PR, never auto-merge — manual review",
       "matchUpdateTypes": ["major"],
       "dependencyDashboardApproval": false,

--- a/kubernetes/apps/home/esphome/app/helmrelease.yaml
+++ b/kubernetes/apps/home/esphome/app/helmrelease.yaml
@@ -44,15 +44,9 @@ spec:
 
         containers:
           app:
-            # Pinned to the last-good 2026.6.x series. esphome 2026.7.0 switched to
-            # a native ESP-IDF installer that verifies openocd by executing it; the
-            # upstream image ships no libusb-1.0-0, so the check fails and every
-            # ESP-IDF device firmware compile aborts (esphome/esphome#17685). Renovate
-            # is held at this series in .github/renovate/packageRules.json5.
-            # workaround: https://github.com/home-operations/containers/issues/1620 — remove (unpin here + in packageRules.json5) when the upstream esphome image ships libusb-1.0-0
             image:
               repository: ghcr.io/home-operations/esphome
-              tag: 2026.6.5@sha256:dafe50b4923d2d4ff48199ac23ea389e40082c60b2c35f6c9e52a86b30e5dedb
+              tag: 2026.7.0@sha256:b9f7c286abbf2b1e3dc2eea7ade23c2ec15eb4cab576a4097e5c7f05154462c3
 
 
             env:


### PR DESCRIPTION
## What

Retire the esphome libusb workaround (#13143):

- **`helmrelease.yaml`**: repin `ghcr.io/home-operations/esphome` off the last-good `2026.6.5` series → **`2026.7.0@sha256:b9f7c286abbf2b1e3dc2eea7ade23c2ec15eb4cab576a4097e5c7f05154462c3`**, and drop the pin-explanation comment.
- **`packageRules.json5`**: remove the Renovate hold rule so esphome tracks upstream again.

## Why

The upstream fix (home-operations/containers#1621, merged 2026-07-19 11:39 UTC) added `libusb-1.0-0` to the esphome Dockerfile. The `2026.7.0` image was **rebuilt at 11:41 UTC** with the fix. `2026.7.0` is the exact release whose new native ESP-IDF installer — which verifies `openocd-esp32` by executing it — was the original breakage, so this bump exercises the fixed path.

## Validation

- Image evidence only at PR time. Authoritative validation is a real ESP-IDF device compile once Flux rolls the new image (esphome dashboard StatefulSet restart — a build tool, not a running-device dependency; already-flashed firmware is unaffected).

Closes #13143

🤖 Generated with [Claude Code](https://claude.com/claude-code)