### PR TITLE
feat(ai): equip opencode — tools, standing rules, skills, memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ _Production-grade Kubernetes for a household._
 ![helmreleases](https://img.shields.io/badge/HelmReleases-172-326CE5?style=for-the-badge&logo=helm&logoColor=white)
 ![nodes](https://img.shields.io/badge/k8s_nodes-11-326CE5?style=for-the-badge&logo=kubernetes&logoColor=white)
 ![cnpg](https://img.shields.io/badge/Postgres_clusters-22-336791?style=for-the-badge&logo=postgresql&logoColor=white)
-![secrets](https://img.shields.io/badge/secrets-90-0572EC?style=for-the-badge&logo=1password&logoColor=white)
+![secrets](https://img.shields.io/badge/secrets-91-0572EC?style=for-the-badge&logo=1password&logoColor=white)
 ![age](https://img.shields.io/badge/cluster_age-5%2B_years-success?style=for-the-badge)
 
 </div>

--- a/kubernetes/apps/ai/opencode/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/opencode/app/externalsecret.yaml
@@ -51,3 +51,31 @@ spec:
   dataFrom:
     - extract:
         key: opencode-git
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+#
+# Standing rules + skills, sourced from the vault via 1Password rather than
+# committed. This repo is PUBLIC, and HOMELAB-SPEC names the media-download
+# stacks (L2 invariant #2) — so it must not land in git. Delivering it as a
+# Secret keeps the content in-cluster while still giving agents the rules
+# they are expected to operate under.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: opencode-instructions
+spec:
+  refreshInterval: 12h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: opencode-instructions-secret
+    creationPolicy: Owner
+    template:
+      data:
+        HOMELAB_SPEC: "{{ .HOMELAB_SPEC }}"
+        PERSONA_BASE: "{{ .PERSONA_BASE }}"
+        SKILLS_TGZ_B64: "{{ .SKILLS_TGZ_B64 }}"
+  dataFrom:
+    - extract:
+        key: opencode-instructions

--- a/kubernetes/apps/ai/opencode/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/opencode/app/helmrelease.yaml
@@ -75,6 +75,23 @@ spec:
                 rm -f /data/config/agent/*.md
                 cp -f /src/agents/*.md /data/config/agent/
                 echo "staged opencode config + $(ls -1 /data/config/agent/*.md | wc -l) agent personas"
+                # Standing rules + skills come from a Secret, not git: this
+                # repo is public and HOMELAB-SPEC names the media-download
+                # stacks (L2 #2). Without these the agents run with no
+                # standing rules and no skills at all.
+                mkdir -p /data/config/instructions /data/config/skills
+                if [ -s /secrets/HOMELAB_SPEC ]; then
+                  cp -f /secrets/HOMELAB_SPEC /data/config/instructions/HOMELAB-SPEC.md
+                fi
+                if [ -s /secrets/PERSONA_BASE ]; then
+                  cp -f /secrets/PERSONA_BASE /data/config/instructions/persona-base.md
+                fi
+                if [ -s /secrets/SKILLS_TGZ_B64 ]; then
+                  base64 -d < /secrets/SKILLS_TGZ_B64 > /tmp/skills.tgz 2>/dev/null &&
+                    tar -xzf /tmp/skills.tgz -C /data/config --strip-components=1 2>/dev/null &&
+                    rm -f /tmp/skills.tgz
+                fi
+                echo "staged $(ls -1 /data/config/instructions 2>/dev/null | wc -l) instruction files, $(ls -1 /data/config/skills 2>/dev/null | wc -l) skills"
             resources:
               requests:
                 cpu: 10m
@@ -372,6 +389,16 @@ spec:
           opencode:
             stage-config:
               - path: /src/agents
+                readOnly: true
+      # Vault-sourced standing rules + skills bundle (see externalsecret).
+      # initContainer only — the app reads the copies staged onto the PVC.
+      instructions-src:
+        type: secret
+        name: opencode-instructions-secret
+        advancedMounts:
+          opencode:
+            stage-config:
+              - path: /secrets
                 readOnly: true
       # Agent working tree — Longhorn PVC (see workspace-pvc.yaml). Holds the
       # repo clones plus accumulated in-flight work, which unattended agents

--- a/kubernetes/apps/ai/opencode/app/resources/opencode.json
+++ b/kubernetes/apps/ai/opencode/app/resources/opencode.json
@@ -41,11 +41,46 @@
   "model": "vllm-driver/qwen3.6-35b-a3b",
   "small_model": "ollama-p40/qwen2.5-coder:7b",
   "tools": {
-    "lovenet-gateway_*": false
+    "lovenet-gateway_*": false,
+    "lovenet-gateway_discover_tools": true,
+    "lovenet-gateway_select_tools": true,
+    "lovenet-gateway_kubectl_get_pods": true,
+    "lovenet-gateway_kubectl_get_nodes": true,
+    "lovenet-gateway_kubectl_get_nodes_summary": true,
+    "lovenet-gateway_kubectl_get_events": true,
+    "lovenet-gateway_kubectl_get_deployments": true,
+    "lovenet-gateway_kubectl_get_statefulsets": true,
+    "lovenet-gateway_kubectl_get_services": true,
+    "lovenet-gateway_kubectl_get_namespaces": true,
+    "lovenet-gateway_kubectl_get_pvcs": true,
+    "lovenet-gateway_kubectl_get_persistent_volumes": true,
+    "lovenet-gateway_kubectl_get_logs": true,
+    "lovenet-gateway_kubectl_get_pod_events": true,
+    "lovenet-gateway_kubectl_describe": true,
+    "lovenet-gateway_kubectl_health_check": true,
+    "lovenet-gateway_kubectl_check_pod_health": true,
+    "lovenet-gateway_kubectl_get_cluster_info": true,
+    "lovenet-gateway_kubectl_gitops_apps_list_tool": true,
+    "lovenet-gateway_prom_execute_query": true,
+    "lovenet-gateway_prom_execute_range_query": true,
+    "lovenet-gateway_prom_list_metrics": true,
+    "lovenet-gateway_prom_health_check": true,
+    "lovenet-gateway_memory_search": true,
+    "lovenet-gateway_memory_recent": true,
+    "lovenet-gateway_memory_get_entity": true,
+    "lovenet-gateway_memory_list_entities": true,
+    "lovenet-gateway_memory_graph_walk": true,
+    "lovenet-gateway_memory_create_entity": true,
+    "lovenet-gateway_memory_add_observation": true,
+    "lovenet-gateway_memory_link": true,
+    "lovenet-gateway_time_current_time": true,
+    "lovenet-gateway_time_convert_time": true
   },
   "instructions": [
     ".agents/instructions/*.md",
-    "AGENTS.md"
+    "AGENTS.md",
+    "/root/.config/opencode/instructions/HOMELAB-SPEC.md",
+    "/root/.config/opencode/instructions/persona-base.md"
   ],
   "mcp": {
     "lovenet-gateway": {


### PR DESCRIPTION
The in-cluster server was running with almost none of what makes an agent effective. Running `/health-check` against it returned nothing useful — not a reasoning failure, an equipment failure.

## What was missing

| | before | after |
|---|---|---|
| MCP tools | **all disabled** | 33 read-only tools |
| Standing rules | none | HOMELAB-SPEC + persona-base |
| Skills | **zero** | 7, from the vault |
| Memory | none | shared knowledge-graph MCP |

## 1. MCP tools

`"lovenet-gateway_*": false` disabled **everything** — including `discover_tools` and `select_tools`. Since opencode namespaces MCP tools as `<server>_*` ([docs](https://opencode.ai/docs/mcp-servers/)), that pattern left the entire surface inert with **no in-band way for a session to enable anything**.

Replaced with an explicit read-only allowlist (33 tools):

- `kubectl` — get pods/nodes/events/deployments/services/pvcs/logs, describe, health checks, gitops app list
- `prom` — queries, range queries, metric list, health
- `memory` — search, recent, entity read, graph walk, and write (create entity / add observation / link)
- `time`, plus `discover_tools` / `select_tools`

**Deliberately excluded**: every mutating tool. No `kubectl_apply`/`patch`/`delete`/`scale`/`rollout`, no `omada_*`, no `ha_*`, no `arr_*`, no `github_*`. This matches the read-only posture already chosen for the deploy keys.

## 2. Skills

The pod had **zero** skills — locally they're a symlink to `~/.claude-personal/skills`, which obviously doesn't exist in a container. Bundled and staged onto the PVC by the initContainer.

## 3. Standing rules

`HOMELAB-SPEC.md` and `persona-base.md` delivered via a **Secret**, not git. This repo is public and HOMELAB-SPEC names the media-download stacks (**L2 invariant #2**), so committing it is not an option. The Secret keeps the content in-cluster while giving agents the rules they're expected to operate under.

The personal `~/.claude-personal/CLAUDE.md` is deliberately **not** included — it carries career/medical context with no operational bearing on the cluster.

## 4. Memory

Falls out of (1). The gateway federates a knowledge-graph memory MCP that Claude Code and opencode can now **share** — meaning a fact learned by one is available to the other.

## Honest scope note

The client-side `tools` gate bounds *accidental* use. It is **not** a security boundary against a compromised or badly-steered agent — opencode enforces it, so anything that bypasses opencode bypasses it. Real enforcement still needs the [AuthPolicy work](https://github.com/rwlove/home-ops/blob/main/docs/src/mcp_tool_authz_design.md).

## Validation

- `opencode.json` parses; `kubectl kustomize` builds
- envsubst audit: only `${SECRET_DOMAIN}` unescaped
- both initContainer scripts pass `bash -n` after simulating `$$` → `$`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
