### PR TITLE
feat(ai): cut RAG embeddings over to tei-embed-spark (Phase 2)

### DIFF
--- a/kubernetes/apps/ai/lightrag/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/lightrag/app/cnp-allow.yaml
@@ -37,8 +37,9 @@ spec:
               protocol: TCP
   egress:
     # LLM (graph extraction + query synthesis) → vllm-driver-spark:8000
-    # (OpenAI /v1) as of the 2026-07-24 cutover. Embeddings (bge-m3) still
-    # → ollama-spark:11434 until the embed cutover to tei-embed-spark.
+    # (OpenAI /v1) as of the 2026-07-24 cutover. Embeddings (bge-m3) →
+    # tei-embed-spark:3000 (OpenAI /v1) as of the 2026-07-25 cutover; the
+    # ollama-spark:11434 hole retires with it.
     # Baseline allow-intra-namespace already covers ai→ai; explicit here
     # for grep-ability (paperless-ai pattern).
     - toEndpoints:
@@ -52,10 +53,10 @@ spec:
     - toEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: ai
-            app.kubernetes.io/name: ollama-spark
+            app.kubernetes.io/name: tei-embed-spark
       toPorts:
         - ports:
-            - port: "11434"
+            - port: "3000"
               protocol: TCP
     # tiktoken downloads its BPE vocab (o200k_base) from
     # openaipublic.blob.core.windows.net on first startup, or LightRAG

--- a/kubernetes/apps/ai/lightrag/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/lightrag/app/helmrelease.yaml
@@ -80,12 +80,31 @@ spec:
               # completes cleanly.
               MAX_ASYNC: "2"
               MAX_PARALLEL_INSERT: "1"
-              # --- Embeddings: bge-m3 (1024-dim) on Ollama-Spark ---
-              EMBEDDING_BINDING: ollama
-              EMBEDDING_BINDING_HOST: http://ollama-spark.ai.svc.cluster.local:11434
-              EMBEDDING_MODEL: bge-m3:latest
+              # --- Embeddings: bge-m3 (1024-dim) on TEI ---
+              # Cut over 2026-07-25 from ollama-spark/bge-m3:latest to
+              # tei-embed-spark, the dedicated TEI embedder. NOTE: openai
+              # binding, not ollama — TEI speaks /v1, not the ollama API.
+              # Same weights (BAAI/bge-m3), so EXISTING VECTORS STAY VALID:
+              # a parity check over 5 inputs (incl. multilingual + a single
+              # char) measured cosine ≥0.999995 vs the ollama path, identical
+              # 1024 dim, both L2-normalised, identical retrieval rank order.
+              # No re-embed needed.
+              EMBEDDING_BINDING: openai
+              EMBEDDING_BINDING_HOST: http://tei-embed-spark.ai.svc.cluster.local:3000/v1
+              # TEI serves exactly one model and ignores the request's `model`
+              # field (verified: any string returns BAAI/bge-m3). Kept
+              # descriptive rather than load-bearing.
+              EMBEDDING_MODEL: bge-m3
               EMBEDDING_DIM: "1024"
-              OLLAMA_EMBEDDING_NUM_CTX: "8192"
+              # TEI requires no auth, but the openai binding sends an
+              # Authorization header unconditionally — a placeholder keeps
+              # the client library happy. Same pattern as LLM_BINDING_API_KEY.
+              EMBEDDING_BINDING_API_KEY: tei
+              # TEI hard-rejects client batches >32 with HTTP 422 (Ollama
+              # accepted any size). LightRAG's default is 10, but pin it so
+              # the cutover doesn't silently depend on an upstream default
+              # that could rise past the cap in a future release.
+              EMBEDDING_BATCH_NUM: "16"
             envFrom:
               - secretRef:
                   name: lightrag-secret

