### PR TITLE
fix(ai): opencode was loading the image's stock config, not ours

### DIFF
--- a/kubernetes/apps/ai/opencode/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/opencode/app/helmrelease.yaml
@@ -57,6 +57,11 @@ spec:
               - -ceu
               - |
                 mkdir -p /data/config/agent /data/.opencode
+                # The entrypoint's `ln -sf /data/config /root/.config/opencode`
+                # lands *inside* the mounted dir, leaving a self-referential
+                # /data/config/config -> /data/config. Harmless but confusing;
+                # clear it each start.
+                rm -f /data/config/config
                 cp -f /src/config/opencode.json        /data/config/opencode.json
                 cp -f /src/config/oh-my-openagent.json /data/config/oh-my-openagent.json
                 rm -f /data/config/agent/*.md
@@ -170,6 +175,21 @@ spec:
               - path: /data
             app:
               - path: /data
+      # /root/.config/opencode is a REAL directory baked into the image (it
+      # ships an opencode.jsonc), so the entrypoint's
+      #   ln -sf /data/config /root/.config/opencode
+      # does not replace it — it creates the symlink *inside*, and opencode
+      # then loads the image's stock opencode.jsonc instead of ours. Mounting
+      # the PVC's config/ subdir directly over that path is what actually
+      # puts our opencode.json + agent/*.md where opencode looks, mirroring
+      # the workstation layout (~/.config/opencode/).
+      state-config:
+        existingClaim: opencode-state
+        advancedMounts:
+          opencode:
+            app:
+              - path: /root/.config/opencode
+                subPath: config
       # The entrypoint unconditionally does `mkdir -p /home/node/.local/share`
       # (a vestige of the image's node-user design). /home/node is owned by
       # uid 1000, and root cannot write there because `drop: ALL` removes


### PR DESCRIPTION
## Problem

`/root/.config/opencode` is a **real directory baked into the image** (it ships its own `opencode.jsonc`). The entrypoint does:

```bash
if [ ! -L /root/.config/opencode ]; then
    ln -sf "$CONFIG_DIR" /root/.config/opencode
fi
```

Because the path exists as a directory, the `[ ! -L ]` guard passes and `ln -sf` creates the link **inside** it:

```
/root/.config/opencode/
  config -> /data/config      <- one level too deep
  opencode.jsonc              <- image default, 50 bytes
```

opencode therefore loaded the stock `opencode.jsonc`. **None of our providers, MCP config, or the 7 agent personas were active** — despite the pod being 1/1 Ready, logging `listening on http://0.0.0.0:4096`, and correctly returning 401 on unauthenticated requests. It looked healthy from every external signal.

## Fix

Mount the PVC's `config/` subdir directly over `/root/.config/opencode`, so `opencode.json` and `agent/*.md` land exactly where opencode looks — mirroring the workstation layout `~/.config/opencode/`.

The initContainer also clears the self-referential `/data/config/config -> /data/config` symlink the entrypoint leaves behind.

## Verification plan

Post-deploy, confirm via the running pod that `/root/.config/opencode/opencode.json` is ours and that the configured providers/MCP are loaded — not just that the port is listening. The lesson from this chain is that liveness is not the same as correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)