### PR TITLE
fix(ai): opencode — stop image CMD duplicating the serve positional

### DIFF
--- a/kubernetes/apps/ai/opencode/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/opencode/app/helmrelease.yaml
@@ -83,6 +83,16 @@ spec:
               # datasource/extractVersion to auto-bump — track as follow-up.
               repository: ghcr.io/felixclements/opencode-server-docker
               tag: upstream-v1.17.4@sha256:daff7a4ea70ea43634640d7303a5cf0731abb7522fd7368d7513025a0b8d8352
+            # The image's entrypoint ends with `exec opencode $COMMAND "$@"`,
+            # where $COMMAND is the flag string it builds from PORT/HOSTNAME
+            # and "$@" is the image CMD (["serve"]). Left alone that yields
+            # `opencode serve --port 4096 --hostname 0.0.0.0 serve` — a
+            # duplicate positional, so opencode printed help and exited.
+            # Setting `command` with no `args` makes Kubernetes ignore the
+            # image CMD, so "$@" is empty. Verified in-cluster: the server
+            # then logs "opencode server listening on http://0.0.0.0:4096".
+            command:
+              - /usr/local/bin/docker-entrypoint.sh
             env:
               PORT: &port "4096"
               HOSTNAME_OVERRIDE: 0.0.0.0


### PR DESCRIPTION
The entrypoint ends with:

```bash
exec opencode $COMMAND "$@"
```

where `$COMMAND` is the flag string built from `PORT`/`HOSTNAME_OVERRIDE`, and `"$@"` is the image `CMD` (`["serve"]`). The result was:

```
opencode serve --port 4096 --hostname 0.0.0.0 serve
```

a duplicate positional — so opencode printed its usage and exited. The pod sat Running-but-never-Ready, then crashlooped.

## Fix

Set `command` with no `args`. Kubernetes then ignores the image CMD entirely, so `"$@"` is empty.

`args: []` does **not** work — the API server drops the empty array and the image CMD still applies. I tested that first and it reproduced the same help output.

## Verified before committing

Ran a throwaway pod in-cluster with the override:

```
Creating OpenCode data directories...
Directory structure created successfully.
Starting opencode server...
opencode server listening on http://0.0.0.0:4096
```

Third and final path/runtime defect in this chain (after #13248 and #13249) — all three came from the image contract, and this one is now confirmed empirically rather than by inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)