### PR TITLE
fix(ai): skills bundle extracted to the wrong path

### DIFF
--- a/kubernetes/apps/ai/opencode/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/opencode/app/helmrelease.yaml
@@ -86,10 +86,19 @@ spec:
                 if [ -s /secrets/PERSONA_BASE ]; then
                   cp -f /secrets/PERSONA_BASE /data/config/instructions/persona-base.md
                 fi
+                # The bundle's root entry is already `skills/`, so extract it
+                # as-is. An earlier --strip-components=1 removed that prefix
+                # and scattered each skill loose into /data/config; the loop
+                # below clears any such strays left by that version.
                 if [ -s /secrets/SKILLS_TGZ_B64 ]; then
-                  base64 -d < /secrets/SKILLS_TGZ_B64 > /tmp/skills.tgz 2>/dev/null &&
-                    tar -xzf /tmp/skills.tgz -C /data/config --strip-components=1 2>/dev/null &&
+                  if base64 -d < /secrets/SKILLS_TGZ_B64 > /tmp/skills.tgz 2>/dev/null; then
+                    for s in $(tar -tzf /tmp/skills.tgz 2>/dev/null | sed -n 's|^skills/\([^/]*\)/$|\1|p'); do
+                      [ -d "/data/config/$${s}" ] && rm -rf "/data/config/$${s}"
+                    done
+                    rm -rf /data/config/skills
+                    tar -xzf /tmp/skills.tgz -C /data/config 2>/dev/null
                     rm -f /tmp/skills.tgz
+                  fi
                 fi
                 echo "staged $(ls -1 /data/config/instructions 2>/dev/null | wc -l) instruction files, $(ls -1 /data/config/skills 2>/dev/null | wc -l) skills"
             resources:


### PR DESCRIPTION
Follow-up to #13273. Instructions landed correctly, but skills reported `0`.

## Cause

The bundle is built with root entry `skills/`, so `--strip-components=1` removed that prefix and scattered each skill loose into `/data/config`:

```text
/data/config/handoff            <- should be /data/config/skills/handoff
/data/config/whats-next
/data/config/merge-when-green
/data/config/skills            <- empty
```

So opencode still saw **zero** skills.

## Fix

Extract as-is, and clear strays from the previous version by deriving their names from the tarball listing rather than hardcoding a list that would rot.

## Verified

Extracted the same bundle locally before committing: yields `skills/` with 7 entries. Passes `bash -n` after simulating the `$$` → `$` substitution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)