--- a/kubernetes/apps/ai/tei-embed-spark/app/prometheusrule.yaml
+++ b/kubernetes/apps/ai/tei-embed-spark/app/prometheusrule.yaml
@@ -15,12 +15,11 @@ spec:
     # failure modes we can act on.
     - name: tei-embed-spark.availability
       rules:
-        # Pod-level failure. Until the embedding-cutover PR repoints RAG
-        # traffic here, this is dark capacity and only fires on infra
-        # failure (image-pull, OOM, GPU-bind, node loss). Post-cutover it
-        # covers user-visible RAG degradation: embedding calls from Open
-        # WebUI / LightRAG / memory-mcp / paperless-RAG fail when the pod
-        # is unready.
+        # Pod-level failure. Live as of the 2026-07-25 embedding cutover —
+        # Open WebUI RAG and LightRAG now embed here, so this covers
+        # user-visible RAG degradation, not just infra failure
+        # (image-pull, OOM, GPU-bind, node loss). memory-mcp and the
+        # paperless-RAG Windmill flow follow in the non-git cutover.
         - alert: SparkTeiEmbedPodDown
           annotations:
             summary: tei-embed-spark Pod not Ready (embedding surface unavailable)
@@ -35,6 +34,42 @@ spec:
           expr: |-
             kube_pod_status_ready{namespace="ai",pod=~"tei-embed-spark-.*",condition="true"} == 0
           for: 5m
+          labels:
+            severity: critical
+        # Synthetic-probe wedge detector — the sister of SparkOllamaWedged,
+        # and the reason the cutover doesn't leave the new embedding path
+        # blind. Pod-Ready above cannot distinguish "TEI is serving" from
+        # "TEI is up but failing every request"; the tei-embed-spark-embed
+        # Probe (blackbox-exporter/app/probes.yaml, 1-min cadence) POSTs a
+        # real /v1/embeddings call and asserts the OpenAI response shape.
+        #
+        # Companion alert: the generic BlackboxProbeFailed also fires on
+        # this probe. Same dupe trade as ollama-spark's rule — two
+        # notifications for one root cause, accepted for the runbook
+        # context below.
+        - alert: SparkTeiEmbedWedged
+          annotations:
+            summary: tei-embed-spark synthetic embed probe failing (RAG embedding unavailable)
+            description: |
+              The tei-embed-spark-embed Probe (POST /v1/embeddings) has
+              been failing for ≥3 minutes. The pod may report Ready
+              while TEI is not actually serving. Impact: Open WebUI RAG
+              retrieval and LightRAG ingest/query both stall. Checks:
+              (1) `kubectl -n ai logs deploy/tei-embed-spark --tail=200`
+                  — CUDA OOM is the likeliest cause, the GB10 is shared
+                  with the vLLM driver and comfyui;
+              (2) confirm the model is resident —
+                  `curl tei-embed-spark.ai:3000/info` should return
+                  BAAI/bge-m3;
+              (3) if wedged rather than crashed,
+                  `kubectl -n ai rollout restart deploy/tei-embed-spark`;
+              (4) rollback path — flip RAG_EMBEDDING_ENGINE back to
+                  ollama in open-webui and EMBEDDING_BINDING back to
+                  ollama in lightrag; ollama-spark still hosts bge-m3
+                  and vectors are interchangeable (cosine ≥0.999995).
+          expr: |-
+            probe_success{instance=~"https?://tei-embed-spark.*"} == 0
+          for: 3m
           labels:
             severity: critical
     - name: tei-embed-spark.errors

--- a/kubernetes/apps/collab/open-webui/app/cnp-allow.yaml
+++ b/kubernetes/apps/collab/open-webui/app/cnp-allow.yaml
@@ -36,9 +36,11 @@ spec:
         - ports:
             - port: "8000"
               protocol: TCP
