### PR TITLE
feat(ai): add tei-embed-spark (bge-m3 embeddings on TEI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ _Production-grade Kubernetes for a household._
 
 <br/>
 
-![apps](https://img.shields.io/badge/apps-156-blue?style=for-the-badge)
-![helmreleases](https://img.shields.io/badge/HelmReleases-168-326CE5?style=for-the-badge&logo=helm&logoColor=white)
+![apps](https://img.shields.io/badge/apps-157-blue?style=for-the-badge)
+![helmreleases](https://img.shields.io/badge/HelmReleases-169-326CE5?style=for-the-badge&logo=helm&logoColor=white)
 ![nodes](https://img.shields.io/badge/k8s_nodes-11-326CE5?style=for-the-badge&logo=kubernetes&logoColor=white)
 ![cnpg](https://img.shields.io/badge/Postgres_clusters-22-336791?style=for-the-badge&logo=postgresql&logoColor=white)
 ![secrets](https://img.shields.io/badge/secrets-88-0572EC?style=for-the-badge&logo=1password&logoColor=white)

--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -20,5 +20,6 @@ resources:
   - ./ollama/ks.yaml
   - ./ollama-spark/ks.yaml
   - ./paperless-ai/ks.yaml
+  - ./tei-embed-spark/ks.yaml
   - ./tei-spark/ks.yaml
   - ./khoj/ks.yaml

--- a/kubernetes/apps/ai/tei-embed-spark/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/tei-embed-spark/app/cnp-allow.yaml
@@ -1,0 +1,53 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: tei-embed-spark-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: tei-embed-spark
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # API + metrics share port 3000 (TEI HTTP variant — /metrics on the
+    # main port; same finding as tei-spark). Embedding consumers are
+    # listed up front; the matching egress rule lands on each consumer's
+    # CNP in the embedding-cutover PR, so this is inert until then.
+    # Consumers: Open WebUI RAG embed, LightRAG, memory-mcp, the
+    # paperless-RAG Windmill flow, and the blackbox synthetic embed probe.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: collab
+            app.kubernetes.io/name: open-webui
+        - matchLabels:
+            io.kubernetes.pod.namespace: ai
+            app.kubernetes.io/name: lightrag
+        - matchLabels:
+            io.kubernetes.pod.namespace: mcp-system
+            app.kubernetes.io/name: memory-mcp
+        - matchLabels:
+            io.kubernetes.pod.namespace: home
+            app.kubernetes.io/name: windmill
+        - matchLabels:
+            io.kubernetes.pod.namespace: observability
+            app.kubernetes.io/name: blackbox-exporter
+        - matchLabels:
+            io.kubernetes.pod.namespace: observability
+            app.kubernetes.io/name: prometheus
+      toPorts:
+        - ports:
+            - port: "3000"
+              protocol: TCP
+  egress:
+    # HuggingFace Hub model download — bge-m3 weights pulled to the model
+    # cache PVC on first start. Reuses the world:443 pattern from
+    # tei-spark / ollama-spark (HF / CDN IPs are not FQDN-stable enough
+    # for toFQDNs).
+    - toEntities: [world]
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/ai/tei-embed-spark/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/tei-embed-spark/app/helmrelease.yaml
@@ -1,0 +1,165 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: tei-embed-spark
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 30m
+  install:
+    disableWait: true
+  upgrade:
+    disableWait: true
+  values:
+    controllers:
+      tei:
+        pod:
+          nodeSelector:
+            node-role.kubernetes.io/gpu: blackwell
+
+          # Spark taints: arm64 (keeps amd64-only workloads off — kubelet
+          # only catches arch mismatch at pull time, too late) and the
+          # nvidia.com/gpu reservation. Mirrors tei-spark / ollama-spark.
+          tolerations:
+            - key: kubernetes.io/arch
+              operator: Equal
+              value: arm64
+              effect: NoSchedule
+            - key: nvidia.com/gpu
+              operator: Equal
+              value: "true"
+              effect: NoSchedule
+
+          priorityClassName: ai-gpu-critical
+
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            fsGroupChangePolicy: OnRootMismatch
+            seccompProfile:
+              type: RuntimeDefault
+
+        type: deployment
+
+        containers:
+          app:
+            image:
+              # workaround: https://github.com/huggingface/text-embeddings-inference/pull/852
+              #   — remove when TEI cuts a release tag > v1.9.3 containing
+              #   PRs #840 (sm_121 arm64) + #852 (12.1 arm64-restricted),
+              #   both merged 2026-03-31 but still main-only (latest
+              #   release v1.9.3 predates them).
+              # Tracking: home-ops#12477
+              # Same image as tei-spark — one TEI binary serves both the
+              # reranker and this embedder; the model architecture selects
+              # the surface (bge-m3 → /embed, /v1/embeddings).
+              repository: ghcr.io/huggingface/text-embeddings-inference
+              tag: 121-sha-5bc4d88@sha256:f5c419e98b9178184e83bf96856f60e70d515f663493b235f61edf1c5f2de8dc
+
+            env:
+              # bge-m3 (1024-dim) — the cluster's embedding model since the
+              # Phase A eval (2026-05-20). Moving it off ollama-spark onto
+              # TEI is the embedding half of the vLLM-on-Spark migration
+              # (docs/src/vllm_spark_migration_plan.md). Dark capacity until
+              # the embedding-consumer cutover PR repoints RAG traffic here.
+              MODEL_ID: BAAI/bge-m3
+              HOSTNAME: 0.0.0.0
+              # TEI's HTTP variant serves /metrics on the main API port;
+              # --prometheus-port / PROMETHEUS_PORT does NOT open a separate
+              # listener. Single port keeps Service + CNP + ServiceMonitor
+              # coherent (same finding as tei-spark).
+              PORT: &httpPort 3000
+              HUGGINGFACE_HUB_CACHE: &cachePath /data
+              # FP16 — bge-m3 is XLM-RoBERTa-large (~560M params); FP16
+              # halves VRAM and is the CUDA-backend default.
+              DTYPE: float16
+              # Truncate over-long inputs rather than 413 the client.
+              AUTO_TRUNCATE: "true"
+              JSON_OUTPUT: "true"
+
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: *httpPort
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: *httpPort
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              # Generous startup budget: bge-m3 cold start is HF Hub
+              # download (~2.3 GB) + safetensors load to GPU. 60 * 5s =
+              # 5 min; refine once we have Spark wall-clock numbers.
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: *httpPort
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                  timeoutSeconds: 5
+                  failureThreshold: 60
+
+            resources:
+              requests:
+                cpu: 500m
+                memory: 4Gi
+                nvidia.com/gpu: 1
+              limits:
+                memory: 12Gi
+                nvidia.com/gpu: 1
+
+            securityContext:
+              runAsNonRoot: true
+              runAsUser: 1000
+              runAsGroup: 1000
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop: ["ALL"]
+
+    service:
+      app:
+        controller: tei
+        ports:
+          http:
+            port: *httpPort
+
+    persistence:
+      cache:
+        existingClaim: tei-embed-spark-cache-pvc
+        advancedMounts:
+          tei:
+            app:
+              - path: *cachePath
+
+      # TEI extracts safetensors / tokenizers and uses /tmp for the
+      # internal gRPC UDS socket. Read-only rootfs requires a writable
+      # /tmp; emptyDir is the established pattern (see tei-spark,
+      # helmrelease.security.md).
+      tmp:
+        type: emptyDir
+        advancedMounts:
+          tei:
+            app:
+              - path: /tmp

--- a/kubernetes/apps/ai/tei-embed-spark/app/kustomization.yaml
+++ b/kubernetes/apps/ai/tei-embed-spark/app/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../components/repos/app-template
+
+resources:
+  - ./cnp-allow.yaml
+  - ./helmrelease.yaml
+  - ./prometheusrule.yaml
+  - ./pvc.yaml
+  - ./servicemonitor.yaml

--- a/kubernetes/apps/ai/tei-embed-spark/app/prometheusrule.yaml
+++ b/kubernetes/apps/ai/tei-embed-spark/app/prometheusrule.yaml
@@ -1,0 +1,73 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: tei-embed-spark-rules
+spec:
+  groups:
+    # GB10 DCGM utilization counters are broken on this arch — see
+    # reference_dcgm_gb10_broken_counters.md / ollama-spark
+    # prometheusrule.yaml. POWER_USAGE / SM_CLOCK are the only reliable
+    # signals on Spark, and this embedder shares the GPU with tei-spark
+    # and the vLLM fleet, so a power heuristic would conflate workloads —
+    # skipped on purpose. Pod liveness + request-success rate cover the
+    # failure modes we can act on.
+    - name: tei-embed-spark.availability
+      rules:
+        # Pod-level failure. Until the embedding-cutover PR repoints RAG
+        # traffic here, this is dark capacity and only fires on infra
+        # failure (image-pull, OOM, GPU-bind, node loss). Post-cutover it
+        # covers user-visible RAG degradation: embedding calls from Open
+        # WebUI / LightRAG / memory-mcp / paperless-RAG fail when the pod
+        # is unready.
+        - alert: SparkTeiEmbedPodDown
+          annotations:
+            summary: tei-embed-spark Pod not Ready (embedding surface unavailable)
+            description: |
+              Pod {{ $labels.namespace }}/{{ $labels.pod }} on Spark
+              has been not-Ready for >5 minutes. Inspect with
+              `kubectl -n ai describe pod {{ $labels.pod }}` and
+              `kubectl -n ai logs {{ $labels.pod }} --previous`.
+              Post-cutover impact: RAG embedding is unavailable —
+              Open WebUI / LightRAG / memory-mcp / paperless-RAG
+              retrieval and ingest degrade or stall.
+          expr: |-
+            kube_pod_status_ready{namespace="ai",pod=~"tei-embed-spark-.*",condition="true"} == 0
+          for: 5m
+          labels:
+            severity: critical
+    - name: tei-embed-spark.errors
+      rules:
+        # Elevated request-failure rate. TEI exposes te_request_count
+        # (total) and te_request_success separately; the difference over
+        # a rate window is the failure rate. Guarded by request_count
+        # rate > 0 so the alert is inert without traffic (the pre-cutover
+        # dark-capacity window).
+        #
+        # 5% over 10m matches "user-visible RAG quality degradation"
+        # rather than transient blips — a sustained embed failure rate
+        # translates to retrieval quality loss across every RAG consumer.
+        - alert: SparkTeiEmbedErrorRate
+          annotations:
+            summary: tei-embed-spark embedding error rate elevated (>5% for 10m)
+            description: |
+              tei-embed-spark embedding requests are failing at >5% over
+              the last 10 minutes. Check `kubectl -n ai logs
+              deploy/tei-embed-spark` for backend errors (CUDA OOM,
+              tokenizer faults, model eviction). Sustained failures
+              degrade retrieval across all RAG consumers.
+          expr: |-
+            sum(rate(te_request_count{job="tei-embed-spark"}[5m])) > 0
+            and
+            (
+              sum(rate(te_request_count{job="tei-embed-spark"}[5m]))
+              -
+              sum(rate(te_request_success{job="tei-embed-spark"}[5m]))
+            )
+            /
+            sum(rate(te_request_count{job="tei-embed-spark"}[5m]))
+            > 0.05
+          for: 10m
+          labels:
+            severity: warning

--- a/kubernetes/apps/ai/tei-embed-spark/app/pvc.yaml
+++ b/kubernetes/apps/ai/tei-embed-spark/app/pvc.yaml
@@ -1,0 +1,13 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: tei-embed-spark-cache-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: ceph-block
+  resources:
+    requests:
+      storage: 5Gi

--- a/kubernetes/apps/ai/tei-embed-spark/app/servicemonitor.yaml
+++ b/kubernetes/apps/ai/tei-embed-spark/app/servicemonitor.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/servicemonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: tei-embed-spark
+  labels:
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/instance: tei-embed-spark
+    app.kubernetes.io/name: tei-embed-spark
+    prometheus: kube-prometheus
+spec:
+  endpoints:
+    - interval: 30s
+      path: /metrics
+      port: http
+      scheme: http
+      scrapeTimeout: 10s
+  namespaceSelector:
+    matchNames:
+      - ai
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tei-embed-spark

--- a/kubernetes/apps/ai/tei-embed-spark/ks.yaml
+++ b/kubernetes/apps/ai/tei-embed-spark/ks.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app tei-embed-spark
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: ai
+  path: "./kubernetes/apps/ai/tei-embed-spark/app"
+  interval: 30m
+  timeout: 5m
+  dependsOn:
+    - name: onepassword-connect
+      namespace: external-secrets
+    - name: gpu-operator
+      namespace: kube-system
+    - name: rook-ceph-cluster
+      namespace: rook-ceph


### PR DESCRIPTION
## What

New TEI deployment serving **`BAAI/bge-m3`** embeddings on the Spark. **PR 2** of the vLLM-on-Spark migration series (plan: #13217). This is the embedding half — moving embeddings off `ollama-spark` onto TEI so Ollama can be retired once the vLLM LLM fleet lands.

## Additive & non-disruptive

Cloned from the `tei-spark` reranker — **same** TEI binary, GB10 image digest, security context, probes, PVC pattern — with `MODEL_ID=BAAI/bge-m3`. It's **dark capacity** on merge: no consumer is repointed here yet. RAG embedding traffic (Open WebUI, LightRAG, memory-mcp, paperless-RAG, the blackbox embed probe) moves here in the later embedding-cutover PR.

The CNP lists those consumers up front (ingress); the matching **egress** rule lands on each consumer's CNP at cutover, so this is inert until then.

## Fits the budget

~2 GB (bge-m3 FP16 ~1.1 GB + runtime) via GPU time-slicing alongside tei-spark — see the memory budget in #13217.

## Files

Standard `ai`-namespace app: `ks.yaml` + `app/{helmrelease,pvc,cnp-allow,servicemonitor,prometheusrule,kustomization}.yaml`, registered in `kubernetes/apps/ai/kustomization.yaml`. README badge counts updated.

## Test

`kustomize build` renders clean; all pre-commit hooks pass (yaml, schemas, CNP-rules, readme-drift). Post-merge validation: pod Ready on Spark, `/embed` returns 1024-dim vectors, `/metrics` scraped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)