### PR TITLE
feat(ai): read-only deploy keys for opencode's private repo clones

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ _Production-grade Kubernetes for a household._
 ![helmreleases](https://img.shields.io/badge/HelmReleases-172-326CE5?style=for-the-badge&logo=helm&logoColor=white)
 ![nodes](https://img.shields.io/badge/k8s_nodes-11-326CE5?style=for-the-badge&logo=kubernetes&logoColor=white)
 ![cnpg](https://img.shields.io/badge/Postgres_clusters-22-336791?style=for-the-badge&logo=postgresql&logoColor=white)
-![secrets](https://img.shields.io/badge/secrets-89-0572EC?style=for-the-badge&logo=1password&logoColor=white)
+![secrets](https://img.shields.io/badge/secrets-90-0572EC?style=for-the-badge&logo=1password&logoColor=white)
 ![age](https://img.shields.io/badge/cluster_age-5%2B_years-success?style=for-the-badge)
 
 </div>

--- a/kubernetes/apps/ai/opencode/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/opencode/app/externalsecret.yaml
@@ -21,3 +21,31 @@ spec:
   dataFrom:
     - extract:
         key: opencode
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+#
+# Read-only GitHub deploy keys for the two private repos the agents clone.
+# Deploy keys rather than a PAT: they are per-repository and carry a
+# repo-side read_only flag, so the credential cannot push even if the pod is
+# compromised (verified: `git push` is rejected by GitHub). A key cannot be
+# reused across repos, hence one per repo. home-ops is public and needs none.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: opencode-git
+spec:
+  refreshInterval: 12h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: opencode-git-secret
+    creationPolicy: Owner
+    template:
+      data:
+        SSH_KEY_LOVENET: "{{ .SSH_KEY_LOVENET }}"
+        SSH_KEY_CONTAINERS: "{{ .SSH_KEY_CONTAINERS }}"
+        KNOWN_HOSTS: "{{ .KNOWN_HOSTS }}"
+  dataFrom:
+    - extract:
+        key: opencode-git

--- a/kubernetes/apps/ai/opencode/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/opencode/app/helmrelease.yaml
@@ -103,25 +103,44 @@ spec:
               # Kustomization build with "missing closing brace" (see the same
               # warning in mcp-system/mcp-gateway/app/rotator-cronjob.yaml).
               - |
-                AUTH=()
-                if [ -n "$${GH_TOKEN:-}" ]; then
-                  B64=$$(printf 'x-access-token:%s' "$${GH_TOKEN}" | base64 -w0)
-                  AUTH=(-c "http.extraheader=AUTHORIZATION: basic $${B64}")
-                  echo "git credentials: present"
-                else
-                  echo "git credentials: absent — public repos only"
+                # Deploy keys land in the container's ephemeral /tmp, never on
+                # the workspace PVC — private keys must not end up in a
+                # Longhorn backup.
+                SSHD=/tmp/ssh
+                mkdir -p "$${SSHD}"; chmod 700 "$${SSHD}"
+                [ -n "$${KNOWN_HOSTS:-}" ] && printf '%s\n' "$${KNOWN_HOSTS}" > "$${SSHD}/known_hosts"
+                if [ -n "$${SSH_KEY_LOVENET:-}" ]; then
+                  printf '%s\n' "$${SSH_KEY_LOVENET}" > "$${SSHD}/lovenet"; chmod 600 "$${SSHD}/lovenet"
+                fi
+                if [ -n "$${SSH_KEY_CONTAINERS:-}" ]; then
+                  printf '%s\n' "$${SSH_KEY_CONTAINERS}" > "$${SSHD}/containers"; chmod 600 "$${SSHD}/containers"
                 fi
                 for r in home-ops lovenet-network-configuration containers; do
+                  KEY=""
+                  case "$${r}" in
+                    home-ops) URL="https://github.com/rwlove/$${r}.git" ;;
+                    lovenet-network-configuration) URL="git@github.com:rwlove/$${r}.git"; KEY="$${SSHD}/lovenet" ;;
+                    containers) URL="git@github.com:rwlove/$${r}.git"; KEY="$${SSHD}/containers" ;;
+                  esac
+                  if [ -n "$${KEY}" ] && [ ! -f "$${KEY}" ]; then
+                    echo "  SKIP $${r} (no deploy key)"; continue
+                  fi
+                  if [ -n "$${KEY}" ]; then
+                    export GIT_SSH_COMMAND="ssh -i $${KEY} -o IdentitiesOnly=yes -o UserKnownHostsFile=$${SSHD}/known_hosts -o StrictHostKeyChecking=yes"
+                  else
+                    unset GIT_SSH_COMMAND
+                  fi
                   if [ -d "/workspace/$${r}/.git" ]; then
-                    if git "$${AUTH[@]}" -C "/workspace/$${r}" fetch --all --prune --quiet 2>/dev/null; then
+                    git -C "/workspace/$${r}" remote set-url origin "$${URL}" 2>/dev/null
+                    if git -C "/workspace/$${r}" fetch --all --prune --quiet 2>/dev/null; then
                       echo "  fetched $${r}"
                     else
-                      echo "  SKIP $${r} (fetch failed — credentials?)"
+                      echo "  SKIP $${r} (fetch failed)"
                     fi
-                  elif git "$${AUTH[@]}" clone --quiet "https://github.com/rwlove/$${r}.git" "/workspace/$${r}" 2>/dev/null; then
+                  elif git clone --quiet "$${URL}" "/workspace/$${r}" 2>/dev/null; then
                     echo "  cloned $${r}"
                   else
-                    echo "  SKIP $${r} (clone failed — private repo needs credentials)"
+                    echo "  SKIP $${r} (clone failed)"
                   fi
                 done
                 echo "workspace: $$(ls -1 /workspace 2>/dev/null | tr '\n' ' ')"


### PR DESCRIPTION
Completes the credential half of the workspace work (#13253).

## Why deploy keys instead of the PAT

**GitHub has no API to create a personal access token** — fine-grained PATs are UI-only, by design. Deploy keys *can* be created via API, and are a **tighter** credential for this job:

| | fine-grained PAT | deploy keys (this PR) |
|---|---|---|
| scope | one token across 3 repos | one key per repository |
| write path | scope-dependent | `read_only=true` enforced server-side |
| creatable by automation | no | yes |

A key cannot be reused across repositories, so it is one key per private repo. `home-ops` is public and needs no credential at all.

## Created and verified out-of-band

- `rwlove/lovenet-network-configuration` — deploy key id `158310115`, `read_only=true`
- `rwlove/containers` — deploy key id `158310116`, `read_only=true`
- Both **clone successfully**; `git push --dry-run` is **rejected** by GitHub — read-only is enforced, not merely declared
- Private keys + `github.com` known_hosts stored in 1Password item `opencode-git` (Kubernetes vault)

## Changes

- **ExternalSecret** `opencode-git` → `opencode-git-secret` (`SSH_KEY_LOVENET`, `SSH_KEY_CONTAINERS`, `KNOWN_HOSTS`).
- **stage-repos** picks transport per repo: `home-ops` over HTTPS (no credential), the two private repos over SSH with their own key and `StrictHostKeyChecking=yes` against the pinned `known_hosts`.
- Keys are written to the container's **ephemeral `/tmp`**, never the workspace PVC — private keys must not land in a Longhorn backup.
- Existing clones get `git remote set-url`, so the https→ssh switch is handled in place rather than requiring a re-clone.
- The initContainer stays non-fatal: a missing key logs `SKIP <repo>` and the server still starts.

## Validation

- `kubectl kustomize` builds
- envsubst audit: only `${SECRET_DOMAIN}` left unescaped
- the script passes `bash -n` **after simulating Flux's `$$` → `$` substitution** — the check that would have caught the envsubst break in #13253

🤖 Generated with [Claude Code](https://claude.com/claude-code)
