### PR TITLE
fix(mcp): let Flux recreate the immutable memory-mcp migrate Job

### DIFF
--- a/kubernetes/apps/mcp-system/memory-mcp/ks.yaml
+++ b/kubernetes/apps/mcp-system/memory-mcp/ks.yaml
@@ -18,6 +18,22 @@ spec:
       namespace: mcp-system
     - name: langgraph-memory
       namespace: databases
+  # This path ships a one-shot `memory-mcp-migrate` Job, and a Job's
+  # spec.template is IMMUTABLE. Any image bump to that Job therefore makes
+  # the whole Kustomization fail its dry-run with "field is immutable" —
+  # which is exactly what happened bumping v0.2.1 -> v0.3.0 in #13275, and
+  # it also stalled the two Kustomizations that depend on this one.
+  #
+  # `force` lets Flux delete and recreate a resource when an immutable
+  # field changes, instead of wedging. Safe here specifically because the
+  # migration is idempotent by design — schema.sql is 9 x
+  # `CREATE ... IF NOT EXISTS` with zero destructive statements, and
+  # migrate.py documents that re-running it as a Job is expected.
+  #
+  # Scope check before enabling: this path's other resources (HelmRelease,
+  # CiliumNetworkPolicy, ServiceMonitor) have no immutable fields that
+  # matter, so `force` only ever bites on the Job.
+  force: true
   retryInterval: 2m
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json


### PR DESCRIPTION
## What I broke

#13275 bumped the memory-mcp image in **two** places — the HelmRelease and the one-shot `memory-mcp-migrate` Job. Bumping both was right (they ship the same package), but **a Job's `spec.template` is immutable**, so every reconcile since has failed its dry-run:

```
Job/mcp-system/memory-mcp-migrate dry-run failed (Invalid):
  spec.template: field is immutable
```

Consequences: the HelmRelease never left v0.2.1, and the two Kustomizations depending on this one (`mcp-system-observability`, `memory-mcp-mcpserverregistration`) stalled behind it.

**Nothing was down** — v0.2.1 kept serving — but the cutover couldn't land.

## Fix

`force: true` on this Kustomization lets Flux replace a resource when an immutable field changes instead of wedging on it.

**Verified idempotent before enabling**, because `force` means the migration re-runs against the live database:

| check | result |
|---|---|
| `CREATE … IF NOT EXISTS` guards in `schema.sql` | 9 |
| destructive statements (`DROP`/`TRUNCATE`/`DELETE`) | **0** |
| unguarded `CREATE` | none |
| `migrate.py` docstring | *"every statement is `CREATE … IF NOT EXISTS`, so running this repeatedly — e.g. as a Job — is safe"* |

**Scope-checked**: the other resources on this path (HelmRelease, CiliumNetworkPolicy, ServiceMonitor) have no immutable fields that matter, so `force` only ever bites on the Job.

## Alternative rejected

Reverting the Job's pin to v0.2.1 unwedges just as fast, but leaves the `memory-mcp-migrate` entry point running different code than the server on any future rebuild — and re-arms the same trap for the next bump. Fixing the mechanism beats papering over it.

## Note

**First use of `force` in this repo.** Deliberately scoped to the one Kustomization that ships a Job, not adopted as a general default. Worth knowing about as a pattern for any future one-shot-Job path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)