### PR TITLE
fix(ai): disableWait on opencode — rollout outruns helm's 5m wait

### DIFF
--- a/kubernetes/apps/ai/opencode/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/opencode/app/helmrelease.yaml
@@ -9,10 +9,18 @@ spec:
     kind: OCIRepository
     name: app-template
   interval: 30m
+  # strategy: Recreate on an RWO Longhorn PVC means every rollout is:
+  # terminate old pod -> Longhorn detach -> schedule -> attach -> run two
+  # initContainers (one of which clones three git repos) -> start. That
+  # routinely outruns helm-controller's 5m wait, which failed the upgrade
+  # and rolled back in a loop. disableWait matches the documented repo
+  # pattern (see khoj + project_helmrelease_disablewait.md).
   install:
+    disableWait: true
     remediation:
       retries: 3
   upgrade:
+    disableWait: true
     cleanupOnFail: true
     remediation:
       retries: 3


### PR DESCRIPTION
The deploy-keys change (#13259) never took effect: the Helm upgrade timed out and remediation rolled back, leaving the previous initContainer script live and the release flapping.

```
Released:   UpgradeFailed
  timeout waiting for: [Deployment/ai/opencode status: 'InProgress']
Remediated: RollbackSucceeded
```

## Why

Every opencode rollout is a full serial cycle, because `strategy: Recreate` on an RWO Longhorn PVC cannot overlap pods:

1. terminate old pod
2. Longhorn detaches the volume
3. new pod schedules
4. volume attaches
5. two initContainers run — one clones three git repos
6. app starts

That routinely exceeds helm-controller's 5m wait.

## Fix

`disableWait: true` on install and upgrade — the documented pattern in this repo. khoj carries the same for the same class of reason (`project_helmrelease_disablewait.md`):

> First start downloads ... into the PVC; helm-controller's 5-min wait can outlast this.

## Tradeoff

Flux no longer blocks on readiness, so a genuinely broken rollout will report success at the HelmRelease level. Pod health still surfaces via probes and alerting — the same tradeoff the repo already accepts for khoj.

🤖 Generated with [Claude Code](https://claude.com/claude-code)