### PR TITLE
fix(paperless): set PAPERLESS_SECRET_KEY (mandatory in paperless-ngx 3.0.0)

### DIFF
--- a/kubernetes/apps/collab/paperless/app/externalsecret.yaml
+++ b/kubernetes/apps/collab/paperless/app/externalsecret.yaml
@@ -14,6 +14,9 @@ spec:
       engineVersion: v2
       data:
         # App
+        # Mandatory since paperless-ngx 3.0.0 — the 'change-me' default
+        # fallback was removed and startup hard-fails without a real key.
+        PAPERLESS_SECRET_KEY: "{{ .SECRET_KEY }}"
         PAPERLESS_ADMIN_USER: "{{ .ADMIN_USERNAME }}"
         PAPERLESS_ADMIN_PASSWORD: "{{ .ADMIN_PASSWORD }}"
         PAPERLESS_DBNAME: &dbName "paperless"


### PR DESCRIPTION
## What

Wire `PAPERLESS_SECRET_KEY` into paperless via the existing ExternalSecret (new `SECRET_KEY` field on the 1Password `paperless` item).

## Why

`paperless-0` is in CrashLoopBackOff. paperless-ngx **3.0.0 removed the `change-me` SECRET_KEY default** and now hard-fails at startup:

```
ImproperlyConfigured: PAPERLESS_SECRET_KEY is not set or is the default 'change-me' value.
```

The pod had been running fine on the old default; a restart (~19:13Z) forced a fresh startup and detonated the latent gap (`init-migrations` exits 1). No SECRET_KEY existed anywhere in the config.

## Impact

Setting a real key invalidates existing Django sessions (users re-login). It does **not** touch stored documents — paperless doesn't encrypt docs at rest by default. Low blast radius.

🤖 Generated with [Claude Code](https://claude.com/claude-code)