### PR TITLE
feat(ai): add vllm-coder-spark (Qwen3.6-27B-FP8 on vLLM)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ _Production-grade Kubernetes for a household._
 
 <br/>
 
-![apps](https://img.shields.io/badge/apps-156-blue?style=for-the-badge)
-![helmreleases](https://img.shields.io/badge/HelmReleases-168-326CE5?style=for-the-badge&logo=helm&logoColor=white)
+![apps](https://img.shields.io/badge/apps-157-blue?style=for-the-badge)
+![helmreleases](https://img.shields.io/badge/HelmReleases-169-326CE5?style=for-the-badge&logo=helm&logoColor=white)
 ![nodes](https://img.shields.io/badge/k8s_nodes-11-326CE5?style=for-the-badge&logo=kubernetes&logoColor=white)
 ![cnpg](https://img.shields.io/badge/Postgres_clusters-22-336791?style=for-the-badge&logo=postgresql&logoColor=white)
 ![secrets](https://img.shields.io/badge/secrets-88-0572EC?style=for-the-badge&logo=1password&logoColor=white)

--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -21,4 +21,5 @@ resources:
   - ./ollama-spark/ks.yaml
   - ./paperless-ai/ks.yaml
   - ./tei-spark/ks.yaml
+  - ./vllm-coder-spark/ks.yaml
   - ./khoj/ks.yaml

--- a/kubernetes/apps/ai/vllm-coder-spark/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/vllm-coder-spark/app/cnp-allow.yaml
@@ -1,0 +1,47 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: vllm-coder-spark-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: vllm-coder-spark
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  ingress:
+    # HTTPRoute on the internal gateway → vllm-coder-spark:8000
+    # (vllm-coder-spark.${SECRET_DOMAIN} — opencode's coder model reaches
+    # it off-cluster).
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "8000"
+              protocol: TCP
+    # In-cluster consumers + Prometheus /metrics scrape. Open WebUI exposes
+    # the coder as a selectable model; LightRAG uses the driver, not this.
+    # Traffic lands at the LLM-consumer cutover PR (egress rules follow).
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: collab
+            app.kubernetes.io/name: open-webui
+        - matchLabels:
+            io.kubernetes.pod.namespace: observability
+            app.kubernetes.io/name: prometheus
+      toPorts:
+        - ports:
+            - port: "8000"
+              protocol: TCP
+  egress:
+    # HuggingFace Hub — vLLM downloads the FP8 weights on first start.
+    # Same world:443 pattern as vllm-driver-spark / tei-spark.
+    - toEntities: [world]
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/ai/vllm-coder-spark/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/vllm-coder-spark/app/helmrelease.yaml
@@ -1,0 +1,187 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: vllm-coder-spark
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 30m
+  install:
+    disableWait: true
+  upgrade:
+    disableWait: true
+  values:
+    controllers:
+      vllm:
+        annotations:
+          reloader.stakater.com/auto: "true"
+
+        # StatefulSet for the same reason as vllm-driver-spark / ollama-spark:
+        # RWO cache PVC + never two pods contending for the GPU slice.
+        type: statefulset
+
+        pod:
+          nodeSelector:
+            node-role.kubernetes.io/gpu: blackwell
+
+          tolerations:
+            - key: kubernetes.io/arch
+              operator: Equal
+              value: arm64
+              effect: NoSchedule
+            - key: nvidia.com/gpu
+              operator: Equal
+              value: "true"
+              effect: NoSchedule
+
+          priorityClassName: ai-gpu-critical
+
+        containers:
+          app:
+            image:
+              # workaround: https://github.com/vllm-project/vllm/issues/36821
+              #   — remove when upstream vLLM publishes an official sm_121
+              #   (GB10) arm64 image (#36821 / #31128). Same community image
+              #   + pinning rationale as vllm-driver-spark; keep the two
+              #   instances on the same digest so they upgrade in lockstep.
+              # Base image has no entrypoint (Cmd=bash) → `command` below.
+              repository: ghcr.io/timothystewart6/vllm-gb10
+              tag: v0.25.1-cu13.2-torch2.11-gb10.3@sha256:30e70a376ff076f4dc3e1e5fd5ee5f99f36a8ba274f6f590fa1d7894045a66d8
+
+            command: ["vllm", "serve"]
+            args:
+              # Qwen3.6-27B is the DENSE flagship coder (higher code quality
+              # than the MoE driver; slower single-stream since it reads all
+              # 27B/token — the accepted tradeoff for the coder role).
+              - Qwen/Qwen3.6-27B-FP8
+              - --served-model-name
+              - qwen3.6-27b
+              - --host
+              - 0.0.0.0
+              - --port
+              - "8000"
+              - --max-model-len
+              - "32768"
+              # ~0.35 ≈ 45 GB (27 GB weights + KV). Sized so driver (0.42) +
+              # this + TEI fit the 128 GB. Tuned in Phase 3 on-box.
+              - --gpu-memory-utilization
+              - "0.35"
+              - --kv-cache-dtype
+              - fp8
+              - --reasoning-parser
+              - qwen3
+              - --tool-call-parser
+              - qwen3_xml
+              - --enable-auto-tool-choice
+
+            env:
+              HF_HOME: &cachePath /data
+              VLLM_LOGGING_LEVEL: INFO
+
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: &httpPort 8000
+                  initialDelaySeconds: 60
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: *httpPort
+                  initialDelaySeconds: 30
+                  periodSeconds: 15
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              # First start downloads ~27 GB FP8 + loads to GPU. 120 * 15s =
+              # 30 min; disableWait means Flux won't block on it.
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: *httpPort
+                  initialDelaySeconds: 30
+                  periodSeconds: 15
+                  timeoutSeconds: 5
+                  failureThreshold: 120
+
+            resources:
+              requests:
+                cpu: 1000m
+                memory: 12Gi
+                nvidia.com/gpu: 1
+              limits:
+                # Generous ceiling; unified-memory cgroup accounting is
+                # validated/tightened in Phase 3 (see vllm-driver-spark).
+                memory: 48Gi
+                nvidia.com/gpu: 1
+
+            securityContext:
+              # Root image + vLLM compiles/writes caches → runAsNonRoot /
+              # readOnlyRootFilesystem off (same as vllm-driver-spark /
+              # ollama-spark). Rest of the baseline hardening kept.
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop: ["ALL"]
+              seccompProfile:
+                type: RuntimeDefault
+
+    service:
+      app:
+        controller: vllm
+        ports:
+          http:
+            port: *httpPort
+
+    # Internal (LAN-only) route — opencode's coder model points here at
+    # cutover. Mirrors vllm-driver-spark / ollama-spark.
+    route:
+      main:
+        hostnames:
+          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: *httpPort
+
+    persistence:
+      cache:
+        existingClaim: vllm-coder-spark-cache-pvc
+        advancedMounts:
+          vllm:
+            app:
+              - path: *cachePath
+
+      # vLLM needs a larger /dev/shm than the default 64 MB.
+      shm:
+        type: emptyDir
+        medium: Memory
+        sizeLimit: 8Gi
+        advancedMounts:
+          vllm:
+            app:
+              - path: /dev/shm
+
+      tmp:
+        type: emptyDir
+        advancedMounts:
+          vllm:
+            app:
+              - path: /tmp

--- a/kubernetes/apps/ai/vllm-coder-spark/app/kustomization.yaml
+++ b/kubernetes/apps/ai/vllm-coder-spark/app/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../components/repos/app-template
+
+resources:
+  - ./cnp-allow.yaml
+  - ./helmrelease.yaml
+  - ./prometheusrule.yaml
+  - ./pvc.yaml
+  - ./servicemonitor.yaml

--- a/kubernetes/apps/ai/vllm-coder-spark/app/prometheusrule.yaml
+++ b/kubernetes/apps/ai/vllm-coder-spark/app/prometheusrule.yaml
@@ -1,0 +1,34 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: vllm-coder-spark-rules
+spec:
+  groups:
+    # GB10 DCGM counters broken (see vllm-driver-spark rule). Pod liveness
+    # is the reliable, actionable signal; richer vLLM alerts land with the
+    # Spark dashboards once on-box baselines exist.
+    - name: vllm-coder-spark.availability
+      rules:
+        # Pod-level failure. Dark until the LLM-consumer cutover; then it
+        # covers coder-model outage: opencode's coder + Open WebUI's coder
+        # option fail. Lower blast radius than the driver (the driver can
+        # cover coding if this is down), so severity is warning, not
+        # critical.
+        - alert: SparkVllmCoderPodDown
+          annotations:
+            summary: vllm-coder-spark Pod not Ready (coder LLM unavailable)
+            description: |
+              Pod {{ $labels.namespace }}/{{ $labels.pod }} on Spark
+              has been not-Ready for >5 minutes. Inspect with
+              `kubectl -n ai describe pod {{ $labels.pod }}` and
+              `kubectl -n ai logs {{ $labels.pod }} --previous`.
+              Impact: the dedicated coder (qwen3.6-27b) is down; opencode /
+              coder-agent work falls back to the driver model. A cold
+              restart re-downloads/loads ~27 GB — do not thrash the pod.
+          expr: |-
+            kube_pod_status_ready{namespace="ai",pod=~"vllm-coder-spark-.*",condition="true"} == 0
+          for: 5m
+          labels:
+            severity: warning

--- a/kubernetes/apps/ai/vllm-coder-spark/app/pvc.yaml
+++ b/kubernetes/apps/ai/vllm-coder-spark/app/pvc.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: vllm-coder-spark-cache-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: ceph-block
+  resources:
+    requests:
+      # HF cache for Qwen3.6-27B-FP8 (~27 GB) + tokenizer/config + compile
+      # artifacts. 50 Gi leaves headroom for an in-place model bump.
+      storage: 50Gi

--- a/kubernetes/apps/ai/vllm-coder-spark/app/servicemonitor.yaml
+++ b/kubernetes/apps/ai/vllm-coder-spark/app/servicemonitor.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/servicemonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: vllm-coder-spark
+  labels:
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/instance: vllm-coder-spark
+    app.kubernetes.io/name: vllm-coder-spark
+    prometheus: kube-prometheus
+spec:
+  endpoints:
+    - interval: 30s
+      path: /metrics
+      port: http
+      scheme: http
+      scrapeTimeout: 10s
+  namespaceSelector:
+    matchNames:
+      - ai
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: vllm-coder-spark

--- a/kubernetes/apps/ai/vllm-coder-spark/ks.yaml
+++ b/kubernetes/apps/ai/vllm-coder-spark/ks.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app vllm-coder-spark
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: ai
+  path: "./kubernetes/apps/ai/vllm-coder-spark/app"
+  interval: 30m
+  timeout: 5m
+  dependsOn:
+    - name: onepassword-connect
+      namespace: external-secrets
+    - name: gpu-operator
+      namespace: kube-system
+    - name: rook-ceph-cluster
+      namespace: rook-ceph


### PR DESCRIPTION
## What

The dedicated **coder** half of the Spark's vLLM fleet — **PR 4** of the vLLM-on-Spark migration (plan: #13217). Serves `Qwen/Qwen3.6-27B-FP8` (dense flagship coder — higher code quality than the MoE driver, slower single-stream; the accepted tradeoff for the coder role) over an OpenAI `/v1` endpoint.

## Near-clone of vllm-driver-spark (#13219)

Same GB10 image (**same digest** → the two instances upgrade in lockstep), same serve-flag shape (reasoning + `qwen3_xml` tool-calling + fp8 KV), same StatefulSet / route / probe pattern.

**Differences:** `Qwen/Qwen3.6-27B-FP8`, `--served-model-name qwen3.6-27b`, `--gpu-memory-utilization 0.35` (~45 GB — sized so driver 0.42 + this + TEI fit the 128 GB, see #13217), 50 Gi cache PVC. Pod-down alert is **warning** not critical — the driver can cover coding if the coder is down.

## Additive & dark

Consumers are opencode's coder model + Open WebUI's coder option (**not** LightRAG — that uses the driver). Traffic lands at the LLM-consumer cutover PR, gated on the Phase-3 on-box **co-residency memory validation** (this is the second of the two instances that must fit together).

## Test

`kustomize build` clean; all pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)