### PR TITLE
feat(ai): opencode workspace PVC + repo clone machinery

### DIFF
--- a/kubernetes/apps/ai/opencode/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/opencode/app/helmrelease.yaml
@@ -79,6 +79,64 @@ spec:
                 drop: ["ALL"]
               seccompProfile:
                 type: RuntimeDefault
+          # Clone/refresh the repos the agents work against. Uses the opencode
+          # image itself (already digest-pinned, already has git 2.39.5) so no
+          # extra image enters the supply chain.
+          #
+          # Deliberately NON-FATAL: a clone failure must never stop the server
+          # from starting. home-ops is public and clones without credentials;
+          # the two private repos are skipped with a message until the
+          # opencode-git-secret exists (optional secretRef below).
+          #
+          # The token is passed as a transient `-c http.extraheader` so it is
+          # never written into .git/config on the PVC — no credential at rest.
+          stage-repos:
+            image:
+              repository: ghcr.io/felixclements/opencode-server-docker
+              tag: upstream-v1.17.4@sha256:daff7a4ea70ea43634640d7303a5cf0731abb7522fd7368d7513025a0b8d8352
+            command:
+              - /bin/bash
+              - -cu
+              - |
+                AUTH=()
+                if [ -n "${GH_TOKEN:-}" ]; then
+                  B64=$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 -w0)
+                  AUTH=(-c "http.extraheader=AUTHORIZATION: basic ${B64}")
+                  echo "git credentials: present"
+                else
+                  echo "git credentials: absent — public repos only"
+                fi
+                for r in home-ops lovenet-network-configuration containers; do
+                  if [ -d "/workspace/$r/.git" ]; then
+                    if git "${AUTH[@]}" -C "/workspace/$r" fetch --all --prune --quiet 2>/dev/null; then
+                      echo "  fetched $r"
+                    else
+                      echo "  SKIP $r (fetch failed — credentials?)"
+                    fi
+                  elif git "${AUTH[@]}" clone --quiet "https://github.com/rwlove/$r.git" "/workspace/$r" 2>/dev/null; then
+                    echo "  cloned $r"
+                  else
+                    echo "  SKIP $r (clone failed — private repo needs credentials)"
+                  fi
+                done
+                echo "workspace: $(ls -1 /workspace 2>/dev/null | tr '\n' ' ')"
+                exit 0
+            envFrom:
+              - secretRef:
+                  name: opencode-git-secret
+                  optional: true          # absent until the PAT is created
+            resources:
+              requests:
+                cpu: 50m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop: ["ALL"]
+              seccompProfile:
+                type: RuntimeDefault
         containers:
           app:
             image:
@@ -234,11 +292,15 @@ spec:
             stage-config:
               - path: /src/agents
                 readOnly: true
-      # Project workspace the agent operates in. emptyDir scratch for v1;
-      # promote to a git-synced PVC once a target repo/workflow is chosen.
+      # Agent working tree — Longhorn PVC (see workspace-pvc.yaml). Holds the
+      # repo clones plus accumulated in-flight work, which unattended agents
+      # make unreconstructable. Mounted into stage-repos (to clone/fetch) and
+      # the app (to work in).
       workspace:
-        type: emptyDir
+        existingClaim: opencode-workspace
         advancedMounts:
           opencode:
+            stage-repos:
+              - path: /workspace
             app:
               - path: /workspace

--- a/kubernetes/apps/ai/opencode/app/kustomization.yaml
+++ b/kubernetes/apps/ai/opencode/app/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - ./helmrelease.yaml
   - ./httproute.yaml
   - ./pvc.yaml
+  - ./workspace-pvc.yaml
   - ./securitypolicy.yaml
 configMapGenerator:
   # opencode reads its config from /root/.config/opencode. This is a

--- a/kubernetes/apps/ai/opencode/app/workspace-pvc.yaml
+++ b/kubernetes/apps/ai/opencode/app/workspace-pvc.yaml
@@ -1,0 +1,52 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim-v1.json
+# Agent working tree: clones of home-ops, lovenet-network-configuration and
+# containers, plus whatever in-flight work the agents accumulate.
+#
+# Longhorn rather than ceph-block: with agents running unattended this stops
+# being a disposable checkout (rule 2) and becomes accumulated work-in-progress
+# — partial branches, uncommitted edits, analysis output — that no git remote
+# can reconstruct. That is rule 3, so it gets the cluster-loss-survivable tier
+# and the auto-`default` recurring-job backup group.
+#
+# Static named-class + pinned PV per repo convention (jellyfin/romm). NOTE:
+# that pattern requires the Longhorn volume `opencode-workspace-xfs` to exist
+# BEFORE this is applied — Longhorn does not auto-create it for a statically
+# provisioned PV. It was created out-of-band on 2026-07-24.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: opencode-workspace
+  labels:
+    type: longhorn
+spec:
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: 20Gi
+  volumeName: opencode-workspace-pv
+  storageClassName: opencode-workspace-storage-class
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: opencode-workspace-pv
+  labels:
+    type: longhorn
+spec:
+  capacity:
+    storage: 20Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: opencode-workspace-storage-class
+  csi:
+    driver: driver.longhorn.io
+    fsType: xfs
+    volumeAttributes:
+      numberOfReplicas: "2"
+      staleReplicaTimeout: "2880"
+    volumeHandle: opencode-workspace-xfs


### PR DESCRIPTION
## What

Replace the `/workspace` emptyDir with a **20Gi Longhorn PVC** and add a `stage-repos` initContainer that clones/refreshes `home-ops`, `lovenet-network-configuration`, and `containers`.

## Why Longhorn, not ceph-block

A git checkout alone is reconstructable (rule 2 → ceph-block). But with agents running **unattended**, `/workspace` stops being a disposable checkout and becomes accumulated in-flight work — partial branches, uncommitted edits, analysis output — that no remote can rebuild. That is rule 3: cluster-loss-survivable tier plus the auto-`default` backup group.

## Ordering note

The Longhorn volume `opencode-workspace-xfs` was created **out-of-band first**. This repo's static named-class + pinned-PV pattern (jellyfin/romm) does not auto-create the volume — applying the PVC without it would have failed to attach and taken down a working server. That failure mode already cost one round earlier today.

## stage-repos

- **Reuses the opencode image** (already digest-pinned, ships git 2.39.5) — no new image in the supply chain.
- **Non-fatal by design**: a clone failure never blocks the server from starting.
- `home-ops` is public and clones anonymously. The two private repos are skipped with a clear message until `opencode-git-secret` exists (`optional: true` secretRef) — that lands when the read-only PAT is created.
- The token is passed as a transient `-c http.extraheader`, so it is **never written into `.git/config`** on the PVC. No credential at rest.

## Verified locally before commit

```
RUN 1: cloned home-ops / SKIP lovenet-network-configuration / SKIP containers
RUN 2: fetched home-ops   (idempotent — fetch, not re-clone)
credential at rest in .git/config: 0
size: 84M
```

## Known gap

Multiple concurrent unattended sessions will share these clones, which is exactly what `.agents/instructions/worktree-isolation.md` warns against. Not addressed here — flagged for the follow-up that decides per-session worktree layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)