### PR TITLE
fix(ai): scope opencode's MCP view — 319k tokens of schemas broke every turn

### DIFF
--- a/kubernetes/apps/ai/opencode/app/resources/opencode.json
+++ b/kubernetes/apps/ai/opencode/app/resources/opencode.json
@@ -86,7 +86,10 @@
     "lovenet-gateway": {
       "type": "remote",
       "url": "http://mcp-gateway-istio.mcp-system.svc.cluster.local:8080/mcp",
-      "enabled": true
+      "enabled": true,
+      "headers": {
+        "x-mcp-virtualserver": "opencode-readonly"
+      }
     }
   }
 }

--- a/kubernetes/apps/mcp-system/mcp-gateway/app/kustomization.yaml
+++ b/kubernetes/apps/mcp-system/mcp-gateway/app/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - ./httproute-broker.yaml
   - ./httproute.yaml
   - ./mcpgatewayextension.yaml
+  - ./mcpvirtualserver-opencode.yaml
   - ./ocirepository.yaml
   - ./podmonitor.yaml
   - ./rotator-cronjob.yaml

--- a/kubernetes/apps/mcp-system/mcp-gateway/app/mcpvirtualserver-opencode.yaml
+++ b/kubernetes/apps/mcp-system/mcp-gateway/app/mcpvirtualserver-opencode.yaml
@@ -1,0 +1,73 @@
+---
+# TODO: apply schema (mcp.kuadrant.io CRDs ship none)
+#
+# Why this exists: the MCP gateway federates ~1300 tools across 18 servers.
+# A `tools/list` against the broker returns ~1.28 MB — roughly 319k tokens,
+# about 5x the 65k context window of the driver model. opencode fetches the
+# full schema set when it connects, so every turn died silently while
+# assembling context: the prompt was admitted, then nothing.
+#
+# An MCPVirtualServer exposes a named subset. opencode selects it with the
+# `x-mcp-virtualserver` header (see the mcp block in opencode.json), so
+# tools/list returns only these and the payload stays small.
+#
+# NOTE ON SCOPE: this is a CONTEXT-management mechanism, not a security
+# boundary — the header is chosen by the client, so a session could ask for
+# a different virtual server. Real per-tool enforcement needs a Kuadrant
+# AuthPolicy; see docs/src/mcp_tool_authz_design.md. The client-side
+# `tools` allowlist in opencode.json remains as defence in depth.
+#
+# Read-only by design, matching the posture chosen for the deploy keys:
+# no kubectl apply/patch/delete/scale, no omada_*, no ha_*, no arr_*,
+# no github_* writes.
+apiVersion: mcp.kuadrant.io/v1alpha1
+kind: MCPVirtualServer
+metadata:
+  name: opencode-readonly
+  labels:
+    app.kubernetes.io/name: opencode
+spec:
+  description: >-
+    Read-only cluster observability subset for the in-cluster opencode
+    agent: kubectl reads, Prometheus queries, shared memory graph, time.
+  tools:
+    # --- discovery (lets a session widen scope deliberately) ---
+    - discover_tools
+    - select_tools
+    # --- kubectl: reads only ---
+    - kubectl_get_pods
+    - kubectl_get_nodes
+    - kubectl_get_nodes_summary
+    - kubectl_get_events
+    - kubectl_get_deployments
+    - kubectl_get_statefulsets
+    - kubectl_get_services
+    - kubectl_get_namespaces
+    - kubectl_get_pvcs
+    - kubectl_get_persistent_volumes
+    - kubectl_get_logs
+    - kubectl_get_pod_events
+    - kubectl_describe
+    - kubectl_health_check
+    - kubectl_check_pod_health
+    - kubectl_get_cluster_info
+    - kubectl_gitops_apps_list_tool
+    - kubectl_get_node_metrics
+    - kubectl_get_pod_metrics
+    # --- prometheus: queries are inherently read-only ---
+    - prom_execute_query
+    - prom_execute_range_query
+    - prom_list_metrics
+    - prom_health_check
+    # --- shared knowledge graph (read + write; low blast radius) ---
+    - memory_search
+    - memory_recent
+    - memory_get_entity
+    - memory_list_entities
+    - memory_graph_walk
+    - memory_create_entity
+    - memory_add_observation
+    - memory_link
+    # --- time ---
+    - time_current_time
+    - time_convert_time


### PR DESCRIPTION
## Root cause

The in-cluster agent produced nothing for any prompt. Measured from inside the pod:

```text
MCP tools/list payload : 1,277,594 bytes  (~319,000 tokens)
Driver model context   :                      65,536 tokens
```

The gateway federates ~1300 tools across 18 servers. opencode fetches the full schema set on connect, so every turn was **admitted and then died silently** while assembling context — roughly 5x the entire context window. The event stream showed `session.next.prompt.admitted` followed by nothing, and zero messages were ever recorded.

This is exactly what the original `lovenet-gateway_*: false` was protecting against. The client-side allowlist added in #13273 does **not** help: the schemas are fetched from the gateway *before* opencode applies its filter.

It also explains the user-visible symptom — `/health-check` and `/cluster-health` each burning ~30s and returning nothing.

## Fix

An `MCPVirtualServer` (`opencode-readonly`, 35 tools), selected from opencode via the `x-mcp-virtualserver` header. `tools/list` then returns only that subset.

Contents: kubectl reads, Prometheus queries, the shared memory graph, time, plus `discover_tools`/`select_tools` so a session can widen scope deliberately. No `kubectl apply`/`patch`/`delete`/`scale`, no `omada_*`, `ha_*`, `arr_*`, or `github_*`.

## Placement

The CR lives in the **mcp-gateway** app, not the opencode app. The `ai` Kustomization sets `targetNamespace: ai`, which would have overridden the CR namespace and placed it away from the gateway.

## Scope note

This is **context management, not security** — the header is client-chosen, so a session could request a different virtual server. Real per-tool enforcement still needs a Kuadrant AuthPolicy ([design](https://github.com/rwlove/home-ops/blob/main/docs/src/mcp_tool_authz_design.md)). The client-side `tools` allowlist stays as defence in depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)