### PR TITLE
fix(network): retarget frigate GenAI to the P40 and retire dead CNP rules

### DIFF
--- a/kubernetes/apps/ai/ollama-spark/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/ollama-spark/app/cnp-allow.yaml
@@ -24,23 +24,26 @@ spec:
         - ports:
             - port: "11434"
               protocol: TCP
-    # Cross-ns callers (mirrors the existing ollama CNP; both Services
-    # serve the same surface of consumers post-Phase-2 factory cutover).
+    # Cross-ns callers. Trimmed 2026-07-26 to the consumers that actually
+    # reach this Service. Each removal was justified by the SAME asymmetry
+    # test that exposed the frigate bug: an ingress entry whose consumer
+    # has no matching egress rule to this Service can never carry traffic.
+    #   - home-assistant  — its Ollama integration is configured against
+    #                       `ollama.ai:11434` (the P40); no egress here.
+    #   - suggestarr      — egresses to `ai/ollama` only.
+    #   - windmill-workers— egress retired in this PR (fan-out on TEI).
+    #   - mcp-system/*    — egress retired in this PR (memory-mcp on TEI).
+    # Corroborated by traffic: 24h of logs show /api/generate = 0,
+    # /api/chat = 0, and /api/embed = 290 ≈ exactly the 5-min synthetic
+    # probe. No consumer does real inference here.
     - fromEndpoints:
-        - matchLabels:
-            io.kubernetes.pod.namespace: home
-            app.kubernetes.io/name: home-assistant
-        - matchLabels:
-            io.kubernetes.pod.namespace: home
-            app.kubernetes.io/name: windmill-workers
-        - matchLabels:
-            io.kubernetes.pod.namespace: media
-            app.kubernetes.io/name: suggestarr
+        # Model-list polling for OLLAMA_BASE_URLS (2347 /api/tags in 24h).
+        # The last genuine consumer; retire it when ollama-spark is
+        # decommissioned, which also needs ollama-spark dropped from
+        # open-webui's OLLAMA_BASE_URLS or it will poll a dead endpoint.
         - matchLabels:
             io.kubernetes.pod.namespace: collab
             app.kubernetes.io/name: open-webui
-        - matchLabels:
-            io.kubernetes.pod.namespace: mcp-system
         # OllamaWedged synthetic probe (ollama_embed blackbox module
         # against bge-m3). Distinct from the Prometheus scrape allowed
         # by the baseline allow-monitoring-scrape — that one matches

--- a/kubernetes/apps/home/frigate/app/cnp-allow.yaml
+++ b/kubernetes/apps/home/frigate/app/cnp-allow.yaml
@@ -113,17 +113,28 @@ spec:
             - port: "1935"
               protocol: TCP
     # Frigate genai integration — Ollama VLM descriptions for detection
-    # events (genai.provider=ollama, model=llama3.2-vision:11b,
-    # base_url=ollama-spark.ai.svc.cluster.local). Routed to the Spark
-    # Ollama, NOT the P40 (`ollama`): the P40 is already full (immich-ml +
-    # pet-tagger + comfyui ≈ 16Gi resident) and an 11b VLM would thrash
-    # against the qwen2.5:7b that six local-p40 langgraph agents depend on.
-    # Spark (GB10, 480Gi unified) has the headroom and is the routing-doc
-    # home for larger inference.
+    # events. Retargeted 2026-07-26 from ollama-spark to the P40 `ollama`
+    # (small VLM, ~3.2 GiB) as part of retiring ollama-spark.
+    #
+    # This rule is why GenAI never worked. The policy halves were authored
+    # for DIFFERENT targets at different times and never matched:
+    #   frigate egress → ollama-spark : present     ollama-spark ingress ← frigate : ABSENT
+    #   frigate egress → ollama       : ABSENT      ollama       ingress ← frigate : present
+    # Cilium silently dropped every request, Frigate's provider timed out
+    # at init and never retried, and the DB accumulated 13,017 events with
+    # ZERO descriptions. `ai/ollama`'s ingress has carried a frigate rule
+    # (commented "Frigate genai integration") the whole time — only this
+    # egress side was missing, so this closes the pair.
+    #
+    # The old comment argued the P40 was too full for an 11b VLM. That was
+    # correct for 11b: measured today, the P40 has ~12.7 GiB free and
+    # coder(4.6) + bge-m3(0.6) + an 11b(7.3) leaves ~0 for Immich CLIP
+    # bursts. A ~3 GiB VLM fits with ~5.5 GiB of burst headroom, which is
+    # what makes the P40 viable now where it wasn't before.
     - toEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: ai
-            app.kubernetes.io/name: ollama-spark
+            app.kubernetes.io/name: ollama
       toPorts:
         - ports:
             - port: "11434"

--- a/kubernetes/apps/home/windmill/app/cnp-allow.yaml
+++ b/kubernetes/apps/home/windmill/app/cnp-allow.yaml
@@ -133,13 +133,12 @@ spec:
         - ports:
             - port: "8000"
               protocol: TCP
-    # Embeddings moved off ollama-spark to tei-embed-spark (OpenAI /v1)
-    # on 2026-07-25, completing the git-side half of the Phase 2 cutover.
-    # The ollama-spark hole is retained deliberately: the fan-out script
-    # lives in Windmill (no git→workspace sync) and is repointed by a
-    # separate MCP deploy, so this rule must permit BOTH endpoints across
-    # the window where manifest and script disagree. Drop the ollama-spark
-    # entry once the script is confirmed on /v1/embeddings.
+    # Embeddings moved off ollama-spark to tei-embed-spark (OpenAI /v1) on
+    # 2026-07-25. The transitional ollama-spark hole is now RETIRED — its
+    # stated condition ("drop once the script is confirmed on
+    # /v1/embeddings") is met: the deployed fan-out is hash
+    # 7ad0be5d1bbdce5a on /v1/embeddings, has run every 15 min for a day
+    # with zero failures, and TEI has served the traffic.
     - toEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: ai
