### PR TITLE
fix(ai): opencode /home/node writability + real session persistence

### DIFF
--- a/kubernetes/apps/ai/opencode/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/opencode/app/helmrelease.yaml
@@ -56,7 +56,7 @@ spec:
               - /bin/sh
               - -ceu
               - |
-                mkdir -p /data/config/agent
+                mkdir -p /data/config/agent /data/.opencode
                 cp -f /src/config/opencode.json        /data/config/opencode.json
                 cp -f /src/config/oh-my-openagent.json /data/config/oh-my-openagent.json
                 rm -f /data/config/agent/*.md
@@ -160,6 +160,31 @@ spec:
               - path: /data
             app:
               - path: /data
+      # The entrypoint unconditionally does `mkdir -p /home/node/.local/share`
+      # (a vestige of the image's node-user design). /home/node is owned by
+      # uid 1000, and root cannot write there because `drop: ALL` removes
+      # CAP_DAC_OVERRIDE — this is what crashed the pod. A writable emptyDir
+      # satisfies it without granting the capability back. Nothing durable
+      # lands here; the symlink it creates points into /data/.opencode.
+      node-home:
+        type: emptyDir
+        advancedMounts:
+          opencode:
+            app:
+              - path: /home/node/.local
+      # The entrypoint symlinks /home/node/.local/share/opencode but NOT
+      # /root/.local/share/opencode — yet the Dockerfile sets no USER/HOME,
+      # so opencode runs as root with HOME=/root and writes sessions +
+      # auth.json to /root/.local/share/opencode. Without this mount that
+      # state would sit on the ephemeral rootfs and vanish on restart.
+      # Bind the same PVC subdir the entrypoint uses, so both paths agree.
+      state-opencode:
+        existingClaim: opencode-state
+        advancedMounts:
+          opencode:
+            app:
+              - path: /root/.local/share/opencode
+                subPath: .opencode
       # Read-only staging sources — initContainer only, never the app.
       # Mounting these under /root/.config/opencode would block the
       # entrypoint's symlink; they are copied into /data/config instead.


### PR DESCRIPTION
Follow-up to #13248. Two more defects in the image's entrypoint contract — both found by reading `docker-entrypoint.sh` and the `Dockerfile` this time, not the README.

## 1. Crash: `/home/node/.local` not writable

```
mkdir: cannot create directory '/home/node/.local': Permission denied
```

The entrypoint unconditionally runs `mkdir -p /home/node/.local/share` — a vestige of the image's node-user design, executed even when running as root. `/home/node` is owned by uid 1000, and root **cannot** write there because `capabilities: drop: ALL` removes `CAP_DAC_OVERRIDE`.

**Fix:** a writable `emptyDir` at `/home/node/.local`, rather than granting the capability back. Nothing durable lands there — the symlink it creates points into `/data/.opencode`.

## 2. Silent data loss: sessions were going to the ephemeral rootfs

The entrypoint symlinks `/home/node/.local/share/opencode` → `/data/.opencode`, but **not** `/root/.local/share/opencode`. The Dockerfile sets no `USER` and no `ENV HOME`:

```dockerfile
FROM node:24-bookworm-slim
WORKDIR /app
```

So opencode runs as **root with `HOME=/root`** and writes sessions + `auth.json` to `/root/.local/share/opencode` — which was the ephemeral container filesystem. Every restart would have silently discarded all session history, while the Longhorn PVC sat there looking healthy.

This is the failure mode the storage review was specifically trying to prevent (session history as irreplaceable state), defeated one layer down by a path assumption.

**Fix:** bind `/root/.local/share/opencode` to the PVC subdir `.opencode` — the same directory the entrypoint's own symlink targets, so both paths resolve to identical storage. The initContainer pre-creates `/data/.opencode`.

## Verification

`kubectl kustomize` renders the intended mount table:

```
stage-config  /src/agents                   <- agents-src
stage-config  /src/config                   <- config-src
stage-config  /data                         <- state
app           /data                         <- state
app           /root/.local/share/opencode   <- state [subPath=.opencode]
app           /home/node/.local             <- node-home (emptyDir)
app           /workspace                    <- workspace (emptyDir)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
