### PR TITLE
fix(ai): raise vllm-driver-spark max-model-len 32768 → 131072 (free)

### DIFF
--- a/kubernetes/apps/ai/vllm-driver-spark/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/vllm-driver-spark/app/helmrelease.yaml
@@ -69,12 +69,17 @@ spec:
               - 0.0.0.0
               - --port
               - "8000"
-              # Capped from the model's native 262144. The two-instance
-              # co-residency budget (see vllm_spark_migration_plan.md) needs
-              # KV modest; 32k is ample for chat + agentic coding. Raise
-              # only with headroom proven on-box.
+              # Raised 32768 -> 131072 (2026-07-23) at ZERO memory cost. The
+              # coder was dropped (couldn't co-reside), so this is single-tenant
+              # now, and the KV cache was wildly over-provisioned: 27.65 GiB =
+              # 2.38M tokens = 72x concurrency at 32k, on a fleet that runs ~1
+              # request at a time. At 128k that's still ~18x concurrency — fits
+              # the SAME 0.36 util budget with no increase. Fixes opencode's
+              # context overflow (its agent scaffolding is ~24.5k input tokens,
+              # which overflowed the old 32k). Native max is 262144; fall back
+              # to 65536 (36x concurrency) if 128k profiles greedy on-box.
               - --max-model-len
-              - "32768"
+              - "131072"
               # Explicit cap. TUNED FROM LIVE MEASUREMENT (2026-07-23):
               # vLLM sees 121.63 GiB total; the non-vLLM co-tenants
               # (comfyui, tei x2, pump-cv, av1corrector, bge-m3, CUDA


### PR DESCRIPTION
## What

Raise the driver's context **32768 → 131072** at **zero memory cost**, fixing opencode's context overflow.

## Why it's free

The KV cache is wildly over-provisioned: **27.65 GiB = 2.38M tokens = 72× concurrency at 32k**, on a fleet that runs ~1 request at a time. At 128k that's still **~18× concurrency** — fits the *same* 0.36 util budget, no memory increase. The coder was dropped (couldn't co-reside), so the driver is single-tenant and this trade is pure upside.

opencode's agent scaffolding is **~24.5k input tokens**, which overflowed the old 32k. 128k gives ample headroom. Fallback 65536 (36× concurrency) if 128k profiles greedy on-box.

From the ml-operator fleet review. opencode client-side context limit already raised to match (`~/.config`).

## Rollout

Flux redeploys the driver → ~18 min cold reload → vLLM re-profiles KV at 128k. Verify KV concurrency ≥4× on startup; opencode should then run without overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)