### PR TITLE
feat(mcp): cut memory-mcp embeddings to tei-embed-spark (v0.3.0)

### DIFF
--- a/kubernetes/apps/mcp-system/memory-mcp/app/cnp-allow.yaml
+++ b/kubernetes/apps/mcp-system/memory-mcp/app/cnp-allow.yaml
@@ -24,10 +24,24 @@ spec:
         - ports:
             - port: "5432"
               protocol: TCP
-    # Ollama for embedding generation. Phase A of the
-    # Spark-unblocks-RAG plan picked bge-m3 (1024-dim), which only
-    # lives on ollama-spark. P40 ollama kept in the egress for
-    # rollback (fast env-flip back to nomic-embed-text if needed).
+    # Embeddings → tei-embed-spark (OpenAI /v1) as of the 2026-07-25
+    # cutover. Selector verified against the live pod label rather than
+    # assumed — see rwlove/home-ops#13264 and #13269, where two rules in
+    # this cluster named pods that don't exist and silently dropped all
+    # traffic.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: ai
+            app.kubernetes.io/name: tei-embed-spark
+      toPorts:
+        - ports:
+            - port: "3000"
+              protocol: TCP
+    # Both Ollamas retained purely as a rollback path: reverting this app
+    # to v0.2.1 (or setting EMBED_BACKEND=ollama) must not also require a
+    # CNP change to recover. bge-m3 still lives on ollama-spark, and the
+    # P40 ollama covers a fallback to nomic-embed-text.
+    # Drop these once the TEI path has soaked.
     - toEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: ai

--- a/kubernetes/apps/mcp-system/memory-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/memory-mcp/app/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwlove/memory-mcp
-              tag: v0.2.1@sha256:bc78855b3fa8342b6ba31bfaec2fae44edabd63eee70609de689db4f7ae5c613
+              tag: v0.3.0@sha256:e6af1677dd6a82f0cd6c8779c6088b2316c6b4a4ab3f44fe2056bfb132644c9a
             env:
               # CNPG-generated app Secret reflected from databases ns
               # via emberstack reflector (see langgraph-memory
@@ -36,16 +36,37 @@ spec:
                   secretKeyRef:
                     name: postgres-langgraph-memory-app
                     key: uri
+              # Embeddings cut from ollama-spark to tei-embed-spark
+              # 2026-07-25, the last git-managed consumer of the Spark's
+              # Ollama. Requires v0.3.0, which added the openai dialect
+              # (rwlove/containers#161) — v0.2.1 could only speak
+              # /api/embed, which is why this consumer lagged the others.
+              #
+              # Same bge-m3 weights, so the pgvector column is unaffected:
+              # measured cosine 0.99999941 between the two backends through
+              # the server's own embed(). No re-embed of kg.observations.
+              EMBED_BACKEND: openai
+              EMBED_BASE_URL: http://tei-embed-spark.ai.svc.cluster.local:3000
+              # Informational only — TEI serves one model and ignores the
+              # request's `model` field. Kept so the config is self-describing.
               EMBED_MODEL: bge-m3
               HOST: "0.0.0.0"
-              OLLAMA_BASE_URL: http://ollama-spark.ai.svc.cluster.local:11434
               PORT: "8070"
               TZ: America/New_York
             probes:
-              # v0.1.2 server exposes /healthz (DB ping) and /readyz
-              # (DB + Ollama probe) via FastMCP custom_route. Switch from
-              # TCP-only to httpGet so the kubelet drops us out of
-              # Service rotation if Postgres or Ollama go sideways.
+              # v0.1.2 server exposes /healthz (DB ping) and /readyz via
+              # FastMCP custom_route. Switch from TCP-only to httpGet so the
+              # kubelet drops us out of Service rotation if Postgres or the
+              # embedder go sideways.
+              #
+              # v0.3.0 changed what /readyz checks: it now performs a real
+              # one-token embed instead of Ollama's `GET /api/tags` (TEI has
+              # no equivalent — /api/tags and /v1/models both 404). That
+              # makes readiness STRICTER: an embedder that is reachable but
+              # not serving now drops this pod from the Service, where
+              # before it stayed in. Intended — but if readiness ever flaps
+              # on a cold backend, raise READYZ_EMBED_TIMEOUT (default 5s)
+              # rather than reverting.
               liveness:
                 enabled: true
                 custom: true