-    # ai/ollama (P40, qwen2.5:7b selectable) + ai/ollama-spark (bge-m3 for
-    # RAG_OLLAMA_BASE_URL embeddings until the tei-embed cutover). The Spark
-    # chat models moved to vllm-driver-spark above.
+    # ai/ollama (P40, qwen2.5:7b selectable) + ai/ollama-spark. RAG
+    # embeddings left ollama-spark in the 2026-07-25 TEI cutover, but both
+    # endpoints stay in OLLAMA_BASE_URLS for model listing (ollama-spark
+    # still hosts the vision model), so both holes stay. The Spark chat
+    # models moved to vllm-driver-spark above.
     - toEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: ai
@@ -52,10 +54,16 @@ spec:
               protocol: TCP
     # ai/tei-spark — external reranker (RAG_RERANKING_ENGINE=external,
     # RAG_EXTERNAL_RERANKER_URL points at tei-spark:3000/rerank).
+    # ai/tei-embed-spark — RAG embeddings (RAG_EMBEDDING_ENGINE=openai,
+    # RAG_OPENAI_API_BASE_URL points at tei-embed-spark:3000/v1) as of the
+    # 2026-07-25 cutover. Same port, same namespace — one rule.
     - toEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: ai
             app.kubernetes.io/name: tei-spark
+        - matchLabels:
+            io.kubernetes.pod.namespace: ai
+            app.kubernetes.io/name: tei-embed-spark
       toPorts:
         - ports:
             - port: "3000"

--- a/kubernetes/apps/collab/open-webui/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/open-webui/app/helmrelease.yaml
@@ -86,21 +86,25 @@ spec:
               # is kept aligned for DR / persistent-config-off scenarios.
               DEFAULT_MODELS: qwen3.6-35b-a3b
               ENABLE_RAG_WEB_SEARCH: true
-              RAG_EMBEDDING_ENGINE: ollama
-              # Pin RAG embedding traffic to Spark. Without this,
-              # open-webui v0.9.5 falls back to OLLAMA_BASE_URL
-              # (default '/ollama' → first persisted endpoint in
-              # webui.db), which currently resolves to the P40. That
-              # puts bge-m3 on the P40 chat hot path, where Immich
-              # CLIP and whisper bursts evict it and trigger cold-load
-              # latency on every RAG call. Spark already serves
-              # embedders for memory-mcp and paperless RAG (Windmill)
-              # — this aligns Open WebUI with those consumers. bge-m3
-              # is kept steady-resident on Spark by the blackbox
-              # synthetic embed probe (5-min cadence,
-              # doubles as wedge detector — see ollama-spark
-              # prometheusrule.yaml).
-              RAG_OLLAMA_BASE_URL: http://ollama-spark.ai.svc.cluster.local:11434
+              # Embeddings cut over 2026-07-25 from ollama-spark/bge-m3 to
+              # tei-embed-spark, the dedicated TEI embedder. TEI speaks the
+              # OpenAI embeddings API, so the engine flips ollama → openai
+              # and RAG_OLLAMA_BASE_URL retires.
+              #
+              # Same weights (BAAI/bge-m3) → EXISTING KNOWLEDGE COLLECTIONS
+              # STAY VALID. Parity measured over 5 inputs (incl. multilingual
+              # + a single char): cosine ≥0.999995 vs the ollama path,
+              # identical 1024 dim, both L2-normalised, identical retrieval
+              # rank order. No re-embed needed — unlike the nomic → bge-m3
+              # move below, this one is non-destructive.
+              RAG_EMBEDDING_ENGINE: openai
+              # These RAG_OPENAI_* vars are read only by the RAG embedder;
+              # they do NOT touch the chat OpenAI connection (that lives in
+              # webui.db openai.*, pointed at vllm-driver-spark).
+              RAG_OPENAI_API_BASE_URL: http://tei-embed-spark.ai.svc.cluster.local:3000/v1
+              # TEI requires no auth; Open WebUI sends the header regardless,
+              # so a placeholder satisfies the client.
+              RAG_OPENAI_API_KEY: tei
               # Phase A benchmark (2026-05-20, 50-doc Paperless eval)
               # showed bge-m3 (1024-dim) beats nomic-embed-text (768) by
               # +23 MRR@10 pts. The cluster moves to bge-m3 for new
