### PR TITLE
fix(collab): label monica cron pod so the CNP allows its postgres egress

### DIFF
--- a/kubernetes/apps/collab/monica/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/monica/app/helmrelease.yaml
@@ -122,14 +122,24 @@ spec:
         memory: 256Mi
       limits:
         memory: 1Gi
-  # The chart mounts monica-data-pvc (RWO Longhorn, single-node attach)
-  # into both the web Deployment and the every-minute scheduler CronJob,
-  # but hardcodes the cron jobTemplate pod spec with no affinity — so the
-  # cron pod wedged in PodInitializing whenever it scheduled onto a node
-  # other than the web pod. There is no chart value for cron affinity, so
-  # inject a required podAffinity via post-render: pin the cron pod to
-  # whatever node currently runs the web pod (component=app). Evaluated at
-  # schedule time, so it follows the web pod across reschedules.
+  # The chart hardcodes the cron jobTemplate pod spec, so two things it
+  # needs are missing and there are no chart values for either. Inject
+  # both via post-render:
+  #
+  # 1. affinity — monica-data-pvc is RWO Longhorn (single-node attach)
+  #    mounted into both the web Deployment and the cron pod. With no
+  #    affinity the cron pod wedged in PodInitializing whenever it landed
+  #    on a node other than the web pod. Pin it (required podAffinity) to
+  #    whatever node runs the web pod (component=app); evaluated at
+  #    schedule time, so it follows the web pod across reschedules.
+  #
+  # 2. pod labels — the chart gives the cron POD no app.kubernetes.io/*
+  #    labels (only the Job controller's job-name/controller-uid). The
+  #    monica-allow CiliumNetworkPolicy selects endpoints by
+  #    app.kubernetes.io/name=monica, so an unlabelled cron pod falls
+  #    under the collab default-deny and its egress to postgres-monica is
+  #    SYN-dropped (SQLSTATE[08006] timeout). Stamp the standard labels so
+  #    the existing CNP egress rule covers it too.
   postRenderers:
     - kustomize:
         patches:
@@ -137,6 +147,13 @@ spec:
               kind: CronJob
               name: monica-cron
             patch: |
+              - op: add
+                path: /spec/jobTemplate/spec/template/metadata
+                value:
+                  labels:
+                    app.kubernetes.io/name: monica
+                    app.kubernetes.io/instance: monica
+                    app.kubernetes.io/component: cronjob
               - op: add
                 path: /spec/jobTemplate/spec/template/spec/affinity
                 value:


### PR DESCRIPTION
Follow-up to #13159 (cron podAffinity). That fix worked — the cron pod now schedules onto the web pod's node and mounts the RWO volume — which surfaced a **second, pre-existing bug** the wedge had been masking.

## Problem

With the cron pod finally running, it fails immediately on DB connect:

```
SQLSTATE[08006] connection to postgres-monica-rw.databases.svc.cluster.local:5432 failed: timeout expired
```

`timeout expired` (silent SYN drop, not "connection refused") is the Cilium default-deny signature.

**Root cause:** the monicahq chart gives the cron **pod** no `app.kubernetes.io/*` labels — only the Job controller's `job-name` / `controller-uid`. The `monica-allow` `CiliumNetworkPolicy` selects endpoints by `app.kubernetes.io/name: monica`, so the unlabelled cron pod isn't covered by the egress allow-rule and falls under the collab namespace default-deny. Its packets to `postgres-monica` are dropped.

The web pod carries the label via the Deployment podTemplate, so it was always fine — and the volume-attach wedge meant the cron never got far enough to attempt a DB connection, hiding this until now. It's orthogonal to storage (the RWX approach would have hit the same wall).

## Fix

Extend the existing post-render patch to stamp the standard `name` / `instance` / `component=cronjob` labels onto the cron pod template. The `app.kubernetes.io/name: monica` label brings the cron pod under the existing CNP egress rules (postgres + smtp-relay). No chart value exposes cron pod labels, so post-render is again the only upgrade-clean lever.

Validated with a local `kubectl kustomize` render of the chart's CronJob + both patch ops: pod template gets `metadata.labels` (name/instance/component) alongside the affinity.

## Deploy

Pure GitOps — merge and reconcile. No migration.

## Verify (after reconcile)

- `kubectl -n collab get cronjob monica-cron -o jsonpath='{.spec.jobTemplate.spec.template.metadata.labels}'` → shows `app.kubernetes.io/name: monica`.
- Wait ~2 min, then `kubectl -n collab get jobs | grep monica-cron` → newest job `succeeded=1` / `Complete` (not `failed`).
- `kubectl -n collab logs -l job-name=<newest-monica-cron-job> -c monica-cronjob` → no `SQLSTATE[08006]`; scheduler runs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
