### PR TITLE
fix(ai): opencode persistence must live under /data (image contract)

### DIFF
--- a/kubernetes/apps/ai/opencode/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/opencode/app/helmrelease.yaml
@@ -22,11 +22,15 @@ spec:
       opencode:
         annotations:
           reloader.stakater.com/auto: "true"
-        # Community image (ghcr.io/felixclements/opencode-server-docker)
-        # runs as root and reads/writes under /root (.config/opencode,
-        # .local/share/opencode, npm cache for the oh-my-openagent plugin).
-        # Same root fallback as khoj; readOnlyRootFilesystem stays off
-        # because opencode + node + `bash` tool write across the rootfs.
+        # Community image (ghcr.io/felixclements/opencode-server-docker).
+        # Its docker-entrypoint.sh puts EVERYTHING under /data:
+        #   DATA_DIR=/data, CONFIG_DIR=/data/config, OPENCODE_DIR=/data/.opencode
+        # and then symlinks /root/.config/opencode -> /data/config (plus
+        # /home/node/.local/share/opencode -> /data/.opencode). So the PVC
+        # mounts at /data and nothing may be mounted at /root/.config/opencode
+        # — a mount there blocks the symlink the entrypoint needs to create.
+        # Runs as root; readOnlyRootFilesystem stays off because opencode +
+        # node + the `bash` tool write across the rootfs.
         pod:
           securityContext:
             runAsNonRoot: false
@@ -37,6 +41,39 @@ spec:
         type: deployment
         replicas: 1
         strategy: Recreate  # single-replica, RWO PVC
+        initContainers:
+          # ConfigMaps cannot be mounted inside the PVC path, so stage them
+          # from a read-only mount into /data/config, reproducing the exact
+          # layout that works on the workstation (~/.config/opencode/):
+          #   opencode.json, oh-my-openagent.json, agent/*.md
+          # Idempotent: re-copied every start so a ConfigMap change wins
+          # (paired with reloader annotation above).
+          stage-config:
+            image:
+              repository: docker.io/library/busybox
+              tag: 1.37.0@sha256:9532d8c39891ca2ecde4d30d7710e01fb739c87a8b9299685c63704296b16028
+            command:
+              - /bin/sh
+              - -ceu
+              - |
+                mkdir -p /data/config/agent
+                cp -f /src/config/opencode.json        /data/config/opencode.json
+                cp -f /src/config/oh-my-openagent.json /data/config/oh-my-openagent.json
+                rm -f /data/config/agent/*.md
+                cp -f /src/agents/*.md /data/config/agent/
+                echo "staged opencode config + $(ls -1 /data/config/agent/*.md | wc -l) agent personas"
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
+              limits:
+                memory: 64Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop: ["ALL"]
+              seccompProfile:
+                type: RuntimeDefault
         containers:
           app:
             image:
@@ -112,37 +149,36 @@ spec:
       # history is irreplaceable accumulated state, not regenerable.
       # Backed up via Longhorn's auto-`default` recurring-job group. See
       # pvc.yaml. (storage-operator review, 2026-07-24.)
+      # Mounted at /data — the entrypoint's DATA_DIR. It holds config/
+      # (symlinked to /root/.config/opencode) and .opencode/ (sessions,
+      # auth.json), so this one claim covers all durable state.
       state:
         existingClaim: opencode-state
         advancedMounts:
           opencode:
+            stage-config:
+              - path: /data
             app:
-              - path: /root/.local/share/opencode
-      # Tailored opencode.json (single-file subPath mount).
-      config-file:
+              - path: /data
+      # Read-only staging sources — initContainer only, never the app.
+      # Mounting these under /root/.config/opencode would block the
+      # entrypoint's symlink; they are copied into /data/config instead.
+      config-src:
         type: configMap
         name: opencode-config
         advancedMounts:
           opencode:
-            app:
-              - path: /root/.config/opencode/opencode.json
-                subPath: opencode.json
-      omopenagent:
-        type: configMap
-        name: opencode-config
-        advancedMounts:
-          opencode:
-            app:
-              - path: /root/.config/opencode/oh-my-openagent.json
-                subPath: oh-my-openagent.json
-      # Operator personas -> /root/.config/opencode/agent/*.md
-      agents:
+            stage-config:
+              - path: /src/config
+                readOnly: true
+      agents-src:
         type: configMap
         name: opencode-agents
         advancedMounts:
           opencode:
-            app:
-              - path: /root/.config/opencode/agent
+            stage-config:
+              - path: /src/agents
+                readOnly: true
       # Project workspace the agent operates in. emptyDir scratch for v1;
       # promote to a git-synced PVC once a target repo/workflow is chosen.
       workspace:


### PR DESCRIPTION
## Problem

opencode crashlooped immediately after #13243 deployed:

```
Creating OpenCode data directories...
mkdir: cannot create directory '/data': Permission denied
```

The persistence layout in #13243 was derived from the image's **README summary**, not its **entrypoint**. The actual `docker-entrypoint.sh`:

```bash
DATA_DIR="/data"; CONFIG_DIR="/data/config"; OPENCODE_DIR="/data/.opencode"
mkdir -p "$CONFIG_DIR" "$OPENCODE_DIR"/{agents,commands,...}
ln -sf "$CONFIG_DIR" /root/.config/opencode
ln -sf "$OPENCODE_DIR" /home/node/.local/share/opencode
```

Every path was wrong:

| #13243 | Actual contract |
|---|---|
| PVC at `/root/.local/share/opencode` | PVC at **`/data`** |
| ConfigMaps into `/root/.config/opencode/` | that dir is **replaced by a symlink** to `/data/config` |

Nothing was mounted at `/data`, so the entrypoint's `mkdir` hit the rootfs — denied even as root, because `capabilities: drop: ALL` removes `CAP_DAC_OVERRIDE`.

## Fix

- **PVC mounts at `/data`** — one claim covers `config/` and `.opencode/` (sessions, `auth.json`).
- **ConfigMaps staged read-only at `/src/*`**, copied into `/data/config` by a `stage-config` initContainer, reproducing the layout that works on the workstation: `opencode.json`, `oh-my-openagent.json`, `agent/*.md`. ConfigMaps cannot mount inside the PVC path, and mounting at `/root/.config/opencode` would block the entrypoint's symlink.
- The copy is idempotent (re-runs each start), so ConfigMap changes take effect on restart via the existing reloader annotation.
- busybox pinned by digest.

## Deploy notes

- The `opencode` Flux Kustomization is currently **suspended** and the Deployment scaled to 0 to stop the crashloop. It needs to be un-suspended after merge (Rob's call, per the repo suspension gate).
- The Longhorn volume `opencode-state-xfs` was created out-of-band — the static-PV pattern this repo uses for jellyfin/romm/wg-easy requires a pre-existing volume. It is `attached`/`healthy` and retained.

Verified against the entrypoint script this time, not the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
