### PR TITLE
fix(paperless): bump 3.0.1 → 3.0.2 to clear broken migration

### DIFF
--- a/kubernetes/apps/collab/paperless/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/paperless/app/helmrelease.yaml
@@ -60,7 +60,7 @@ spec:
           app:
             image:
               repository: ghcr.io/paperless-ngx/paperless-ngx
-              tag: 3.0.1@sha256:087be9870c285b06fea34cfd6490c02eb3281052f6ff338ca6cd1f068ff3ff28
+              tag: 3.0.2@sha256:fef384c955d2ec2acf1bd0882ffc195ecc170266c803dfe28b79df6deabb3569
             env:
               # Configure application
               PAPERLESS_URL: "https://paperless.${SECRET_DOMAIN}"


### PR DESCRIPTION
## Problem

paperless-ngx has been in `CrashLoopBackOff` since 3.0.1 rolled out (2026-07-23 21:10 ET) — 354 restarts, ~31h of downtime. The container never gets past the `init-migrations` s6 step, so s6 tears the whole container down:

```
django.db.migrations.exceptions.InconsistentMigrationHistory:
Migration paperless_mail.0002_optimize_integer_field_sizes is applied
before its dependency paperless_mail.0001_1_clamp_mailrule_maximum_age
```

## Root cause

3.0.1 added a *new* migration `paperless_mail/0001_1_clamp_mailrule_maximum_age.py` and retroactively made the pre-existing `0002_optimize_integer_field_sizes` depend on it. Our DB applied `0002` during the 3.0.0 upgrade on 2026-07-22:

```
374 | 0002_optimize_integer_field_sizes  | 2026-07-22 15:47:34
379 | 0001_squashed                      | 2026-07-22 15:47:34
```

Django's `check_consistent_history()` sees a dependency recorded *after* its dependent and hard-fails every boot.

Upstream regression — paperless-ngx/paperless-ngx#13241.

## Fix

Bump to 3.0.2, which fixes it upstream via paperless-ngx/paperless-ngx#13242. That PR *deletes* `0001_1_clamp_mailrule_maximum_age.py` and folds the clamp back into `0002`. With the file gone, the consistency check passes against the existing `django_migrations` rows — **no manual DB surgery required.**

`0002` applied cleanly at 3.0.0, so no `maximum_age` value overflowed and the clamp had nothing to do on this install anyway.

## Verification

- Digest resolved live against ghcr.io: `sha256:fef384c9...`
- Post-merge: watch `paperless-0` through restart, confirm `init-migrations` completes and the pod reaches `Ready`.

## Notes

Restoration of a hard-down service — no maintenance window needed. Renovate had not yet opened the 3.0.2 PR (3.0.2 released ~2h after 3.0.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)