--- a/kubernetes/apps/mcp-system/memory-mcp/app/schema-init-job.yaml
+++ b/kubernetes/apps/mcp-system/memory-mcp/app/schema-init-job.yaml
@@ -33,7 +33,11 @@ spec:
           type: RuntimeDefault
       containers:
         - name: migrate
-          image: ghcr.io/rwlove/memory-mcp:v0.2.1@sha256:bc78855b3fa8342b6ba31bfaec2fae44edabd63eee70609de689db4f7ae5c613
+          # Keep in lockstep with the HelmRelease image — this Job runs the
+          # `memory-mcp-migrate` entry point from the SAME package, so a
+          # drifted pin means migrating with different code than the server
+          # runs. Two references, one version.
+          image: ghcr.io/rwlove/memory-mcp:v0.3.0@sha256:e6af1677dd6a82f0cd6c8779c6088b2316c6b4a4ab3f44fe2056bfb132644c9a
           command:
             - memory-mcp-migrate
           env:


### PR DESCRIPTION
## What

Completes **Phase 2** of the vLLM-on-Spark migration. `memory-mcp` was the last git-managed consumer still embedding against `ollama-spark`, and it *couldn't* move on v0.2.1 — that build only spoke Ollama's `/api/embed`, and TEI serves no such route. rwlove/containers#161 added an `openai` dialect; this consumes it.

| | before | after |
|---|---|---|
| image | `v0.2.1` | `v0.3.0@sha256:e6af1677…` |
| backend | Ollama `/api/embed` | `EMBED_BACKEND: openai` → `/v1/embeddings` |
| target | `ollama-spark:11434` | `tei-embed-spark:3000` |

## Vectors are unaffected

Same bge-m3 weights. Measured **cosine 0.99999941** between the two backends *through the server's own `embed()`*, both 1024-dim. **No re-embed of `kg.observations`** — the pgvector column stays valid.

## Both image pins moved

The schema-init Job carries its own hardcoded pin and **silently stayed on v0.2.1 in my first draft**. It runs the `memory-mcp-migrate` entry point from the same package, so a drifted pin means migrating with different code than the server runs.

Caught by diffing the *rendered* output rather than the source — the HelmRelease splits `repository`/`tag` across two lines, so a naive grep for `memory-mcp:v` only matches the Job. Comment added at both sites.

## CNP

New `tei-embed-spark:3000` egress. The `ollama-spark` and P40-`ollama` holes are **deliberately retained**: a rollback to v0.2.1, or an `EMBED_BACKEND=ollama` flip, must not also require a network change to recover. Marked for retirement once this has soaked.

The new selector was checked against the live pod label before committing — two rules in this cluster named pods that don't exist this week (#13264 `blackbox-exporter` vs `prometheus-blackbox-exporter`, #13269 `windmill` vs `windmill-workers`) and silently dropped all traffic. A `matchLabels` typo denies rather than errors, so it can't be caught by reading YAML.

## ⚠️ Behaviour change: readiness is stricter

v0.3.0 replaces `/readyz`'s `GET /api/tags` with a **real one-token embed** — TEI serves neither `/api/tags` nor `/v1/models` (both 404), and a metadata check only proved the process answers, not that embeddings work.

Consequence: an embedder that is *reachable but not serving* now drops this pod from the Service, where before it stayed in. That's the intent, but it is a genuine change in failure behaviour. If readiness ever flaps on a cold backend, raise `READYZ_EMBED_TIMEOUT` (default 5s) rather than reverting.

## Rollback

Revert the PR. Both Ollama egress holes are still open and `bge-m3` is still resident on `ollama-spark`, so v0.2.1 comes straight back with no network change.

## What this does *not* unblock

`ollama-spark` still **cannot** be decommissioned — it remains the only host of `llama3.2-vision:11b` for Frigate's GenAI. That relocation is untouched and is now the sole remaining blocker.

## Pre-submit

`yamllint` clean · kustomization builds · rendered output verified for both image pins and the env block (`OLLAMA_BASE_URL` gone) · CNP selectors checked against live pod labels · all pre-commit hooks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)