### PR TITLE
fix(ai): right-size vLLM fleet gpu-memory-utilization from live measurement

### DIFF
--- a/docs/src/vllm_spark_migration_plan.md
+++ b/docs/src/vllm_spark_migration_plan.md
@@ -105,8 +105,8 @@ TEI (confirmed live — 5 of 8 GPU time-slices in use; see below). Their memory
 
 | Workload | Resident footprint | `--gpu-memory-utilization` (of 128 GB) |
 |---|---|---|
-| `vllm-driver-spark` — Qwen3.6-35B-A3B-FP8 (35 GB + KV) | ~51 GB | ~0.40 |
-| `vllm-coder-spark` — Qwen3.6-27B-FP8 (dense, 27 GB + KV) | ~39 GB | ~0.30 |
+| `vllm-driver-spark` — Qwen3.6-35B-A3B-FP8 (35 GB + KV) | ~44 GB | **0.36** |
+| `vllm-coder-spark` — Qwen3.6-27B-FP8 (dense, 27 GB + KV) | ~34 GB | **0.28** |
 | `tei-embed-spark` + `tei-spark` | ~4 GB | — |
 | **comfyui-spark** (idle ~2 GB, **bursts to tens of GB** loading an image-gen model) | **~2–20 GB** | — |
 | **pump-cv** (CV model) | ~2 GB | — |
@@ -116,9 +116,12 @@ TEI (confirmed live — 5 of 8 GPU time-slices in use; see below). Their memory
 | **Total (comfyui mid-generation)** | **~110 GB+** | — |
 
 So it fits **at rest with headroom, but a comfyui image-generation burst while
-both vLLM instances are resident can approach or exceed 128 GB.** The coder's
-utilization is cut to **~0.30** (from 0.35) to widen the shared headroom for
-those bursty co-tenants; final values are set from the Phase-3 measurement.
+both vLLM instances are resident can approach or exceed 128 GB.** **Live-tuned
+2026-07-23:** vLLM reports **121.63 GiB** usable (not 128 — ~6 GiB
+system/firmware), and the non-vLLM co-tenants measured **~32 GiB** (more than
+first drafted). `0.42 + 0.35` overshot and the coder failed to init; **driver
+cut to 0.36, coder to 0.28** — the pair (~78 GiB) + co-tenants (~32) leaves
+**~12 GiB** for comfyui bursts.
 
 **Measuring the real number is hard on the GB10** — and that is a first-class
 caveat, not a footnote:

--- a/kubernetes/apps/ai/vllm-coder-spark/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/vllm-coder-spark/app/helmrelease.yaml
@@ -65,10 +65,14 @@ spec:
               - "8000"
               - --max-model-len
               - "32768"
-              # ~0.35 ≈ 45 GB (27 GB weights + KV). Sized so driver (0.42) +
-              # this + TEI fit the 128 GB. Tuned in Phase 3 on-box.
+              # TUNED FROM LIVE MEASUREMENT (2026-07-23): 0.28 ≈ 34 GiB
+              # (27 weights + ~7 KV). Was 0.35, which failed to init —
+              # with the driver holding 0.42 only 38.74 GiB was free vs
+              # the 42.57 GiB 0.35 wanted. Driver also dropped to 0.36 so
+              # the pair + ~32 GiB of co-tenants + ~12 GiB comfyui-burst
+              # headroom fit the 121.63 GiB vLLM sees.
               - --gpu-memory-utilization
-              - "0.35"
+              - "0.28"
               - --kv-cache-dtype
               - fp8
               - --reasoning-parser

--- a/kubernetes/apps/ai/vllm-driver-spark/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/vllm-driver-spark/app/helmrelease.yaml
@@ -75,11 +75,15 @@ spec:
               # only with headroom proven on-box.
               - --max-model-len
               - "32768"
-              # Explicit cap so this instance + vllm-coder-spark + TEI fit
-              # the 128 GB. ~0.42 ≈ 54 GB (35 GB weights + KV). Tuned in the
-              # Phase 3 on-box memory validation before consumer cutover.
+              # Explicit cap. TUNED FROM LIVE MEASUREMENT (2026-07-23):
+              # vLLM sees 121.63 GiB total; the non-vLLM co-tenants
+              # (comfyui, tei x2, pump-cv, av1corrector, bge-m3, CUDA
+              # contexts) hold ~32 GiB. 0.36 ≈ 44 GiB (35 weights + ~9 KV);
+              # with coder 0.28 that leaves ~12 GiB for comfyui image-gen
+              # bursts. Was 0.42 — dropped because 0.42+0.35 overshot free
+              # memory and the coder failed to init.
               - --gpu-memory-utilization
-              - "0.42"
+              - "0.36"
               # FP8 KV cache — halves KV footprint, key to fitting two
               # instances (per the vLLM Qwen3.6 recipe).
               - --kv-cache-dtype


### PR DESCRIPTION
## What

Phase-3 on-box tuning. `vllm-coder-spark` failed engine init:

> `Free memory on cuda:0 (38.74/121.63 GiB) < desired utilization (0.35, 42.57 GiB)`

**Live facts vs the drafted budget:**
- vLLM sees **121.63 GiB** usable (not 128 — ~6 GiB system/firmware)
- Non-vLLM co-tenants (comfyui, tei ×2, pump-cv, av1corrector, bge-m3, CUDA contexts) hold **~32 GiB** — more than budgeted

So `0.42 + 0.35` overshot. **Driver 0.42→0.36** (~44 GiB), **coder 0.35→0.28** (~34 GiB): the pair ~78 GiB + co-tenants ~32 leaves **~12 GiB** for comfyui bursts. Driver is dark (no consumer) so its restart at the new util is free. Plan budget updated to the measured numbers.

## Rollout

On merge, Flux redeploys both at the new utils — driver reloads from its cache PVC (~1-2 min, no re-download), coder now fits and completes init.