### PR TITLE
fix(ai): opencode MCP was pointed at the broker, not the istio gateway

### DIFF
--- a/kubernetes/apps/ai/opencode/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/opencode/app/cnp-allow.yaml
@@ -36,13 +36,17 @@ spec:
   # Rob-only via extAuth). Do not point an unattended loop at this pod
   # until per-tool authz lands.
   egress:
-    # Lovenet MCP gateway (Kuadrant broker) — internal svc, no token.
-    # Selector confirmed against mcp-gateway's own mcp-gateway-broker-allow
-    # CNP (network-operator review, 2026-07-24).
+    # Lovenet MCP gateway — the ISTIO-managed gateway service, not the
+    # broker. The broker (app.kubernetes.io/name: mcp-gateway) accepts
+    # ingress only from the istio gateway pod, so addressing it directly is
+    # dropped by mcp-gateway-broker-allow — which is why MCP was silently
+    # dead here. In-cluster clients hit mcp-gateway-istio.mcp-system:8080 by
+    # DNS, which mcp-gateway-istio-allow permits via `fromEntities: cluster`.
+    # Namespace-wide selector matches the langgraph-agents precedent (the
+    # reference in-cluster MCP client named in that policy's comment).
     - toEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: mcp-system
-            app.kubernetes.io/name: mcp-gateway
       toPorts:
         - ports:
             - port: "8080"

--- a/kubernetes/apps/ai/opencode/app/resources/opencode.json
+++ b/kubernetes/apps/ai/opencode/app/resources/opencode.json
@@ -43,7 +43,7 @@
   "mcp": {
     "lovenet-gateway": {
       "type": "remote",
-      "url": "http://mcp-gateway.mcp-system.svc.cluster.local:8080/mcp",
+      "url": "http://mcp-gateway-istio.mcp-system.svc.cluster.local:8080/mcp",
       "enabled": true
     }
   }


### PR DESCRIPTION
## Problem

opencode's MCP has been **silently dead since deploy**. `opencode.json` addressed `mcp-gateway.mcp-system:8080` — the broker — but `mcp-gateway-broker-allow` permits ingress **only** from the istio gateway pod:

```yaml
ingress:
  - fromEndpoints:
      - matchLabels:
          io.kubernetes.pod.namespace: mcp-system
          gateway.networking.k8s.io/gateway-name: mcp-gateway
```

So every request was dropped by Cilium. Verified from inside the pod — connect timeout, exit 28.

The egress rule was wrong too: it selected `app.kubernetes.io/name: mcp-gateway`, which does not match the istio gateway pod (labelled `gateway.networking.k8s.io/gateway-name=mcp-gateway`). Even the corrected URL would have been blocked.

Nothing surfaced this: the pod was Ready, the config parsed, and an MCP server that never connects looks identical to one that is simply idle.

## Fix

Both now follow the **langgraph-agents** precedent — the reference in-cluster MCP client named in `mcp-gateway-istio-allow`'s own comment:

| | before | after |
|---|---|---|
| url | `mcp-gateway.mcp-system:8080` | `mcp-gateway-istio.mcp-system:8080` |
| egress CNP | label-scoped to broker pod | namespace-wide `mcp-system:8080` |

No token is required in-cluster: `mcp-gateway-istio-allow` permits `fromEntities: cluster` on 8080, and langgraph-agents sends no JWT. That part of the original design was right — it was aimed at the wrong service.

## Follow-up (not in this PR)

Tool-level authz is achievable but is its own project. Findings:

- `MCPVirtualServer` (`spec.tools`) filters `tools/list`, but the client selects it via an `x-mcp-virtualserver` header — **client-controlled, so not a security boundary**.
- Real enforcement for `tools/call` is a Kuadrant **AuthPolicy** evaluated by Authorino in the Envoy data path, keyed on JWT + tool name.
- In-cluster clients currently send **no** identity, so there is nothing for an AuthPolicy to key on. Constraining opencode specifically would require giving it its own Authelia identity plus an AuthPolicy allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)