### PR TITLE
feat(ai): give opencode agents a git identity

### DIFF
--- a/kubernetes/apps/ai/opencode/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/opencode/app/helmrelease.yaml
@@ -152,6 +152,13 @@ spec:
                   else
                     echo "  SKIP $${r} (clone failed)"
                   fi
+                  # Belt-and-braces alongside the GIT_* env vars on the app
+                  # container: some tooling reads `git config user.email`
+                  # directly rather than honouring the environment.
+                  if [ -d "/workspace/$${r}/.git" ]; then
+                    git -C "/workspace/$${r}" config user.name  "opencode-agent" 2>/dev/null
+                    git -C "/workspace/$${r}" config user.email "opencode-agent@${SECRET_DOMAIN}" 2>/dev/null
+                  fi
                 done
                 echo "workspace: $$(ls -1 /workspace 2>/dev/null | tr '\n' ' ')"
                 exit 0
@@ -193,6 +200,15 @@ spec:
             env:
               PORT: &port "4096"
               HOSTNAME_OVERRIDE: 0.0.0.0
+              # Agents could not commit at all without an identity. Kept
+              # deliberately distinct from Rob's so agent-authored commits
+              # are identifiable in history rather than indistinguishable
+              # from human ones. Git honours these without a config file,
+              # so they apply in every repo including ones cloned later.
+              GIT_AUTHOR_NAME: &gitName opencode-agent
+              GIT_COMMITTER_NAME: *gitName
+              GIT_AUTHOR_EMAIL: &gitEmail opencode-agent@${SECRET_DOMAIN}
+              GIT_COMMITTER_EMAIL: *gitEmail
               # Config + agents delivered via ConfigMap mounts below; the
               # oh-my-openagent plugin self-installs from npm on first run.
             envFrom:


### PR DESCRIPTION
Agents could not commit **at all** — git refuses without `user.name`/`user.email`, and neither was set on the in-cluster server. Verified from inside the pod: `git config user.email` returned nothing.

## Change

- `GIT_AUTHOR_*` / `GIT_COMMITTER_*` env vars on the app container. Git honours these with no config file, so they cover repos cloned later too.
- Per-repo `git config` in `stage-repos` as belt-and-braces, since some tooling reads `git config user.email` directly rather than the environment.

The identity is **deliberately distinct from Rob's**, so agent-authored commits are identifiable in history rather than indistinguishable from human ones.

Email uses `${SECRET_DOMAIN}` — this repo is public, so the domain must not be hardcoded. Verified: the rendered manifest contains no literal domain.

## Scope

This only unblocks **committing**. Pushing over SSH still fails because the deploy keys are `read_only=true`. Agents can already write to GitHub via the `github_*` MCP tools, which is a separate (and wider) path — see the note below.

## Related: branch protection now enabled on `main`

Applied alongside this, because `github_merge_pull_request` is reachable from the cluster and `main` was previously unprotected — meaning an agent could merge straight to main and trigger a live Flux deploy with nothing in the way.

```
required checks : Lint successful, flate successful,
                  Image registry check successful, Webhook Validate successful
strict          : false   (no forced rebase churn from Renovate)
approvals       : 0       (sole collaborator — GitHub forbids self-approval,
                           so requiring 1 would lock Rob out entirely)
enforce_admins  : false   (Rob can still bypass in an emergency; agents cannot)
force pushes    : blocked
branch deletion : blocked
```

This blocks *broken* merges, not *unreviewed* ones. True review-gating needs agents to have a separate GitHub identity so their PRs are Rob's to approve — tracked as follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)