### PR TITLE
fix(slskd): migrate permissions to transfers.download schema (0.26)

### DIFF
--- a/kubernetes/apps/downloads/slskd/app/resources/slskd.yml
+++ b/kubernetes/apps/downloads/slskd/app/resources/slskd.yml
@@ -9,11 +9,6 @@ metrics:
   url: /metrics
   authentication:
     disabled: true
-permissions:
-  file:
-    mode: 770
-  directory:
-    mode: 770
 remote_configuration: false
 shares:
   directories:
@@ -22,3 +17,11 @@ shares:
     - \.ini$
     - Thumbs.db$
     - \.DS_Store$
+# slskd 0.26 moved download-permissions under transfers.download.destination
+# (single mode for files+dirs). See slskd/slskd#1756. 770 keeps downloads
+# group-writable so soularr can rename into Lidarr's artist-album layout.
+transfers:
+  download:
+    destination:
+      permissions:
+        mode: 770


### PR DESCRIPTION
## Problem

`slskd-0` is in `CrashLoopBackOff` — slskd 0.26 rejects the config at startup:

```
Invalid configuration:
  The 'permissions' keys have been moved under a new 'destination' key under
  transfers -> download, and the behavior has changed. See slskd/slskd#1756
```

The top-level `permissions.{file,directory}.mode` block was valid on the slskd version the pod last (re)started with, but the image has since bumped to 0.26 and the old pod survived on stale in-memory config. A config reload (reloader picking up an unrelated ConfigMap change) restarted the pod and exposed the latent schema break.

## Fix

Migrate to the new schema per slskd/slskd#1756 — a single `mode` under `transfers.download.destination.permissions`, preserving `770` (group-write, needed so soularr can rename downloads into Lidarr's artist-album layout).

```yaml
transfers:
  download:
    destination:
      permissions:
        mode: 770
```

Restores slskd to service. Backend-only (not Renee-facing); slskd re-scans its share on startup (~15–20 min) before the HTTP listener rebinds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)