### PR TITLE
fix(slskd): drop dead auth block breaking Flux strict substitution

### DIFF
--- a/kubernetes/apps/downloads/slskd/app/resources/slskd.yml
+++ b/kubernetes/apps/downloads/slskd/app/resources/slskd.yml
@@ -1,9 +1,4 @@
 ---
-authentication:
-    api_keys:
-      my_api_key:
-        key: ${SLSKD_API_KEY}
-        cidr: 10.0.0.0/8,192.168.0.0/16
 directories:
   downloads: /media/complete
   incomplete: /media/incomplete


### PR DESCRIPTION
## Problem

The `downloads/slskd` Flux Kustomization was in `BuildFailed`, cascading to `media/soularr` and `media/lidarr-bridge` (both `dependsOn` the chain):

```
post build failed for 'ConfigMap.v1.[noGrp]/slskd-configmap': envsubst error:
variable substitution failed: variable not set (strict mode): "SLSKD_API_KEY"
```

`slskd.yml` (baked into `slskd-configmap` via `configMapGenerator`) had a top-level `authentication.api_keys` block with `key: ${SLSKD_API_KEY}`. Flux 2.9 postBuild strict substitution runs across rendered ConfigMap data and hard-fails on the unresolved `${SLSKD_API_KEY}` (only `APP` is defined in the ks `postBuild.substitute`).

No outage — the HelmReleases stayed `True` (pods running on last-good config); this was a reconciliation block on three apps.

## Why delete rather than `$$`-escape

The block was inert regardless:
- slskd does **not** interpolate `${VAR}` in its YAML (precedence is env vars < YAML; no substitution layer).
- api_keys must live under `web.authentication`, not top-level `authentication` — so slskd ignored the block.
- The primary API key is already injected via the `SLSKD_API_KEY` env var (`envFrom: secretRef: slskd`), which is slskd's actual primary-key mechanism — separate from the YAML `api_keys` map.
- `SLSKD_NO_AUTH: true` disables auth anyway.

Deleting fixes the reconcile and removes triply-dead, misleading config.

## Impact

Unblocks `slskd` → `soularr` → `lidarr-bridge`. Reloader will restart slskd on the ConfigMap change; slskd re-scans its share on startup (~15–20 min before the HTTP listener rebinds — downloads pause during that window, non-Renee-facing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)