### PR TITLE
feat(ai): wire memory-mcp directly; disable the aggregating gateway

### DIFF
--- a/kubernetes/apps/ai/opencode/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/opencode/app/cnp-allow.yaml
@@ -44,12 +44,21 @@ spec:
     # DNS, which mcp-gateway-istio-allow permits via `fromEntities: cluster`.
     # Namespace-wide selector matches the langgraph-agents precedent (the
     # reference in-cluster MCP client named in that policy's comment).
+    #
+    # 8070 is memory-mcp, addressed DIRECTLY rather than through the broker.
+    # The aggregating gateway returns ~319k tokens of tool schemas against a
+    # 65k-context model, which silently killed every turn; memory-mcp alone
+    # is 14 tools / ~2.9k tokens. Until broker-side filtering exists
+    # (Kuadrant AuthPolicy — see docs/src/mcp_tool_authz_design.md), narrow
+    # direct connections are the only way an agent gets usable MCP tools.
     - toEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: mcp-system
       toPorts:
         - ports:
             - port: "8080"
+              protocol: TCP
+            - port: "8070"
               protocol: TCP
     # Model providers (vllm-driver-spark, vllm-coder-spark, ollama) are
     # in-cluster Services in THIS namespace — reached via the baseline

--- a/kubernetes/apps/ai/opencode/app/resources/opencode.json
+++ b/kubernetes/apps/ai/opencode/app/resources/opencode.json
@@ -42,39 +42,7 @@
   "small_model": "ollama-p40/qwen2.5-coder:7b",
   "tools": {
     "lovenet-gateway_*": false,
-    "lovenet-gateway_discover_tools": true,
-    "lovenet-gateway_select_tools": true,
-    "lovenet-gateway_kubectl_get_pods": true,
-    "lovenet-gateway_kubectl_get_nodes": true,
-    "lovenet-gateway_kubectl_get_nodes_summary": true,
-    "lovenet-gateway_kubectl_get_events": true,
-    "lovenet-gateway_kubectl_get_deployments": true,
-    "lovenet-gateway_kubectl_get_statefulsets": true,
-    "lovenet-gateway_kubectl_get_services": true,
-    "lovenet-gateway_kubectl_get_namespaces": true,
-    "lovenet-gateway_kubectl_get_pvcs": true,
-    "lovenet-gateway_kubectl_get_persistent_volumes": true,
-    "lovenet-gateway_kubectl_get_logs": true,
-    "lovenet-gateway_kubectl_get_pod_events": true,
-    "lovenet-gateway_kubectl_describe": true,
-    "lovenet-gateway_kubectl_health_check": true,
-    "lovenet-gateway_kubectl_check_pod_health": true,
-    "lovenet-gateway_kubectl_get_cluster_info": true,
-    "lovenet-gateway_kubectl_gitops_apps_list_tool": true,
-    "lovenet-gateway_prom_execute_query": true,
-    "lovenet-gateway_prom_execute_range_query": true,
-    "lovenet-gateway_prom_list_metrics": true,
-    "lovenet-gateway_prom_health_check": true,
-    "lovenet-gateway_memory_search": true,
-    "lovenet-gateway_memory_recent": true,
-    "lovenet-gateway_memory_get_entity": true,
-    "lovenet-gateway_memory_list_entities": true,
-    "lovenet-gateway_memory_graph_walk": true,
-    "lovenet-gateway_memory_create_entity": true,
-    "lovenet-gateway_memory_add_observation": true,
-    "lovenet-gateway_memory_link": true,
-    "lovenet-gateway_time_current_time": true,
-    "lovenet-gateway_time_convert_time": true
+    "memory_*": true
   },
   "instructions": [
     ".agents/instructions/*.md",
@@ -86,10 +54,15 @@
     "lovenet-gateway": {
       "type": "remote",
       "url": "http://mcp-gateway-istio.mcp-system.svc.cluster.local:8080/mcp",
-      "enabled": true,
+      "enabled": false,
       "headers": {
         "x-mcp-virtualserver": "opencode-readonly"
       }
+    },
+    "memory": {
+      "type": "remote",
+      "url": "http://memory-mcp.mcp-system.svc.cluster.local:8070/mcp",
+      "enabled": true
     }
   }
 }


### PR DESCRIPTION
The gateway connection is what was killing every turn.

```text
gateway tools/list : 1,277,594 bytes  (~319,000 tokens)
model hard limit   :                      65,536 tokens
memory-mcp direct  :    11,663 bytes  (~2,915 tokens)   <- measured
```

Prompts were admitted and then died silently while assembling context. No client-side setting fixes it: opencode fetches every schema from the broker **before** its own `tools` filter applies, and `MCPVirtualServer` filtering requires Authorino's signed wristband — Authorino is not installed (verified: the CR reconciled with 35 tools in spec, and the `x-mcp-virtualserver` header still returned all 1,266).

## Change

- **Disable** the `lovenet-gateway` MCP entry. Kept in config, header and all, so it can be re-enabled the moment Kuadrant lands.
- **Connect `memory-mcp` directly** at `memory-mcp.mcp-system:8070` — 14 tools, ~2.9k tokens.
- CNP opens `mcp-system:8070` alongside `8080`.
- The `lovenet-gateway_*: false` guard **stays**, so re-enabling the gateway cannot silently flood context again.

## Why memory first

Its own server instructions describe the graph as **shared across LangGraph, Claude Code, Open WebUI and HolmesGPT**, with provenance on writes. So this is the one tool that closes the gap between what Claude Code knows and what opencode knows — a fact learned by one becomes readable by the other.

It was also completely orphaned until #13278: no persona claimed it.

## Not fixed by this

`kubectl` remains unavailable — that server alone is ~275 tools (~69k tokens), over budget on its own. A real cluster-health capability still needs broker-side filtering ([design](https://github.com/rwlove/home-ops/blob/main/docs/src/mcp_tool_authz_design.md)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)