@@ -110,6 +114,13 @@ spec:
               # need a re-embed from the UI. The first such collection
               # (Paperless) doesn't exist yet, so this PR has no
               # in-flight re-index cost.
+              #
+              # Deliberately UNCHANGED across the 2026-07-25 TEI cutover.
+              # TEI serves one model and ignores the request's `model` field
+              # (verified: any string returns BAAI/bge-m3), so this string is
+              # free to stay `bge-m3` — which matters because Open WebUI
+              # treats a changed RAG_EMBEDDING_MODEL as a re-index trigger
+              # for existing knowledge collections.
               RAG_EMBEDDING_MODEL: bge-m3
               # Cross-encoder reranker — external mode via TEI on Spark
               # (PR-3 of Stream 2). RAG_RERANKING_MODEL is informational;

--- a/kubernetes/apps/observability/exporters/blackbox-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/exporters/blackbox-exporter/app/helmrelease.yaml
@@ -56,6 +56,30 @@ spec:
             valid_status_codes: [200]
           prober: http
           timeout: 30s
+        # Synthetic embed prober for tei-embed-spark, the TEI embedder that
+        # took over RAG embeddings from ollama-spark on 2026-07-25. Sister
+        # of ollama_embed, but against the OpenAI surface (/v1/embeddings),
+        # so the success assertion is the OpenAI response shape ("data")
+        # rather than ollama's ("embeddings").
+        #
+        # Shorter timeout than ollama_embed (10s vs 30s): TEI loads its one
+        # model at startup and never evicts it, so there is no cold-load
+        # case to absorb — a slow response here is a real fault, not a
+        # warm-up. Keeping 30s would just delay detection.
+        tei_embed:
+          http:
+            body: |-
+              {"model":"bge-m3","input":"prober heartbeat"}
+            fail_if_body_not_matches_regexp:
+              - "\"data\""
+            headers:
+              Content-Type: application/json
+            method: POST
+            preferred_ip_protocol: "ip4"
+            valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
+            valid_status_codes: [200]
+          prober: http
+          timeout: 10s
         tcp_connect:
           prober: tcp
           tcp:

--- a/kubernetes/apps/observability/exporters/blackbox-exporter/app/probes.yaml
+++ b/kubernetes/apps/observability/exporters/blackbox-exporter/app/probes.yaml
@@ -164,3 +164,30 @@ spec:
     staticConfig:
       static:
         - http://ollama.ai.svc.cluster.local:11434/api/embed
+
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/probe_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: tei-embed-spark-embed
+spec:
+  # Wedge detector for tei-embed-spark, which took over RAG embeddings
+  # from ollama-spark on 2026-07-25. Without this the new embedding path
+  # — now serving Open WebUI RAG and LightRAG — has no liveness signal
+  # beyond pod-Ready, and TEI can report Ready while failing requests.
+  #
+  # 1m interval (vs ollama's 5m): TEI has no model-eviction problem, so
+  # the probe is not doing double duty as a keep-warm heartbeat and is
+  # free to be purely a detector. A 1-min cadence cuts worst-case
+  # detection latency on the RAG hot path without meaningful cost — the
+  # request is ~10ms warm against a model that is always resident.
+  interval: 1m
+  scrapeTimeout: 15s
+  module: tei_embed
+  prober:
+    url: blackbox-exporter.observability.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - http://tei-embed-spark.ai.svc.cluster.local:3000/v1/embeddings


### PR DESCRIPTION
## What

Phase 2 of the vLLM-on-Spark migration: repoint the **git-managed** embedding consumers from `ollama-spark`/`bge-m3` to `tei-embed-spark`, the dedicated TEI embedder stood up in #13218 and idle-healthy for 24h.

TEI speaks the OpenAI embeddings API, so both consumers flip binding/engine `ollama` → `openai` — not just a URL swap.

