### PR TITLE
fix(ai): allow the Windmill RAG fan-out to reach tei-embed-spark

### DIFF
--- a/kubernetes/apps/ai/tei-embed-spark/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/tei-embed-spark/app/cnp-allow.yaml
@@ -28,9 +28,15 @@ spec:
         - matchLabels:
             io.kubernetes.pod.namespace: mcp-system
             app.kubernetes.io/name: memory-mcp
+        # Windmill executes scripts on its WORKER pods, labelled
+        # `windmill-workers`. Nothing is labelled plain `windmill` (the
+        # others are `windmill-app` / `windmill-extra`), so the short name
+        # silently selected nothing — same failure class as the blackbox
+        # selector below. Verified against live pod labels, and matches how
+        # lightrag's CNP already names this same ingest pusher.
         - matchLabels:
             io.kubernetes.pod.namespace: home
-            app.kubernetes.io/name: windmill
+            app.kubernetes.io/name: windmill-workers
         # The chart names the pod `prometheus-blackbox-exporter`, not
         # `blackbox-exporter` — the Release name and the app label differ.
         # Matching the short name silently selects nothing, so the probe

--- a/kubernetes/apps/home/windmill/app/cnp-allow.yaml
+++ b/kubernetes/apps/home/windmill/app/cnp-allow.yaml
@@ -120,9 +120,9 @@ spec:
             - port: "8080"
               protocol: TCP
     # Paperless RAG ingest workflows
-    # (paperless-rag-ingest, paperless-rag-tombstone):
+    # (paperless-rag-fanout, paperless-rag-tombstone):
     # - paperless (collab ns) for doc list + content
-    # - ollama-spark (ai ns) for bge-m3 embeddings
+    # - tei-embed-spark (ai ns) for bge-m3 embeddings
     # - qdrant (databases ns) for point upsert + scroll
     # Each scoped to its specific Service rather than ns-wide.
     - toEndpoints:
@@ -132,6 +132,21 @@ spec:
       toPorts:
         - ports:
             - port: "8000"
+              protocol: TCP
+    # Embeddings moved off ollama-spark to tei-embed-spark (OpenAI /v1)
+    # on 2026-07-25, completing the git-side half of the Phase 2 cutover.
+    # The ollama-spark hole is retained deliberately: the fan-out script
+    # lives in Windmill (no git→workspace sync) and is repointed by a
+    # separate MCP deploy, so this rule must permit BOTH endpoints across
+    # the window where manifest and script disagree. Drop the ollama-spark
+    # entry once the script is confirmed on /v1/embeddings.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: ai
+            app.kubernetes.io/name: tei-embed-spark
+      toPorts:
+        - ports:
+            - port: "3000"
               protocol: TCP
     - toEndpoints:
         - matchLabels:


### PR DESCRIPTION
## What

Network-side prep for moving the paperless RAG fan-out's embeddings off `ollama-spark`. Two CNP changes; **no behaviour change on its own**.

## 1. tei-embed-spark ingress named a pod that doesn't exist

The rule allowed `app.kubernetes.io/name: windmill`. Nothing carries that label:

| Real label | Pods |
|---|---|
| `windmill-app` | 1 |
| `windmill-extra` | 1 |
| **`windmill-workers`** | 2 (`default`, `native`) |

Scripts execute on the **workers**. Same silent-drop class as the blackbox selector fixed in #13264 — a `matchLabels` that selects nothing *denies* rather than errors. `lightrag`'s CNP already names this same pusher `windmill-workers`, so this aligns them.

**I audited every other selector on that rule against live pod labels while I was in there** — given #13264, one instance implies checking the rest:

| Namespace | Expected | Actual | |
|---|---|---|---|
| collab | `open-webui` | `open-webui` | ✅ |
| ai | `lightrag` | `lightrag` | ✅ |
| mcp-system | `memory-mcp` | `memory-mcp` | ✅ |
| home | `windmill` | `windmill-workers` | ❌ fixed here |
| observability | `prometheus-blackbox-exporter` | same | ✅ |
| observability | `prometheus` | same | ✅ |

Worth stating plainly: `open-webui` and `lightrag` being correct is what confirms **#13263's cutover is genuinely working** — I'd only proven the probe path before this audit.

## 2. Windmill egress to tei-embed-spark, keeping ollama-spark

The fan-out script lives in Windmill with **no git→workspace sync** and gets repointed by a separate MCP deploy. So there's a window where the manifest and the running script disagree, and both endpoints must be reachable across it. The `ollama-spark` hole retires once the script is confirmed on `/v1/embeddings` — noted inline so it doesn't become permanent by forgetfulness.

## Scope note

Two of the three "remaining consumers" turned out not to be migratable from this repo:

- **khoj** — not an embedding consumer at all. Live env has only `OPENAI_BASE_URL` → P40 ollama for *chat*; embeddings are in-process sentence-transformers. Never touched bge-m3 on ollama-spark.
- **memory-mcp** — blocked upstream. It speaks the Ollama API natively (`OLLAMA_BASE_URL`; its `/readyz` pings Ollama) and TEI has no `/api/embed`. Needs an OpenAI-embeddings backend in the `memory-mcp` repo — outside home-ops.

**Consequence: `ollama-spark` cannot be decommissioned yet** — memory-mcp pins it regardless of the vision-model relocation.

## Pre-submit

`yamllint` clean · both kustomizations build · selectors verified against live pod labels · all pre-commit hooks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)