### PR TITLE
fix(ai): tei-embed-spark CNP selects the wrong blackbox pod label

### DIFF
--- a/kubernetes/apps/ai/tei-embed-spark/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/tei-embed-spark/app/cnp-allow.yaml
@@ -31,9 +31,14 @@ spec:
         - matchLabels:
             io.kubernetes.pod.namespace: home
             app.kubernetes.io/name: windmill
+        # The chart names the pod `prometheus-blackbox-exporter`, not
+        # `blackbox-exporter` — the Release name and the app label differ.
+        # Matching the short name silently selects nothing, so the probe
+        # gets dropped rather than rejected. Same selector as ollama-spark's
+        # working rule; verified against the live pod label.
         - matchLabels:
             io.kubernetes.pod.namespace: observability
-            app.kubernetes.io/name: blackbox-exporter
+            app.kubernetes.io/name: prometheus-blackbox-exporter
         - matchLabels:
             io.kubernetes.pod.namespace: observability
             app.kubernetes.io/name: prometheus


### PR DESCRIPTION
## What

The synthetic embed probe added in #13263 has been returning `probe_success=0` since it went live. Root cause is a one-word selector mismatch in `tei-embed-spark`'s ingress rule:

```yaml
# expects
app.kubernetes.io/name: blackbox-exporter
# actual pod label
app.kubernetes.io/name: prometheus-blackbox-exporter
```

The Helm release is named `blackbox-exporter` but the chart's app label is `prometheus-blackbox-exporter`. A `matchLabels` that selects nothing is a **silent drop**, not a rejection — so the symptom was a failing probe plus a TEI request counter frozen at its pre-cutover value, with nothing in any log.

## How it was found

`ollama-spark`'s equivalent rule already uses the full name:

| Probe | `probe_success` |
|---|---|
| `ollama-spark-embed` | 1 |
| `ollama-embed` | 1 |
| `tei-embed-spark-embed` | **0** |

Two working probes against the same exporter, one broken — the selector was the only difference.

## Not a regression

The rule was written ahead of the probe in #13218 and explicitly marked inert ("the matching egress rule lands on each consumer's CNP in the embedding-cutover PR, so this is inert until then"). #13263 gave it traffic for the first time, which made a latent bug reachable. Nothing that previously worked broke.

Confirmed this is the **only** occurrence of the short-name selector in the tree; the three other CNPs referencing the exporter all use the correct label.

## Impact while unfixed

`SparkTeiEmbedWedged` (severity critical, `for: 3m`) and the generic `BlackboxProbeFailed` both fire on a false positive. **Embedding itself is unaffected** — Open WebUI and LightRAG reach TEI through intra-namespace and consumer-side rules that are correct; only the observability path was blocked.

## Pre-submit

`yamllint` clean · kustomization builds · all pre-commit hooks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)