| Consumer | Before | After |
|---|---|---|
| LightRAG | `EMBEDDING_BINDING: ollama` → ollama-spark:11434 | `openai` → tei-embed-spark:3000/v1 |
| Open WebUI | `RAG_EMBEDDING_ENGINE: ollama` + `RAG_OLLAMA_BASE_URL` | `openai` + `RAG_OPENAI_API_BASE_URL` |

## Verified non-destructive before writing this

Parity measured live against both engines, same inputs:

| Input | dim | ‖v‖ | cosine |
|---|---|---|---|
| English sentence | 1024 / 1024 | 1.0 / 1.0 | **0.999999** |
| Technical prose | 1024 / 1024 | 1.0 / 1.0 | **0.999995** |
| Domain text | 1024 / 1024 | 1.0 / 1.0 | **0.999997** |
| Single char | 1024 / 1024 | 1.0 / 1.0 | **1.000000** |
| French (multilingual) | 1024 / 1024 | 1.0 / 1.0 | **0.999997** |

Both CLS-pooled and L2-normalised, and a held-out query produced **identical retrieval rank order** with scores agreeing to 4 decimals. TEI's `hidden_act=gelu` tanh-approximation warning is empirically a non-issue (max deviation ~5×10⁻⁶).

**Existing Qdrant and LightRAG vectors stay valid — nothing needs re-embedding.**

## Two behavioural differences handled

1. **TEI hard-caps client batches at 32** (HTTP 422; Ollama accepted any size). LightRAG's default is 10, but `EMBEDDING_BATCH_NUM: "16"` is now pinned so the cutover doesn't silently depend on an upstream default that could rise past the cap.
2. **`RAG_EMBEDDING_MODEL` deliberately left as `bge-m3`.** TEI serves one model and ignores the request's `model` field (verified: any string returns `BAAI/bge-m3`), so the string is free to stay put — which matters because Open WebUI treats a changed `RAG_EMBEDDING_MODEL` as a re-index trigger for existing knowledge collections.

Also dropped `OLLAMA_EMBEDDING_NUM_CTX` (ollama-specific, meaningless under the openai binding — TEI's own 8192 + `auto_truncate` is equivalent).

## Observability — closing a gap the cutover would otherwise open

`SparkOllamaWedged` is driven by a dedicated synthetic probe, so it survives this change untouched. But `tei-embed-spark` had **no** probe, meaning the new embedding path would have had no liveness signal beyond pod-Ready — and TEI can report Ready while failing every request.

Added: a `tei_embed` blackbox module (asserts the OpenAI `"data"` response shape), a `tei-embed-spark-embed` Probe at 1-min cadence, and `SparkTeiEmbedWedged` with runbook context including the rollback path. The existing `tei-embed-spark-rules` comments that said "until the embedding-cutover PR repoints traffic here" are updated — they describe this PR.

Probe cadence is 1m (vs ollama's 5m) and timeout 10s (vs 30s): TEI loads its model at startup and never evicts, so the probe isn't doing double duty as a keep-warm heartbeat and there's no cold-load case to absorb.

## Not in scope

- **memory-mcp** and the **paperless-RAG Windmill flow** — both need API-shape changes rather than an env flip, and Windmill has no git→workspace sync (deploys via MCP). Separate change.
- **khoj** — points at the P40 ollama and sets its embedding model in the admin UI post-bootstrap; needs verification that it uses bge-m3 at all before touching.
- **ollama-spark decommission** (Phase 5) — still blocked on the above plus relocating the vision model.

## Rollback

Revert the PR. `ollama-spark` still hosts `bge-m3` and the CNP hole for Open WebUI is retained, so both consumers fall straight back; vectors are interchangeable in both directions.

## Pre-submit

`yamllint` clean · all four touched kustomizations build · rendered output verified to contain the intended env/probe/alert and to have dropped the retired vars · all pre-commit hooks passed (gitleaks, CNP-has-rules, literal-credential scan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)