### PR TITLE
fix(mcp-system): let opencode reach memory-mcp directly

### DIFF
--- a/kubernetes/apps/mcp-system/memory-mcp/app/cnp-allow.yaml
+++ b/kubernetes/apps/mcp-system/memory-mcp/app/cnp-allow.yaml
@@ -13,6 +13,21 @@ spec:
   enableDefaultDeny:
     egress: false
     ingress: false
+  ingress:
+    # opencode (ai ns) connects to memory-mcp DIRECTLY rather than through
+    # the broker: the aggregating gateway returns ~319k tokens of tool
+    # schemas, far past the 65k context of the model that agent runs, so a
+    # narrow direct connection is the only way it gets the shared knowledge
+    # graph. Intra-namespace callers (the broker) are covered by the
+    # baseline allow-intra-namespace rule and need nothing here.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: ai
+            app.kubernetes.io/name: opencode
+      toPorts:
+        - ports:
+            - port: "8070"
+              protocol: TCP
   egress:
     # langgraph-memory CNPG primary in databases ns. Per
     # project_cilium_l4_port_targetport, toPorts matches container port.


### PR DESCRIPTION
Follow-up to #13279. opencode's direct connection to memory-mcp timed out even though its own egress rule was correct.

## Cause

`memory-mcp-allow` carried **no ingress rules at all**:

```yaml
enableDefaultDeny: {egress: false, ingress: false}
# ...then straight to egress:
```

The broker reaches memory-mcp only via the baseline `allow-intra-namespace` rule. With `mcp-system` under default-deny (re-enabled 2026-05-18), that means **cross-namespace callers are dropped** — so the `ai` namespace could not connect.

Same shape as the earlier broker discovery: egress permitted on the caller, ingress silently denied on the target.

## Fix

A narrow ingress rule for the opencode pod in `ai` on 8070. Intra-namespace callers are unaffected — the baseline rule still covers the broker.

## Why direct at all

The aggregating gateway returns ~319k tokens of tool schemas against a 65k-context model. memory-mcp alone is 14 tools / ~2.9k tokens (measured), so a narrow direct connection is the only way this agent gets the shared knowledge graph until broker-side filtering exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)