### PR TITLE
feat(ai): add vllm-driver-spark (Qwen3.6-35B-A3B-FP8 on vLLM)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ _Production-grade Kubernetes for a household._
 
 <br/>
 
-![apps](https://img.shields.io/badge/apps-156-blue?style=for-the-badge)
-![helmreleases](https://img.shields.io/badge/HelmReleases-168-326CE5?style=for-the-badge&logo=helm&logoColor=white)
+![apps](https://img.shields.io/badge/apps-157-blue?style=for-the-badge)
+![helmreleases](https://img.shields.io/badge/HelmReleases-169-326CE5?style=for-the-badge&logo=helm&logoColor=white)
 ![nodes](https://img.shields.io/badge/k8s_nodes-11-326CE5?style=for-the-badge&logo=kubernetes&logoColor=white)
 ![cnpg](https://img.shields.io/badge/Postgres_clusters-22-336791?style=for-the-badge&logo=postgresql&logoColor=white)
 ![secrets](https://img.shields.io/badge/secrets-88-0572EC?style=for-the-badge&logo=1password&logoColor=white)

--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -21,4 +21,5 @@ resources:
   - ./ollama-spark/ks.yaml
   - ./paperless-ai/ks.yaml
   - ./tei-spark/ks.yaml
+  - ./vllm-driver-spark/ks.yaml
   - ./khoj/ks.yaml

--- a/kubernetes/apps/ai/vllm-driver-spark/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/vllm-driver-spark/app/cnp-allow.yaml
@@ -1,0 +1,52 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: vllm-driver-spark-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: vllm-driver-spark
+  # Additive — default-deny triggers the lockdown; these rules punch holes.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on the internal gateway → vllm-driver-spark:8000
+    # (vllm-driver-spark.${SECRET_DOMAIN} for off-cluster access, e.g.
+    # opencode on Rob's workstation).
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "8000"
+              protocol: TCP
+    # In-cluster LLM consumers + Prometheus /metrics scrape. Chat + LightRAG
+    # LLM traffic lands here at the LLM-consumer cutover PR; listed up front
+    # so the ingress side is ready (their egress rules land at cutover).
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: collab
+            app.kubernetes.io/name: open-webui
+        - matchLabels:
+            io.kubernetes.pod.namespace: ai
+            app.kubernetes.io/name: lightrag
+        - matchLabels:
+            io.kubernetes.pod.namespace: observability
+            app.kubernetes.io/name: prometheus
+      toPorts:
+        - ports:
+            - port: "8000"
+              protocol: TCP
+  egress:
+    # HuggingFace Hub — vLLM downloads the FP8 weights to the cache PVC on
+    # first start. Same world:443 pattern as ollama-spark / tei-spark (HF /
+    # CDN IPs are not FQDN-stable enough for toFQDNs).
+    - toEntities: [world]
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/ai/vllm-driver-spark/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/vllm-driver-spark/app/helmrelease.yaml
@@ -1,0 +1,217 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: vllm-driver-spark
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 30m
+  install:
+    disableWait: true
+  upgrade:
+    disableWait: true
+  values:
+    controllers:
+      vllm:
+        annotations:
+          reloader.stakater.com/auto: "true"
+
+        # StatefulSet (not Deployment) for the same reason as ollama-spark:
+        # the weight-cache PVC is RWO and we must never have two pods
+        # contending for the single GPU slice — a StatefulSet terminates
+        # the old pod before starting the new one.
+        type: statefulset
+
+        pod:
+          nodeSelector:
+            node-role.kubernetes.io/gpu: blackwell
+
+          # Spark taints: arm64 (keeps amd64-only workloads off) + the
+          # nvidia.com/gpu reservation. Mirrors ollama-spark / tei-spark.
+          tolerations:
+            - key: kubernetes.io/arch
+              operator: Equal
+              value: arm64
+              effect: NoSchedule
+            - key: nvidia.com/gpu
+              operator: Equal
+              value: "true"
+              effect: NoSchedule
+
+          priorityClassName: ai-gpu-critical
+
+        containers:
+          app:
+            image:
+              # workaround: https://github.com/vllm-project/vllm/issues/36821
+              #   — remove when upstream vLLM publishes an official sm_121
+              #   (GB10) arm64 image. Tracked upstream in #36821 / #31128;
+              #   until then this community image (Techno Tim, built via
+              #   GitHub Actions on a Spark runner, every input SHA-pinned)
+              #   tracks upstream vLLM releases directly. Renovate-held —
+              #   bump deliberately, validate on-box before merging.
+              # Base image has no entrypoint (Cmd=bash), so `command`
+              # below invokes vLLM explicitly.
+              repository: ghcr.io/timothystewart6/vllm-gb10
+              tag: v0.25.1-cu13.2-torch2.11-gb10.3@sha256:30e70a376ff076f4dc3e1e5fd5ee5f99f36a8ba274f6f590fa1d7894045a66d8
+
+            command: ["vllm", "serve"]
+            args:
+              - Qwen/Qwen3.6-35B-A3B-FP8
+              # Consumers reference this name (Open WebUI model id, LightRAG
+              # LLM_MODEL, opencode model). Keep stable across image bumps.
+              - --served-model-name
+              - qwen3.6-35b-a3b
+              - --host
+              - 0.0.0.0
+              - --port
+              - "8000"
+              # Capped from the model's native 262144. The two-instance
+              # co-residency budget (see vllm_spark_migration_plan.md) needs
+              # KV modest; 32k is ample for chat + agentic coding. Raise
+              # only with headroom proven on-box.
+              - --max-model-len
+              - "32768"
+              # Explicit cap so this instance + vllm-coder-spark + TEI fit
+              # the 128 GB. ~0.42 ≈ 54 GB (35 GB weights + KV). Tuned in the
+              # Phase 3 on-box memory validation before consumer cutover.
+              - --gpu-memory-utilization
+              - "0.42"
+              # FP8 KV cache — halves KV footprint, key to fitting two
+              # instances (per the vLLM Qwen3.6 recipe).
+              - --kv-cache-dtype
+              - fp8
+              # Reasoning + tool-calling parsers (vLLM Qwen3.6 recipe).
+              # tool-call support is the whole point of the driver role —
+              # opencode/LightRAG drive tools through it.
+              - --reasoning-parser
+              - qwen3
+              - --tool-call-parser
+              - qwen3_xml
+              - --enable-auto-tool-choice
+
+            env:
+              # HF Hub cache on the PVC so the ~35 GB FP8 download survives
+              # pod restarts (re-download otherwise, and it fails under
+              # default-deny without the world:443 egress in cnp-allow).
+              HF_HOME: &cachePath /data
+              VLLM_LOGGING_LEVEL: INFO
+
+            probes:
+              # /health returns 200 once the engine is up and the model is
+              # loaded. Fast once warm.
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: &httpPort 8000
+                  initialDelaySeconds: 60
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: *httpPort
+                  initialDelaySeconds: 30
+                  periodSeconds: 15
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              # Very generous startup budget: FIRST start downloads ~35 GB
+              # FP8 weights from HF + loads to GPU + compiles CUDA graphs.
+              # 120 * 15s = 30 min. disableWait above means Flux won't block
+              # on this. Refine once we have Spark cold-start wall-clock.
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: *httpPort
+                  initialDelaySeconds: 30
+                  periodSeconds: 15
+                  timeoutSeconds: 5
+                  failureThreshold: 120
+
+            resources:
+              requests:
+                cpu: 1000m
+                memory: 16Gi
+                nvidia.com/gpu: 1
+              limits:
+                # Generous ceiling. On GB10 unified memory it's unclear how
+                # much of vLLM's CUDA allocation bills against the cgroup
+                # (ollama-spark observed ~14 GB RSS for a 50 GB model). Set
+                # high to avoid a cgroup OOMKill; validated/tightened in
+                # Phase 3.
+                memory: 64Gi
+                nvidia.com/gpu: 1
+
+            securityContext:
+              # Image runs as root and vLLM compiles CUDA graphs + writes
+              # the HF cache, so runAsNonRoot / readOnlyRootFilesystem are
+              # off (same rationale as ollama-spark). Keep the rest of the
+              # baseline hardening.
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop: ["ALL"]
+              seccompProfile:
+                type: RuntimeDefault
+
+    service:
+      app:
+        controller: vllm
+        ports:
+          http:
+            port: *httpPort
+
+    # Internal (LAN-only) route so off-cluster consumers reach the OpenAI
+    # /v1 endpoint — opencode on Rob's workstation points its ollama-spark
+    # provider baseURL here at cutover. Mirrors ollama-spark's route.
+    route:
+      main:
+        hostnames:
+          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: *httpPort
+
+    persistence:
+      cache:
+        existingClaim: vllm-driver-spark-cache-pvc
+        advancedMounts:
+          vllm:
+            app:
+              - path: *cachePath
+
+      # vLLM uses /dev/shm for intra-process IPC; the default 64 MB is too
+      # small and causes cryptic startup failures. 8 Gi emptyDir(Memory).
+      shm:
+        type: emptyDir
+        medium: Memory
+        sizeLimit: 8Gi
+        advancedMounts:
+          vllm:
+            app:
+              - path: /dev/shm
+
+      # Writable /tmp for compilation scratch (torch.compile / CUDA graphs).
+      tmp:
+        type: emptyDir
+        advancedMounts:
+          vllm:
+            app:
+              - path: /tmp

--- a/kubernetes/apps/ai/vllm-driver-spark/app/kustomization.yaml
+++ b/kubernetes/apps/ai/vllm-driver-spark/app/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../components/repos/app-template
+
+resources:
+  - ./cnp-allow.yaml
+  - ./helmrelease.yaml
+  - ./prometheusrule.yaml
+  - ./pvc.yaml
+  - ./servicemonitor.yaml

--- a/kubernetes/apps/ai/vllm-driver-spark/app/prometheusrule.yaml
+++ b/kubernetes/apps/ai/vllm-driver-spark/app/prometheusrule.yaml
@@ -1,0 +1,40 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: vllm-driver-spark-rules
+spec:
+  groups:
+    # GB10 DCGM utilization counters are broken on this arch (POWER_USAGE /
+    # SM_CLOCK are the only reliable signals — see
+    # reference_dcgm_gb10_broken_counters.md). This instance shares the GPU
+    # with vllm-coder-spark + TEI, so a power heuristic would conflate
+    # workloads. Pod liveness is the reliable, actionable signal here;
+    # richer vLLM alerts (TTFT, queue depth via vllm:* metrics) land with
+    # the Spark dashboards in a follow-up once we have on-box baselines.
+    - name: vllm-driver-spark.availability
+      rules:
+        # Pod-level failure. Until the LLM-consumer cutover PR repoints
+        # chat / LightRAG traffic here, this is dark capacity and only
+        # fires on infra failure (image-pull, OOM, GPU-bind, node loss).
+        # Post-cutover it covers user-visible outage: Open WebUI chat,
+        # LightRAG query/ingest, and opencode all fail when the engine is
+        # down.
+        - alert: SparkVllmDriverPodDown
+          annotations:
+            summary: vllm-driver-spark Pod not Ready (reasoning/driver LLM unavailable)
+            description: |
+              Pod {{ $labels.namespace }}/{{ $labels.pod }} on Spark
+              has been not-Ready for >5 minutes. Inspect with
+              `kubectl -n ai describe pod {{ $labels.pod }}` and
+              `kubectl -n ai logs {{ $labels.pod }} --previous`.
+              Post-cutover impact: Open WebUI chat, LightRAG, and opencode
+              lose the primary reasoning/driver model (qwen3.6-35b-a3b).
+              A cold restart re-downloads/loads ~35 GB — expect a slow
+              recovery; do not thrash the pod.
+          expr: |-
+            kube_pod_status_ready{namespace="ai",pod=~"vllm-driver-spark-.*",condition="true"} == 0
+          for: 5m
+          labels:
+            severity: critical

--- a/kubernetes/apps/ai/vllm-driver-spark/app/pvc.yaml
+++ b/kubernetes/apps/ai/vllm-driver-spark/app/pvc.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: vllm-driver-spark-cache-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: ceph-block
+  resources:
+    requests:
+      # HF cache for Qwen3.6-35B-A3B-FP8 (~35 GB) plus tokenizer/config
+      # and torch.compile artifacts. 60 Gi leaves headroom for an
+      # in-place model bump without a resize.
+      storage: 60Gi

--- a/kubernetes/apps/ai/vllm-driver-spark/app/servicemonitor.yaml
+++ b/kubernetes/apps/ai/vllm-driver-spark/app/servicemonitor.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/servicemonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: vllm-driver-spark
+  labels:
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/instance: vllm-driver-spark
+    app.kubernetes.io/name: vllm-driver-spark
+    prometheus: kube-prometheus
+spec:
+  endpoints:
+    # vLLM serves Prometheus metrics on /metrics on the main API port
+    # (vllm:num_requests_running, vllm:time_to_first_token_seconds, etc.).
+    - interval: 30s
+      path: /metrics
+      port: http
+      scheme: http
+      scrapeTimeout: 10s
+  namespaceSelector:
+    matchNames:
+      - ai
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: vllm-driver-spark

--- a/kubernetes/apps/ai/vllm-driver-spark/ks.yaml
+++ b/kubernetes/apps/ai/vllm-driver-spark/ks.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app vllm-driver-spark
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: ai
+  path: "./kubernetes/apps/ai/vllm-driver-spark/app"
+  interval: 30m
+  timeout: 5m
+  dependsOn:
+    - name: onepassword-connect
+      namespace: external-secrets
+    - name: gpu-operator
+      namespace: kube-system
+    - name: rook-ceph-cluster
+      namespace: rook-ceph


### PR DESCRIPTION
## What

The **reasoning/driver** half of the Spark's vLLM fleet — **PR 3** of the vLLM-on-Spark migration (plan: #13217). Serves `Qwen/Qwen3.6-35B-A3B-FP8` over an OpenAI `/v1` endpoint. Hits the GB10 memory-bandwidth ceiling (~28–30 tok/s) vs Ollama's ~16.

## Image — chosen per the sourcing-principles review

`ghcr.io/timothystewart6/vllm-gb10:v0.25.1-cu13.2-torch2.11-gb10.3@sha256:30e70a37…`

Community sm_121/arm64 image (Techno Tim): tracks upstream vLLM directly, GH Actions build on a Spark runner, every input SHA-pinned. Digest-pinned + `# workaround:` → upstream [#36821](https://github.com/vllm-project/vllm/issues/36821)/[#31128](https://github.com/vllm-project/vllm/issues/31128), removed when official vLLM ships sm_121. **Same precedent as `tei-spark`.** Runner-up was NVIDIA NGC (rejected: lags upstream, disqualifying for a just-released model).

## Serve flags (from the official vLLM Qwen3.6 recipe)

`--reasoning-parser qwen3 --tool-call-parser qwen3_xml --enable-auto-tool-choice` (tool-calling is the whole point of the driver), `--kv-cache-dtype fp8`, `--max-model-len 32768`, `--gpu-memory-utilization 0.42` — the last three sized for the **two-instance + TEI co-residency budget** in the 128 GB (see #13217).

## Additive & dark

No consumer points here yet — chat/LightRAG/opencode move over in the LLM-consumer cutover PR (gated on on-box validation). StatefulSet (RWO cache PVC + single GPU slice), internal route for off-cluster opencode, ServiceMonitor + pod-down alert.

## Validate-on-box before cutover (not merge-blocking, but gates the cutover PR)

- Memory limits (64 Gi) + `--gpu-memory-utilization 0.42` are **starting points** — unified-memory cgroup accounting is the Phase-3 measure-don't-guess item.
- GPU **time-slice capacity**: adding this + coder + tei-embed alongside ollama-spark may need the gpu-operator time-slicing replica count bumped until ollama-spark scales to 0.

## Test

`kustomize build` clean; all pre-commit hooks pass. Image digest cross-verified (skopeo + registry API).

🤖 Generated with [Claude Code](https://claude.com/claude-code)