### PR TITLE
chore(ai): GPU fleet consolidation — park idle comfyui-0 + stuck coder

### DIFF
--- a/kubernetes/apps/ai/comfyui/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/comfyui/app/helmrelease.yaml
@@ -12,6 +12,11 @@ spec:
   values:
     controllers:
       comfyui:
+        # Consolidated 2026-07-23: idle 18 days (empty ComfyUI history, no
+        # generations), and all image-gen targets comfyui-spark (graphic-artist
+        # agent + comfyui MCP). Parked at 0 to free a P40 GPU slice + compute;
+        # manifests + PVCs kept for rollback. Revert to run image-gen on the P40.
+        replicas: 0
         pod:
           affinity:
             nodeAffinity:

--- a/kubernetes/apps/ai/vllm-coder-spark/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/vllm-coder-spark/app/helmrelease.yaml
@@ -16,6 +16,14 @@ spec:
   values:
     controllers:
       vllm:
+        # PARKED 2026-07-23: Qwen3.6-27B (dense, ~34 GiB at 0.28) cannot
+        # co-reside with vllm-driver-spark on the GB10 — the driver's real
+        # footprint is ~97 GiB (caching allocator), leaving only ~24 GiB free.
+        # Confirmed by a reclaim test (stopping the coder freed nothing → no
+        # leak, the driver genuinely holds ~97). replicas:0 stops the crashloop
+        # + Flux revert drift. Coder decision pending (drop, or small coder on
+        # the P40's free ~12 GiB) — see vllm_spark_migration_plan.md.
+        replicas: 0
         annotations:
           reloader.stakater.com/auto: "true"
 


### PR DESCRIPTION
## What

Two consolidations from the ml-operator fleet review (2026-07-23), both reversible `replicas: 0` (no data/manifests destroyed):

| Workload | Why | Frees |
|---|---|---|
| **comfyui** (P40) | Idle **18 days** — empty ComfyUI history, zero generations; all image-gen targets `comfyui-spark` (graphic-artist agent + MCP) | a P40 GPU slice + compute |
| **vllm-coder-spark** | Qwen3.6-27B **can't co-reside** with the driver on the GB10 (driver's real footprint ~97 GiB, only ~24 free; reclaim test confirmed no leak). Was crashlooping; my live `scale 0` had no git backing so Flux would revert it | stops crashloop + Flux-revert drift |

## Not included (gated, not standalone)

**ollama-spark decommission** — the third consolidation the review flagged — is **blocked**: it's still the live embedder (until the cutover to `tei-embed-spark`) *and* the only host of `llama3.2-vision:11b` (Frigate GenAI). It needs the embedding cutover + vision relocation first — a coordinated maintenance-window batch, not a one-line park. Deferred.

## Rollback

Revert the PR (or set `replicas: 1`) — both come straight back; PVCs untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)