### PR TITLE
fix(music-assistant): durable webrtc /data ownership fix; unblock b7

### DIFF
--- a/.github/renovate/packageRules.json5
+++ b/.github/renovate/packageRules.json5
@@ -66,12 +66,6 @@
       matchPackageNames: [
         'ghcr.io/music-assistant/server',
       ],
-      // Block 2.10.0b7: its new WebRTC remote-access cert code crashes on
-      // startup (os.fchmod EPERM on the config volume), crashlooping the pod.
-      // Reverted to b6 on 2026-07-22. Remove this once upstream ships a fixed
-      // beta (b8+ or 2.10.0 GA) — allowedVersions lets those through while
-      // holding b7 out. See memory: project_ma_schema52_stable_path.
-      allowedVersions: '!/^2\\.10\\.0b7$/',
     },
     {
       description: "Custom versioning for frigate",

--- a/kubernetes/apps/media/music-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/media/music-assistant/app/helmrelease.yaml
@@ -78,6 +78,27 @@ spec:
                 done
                 echo "gonic is up"
 
+          # Fix /data ownership so MA (uid 1113) owns its WebRTC cert files.
+          # MA's remote-access code rewrites and then chmods
+          # /data/webrtc_private_key.pem on every boot. chmod requires the
+          # process to OWN the file (uid match) — group-write is not enough —
+          # so a file left owned by uid 1000 (from an earlier run's UID) makes
+          # MA crash on startup with `PermissionError: Operation not permitted`
+          # on both b6 and b7 (crashlooped 221× on 2026-07-22). fsGroup only
+          # sets the group, not the owner, so a root chown is the durable fix.
+          # Idempotent and cheap (two files); no-ops on a fresh PVC.
+          00-fix-webrtc-ownership:
+            image:
+              repository: docker.io/library/alpine
+              tag: "3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b"
+            command:
+              - sh
+              - -c
+              - chown 1113:1113 /data/webrtc_private_key.pem /data/webrtc_certificate.pem 2>/dev/null || true
+            securityContext:
+              runAsUser: 0
+              runAsNonRoot: false
+
         containers:
           app:
             image:
@@ -88,11 +109,13 @@ spec:
               # FORWARD to the beta where the Settings → Players refactor is
               # complete; do NOT downgrade to stable. Renovate tracks the beta
               # channel (see packageRules.json5).
-              # Reverted b7 → b6 (2026-07-22): 2.10.0b7's new WebRTC remote-access
-              # cert code crashes on startup with `PermissionError: [Errno 1]
-              # Operation not permitted` on os.fchmod against the config volume,
-              # crashlooping the pod. b7 is blocked in packageRules.json5 until
-              # upstream fixes it. b6 is last-known-good.
+              # Reverted b7 → b6 during the 2026-07-22 incident, but the
+              # version was a red herring: BOTH b6 and b7 crashloop on the
+              # WebRTC cert chmod when /data/webrtc_private_key.pem is owned by
+              # the wrong UID (see the 00-fix-webrtc-ownership initContainer).
+              # With that fix in place either beta boots. Staying on b6 for now
+              # to avoid an unnecessary Renee-facing restart; Renovate is free
+              # to roll forward to b7+ on the beta channel again.
               tag: 2.10.0b6@sha256:02e0e2534d5d2d2ac094de637210af2ae3459ea9697a49d143fa1395f0157648
 
             env:


### PR DESCRIPTION
## What

- Add a root `00-fix-webrtc-ownership` initContainer that `chown 1113:1113`s the two webrtc cert files in `/data` (idempotent; no-ops on a fresh PVC).
- Drop the b7 `allowedVersions` block in Renovate.
- Correct the now-inaccurate b7 comment on the image tag.

## Why

The 2026-07-22 crashloop (221 restarts) was **misattributed to b7**. Real root cause: MA runs as uid **1113**, but `/data/webrtc_private_key.pem` was owned by uid **1000** (an earlier run's UID). MA's remote-access code rewrites and then `chmod`s that file on every boot — and `chmod` requires *ownership* (group-write isn't enough) → `PermissionError: Operation not permitted` on **both b6 and b7**. `fsGroup` only sets the group, not the owner, so a root `chown` init is the durable fix.

The b6 revert (#13199) restored service by coincidence of the manual file cleanup done during the incident, not because b6 is immune. This makes the fix real and lets us honor the roll-forward-on-the-beta-line strategy again.

## Apply note

This changes the pod template, so reconciling it **restarts music-assistant** (~1 min, Renee-facing). Stays pinned to b6 — no version change. Suggest merging in the Tuesday 02:00–04:00 window, or any time a brief music blip is acceptable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)