### PR TITLE
feat(ai): small coder on the P40; raise ollama MAX_LOADED_MODELS to 2

### DIFF
--- a/kubernetes/apps/ai/ollama/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/ollama/app/helmrelease.yaml
@@ -61,11 +61,26 @@ spec:
               # See docs/src/audit/post-spark-tool-call-leakage-2026-05-18.md.
               OLLAMA_CONTEXT_LENGTH: 8192
               OLLAMA_NUM_PARALLEL: 1
-              # Post-v48 dual-concurrent Ollama: 14b/32b never live on the
-              # P40 (heavy agents route to ollama-spark on Blackwell). P40
-              # only serves qwen2.5:7b for light agents, so the
-              # MAX_LOADED_MODELS=1 cap is safe — there's nothing to evict.
-              OLLAMA_MAX_LOADED_MODELS: 1
+              # Raised 1→2 on 2026-07-25. The old comment claimed the cap
+              # was "safe — there's nothing to evict", but that stopped
+              # being true once bge-m3 landed here: the ollama-embed
+              # blackbox probe reloads bge-m3 every 5 min while opencode's
+              # small_model pulls a chat model, so with a 1-model cap the
+              # two evicted each other continuously. Observed 2026-07-25:
+              # bge-m3 08:18 → qwen2.5:7b 09:26 → bge-m3 09:28, each a
+              # cold GGUF load, `loaded runners count=1` every time.
+              #
+              # 2 lets the embedder and the coder stay co-resident:
+              # bge-m3 (1.1 GiB) + qwen2.5-coder:7b (~4.8 GiB predicted)
+              # = ~5.9 GiB of the ~13.3 GiB the P40 has free after
+              # whisper / immich-ml / pet-tagger, leaving ~7.4 GiB for
+              # Immich CLIP bursts. Deliberately NOT 3 — holding a third
+              # 7b-class model would put ~10.7 GiB resident and cut burst
+              # headroom to ~2.3 GiB, which is how the 2026-05-18 VRAM
+              # exhaustion / CPU-spill incident happened (see
+              # docs/src/audit/post-spark-tool-call-leakage-2026-05-18.md).
+              # Heavy coding still routes to the Spark vLLM driver.
+              OLLAMA_MAX_LOADED_MODELS: 2
 
             resources:
               requests:

--- a/kubernetes/apps/ai/opencode/app/resources/agent/quick.md
+++ b/kubernetes/apps/ai/opencode/app/resources/agent/quick.md
@@ -1,7 +1,7 @@
 ---
 description: Fast, direct assistant on the P40 7B model. No orchestration or subagent delegation — answers and edits directly. Use for quick Q&A, small edits, and one-shot tasks where speed beats depth.
 mode: primary
-model: ollama-p40/qwen2.5:7b
+model: ollama-p40/qwen2.5-coder:7b
 temperature: 0.2
 tools:
   task: false

--- a/kubernetes/apps/ai/opencode/app/resources/oh-my-openagent.json
+++ b/kubernetes/apps/ai/opencode/app/resources/oh-my-openagent.json
@@ -8,7 +8,7 @@
       "model": "vllm-driver/qwen3.6-35b-a3b"
     },
     "explore": {
-      "model": "ollama-p40/qwen2.5:7b"
+      "model": "ollama-p40/qwen2.5-coder:7b"
     },
     "multimodal-looker": {
       "model": "vllm-driver/qwen3.6-35b-a3b"
@@ -19,7 +19,7 @@
     "metis": {
       "model": "vllm-driver/qwen3.6-35b-a3b",
       "fallback_models": [
-        "ollama-p40/qwen2.5:7b"
+        "ollama-p40/qwen2.5-coder:7b"
       ]
     },
     "momus": {
@@ -35,7 +35,7 @@
       "model": "vllm-driver/qwen3.6-35b-a3b"
     },
     "librarian": {
-      "model": "ollama-p40/qwen2.5:7b"
+      "model": "ollama-p40/qwen2.5-coder:7b"
     }
   },
   "categories": {
@@ -52,7 +52,7 @@
       "model": "vllm-driver/qwen3.6-35b-a3b"
     },
     "quick": {
-      "model": "ollama-p40/qwen2.5:7b"
+      "model": "ollama-p40/qwen2.5-coder:7b"
     },
     "unspecified-low": {
       "model": "vllm-driver/qwen3.6-35b-a3b"

--- a/kubernetes/apps/ai/opencode/app/resources/opencode.json
+++ b/kubernetes/apps/ai/opencode/app/resources/opencode.json
@@ -31,12 +31,15 @@
       "models": {
         "qwen2.5:7b": {
           "name": "Qwen2.5 7B (P40)"
+        },
+        "qwen2.5-coder:7b": {
+          "name": "Qwen2.5-Coder 7B (P40, small coder)"
         }
       }
     }
   },
   "model": "vllm-driver/qwen3.6-35b-a3b",
-  "small_model": "ollama-p40/qwen2.5:7b",
+  "small_model": "ollama-p40/qwen2.5-coder:7b",
   "tools": {
     "lovenet-gateway_*": false
   },

