### PR TITLE
docs: MCP tool-level authorization design proposal

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -123,6 +123,7 @@ nav:
       - networkpolicy_rollout_plan.md
       - egress_restriction_design.md
       - mtls_rollout_design.md
+      - mcp_tool_authz_design.md
       - pod_security_audit.md
       - rbac_audit.md
   - Substrate & Orchestration:

--- a/docs/src/mcp_tool_authz_design.md
+++ b/docs/src/mcp_tool_authz_design.md
@@ -1,0 +1,228 @@
+# MCP Tool-Level Authorization Design Proposal
+
+Status: **Proposal — research only, not implemented.** Prerequisite for
+running any agent unattended against the MCP gateway.
+Owner: home-ops
+Last updated: 2026-07-25
+
+## Problem statement
+
+The MCP gateway federates every MCP server in `mcp-system` — 18
+registrations at time of writing, including `kubectl_*`, `omada_*`,
+`ha_*`, `netbox_*` and `comfyui_*`. Any client that reaches the gateway
+can call **any** federated tool. There is no per-caller restriction.
+
+Today that is tolerable because every MCP client is driven interactively
+by Rob. It stops being tolerable the moment an agent runs unattended:
+the in-cluster `opencode` server
+([`kubernetes/apps/ai/opencode`](https://github.com/rwlove/home-ops/tree/main/kubernetes/apps/ai/opencode))
+runs a `bash` tool and has egress to the gateway, so a single
+mis-planned session can mutate the cluster, the network, or Home
+Assistant with nothing in the path to stop it.
+
+The client-side gate in `opencode.json`:
+
+```json
+"tools": { "lovenet-gateway_*": false }
+```
+
+is **configuration, not enforcement**. Any session can lift it at
+runtime via `select_tools`. It reduces accidental tool use; it does not
+bound a compromised or badly-steered agent.
+
+HOMELAB-SPEC Layer 4 anticipates a guardian mode that gates destructive
+operations through a queue, but
+[`orchestration_substrate.md`](orchestration_substrate.md) records that
+the queue substrate does not exist yet. Until it does, tool-level authz
+at the gateway is the only enforcement point available.
+
+## What the gateway already supports
+
+Kuadrant's MCP gateway has a real tool-level authorization story. Three
+mechanisms, easy to confuse — only one of them is a security boundary:
+
+| Mechanism | Set by | Boundary? |
+|---|---|---|
+| `tools: {"lovenet-gateway_*": false}` in `opencode.json` | the client | **No** — client config |
+| `MCPVirtualServer.spec.tools` selected via `x-mcp-virtualserver` header | the client picks the header | **No** — client chooses its own view |
+| `AuthPolicy` matching `x-mcp-toolname` | the **MCP Router** sets the header | **Yes** |
+
+The third is the one that matters. The router extracts the tool name
+from the JSON-RPC body and sets `x-mcp-toolname` itself, so the client
+cannot forge it. Authorino then evaluates a CEL predicate against the
+caller's token claims:
+
+```yaml
+authorization:
+  'tool-access-check':
+    patternMatching:
+      patterns:
+        - predicate: |
+            request.headers['x-mcp-toolname'] in (...token claims...)
+```
+
+`tools/list` filtering is enforced by the same decision, via an
+ES256-signed "wristband" header (`x-authorised-tools`) that Authorino
+issues and the broker validates — so a restricted caller cannot even
+enumerate tools it may not call.
+
+## Blocker: the policy stack is not installed
+
+`AuthPolicy` is **not a known resource type in this cluster**:
+
+```console
+$ kubectl get authpolicy -A
+error: the server doesn't have a resource type "authpolicy"
+```
+
+Only the `mcp.kuadrant.io` CRDs are present (`MCPGatewayExtension`,
+`MCPServerRegistration`, `MCPVirtualServer`). The Kuadrant operator and
+Authorino — which provide `AuthPolicy` and the authorization service —
+are not deployed.
+
+The operator **is** staged in-repo at
+[`kubernetes/apps/kuadrant/kuadrant-operator`](https://github.com/rwlove/home-ops/tree/main/kubernetes/apps/kuadrant)
+(chart `kuadrant-operator` 1.1.0) but is commented out of the top-level
+kustomization:
+
+```yaml
+  - collab
+  # - kuadrant
+  - databases
+```
+
+Git history shows an `archive-kuadrant` commit that was later reverted,
+leaving the app present but disabled. **No rationale is recorded**, and
+per the repo's suspend/disable convention this should not be re-enabled
+without Rob's explicit instruction. Recovering that rationale is step 0
+— if Kuadrant was disabled because it conflicted with Envoy Gateway or
+Istio, this whole design needs rethinking.
+
+## The migration hazard
+
+`AuthPolicy` attaches to a Gateway listener:
+
+```yaml
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: mcp-gateway
+    sectionName: mcp
+```
+
+and applies to **all** traffic arriving at that listener — including
+in-cluster traffic, because in-cluster clients address the istio gateway
+Service directly (`mcp-gateway-istio.mcp-system.svc.cluster.local:8080`).
+
+That is the hazard. Current in-cluster MCP clients send **no identity at
+all**: `langgraph-agents` uses a bare `MCP_GATEWAY_URL` with no token,
+and the CNP `mcp-gateway-istio-allow` deliberately permits
+`fromEntities: cluster` on 8080 for exactly this. Attaching an
+authenticating AuthPolicy to the `mcp` listener would break every one of
+them at once.
+
+The `mcp-gateway` Gateway already has two listeners (`mcp` and `mcps`),
+which makes a non-breaking path available.
+
+## Proposed approach
+
+Staged, each stage independently revertible.
+
+### Stage 0 — recover the Kuadrant rationale
+
+Determine why `# - kuadrant` is commented out. If it was cost,
+complexity, or "not needed yet", proceed. If it was a conflict with
+Envoy Gateway or Istio, stop and redesign. **Rob's call; not an agent
+decision.**
+
+### Stage 1 — enable Kuadrant + Authorino
+
+Uncomment the app, let it reconcile into the existing `kuadrant`
+namespace (manifest and baseline network policy already exist). Verify
+`AuthPolicy` and `AuthConfig` register and that no existing traffic
+changes — installing the operator alone attaches no policy.
+
+Rollback: re-comment, Flux prunes.
+
+### Stage 2 — dedicated authenticated listener
+
+Add a listener (e.g. `mcp-authz`) to the `mcp-gateway` Gateway and
+attach the `AuthPolicy` with `sectionName: mcp-authz`. Existing clients
+stay on `mcp` and are untouched.
+
+This is the key decision: **an additive listener rather than a policy on
+the shared one.** Slightly more moving parts, but it means a mistake in
+the policy cannot take down `langgraph-agents`, Open WebUI, or Rob's own
+Claude Code sessions.
+
+### Stage 3 — identity for opencode
+
+Create an Authelia OIDC client for opencode and mint tokens with the
+client-credentials flow. The rotation machinery already exists and is
+proven: `mcp-gateway-jwt-rotator` is a CronJob that trades client
+credentials for a token and writes it to a Secret. Clone the pattern
+rather than inventing one.
+
+The token's claims carry the allowed tool list that the AuthPolicy CEL
+predicate matches against `x-mcp-toolname`.
+
+### Stage 4 — cut opencode over and verify negatively
+
+Point opencode's `mcp.lovenet-gateway.url` at the authenticated listener
+with the bearer token.
+
+Verification must be **negative**, not just positive:
+
+- an allowed read-only tool (e.g. `kubectl_get_pods`) succeeds
+- a mutating tool (e.g. `kubectl_kubectl_apply`) is **denied**, and is
+  denied even when the session explicitly calls `select_tools` to enable
+  it
+- `tools/list` does not enumerate the denied tools
+- `langgraph-agents` and Open WebUI still work unchanged
+
+The second bullet is the whole point of the exercise. If a session can
+still reach a mutating tool by lifting its own client-side gate, nothing
+has been gained.
+
+## Proposed initial allowlist for opencode
+
+Read-only to start, matching the credential posture already chosen for
+its GitHub access (read-only deploy keys):
+
+- `kubectl_get_*`, `kubectl_describe`, `kubectl_get_logs`
+- `prom_*` (all read-only)
+- `discover_tools`, `select_tools`, `time_*`
+- explicitly excluded: every `omada_*`, `ha_*` mutation, `kubectl_apply`
+  / `patch` / `delete` / `scale` / `rollout`, all `arr_*`
+
+Widening the list later is a one-line policy change; starting wide and
+narrowing after an incident is not.
+
+## Open questions
+
+1. **Why is Kuadrant disabled?** Blocks everything else.
+2. **Does Authorino coexist cleanly with Envoy Gateway's `SecurityPolicy`
+   extAuth?** The cluster already runs Authelia extAuth on the Envoy
+   gateways; Kuadrant/Authorino would run on the Istio gateway in
+   `mcp-system`. They should not interact, but this needs confirming.
+3. **Do the other in-cluster clients eventually get identities too?**
+   The end state is every MCP client authenticated. This proposal only
+   moves opencode, leaving the `mcp` listener unauthenticated.
+4. **Token lifetime vs. long agent sessions.** The rotator's 7-day
+   lifespan with daily refresh suits shell sessions; a long-running
+   server may need refresh-on-401 handling in the client.
+
+## What this does not solve
+
+Tool-level authz bounds what an agent can do **through MCP**. It does
+not bound the `bash` tool, which can reach anything the pod's egress
+policy allows. The CNP remains the outer boundary; this proposal
+tightens the inner one.
+
+## References
+
+- [Advanced authentication and authorization for MCP Gateway](https://developers.redhat.com/articles/2025/12/12/advanced-authentication-authorization-mcp-gateway)
+- [Kuadrant MCP Gateway request flows](https://docs.kuadrant.io/dev/mcp-gateway/docs/design/flows/)
+- [Orchestration substrate](orchestration_substrate.md) — why the guardian queue does not exist yet
+- [Task queue substrate design](task_queue_substrate_design.md)


### PR DESCRIPTION
Research-only proposal (`docs/src/mcp_tool_authz_design.md`) for bounding which MCP tools a caller may invoke — the prerequisite for running any agent unattended against the gateway.

## Three findings that shape it

**1. Kuadrant does support tool-level authz** — I previously said it did not, having only checked the JWT/SecurityPolicy layer. Only one of three similar-looking mechanisms is actually a boundary:

| Mechanism | Set by | Boundary? |
|---|---|---|
| `tools: {"lovenet-gateway_*": false}` in opencode.json | the client | **No** |
| `MCPVirtualServer` via `x-mcp-virtualserver` header | the client picks it | **No** |
| `AuthPolicy` matching `x-mcp-toolname` | the **MCP Router** | **Yes** |

**2. The policy stack is not installed.** `kubectl get authpolicy` returns *"the server doesn't have a resource type"* — Kuadrant operator and Authorino are absent. The operator is staged at `kubernetes/apps/kuadrant` but commented out of the top-level kustomization, and git history shows an `archive-kuadrant` commit later reverted. **No rationale is recorded.** Recovering it is step 0 and is explicitly Rob's call — if Kuadrant was disabled over a conflict with Envoy Gateway or Istio, the design needs rethinking.

**3. AuthPolicy attaches to a Gateway listener and applies to in-cluster traffic.** `langgraph-agents` and Open WebUI send no identity at all, so attaching an authenticating policy to the shared `mcp` listener would break them simultaneously. The proposal uses an **additive listener** instead — more moving parts, but a policy mistake cannot take down existing clients.

## Structure

Five stages, each independently revertible, ending in **negative verification**: a denied tool must stay denied even when a session explicitly calls `select_tools` to enable it. That is the whole point — if a session can lift its own gate and still reach `kubectl_apply`, nothing was gained.

Proposed initial allowlist is read-only, matching the credential posture already chosen for opencode's GitHub access.

## Scope limit, stated in the doc

Tool-level authz bounds what an agent does **through MCP**. It does not bound the `bash` tool, which reaches anything the pod's egress policy allows. The CNP stays the outer boundary; this tightens the inner one.

No cluster changes in this PR — documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)