### PR TITLE
revert(container): re-pin music-assistant to 2.10.0b6 (b7 crashloops on WebRTC cert)

### DIFF
--- a/.github/renovate/packageRules.json5
+++ b/.github/renovate/packageRules.json5
@@ -66,6 +66,12 @@
       matchPackageNames: [
         'ghcr.io/music-assistant/server',
       ],
+      // Block 2.10.0b7: its new WebRTC remote-access cert code crashes on
+      // startup (os.fchmod EPERM on the config volume), crashlooping the pod.
+      // Reverted to b6 on 2026-07-22. Remove this once upstream ships a fixed
+      // beta (b8+ or 2.10.0 GA) — allowedVersions lets those through while
+      // holding b7 out. See memory: project_ma_schema52_stable_path.
+      allowedVersions: '!/^2\\.10\\.0b7$/',
     },
     {
       description: "Custom versioning for frigate",

--- a/kubernetes/apps/media/music-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/media/music-assistant/app/helmrelease.yaml
@@ -88,7 +88,12 @@ spec:
               # FORWARD to the beta where the Settings → Players refactor is
               # complete; do NOT downgrade to stable. Renovate tracks the beta
               # channel (see packageRules.json5).
-              tag: 2.10.0b7@sha256:11c4c2a66f4108bda0584ecafbbd64a6fa4a8ac566d24b571930ec3f035248d3
+              # Reverted b7 → b6 (2026-07-22): 2.10.0b7's new WebRTC remote-access
+              # cert code crashes on startup with `PermissionError: [Errno 1]
+              # Operation not permitted` on os.fchmod against the config volume,
+              # crashlooping the pod. b7 is blocked in packageRules.json5 until
+              # upstream fixes it. b6 is last-known-good.
+              tag: 2.10.0b6@sha256:02e0e2534d5d2d2ac094de637210af2ae3459ea9697a49d143fa1395f0157648
 
             env:
               # Smart Fades' Beat This! beat-tracking model downloads its


### PR DESCRIPTION
## What

Re-pin `music-assistant` `2.10.0b7 → 2.10.0b6` and block b7 in Renovate.

## Why

b7 crashloops on startup:

\`\`\`
PermissionError: [Errno 1] Operation not permitted
  os.fchmod(fd, S_IRUSR | S_IWUSR)   in _save_certificate → get_or_create_remote_id
\`\`\`

The new WebRTC remote-access cert code writes a cert into the config volume and `fchmod`s it, which returns `EPERM`. The uncaught exception exits the process → startup probe fails → pod `NotReady` → `KubeStatefulSetReplicasMismatch`, and Flux is stuck in a failing Helm rollback loop. Music playback (Renee-facing) is down.

b6 is last-known-good. `allowedVersions: '!/^2\.10\.0b7$/'` holds the broken bump out while still letting a fixed b8+ / 2.10.0 GA through.

## Rollback / follow-up

Remove the b7 `allowedVersions` guard once upstream ships a fixed beta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)