### PR TITLE
fix(ai): clone private repos over ssh.github.com:443, not port 22

### DIFF
--- a/kubernetes/apps/ai/opencode/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/opencode/app/helmrelease.yaml
@@ -92,12 +92,14 @@ spec:
           # extra image enters the supply chain.
           #
           # Deliberately NON-FATAL: a clone failure must never stop the server
-          # from starting. home-ops is public and clones without credentials;
-          # the two private repos are skipped with a message until the
-          # opencode-git-secret exists (optional secretRef below).
+          # from starting. home-ops is public and clones over HTTPS with no
+          # credential; the two private repos use per-repo read-only deploy
+          # keys and are skipped with a message if opencode-git-secret is
+          # absent (optional secretRef below).
           #
-          # The token is passed as a transient `-c http.extraheader` so it is
-          # never written into .git/config on the PVC — no credential at rest.
+          # SSH goes to ssh.github.com:443, NOT github.com:22 — the CNP only
+          # permits world:443, and opening port 22 for a pod that runs `bash`
+          # buys nothing when GitHub already serves SSH on 443.
           stage-repos:
             image:
               repository: ghcr.io/felixclements/opencode-server-docker
@@ -127,8 +129,8 @@ spec:
                   KEY=""
                   case "$${r}" in
                     home-ops) URL="https://github.com/rwlove/$${r}.git" ;;
-                    lovenet-network-configuration) URL="git@github.com:rwlove/$${r}.git"; KEY="$${SSHD}/lovenet" ;;
-                    containers) URL="git@github.com:rwlove/$${r}.git"; KEY="$${SSHD}/containers" ;;
+                    lovenet-network-configuration) URL="ssh://git@ssh.github.com:443/rwlove/$${r}.git"; KEY="$${SSHD}/lovenet" ;;
+                    containers) URL="ssh://git@ssh.github.com:443/rwlove/$${r}.git"; KEY="$${SSHD}/containers" ;;
                   esac
                   if [ -n "$${KEY}" ] && [ ! -f "$${KEY}" ]; then
                     echo "  SKIP $${r} (no deploy key)"; continue


### PR DESCRIPTION
The deploy keys from #13259 worked, but the clones **hung**: SSH to `github.com` needs **port 22**, and opencode's CNP only permits `world:443`. Every connection stalled until timeout — confirmed by running `git ls-remote git@github.com:rwlove/containers.git` inside the pod, which hangs rather than erroring.

`ssh` is present in the image and the secret is correctly wired; the only problem was egress.

## Fix

GitHub serves SSH on `ssh.github.com:443` for exactly this situation. Using it keeps egress at 443 only.

The alternative — adding port 22 to the CNP — widens the egress surface of a pod that runs `bash` and can reach the MCP broker, in exchange for nothing GitHub does not already offer on 443.

- clone URLs → `ssh://git@ssh.github.com:443/rwlove/<repo>.git`
- 1Password `opencode-git` `KNOWN_HOSTS` now carries **both** the `github.com` and `[ssh.github.com]:443` host keys, so `StrictHostKeyChecking=yes` still holds

## Verified

Cloned `rwlove/containers` over 443 with its deploy key before committing — 1.2M, success. Script also passes `bash -n` after simulating Flux's `$$` → `$` substitution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)