### PR TITLE
chore(pump): bump to v0.0.106

### DIFF
--- a/kubernetes/apps/collab/pump/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump/app/helmrelease.yaml
@@ -49,7 +49,7 @@ spec:
           pump:
             image:
               repository: ghcr.io/rwlove/pump
-              tag: v0.0.105@sha256:939c5fe794d90d49544a21e64ae35edb9d87c9e5bddd623f34c94a1c17f265fc
+              tag: v0.0.106@sha256:4f255412ab46d6b147d25b49fcf5e05d0ab2dad024fb8dc5642f93a32f18591f
 
             env:
               # Activates the /api/cv/* proxy in pump (see internal/web/exercise.go).


### PR DESCRIPTION
Bumps `collab/pump` from `v0.0.105` → `v0.0.106`.

```
ghcr.io/rwlove/pump:v0.0.106@sha256:4f255412ab46d6b147d25b49fcf5e05d0ab2dad024fb8dc5642f93a32f18591f
```

## What this picks up

[rwlove/PUMP#71](https://github.com/rwlove/PUMP/pull/71) — the last set of any workout day could not be deleted.

Saving is a bulk replace: the UI POSTs the full remaining set list for a date and the server clears the day and reinserts. `setHandler` short-circuited with `200 OK` whenever the form carried no `name` fields, which is exactly the shape of the autosave that follows deleting a day's final entry. The UI reported "Saved" and the row survived a reload.

The empty-form guard now keys on the **date** rather than the set count — a missing date is a `400` with the database untouched, and a valid date with zero sets clears the day as intended.

## Deployment notes

- **No schema migration** in this release, so there's no ordering constraint against the CNPG cluster — this is a straight rolling image swap of the `pump` StatefulSet.
- Digest verified against GHCR before pinning: resolves to tags `["v0.0.106","latest"]`.
- `pump-cv` is unaffected and stays at `v0.6.1`.
- Current state: `pump-0` healthy, 0 restarts, 6d10h uptime, serving normally. Nothing is stuck — git simply still pinned v0.0.105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)