### PR TITLE
feat(ai): swap Spark reasoning tier qwen3-next → qwen3.5:122b-a10b

### DIFF
--- a/kubernetes/apps/ai/lightrag/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/lightrag/app/helmrelease.yaml
@@ -58,15 +58,18 @@ spec:
               # re-downloads every cold start (and fails under default-deny).
               TIKTOKEN_CACHE_DIR: /app/data/tiktoken
               # --- LLM: graph extraction + query synthesis via Ollama-Spark ---
-              # qwen3-next:80b-a3b is an MoE (~3B active) → fast despite the
-              # 80b name, and already warm on the Spark (verified via
-              # `ollama list`). bge-m3 lives there too, so both calls stay on
-              # one host and never touch the P40 (no model-swap churn).
+              # qwen3.5:122b-a10b (MoE, ~10B active) replaced qwen3-next
+              # (~3B active) as the single pinned Spark reasoning model — see
+              # ollama-spark HR. TRADEOFF: ~3x the active compute per token, so
+              # extraction is slower and more ReadTimeout-prone; LLM_TIMEOUT
+              # bumped 600 -> 900 and the tight MAX_ASYNC/INSERT caps below stay.
+              # bge-m3 lives on the same host, so both calls stay on one host
+              # and never touch the P40 (no model-swap churn).
               LLM_BINDING: ollama
               LLM_BINDING_HOST: http://ollama-spark.ai.svc.cluster.local:11434
-              LLM_MODEL: qwen3-next:80b-a3b-instruct-q4_K_M
+              LLM_MODEL: qwen3.5:122b-a10b
               OLLAMA_LLM_NUM_CTX: "32768"
-              LLM_TIMEOUT: "600"
+              LLM_TIMEOUT: "900"
               # Single GB10 serves ~4 concurrent (ollama-spark
               # OLLAMA_NUM_PARALLEL=4) and each 80b call runs at a fraction of
               # GPU speed under load. LightRAG's defaults offer up to

--- a/kubernetes/apps/ai/ollama-spark/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/ollama-spark/app/helmrelease.yaml
@@ -53,37 +53,38 @@ spec:
               OLLAMA_ORIGINS: "*"
               OLLAMA_LOG_LEVEL: info
               OLLAMA_MODELS: &pvc /models
-              # qwen3-next:80b-a3b-instruct is a ~50 GB model whose cold-load
-              # off the ceph PVC + novel-arch init exceeds the old 10m bound
-              # (it hit OLLAMA_LOAD_TIMEOUT and aborted mid-load). 20m gives
-              # it room. KNOWN DOWNSIDE: a cold-load (pod restart / eviction)
+              # qwen3.5:122b-a10b (q4_K_M, ~81 GB) is the reasoning tier. Its
+              # cold-load off the ceph PVC + hybrid-arch init exceeds the 20m
+              # bound tuned for the smaller qwen3-next it replaced; 30m gives
+              # headroom. KNOWN DOWNSIDE: a cold-load (pod restart / eviction)
               # stalls the reasoning tier for >10m — the MAX_LOADED keep-warm
               # below makes cold-loads rare, but can't make them fast.
-              OLLAMA_LOAD_TIMEOUT: 20m
+              OLLAMA_LOAD_TIMEOUT: 30m
               OLLAMA_KV_CACHE_TYPE: q8_0
               OLLAMA_FLASH_ATTENTION: 1
               OLLAMA_CONTEXT_LENGTH: 16384
               OLLAMA_NUM_PARALLEL: 4
               # Never idle-unload. MAX_LOADED lets the working set co-reside,
-              # but the default 5m keep-alive would unload qwen3-next between
-              # bursts on this low-traffic fleet — and its cold-load is ~8.6m.
-              # -1 pins the loaded set (qwen3-next + coder + embedders) warm so
+              # but the default 5m keep-alive would unload qwen3.5 between
+              # bursts on this low-traffic fleet — and its cold-load is >10m.
+              # -1 pins the loaded set (qwen3.5 + coder + embedders) warm so
               # cold-loads happen only on an actual pod restart, not every idle.
               OLLAMA_KEEP_ALIVE: "-1"
-              # Working set after the qwen2.5:32b -> qwen3-next swap:
-              #   qwen3-next:80b-a3b-instruct  -- fleet reasoning + Open WebUI
-              #                                   (one shared model)
+              # Working set after the qwen3-next -> qwen3.5:122b-a10b swap:
+              #   qwen3.5:122b-a10b            -- fleet reasoning + Open WebUI
+              #                                   + LightRAG (one shared model)
               #   qwen2.5-coder:32b            -- coder / reviewer agents
               #   bge-m3 + nomic-embed-text    -- RAG + wedge probe (always-warm)
