### PR TITLE
feat(ai): clone all six repos + load repo conventions into opencode

### DIFF
--- a/kubernetes/apps/ai/opencode/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/opencode/app/externalsecret.yaml
@@ -45,6 +45,8 @@ spec:
       data:
         SSH_KEY_LOVENET: "{{ .SSH_KEY_LOVENET }}"
         SSH_KEY_CONTAINERS: "{{ .SSH_KEY_CONTAINERS }}"
+        SSH_KEY_ANSIBLE: "{{ .SSH_KEY_ANSIBLE }}"
+        SSH_KEY_HOME_ASSISTANT_CONFIG: "{{ .SSH_KEY_HOME_ASSISTANT_CONFIG }}"
         KNOWN_HOSTS: "{{ .KNOWN_HOSTS }}"
   dataFrom:
     - extract:

--- a/kubernetes/apps/ai/opencode/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/opencode/app/helmrelease.yaml
@@ -125,12 +125,26 @@ spec:
                 if [ -n "$${SSH_KEY_CONTAINERS:-}" ]; then
                   printf '%s\n' "$${SSH_KEY_CONTAINERS}" > "$${SSHD}/containers"; chmod 600 "$${SSHD}/containers"
                 fi
-                for r in home-ops lovenet-network-configuration containers; do
+                if [ -n "$${SSH_KEY_ANSIBLE:-}" ]; then
+                  printf '%s\n' "$${SSH_KEY_ANSIBLE}" > "$${SSHD}/ansible"; chmod 600 "$${SSHD}/ansible"
+                fi
+                if [ -n "$${SSH_KEY_HOME_ASSISTANT_CONFIG:-}" ]; then
+                  printf '%s\n' "$${SSH_KEY_HOME_ASSISTANT_CONFIG}" > "$${SSHD}/home-assistant-config"; chmod 600 "$${SSHD}/home-assistant-config"
+                fi
+                # PUMP and home-ops are public (HTTPS, no credential); the rest
+                # are private and use their own read-only deploy key. A key
+                # cannot be shared across repos, hence one file each.
+                # NOTE: ansible's default branch is `master`, not `main` —
+                # plain `git clone` follows the remote HEAD, so nothing special
+                # is needed, but do not hardcode a branch here.
+                for r in home-ops PUMP lovenet-network-configuration containers ansible home-assistant-config; do
                   KEY=""
                   case "$${r}" in
-                    home-ops) URL="https://github.com/rwlove/$${r}.git" ;;
+                    home-ops|PUMP) URL="https://github.com/rwlove/$${r}.git" ;;
                     lovenet-network-configuration) URL="ssh://git@ssh.github.com:443/rwlove/$${r}.git"; KEY="$${SSHD}/lovenet" ;;
                     containers) URL="ssh://git@ssh.github.com:443/rwlove/$${r}.git"; KEY="$${SSHD}/containers" ;;
+                    ansible) URL="ssh://git@ssh.github.com:443/rwlove/$${r}.git"; KEY="$${SSHD}/ansible" ;;
+                    home-assistant-config) URL="ssh://git@ssh.github.com:443/rwlove/$${r}.git"; KEY="$${SSHD}/home-assistant-config" ;;
                   esac
                   if [ -n "$${KEY}" ] && [ ! -f "$${KEY}" ]; then
                     echo "  SKIP $${r} (no deploy key)"; continue

--- a/kubernetes/apps/ai/opencode/app/kustomization.yaml
+++ b/kubernetes/apps/ai/opencode/app/kustomization.yaml
@@ -18,10 +18,15 @@ configMapGenerator:
   #   1. mcp.lovenet-gateway.url -> internal broker svc (no Authelia JWT
   #      needed in-cluster; the public mcp.${SECRET_DOMAIN} route is what
   #      carries the SecurityPolicy JWT check). No Bearer header.
-  #   2. instructions[] omitted: the workstation config loads personal
-  #      vault files (~/.claude-personal/CLAUDE.md, HOMELAB-SPEC.md).
-  #      Committing those to git is a HOMELAB-SPEC L2 #1 concern, so they
-  #      are deferred (see PR notes). MCP scope + agents are carried here.
+  #   2. instructions[] points at the REPOS' own conventions
+  #      (.agents/instructions/*.md, AGENTS.md) — not the workstation's
+  #      personal vault files (~/.claude-personal/CLAUDE.md,
+  #      HOMELAB-SPEC.md), which stay out of git per HOMELAB-SPEC L2 #1.
+  #      This is needed because home-ops' CLAUDE.md pulls those in via
+  #      `@`-imports, a Claude Code mechanism opencode does not expand;
+  #      without it the in-cluster agents silently miss the persona,
+  #      worktree-isolation rule, data classification and storage-class
+  #      guidance.
   #   3. vllm-coder provider dropped: vllm-coder-spark was PARKED
   #      2026-07-23 (replicas:0 — Qwen3.6-27B can't co-reside with the
   #      driver on the GB10, which really holds ~97 GiB). Its Service has

--- a/kubernetes/apps/ai/opencode/app/resources/opencode.json
+++ b/kubernetes/apps/ai/opencode/app/resources/opencode.json
@@ -40,6 +40,10 @@
   "tools": {
     "lovenet-gateway_*": false
   },
+  "instructions": [
+    ".agents/instructions/*.md",
+    "AGENTS.md"
+  ],
   "mcp": {
     "lovenet-gateway": {
       "type": "remote",


### PR DESCRIPTION
Two changes: widen the repo set, and fix a silent gap where in-cluster agents were loading **no repo conventions at all**.

## Repos: 3 → 6

| repo | visibility | how |
|---|---|---|
| home-ops | public | HTTPS, no credential |
| **PUMP** | public | HTTPS, no credential — **new** |
| lovenet-network-configuration | private | deploy key |
| containers | private | deploy key |
| **ansible** | private | deploy key — **new** |
| **home-assistant-config** | private | deploy key — **new** |

Skipped deliberately:

- **langgraph-agents** — Rob's call
- **multicade** — has **no git remote**; it is a local-only repo and cannot be cloned

`ansible`'s default branch is not `main`. Plain `git clone` follows the remote HEAD, so no branch is hardcoded — but do not add one.

### Deploy keys (created and verified out-of-band)

```text
rwlove/ansible                id 158320661  read_only=true
rwlove/home-assistant-config  id 158320662  read_only=true
```

Both clone successfully over `ssh.github.com:443`; write attempts are rejected by GitHub. A key cannot be reused across repositories, hence one per repo.

## The silent gap: no repo conventions were loading

`home-ops/CLAUDE.md` opens with **12 `@`-import lines** pulling in `.agents/instructions/*.md`. That import syntax is a **Claude Code mechanism** — opencode has no equivalent; its instruction system is a config glob array.

So in-cluster agents were reading the CLAUDE.md body at best and treating those 12 lines as literal text, silently missing:

- the repo persona and prime directives
- the **worktree-isolation rule** — the one they most need
- data-classification rules
- storage-class selection guidance

Fixed by giving opencode its own pointer:

```json
"instructions": [".agents/instructions/*.md", "AGENTS.md"]
```

This works regardless of whether opencode auto-loads `CLAUDE.md`, and keeps working if the repos later adopt `AGENTS.md`. Note these are the **repos' own public conventions**, not the personal vault files — those stay out of git per HOMELAB-SPEC L2 #1.

## Validation

- `kubectl kustomize` builds
- envsubst audit: only `${SECRET_DOMAIN}` unescaped
- `bash -n` passes after simulating Flux's `$$` → `$` substitution
- rendered loop confirms all six repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)