--- a/kubernetes/apps/ai/vllm-coder-spark/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/vllm-coder-spark/app/helmrelease.yaml
@@ -21,8 +21,18 @@ spec:
         # footprint is ~97 GiB (caching allocator), leaving only ~24 GiB free.
         # Confirmed by a reclaim test (stopping the coder freed nothing → no
         # leak, the driver genuinely holds ~97). replicas:0 stops the crashloop
-        # + Flux revert drift. Coder decision pending (drop, or small coder on
-        # the P40's free ~12 GiB) — see vllm_spark_migration_plan.md.
+        # + Flux revert drift.
+        #
+        # CODER DECISION RESOLVED 2026-07-25: small-coder-on-P40 won.
+        # `qwen2.5-coder:7b` (Q4_K_M, ~4.8 GiB) now serves opencode's
+        # small_model + the light agents from ai/ollama on the P40; heavy
+        # coding rides the Spark driver (qwen3.6-35b-a3b), itself a strong
+        # coder. A second GB10 vLLM instance is no longer wanted.
+        #
+        # KEPT at replicas:0 rather than deleted, deliberately: this manifest
+        # carries the tuned FP8 serve flags and the memory math, which is the
+        # expensive part to reconstruct if vLLM's unified-memory accounting on
+        # GB10 improves enough to retry co-residency. Parked costs nothing.
         replicas: 0
         annotations:
           reloader.stakater.com/auto: "true"


### PR DESCRIPTION
## What

Resolves the coder question left open when `vllm-coder-spark` was parked in #13222. The GB10 can't hold a second vLLM instance, so the coder moves to the **P40** as a GGUF served by the **existing** `ai/ollama` — Pascal (sm_61) has no FP8 and modern vLLM dropped the arch, so llama.cpp/GGUF is the only route, and reusing the ollama already on that GPU adds no moving parts.

## Swap, not add

`qwen2.5-coder:7b` (Q4_K_M, ~4.8 GiB) **replaces** `qwen2.5:7b` as opencode's `small_model` and for the four light agents that referenced it (`explore`, `librarian`, `quick`, `metis` fallback).

| | resident on P40 | free for CLIP bursts |
|---|---|---|
| swap (this PR) | bge-m3 + coder ≈ **5.9 GiB** | **~7.4 GiB** |
| add (3 models) | bge-m3 + qwen2.5:7b + coder ≈ 10.7 GiB | ~2.3 GiB ⚠️ |

The P40 has four GPU tenants already — ollama, **Renee-facing whisper**, immich-machine-learning, immich-pet-tagger — holding 11.2 of 24 GiB. The 3-model layout would cut burst headroom to ~2.3 GiB, which is precisely how the 2026-05-18 VRAM-exhaustion / CPU-spill incident happened (`docs/src/audit/post-spark-tool-call-leakage-2026-05-18.md`). Not repeating that on the GPU serving Renee's voice.

`qwen2.5:7b` stays on the PVC and in the provider list — reverting is one line.

## Also fixes a live bug this uncovered

`OLLAMA_MAX_LOADED_MODELS` was 1, justified by a comment reading *"the cap is safe — there's nothing to evict."* That stopped being true once bge-m3 landed on the P40. The `ollama-embed` blackbox probe reloads bge-m3 every 5 min while opencode pulls a chat model, so with a 1-model cap **the two evict each other continuously.** Observed today:

| Time | Event |
|---|---|
| 08:18:27 | `bge-m3` loaded (1.1 GiB) |
| 09:26:09 | `qwen2.5:7b` loaded → evicted bge-m3 |
| 09:28:32 | `bge-m3` reloaded → evicted qwen2.5:7b |

`loaded runners count=1` throughout — every one a cold GGUF load. Raising to 2 lets the embedder and coder stay co-resident. Deliberately **not** 3, per the table above.

Separately visible in those logs: `disabling mmap for llama-server load due to host memory pressure` (`system_free 843 MiB / system_total 5.6 GiB`). VRAM is fine (13.3 GiB available); it's the 6G container limit that forces mmap off on every load. **Not touched here** — worker8 memory requests are already at 79%, so raising it deserves its own change. Filed as a follow-up thought, not bundled.

## Verified before committing

Model pulled to the PVC (93 GiB free, no repeat of the ollama-spark fill trap) and exercised through the exact surface opencode uses:

```
POST /v1/chat/completions  model=qwen2.5-coder:7b  ->  "ready"
VRAM with coder resident: 15517 MiB used / 8923 MiB free
```

## vllm-coder-spark

Stays at `replicas: 0` rather than deleted. The manifest carries the tuned FP8 serve flags and memory math — cheap to keep parked, expensive to reconstruct if vLLM's unified-memory accounting on GB10 improves enough to retry co-residency. Comment updated to record the decision.

## Pre-submit

`yamllint` clean · JSON validated · three touched kustomizations build · rendered output confirms `MAX_LOADED_MODELS: 2` and the new `small_model` · all pre-commit hooks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)