@@ -147,14 +146,6 @@ spec:
       toPorts:
         - ports:
             - port: "3000"
-              protocol: TCP
-    - toEndpoints:
-        - matchLabels:
-            io.kubernetes.pod.namespace: ai
-            app.kubernetes.io/name: ollama-spark
-      toPorts:
-        - ports:
-            - port: "11434"
               protocol: TCP
     - toEndpoints:
         - matchLabels:

--- a/kubernetes/apps/mcp-system/memory-mcp/app/cnp-allow.yaml
+++ b/kubernetes/apps/mcp-system/memory-mcp/app/cnp-allow.yaml
@@ -44,6 +44,14 @@ spec:
     # assumed — see rwlove/home-ops#13264 and #13269, where two rules in
     # this cluster named pods that don't exist and silently dropped all
     # traffic.
+    #
+    # The two transitional Ollama rollback holes that sat below this rule
+    # are RETIRED as of 2026-07-26. Their stated condition ("drop these
+    # once the TEI path has soaked") is met: v0.3.0 has run against
+    # tei-embed-spark with 0 restarts and /readyz — which in v0.3.0
+    # performs a REAL embed rather than a metadata GET — passing
+    # throughout. A rollback would now also require an image revert, so it
+    # is a deliberate operation that can carry its own CNP change.
     - toEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: ai
@@ -51,20 +59,4 @@ spec:
       toPorts:
         - ports:
             - port: "3000"
-              protocol: TCP
-    # Both Ollamas retained purely as a rollback path: reverting this app
-    # to v0.2.1 (or setting EMBED_BACKEND=ollama) must not also require a
-    # CNP change to recover. bge-m3 still lives on ollama-spark, and the
-    # P40 ollama covers a fallback to nomic-embed-text.
-    # Drop these once the TEI path has soaked.
-    - toEndpoints:
-        - matchLabels:
-            io.kubernetes.pod.namespace: ai
-            app.kubernetes.io/name: ollama
-        - matchLabels:
-            io.kubernetes.pod.namespace: ai
-            app.kubernetes.io/name: ollama-spark
-      toPorts:
-        - ports:
-            - port: "11434"
               protocol: TCP


### PR DESCRIPTION
## The test applied throughout

An ingress entry whose consumer has **no matching egress** to that Service — or an egress rule whose consumer no longer uses it — can never carry traffic. A `matchLabels` mismatch *denies silently*, so these are invisible until something is broken. That lens exposed the frigate bug; applying it across the ollama surface found more.

## 1. frigate: egress retargeted `ollama-spark` → `ollama` (P40)

**This rule is why Frigate GenAI never worked.** The two halves of the policy were authored for **different targets at different times** and never matched:

| | frigate egress | target ingress |
|---|---|---|
| → ollama-spark | ✅ present | ❌ **absent** |
| → ollama (P40) | ❌ **absent** | ✅ present |

Cilium dropped every request. Frigate initialises its Ollama provider **once per process**, so the timeout was permanent and each qualifying detection logged `Ollama provider has not been initialized`. Result: **13,017 events, zero descriptions.**

`ai/ollama` has carried a frigate ingress rule (commented *"Frigate genai integration"*) the whole time — so this **closes the pair** rather than opening a new hole.

The old comment argued the P40 was too full for a VLM. That was correct **for 11b** — measured today the P40 has ~12.7 GiB free, and coder(4.6) + bge-m3(0.6) + 11b(7.3) leaves ~0 for Immich CLIP bursts. The relocation uses a **~3 GiB** VLM, which fits with ~5.5 GiB of burst headroom.

## 2–3. Transitional rollback holes retired (conditions met)

| App | Condition written into the rule | Evidence it's met |
|---|---|---|
| windmill → ollama-spark | *"drop once the script is confirmed on /v1/embeddings"* | fan-out is hash `7ad0be5d1bbdce5a`, a day of 15-min runs, 0 failures |
| memory-mcp → ollama + ollama-spark | *"drop these once the TEI path has soaked"* | v0.3.0, 0 restarts, `/readyz` (a **real embed** in v0.3.0) passing throughout |

Both were deliberately left open by earlier PRs *with* a retirement condition. This collects on them rather than letting them become permanent.

## 4. ollama-spark ingress trimmed to what can actually reach it

| Removed | Why it could never connect |
|---|---|
| `home-assistant` | its Ollama integration points at `ollama.ai:11434` (**the P40**) — no egress here |
| `suggestarr` | egresses only to `ai/ollama` |
| `windmill-workers` | egress retired in §2 |
| `mcp-system/*` | egress retired in §3 |

Corroborated by traffic — 24h of ollama-spark logs:

```
/api/generate  0
/api/chat      0
/api/embed   290   ≈ exactly the 5-min synthetic probe
/api/tags   2347   open-webui model-list polling
```

**No consumer does real inference on ollama-spark.** What remains: open-webui's polling and the wedge probe.

## Safety check

Every `fromEndpoints`/`toEndpoints` `matchLabels` across all four policies was verified against live pod labels — **0 dead selectors remain**. `yamllint` clean, all four kustomizations build, rendered output confirms frigate now targets `ollama`.

## Deliberately NOT in this PR

**Frigate's own config** (`genai.base_url` + `model`) lives on the **PVC, not in git**, and applying it requires a frigate restart — the provider only initialises at startup. Frigate is **Renee-facing**, so that waits for its Tuesday 02:00–04:00 window or your explicit go-ahead. Until then this egress rule is simply unused, which is harmless.

Supersedes #13284 (closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)