### PR TITLE
fix(collab): cut Open WebUI chat over to vllm-driver (qwen3.6)

### DIFF
--- a/kubernetes/apps/collab/open-webui/app/cnp-allow.yaml
+++ b/kubernetes/apps/collab/open-webui/app/cnp-allow.yaml
@@ -25,8 +25,20 @@ spec:
             - port: "8080"
               protocol: TCP
   egress:
-    # ai/ollama + ai/ollama-spark — LLM backends (OLLAMA_BASE_URLS
-    # advertises both endpoints; Spark is default, P40 selectable).
+    # ai/vllm-driver-spark — primary chat LLM (OpenAI /v1) as of the
+    # 2026-07-24 cutover. Configured as an Open WebUI OpenAI connection
+    # (webui.db openai.api_base_urls); DEFAULT_MODELS = qwen3.6-35b-a3b.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: ai
+            app.kubernetes.io/name: vllm-driver-spark
+      toPorts:
+        - ports:
+            - port: "8000"
+              protocol: TCP
+    # ai/ollama (P40, qwen2.5:7b selectable) + ai/ollama-spark (bge-m3 for
+    # RAG_OLLAMA_BASE_URL embeddings until the tei-embed cutover). The Spark
+    # chat models moved to vllm-driver-spark above.
     - toEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: ai

--- a/kubernetes/apps/collab/open-webui/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/open-webui/app/helmrelease.yaml
@@ -75,17 +75,16 @@ spec:
               # See pod-level comment above — persists the secret key
               # on the PVC instead of the unwritable image cwd.
               WEBUI_SECRET_KEY_FILE: /app/backend/data/.webui_secret_key
-              # Multi-endpoint: Spark (qwen3.5:122b-a10b) is the new default,
-              # P40 (qwen2.5:7b) remains user-selectable per
-              # conversation. Open WebUI parses this as `;`-separated
-              # endpoints and exposes each model under its own provider
-              # label in the model picker. First entry is the default
-              # for new chats.
+              # Ollama endpoints kept for the P40 small model (qwen2.5:7b)
+              # and ollama-spark bge-m3 RAG embeddings. Primary chat LLM
+              # moved to vLLM (Qwen3.6-35B-A3B, OpenAI /v1) 2026-07-24 —
+              # that connection is configured in webui.db (openai.*), since
+              # Open WebUI's persistent config overrides env for connections.
               OLLAMA_BASE_URLS: http://ollama-spark.ai.svc.cluster.local:11434;http://ollama.ai.svc.cluster.local:11434
-              # Declarative default model for new chats (previously set via
-              # the webui.db UI setting). Must match the Ollama tag exactly
-              # as served by ollama-spark.
-              DEFAULT_MODELS: qwen3.5:122b-a10b
+              # Default model for new chats. webui.db ui.default_models is
+              # authoritative (set to qwen3.6-35b-a3b at cutover); this env
+              # is kept aligned for DR / persistent-config-off scenarios.
+              DEFAULT_MODELS: qwen3.6-35b-a3b
               ENABLE_RAG_WEB_SEARCH: true
               RAG_EMBEDDING_ENGINE: ollama
               # Pin RAG embedding traffic to Spark. Without this,


### PR DESCRIPTION
Cuts Open WebUI's primary chat LLM from ollama-spark (dangling DEFAULT_MODELS: qwen3.5:122b-a10b, removed) to the vLLM driver (qwen3.6-35b-a3b, OpenAI /v1).

- **CNP:** egress to vllm-driver-spark:8000. ollama egress kept for the P40 small model + ollama-spark bge-m3 RAG embeddings.
- **HR:** DEFAULT_MODELS -> qwen3.6-35b-a3b.
- **webui.db** (done live): openai.enable=true, api_base_urls -> vllm-driver-spark/v1, ui.default_models -> qwen3.6-35b-a3b. Open WebUI's persistent config overrides env for connections, so the connection lives in the DB; env kept aligned for DR.

Activation: after this CNP merges + the driver is Ready at 128k, restart open-webui to load the DB config.

Generated with Claude Code