-              # = 4 distinct models steady-state; 5 lets the old qwen2.5:32b
-              # stay resident through the swap transition without eviction
-              # churn. q8 KV + qwen3-next's hybrid attention keep KV modest;
-              # worst-case unified-memory residence ~qwen3-next(50) + coder(20)
-              # + embedders(1.3) + KV ~ 90-105 GB of 128 GB. CUDA-mapped
-              # weights on Grace-Blackwell unified memory don't bill against
-              # the kubelet's pod RSS (~14 GB observed), so the 80Gi pod limit
-              # (runtime + KV headroom) still holds.
-              OLLAMA_MAX_LOADED_MODELS: 5
+              # = 4 distinct models steady-state → MAX_LOADED 4 (was 5 to cover
+              # the prior transition; that headroom is gone under the 81 GB
+              # model). TIGHTER BUDGET (accepted): worst-case unified-memory
+              # residence ~qwen3.5(81) + coder(20) + embedders(1.3) + q8 KV ~
+              # 105-115 GB of 128 GB — deliberately tighter than the ~90-105 GB
+              # qwen3-next set. qwen3.5's GQA(2 KV heads) + linear-attention
+              # layers keep KV modest. CUDA-mapped weights on Grace-Blackwell
+              # unified memory don't bill against the kubelet's pod RSS (~14 GB
+              # observed), so the 80Gi pod limit (runtime + KV headroom) holds.
+              OLLAMA_MAX_LOADED_MODELS: 4
 
             resources:
               requests:

--- a/kubernetes/apps/collab/open-webui/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/open-webui/app/helmrelease.yaml
@@ -75,13 +75,17 @@ spec:
               # See pod-level comment above — persists the secret key
               # on the PVC instead of the unwritable image cwd.
               WEBUI_SECRET_KEY_FILE: /app/backend/data/.webui_secret_key
-              # Multi-endpoint: Spark (qwen3-next:80b-a3b-instruct-q4_K_M) is the new default,
+              # Multi-endpoint: Spark (qwen3.5:122b-a10b) is the new default,
               # P40 (qwen2.5:7b) remains user-selectable per
               # conversation. Open WebUI parses this as `;`-separated
               # endpoints and exposes each model under its own provider
               # label in the model picker. First entry is the default
               # for new chats.
               OLLAMA_BASE_URLS: http://ollama-spark.ai.svc.cluster.local:11434;http://ollama.ai.svc.cluster.local:11434
+              # Declarative default model for new chats (previously set via
+              # the webui.db UI setting). Must match the Ollama tag exactly
+              # as served by ollama-spark.
+              DEFAULT_MODELS: qwen3.5:122b-a10b
               ENABLE_RAG_WEB_SEARCH: true
               RAG_EMBEDDING_ENGINE: ollama
               # Pin RAG embedding traffic to Spark. Without this,


### PR DESCRIPTION
## What

Replace `qwen3-next:80b-a3b` with **`qwen3.5:122b-a10b`** (q4_K_M, ~81 GB) as the single pinned Spark reasoning model, across all three consumers.

| File | Change |
|---|---|
| `ollama-spark` HR | `LOAD_TIMEOUT` 20m→**30m** (81 GB cold-load), `MAX_LOADED_MODELS` 5→**4**, working-set/keep-alive comments rewritten to the tighter budget |
| `open-webui` HR | Default provider → qwen3.5; added declarative **`DEFAULT_MODELS: qwen3.5:122b-a10b`** (was a webui.db UI setting) |
| `lightrag` HR | `LLM_MODEL` → **qwen3.5**, `LLM_TIMEOUT` 600→**900** |

## Memory budget (tighter, accepted)

Worst-case unified-memory residence ~qwen3.5(81) + coder(20) + embedders(1.3) + q8 KV ≈ **105–115 GB of 128 GB** — deliberately tighter than the prior ~90–105 GB qwen3-next set. One 81 GB model fits; two large models don't, which is why this is a full swap, not an addition.

## LightRAG tradeoff

qwen3.5 is ~10B active vs qwen3-next's ~3B → slower, more ReadTimeout-prone batch extraction. `LLM_TIMEOUT` bumped to 900s; the tight `MAX_ASYNC=2 / MAX_PARALLEL_INSERT=1` caps stay. Watch the paperless-rag-fanout ingest for stuck-`failed` docs after cutover.

## Rollout / done out-of-band

- **Model already pulled** onto `ollama-spark-models-pvc` (verified: `81 GB`, blob intact).
- PVC was **100% full** on accumulated legacy models; cleared a dead 76 GB `-partial` and pruned `gpt-oss:120b` + `qwen2.5:72b` + `qwen2.5:32b` (all unreferenced) → **95 GB free**. `qwen3-next` kept as rollback.
- **First GPU load is the disruptive step** (>10 min, evicts the live qwen3-next) — merge in a **02:00–05:00** maintenance window so services flip to qwen3.5 in one motion.
- **Ollama 0.32.1 arch support** is the one open risk: model is in Ollama's official registry and 0.32.1 already runs qwen3-next (prior-gen hybrid arch), but the first load is the definitive test. If it errors on arch → bump the `ollama/ollama` image digest before the window.

## Rollback

Revert this PR; `qwen3-next` is still on the PVC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)