### PR TITLE
fix(collab): pin monica scheduler cron to the web pod's node via podAffinity

### DIFF
--- a/kubernetes/apps/collab/monica/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/monica/app/helmrelease.yaml
@@ -122,3 +122,28 @@ spec:
         memory: 256Mi
       limits:
         memory: 1Gi
+  # The chart mounts monica-data-pvc (RWO Longhorn, single-node attach)
+  # into both the web Deployment and the every-minute scheduler CronJob,
+  # but hardcodes the cron jobTemplate pod spec with no affinity — so the
+  # cron pod wedged in PodInitializing whenever it scheduled onto a node
+  # other than the web pod. There is no chart value for cron affinity, so
+  # inject a required podAffinity via post-render: pin the cron pod to
+  # whatever node currently runs the web pod (component=app). Evaluated at
+  # schedule time, so it follows the web pod across reschedules.
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: CronJob
+              name: monica-cron
+            patch: |
+              - op: add
+                path: /spec/jobTemplate/spec/template/spec/affinity
+                value:
+                  podAffinity:
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      - labelSelector:
+                          matchLabels:
+                            app.kubernetes.io/instance: monica
+                            app.kubernetes.io/component: app
+                        topologyKey: kubernetes.io/hostname


### PR DESCRIPTION
## Problem

`monica-cron` (the every-minute Laravel scheduler `CronJob`) was wedging in `PodInitializing` and never running. Root cause is a **Longhorn RWO node-affinity collision**, not an app error:

- `monica-data-pvc` is `ReadWriteOnce` Longhorn → single-node attach.
- The web Deployment pod holds the volume attached on one node (currently `worker6`).
- The monicahq chart mounts the *same* PVC into the cron pod and **hardcodes the cron `jobTemplate` pod spec with no affinity / nodeSelector** — the top-level `affinity` value only feeds the Deployment.
- Whenever the cron pod scheduled onto a different node it couldn't attach the already-live RWO volume → stuck `PodInitializing` until killed, repeating every minute.

Impact is low-urgency (scheduler = reminders / cleanup / stats housekeeping, not user-facing), but the scheduler was effectively never running.

## Fix

No chart value exposes cron affinity, so inject a **required `podAffinity`** via a Flux HelmRelease **kustomize post-renderer**, co-locating the cron pod with whatever node currently runs the web pod (`app.kubernetes.io/component: app`).

- `podAffinity` is evaluated at schedule time against the live web pod, so it **tracks the web pod across reschedules** — robust, unlike a static `nodeSelector` pinned to one node.
- The chart already sets `concurrencyPolicy: Forbid`, so on the rare minute the web pod is mid-reschedule the cron simply skips rather than piling up.

**No storage change** — the volume stays RWO Longhorn. No share-manager, no NFS layer, no migration, no extra moving part. (This replaces the earlier RWX approach after weighing the fewer-moving-parts tradeoff.)

## Why post-render (not a chart value)

The chart's `templates/cronjob.yaml` `jobTemplate.spec.template.spec` only renders `containers`, `restartPolicy`, and `volumes` — there is no hook for affinity/nodeSelector/tolerations on the cron. A post-render kustomize patch is the only upgrade-clean way to add it without forking the chart.

## Deploy

Pure GitOps — merge and let Flux reconcile. No manual migration. The next post-upgrade will re-render the CronJob with the injected affinity; existing wedged cron pods age out.

## Verify (after reconcile)

- `kubectl -n collab get cronjob monica-cron -o jsonpath='{.spec.jobTemplate.spec.template.spec.affinity}'` → shows the `podAffinity` block.
- Wait ~2 min, then `kubectl -n collab get jobs | grep monica-cron` → recent job `Complete` (not stuck active).
- `kubectl -n collab get pods -o wide | grep -E 'monica-c|monica-cron'` → the cron pod lands on the **same node** as the web pod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
