### PR TITLE
fix(ai): ollama-spark never admitted frigate — GenAI has never worked

### DIFF
--- a/kubernetes/apps/ai/ollama-spark/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/ollama-spark/app/cnp-allow.yaml
@@ -36,6 +36,17 @@ spec:
         - matchLabels:
             io.kubernetes.pod.namespace: media
             app.kubernetes.io/name: suggestarr
+        # Frigate GenAI — VLM event descriptions against
+        # llama3.2-vision:11b. This rule was MISSING while frigate's own
+        # CNP already had the matching egress, so Cilium silently dropped
+        # every request: Frigate's Ollama provider timed out at init,
+        # never retried (it initialises once per process), and logged
+        # "Ollama provider has not been initialized" on every qualifying
+        # detection. Result: 13,017 events in the Frigate DB, ZERO with a
+        # description — the feature had never worked. Found 2026-07-26.
+        - matchLabels:
+            io.kubernetes.pod.namespace: home
+            app.kubernetes.io/name: frigate
         - matchLabels:
             io.kubernetes.pod.namespace: collab
             app.kubernetes.io/name: open-webui


### PR DESCRIPTION
## What

Frigate's CNP has had an **egress** rule to `ollama-spark` for months. `ollama-spark`'s **ingress** never had the matching entry.

| Direction | Rule |
|---|---|
| frigate egress → `ai/ollama-spark` | ✅ present |
| ollama-spark ingress ← `home/frigate` | ❌ **absent** |

Cilium dropped every GenAI request silently. Frigate initialises its Ollama provider **once per process**, so the init timeout was permanent for the pod's lifetime, and every qualifying detection logged:

```
frigate.genai.ollama WARNING: Ollama provider has not been initialized,
  a description will not be generated. Check your Ollama configuration.
```

## Measured impact

**13,017 events in the Frigate DB. Zero with a description.** The feature was configured in real detail — custom per-object prompts, `required_zones`, two cameras — and has never once run.

## Mechanism confirmed, not inferred

- From inside `frigate-0`: `ollama-spark:11434` **times out** — a drop, not a refusal.
- `llama3.2-vision:11b` is present (7.3 GiB) and healthy on ollama-spark.

So it's purely the network path.

## Cross-checked the whole policy

This is the **third** instance of this failure class today, so I didn't just patch the hole:

| | Problem |
|---|---|
| #13264 | tei-embed-spark ← `blackbox-exporter` (wrong label) |
| #13269 | tei-embed-spark ← `windmill` (wrong label) |
| **this** | ollama-spark ← `frigate` (absent entirely) |

Every app with an egress rule to ollama-spark is now admitted (`home/windmill`→`windmill-workers`, `mcp-system/memory-mcp`, `collab/open-webui`, `home/frigate`), and **all seven ingress selectors were verified against live pods** — no dead rules:

```
network/envoy                                OK (4 pods)
home/home-assistant                          OK (1)
home/windmill-workers                        OK (2)
media/suggestarr                             OK (1)
home/frigate                                 OK (1)
collab/open-webui                            OK (1)
observability/prometheus-blackbox-exporter   OK (1)
```

## ⚠️ Two things to expect

1. **Requires a frigate pod restart.** The provider only initialises at startup, so this policy change alone will not revive it.
2. **New load on the Spark.** An 11B VLM will run per qualifying event across two cameras — never exercised before. 7.3 GiB against 24.1 GiB free, so it fits, but the load profile changes. Worth watching after the restart.

## Follow-up

This makes `llama3.2-vision` a *real* dependency for the first time, which is the remaining blocker for the `ollama-spark` decommission. Relocation is being handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)