### PR TITLE
feat(ai): put opencode worktrees on the workspace volume

### DIFF
--- a/kubernetes/apps/ai/opencode/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/opencode/app/helmrelease.yaml
@@ -253,6 +253,23 @@ spec:
             app:
               - path: /root/.config/opencode
                 subPath: config
+      # opencode creates isolated per-session copies natively — its v2
+      # `projectCopy.create` API with `strategy: git_worktree` — rooted at
+      # `<data_dir>/worktree`, i.e. /root/.local/share/opencode/worktree.
+      # That path would otherwise land on the *state* PVC while the parent
+      # repos live on the *workspace* PVC; a git worktree stores an absolute
+      # pointer back into its parent's .git, so a restore of one volume
+      # without the other leaves dangling worktrees. Mount the worktree root
+      # from the workspace claim so a repo and its worktrees always share one
+      # volume (and one backup). Satisfies worktree-isolation.md without any
+      # bespoke worktree machinery.
+      worktrees:
+        existingClaim: opencode-workspace
+        advancedMounts:
+          opencode:
+            app:
+              - path: /root/.local/share/opencode/worktree
+                subPath: .worktrees
       # The entrypoint unconditionally does `mkdir -p /home/node/.local/share`
       # (a vestige of the image's node-user design). /home/node is owned by
       # uid 1000, and root cannot write there because `drop: ALL` removes


### PR DESCRIPTION
Resolves the worktree-isolation gap flagged in #13253.

## Key finding: don't build this — opencode already has it

opencode creates isolated per-session copies **natively**. Its v2 API:

```js
projectCopy.create({
  projectID: ...,
  location: {directory: ...},
  strategy: "git_worktree",
  directory: join(Q.worktree, projectID.slice(0,6)),
  name: ...
})
```

The `project_directory` table confirms it — `strategy = git_worktree` — and the worktree root is `g.data + "/worktree"`, i.e. `/root/.local/share/opencode/worktree`.

So the mechanism `.agents/instructions/worktree-isolation.md` asks for is already built into the tool. Per HOMELAB-SPEC's *"project features over bespoke glue"*, this PR adds **no** worktree machinery — it only makes the storage coherent.

## The actual problem: split-brain across two volumes

The worktree root resolved to the **state** PVC (`opencode-state`, via subPath `.opencode`), while the parent repo clones live on the **workspace** PVC (`opencode-workspace`).

A git worktree stores an absolute pointer back into its parent's `.git/worktrees/<name>`. Split across two volumes, that means:

- restoring the workspace volume without the state volume → orphaned worktree metadata
- restoring state without workspace → worktrees pointing at a `.git` that isn't there

Both are recoverable with `git worktree prune`, but it's needless fragility, and the two volumes have independent backup timelines.

## Fix

Mount the worktree root from the **workspace** claim (`subPath: .worktrees`), so a repo and its worktrees always share one volume and restore together.

Rendered mount table — note the nested mount sorts after its parent, so ordering is correct:

```
/data                                  <- state
/home/node/.local                      <- node-home (emptyDir)
/root/.config/opencode                 <- state-config     [subPath=config]
/root/.local/share/opencode            <- state-opencode   [subPath=.opencode]
/root/.local/share/opencode/worktree   <- worktrees        [subPath=.worktrees]
/workspace                             <- workspace
```

Worktrees are cheap here: they share the parent's object store, so each is roughly the working tree only (~9MB for home-ops, whose 165MB is mostly the 156MB `.git`).

## Caveat

I located the API and the path by reading the shipped bundle; I have **not** yet driven the worktree-creation flow end to end from the TUI. The storage layout is correct either way, but the exact UX to trigger a project copy still needs confirming in a real session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
