### PR TITLE
feat(ai): seat Frigate's GenAI VLM on the P40 (MAX_LOADED_MODELS 2→3)

### DIFF
--- a/kubernetes/apps/ai/ollama/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/ollama/app/helmrelease.yaml
@@ -70,17 +70,31 @@ spec:
               # bge-m3 08:18 → qwen2.5:7b 09:26 → bge-m3 09:28, each a
               # cold GGUF load, `loaded runners count=1` every time.
               #
-              # 2 lets the embedder and the coder stay co-resident:
-              # bge-m3 (1.1 GiB) + qwen2.5-coder:7b (~4.8 GiB predicted)
-              # = ~5.9 GiB of the ~13.3 GiB the P40 has free after
-              # whisper / immich-ml / pet-tagger, leaving ~7.4 GiB for
-              # Immich CLIP bursts. Deliberately NOT 3 — holding a third
-              # 7b-class model would put ~10.7 GiB resident and cut burst
-              # headroom to ~2.3 GiB, which is how the 2026-05-18 VRAM
-              # exhaustion / CPU-spill incident happened (see
+              # 2 let the embedder and the coder stay co-resident:
+              # bge-m3 (0.62 GiB measured) + qwen2.5-coder:7b (4.58 GiB
+              # measured) = 5.2 GiB of the ~13 GiB the P40 has free after
+              # whisper / immich-ml / pet-tagger, leaving ~7.9 GiB for
+              # Immich CLIP bursts.
+              #
+              # Raised 2→3 on 2026-07-26 to seat Frigate's GenAI VLM.
+              # The earlier "deliberately NOT 3" reasoning was scoped to a
+              # third 7b-class model (~10.7 GiB resident, ~2.3 GiB left —
+              # the 2026-05-18 VRAM-exhaustion zone, see
               # docs/src/audit/post-spark-tool-call-leakage-2026-05-18.md).
+              # That still holds; this third model is far smaller.
+              # MEASURED, not predicted, on this GPU:
+              #   bge-m3        0.62 GiB
+              #   qwen2.5-coder 4.58 GiB
+              #   qwen2.5vl:3b  2.79 GiB   <- the VLM (3.2 GB on disk)
+              #   ------------------------
+              #   total         7.99 GiB   -> ~4.2 GiB left for CLIP bursts
+              # Roughly double the headroom of the incident configuration,
+              # but meaningfully tighter than the 2-model layout. If Immich
+              # CLIP starts spilling to CPU, this is the first thing to
+              # reconsider.
+              #
               # Heavy coding still routes to the Spark vLLM driver.
-              OLLAMA_MAX_LOADED_MODELS: 2
+              OLLAMA_MAX_LOADED_MODELS: 3
 
             resources:
               requests:


### PR DESCRIPTION
## Two independent reasons GenAI never worked

**1. Asymmetric CNP** — fixed in #13285. frigate's egress pointed at `ollama-spark` while only `ai/ollama` had a matching ingress rule, so Cilium dropped every request.

**2. The model cannot load on the Spark at all:**

```
error loading model: unknown model architecture: 'mllama'
llama-server terminated, exit status 1
```

`llama3.2-vision:11b` has **never run in this cluster**, and its 7.3 GiB on the ollama-spark PVC is dead weight. Both nodes run ollama **0.32.3**, so this is the arm64/GB10 build lacking `mllama` rather than a version skew — *observed, not proven*, since confirming would mean pulling 7.3 GiB onto a P40 that can't spare it.

So this isn't a like-for-like relocation: **it replaces a model that never functioned with one that does.**

## Candidate verified end-to-end

`qwen2.5vl:3b`, against a **real camera snapshot** using Frigate's own person prompt:

| | |
|---|---|
| cold | 45.4 s |
| **warm** | **1.5 s**, 31 tokens |
| item detection | ✅ correctly described the held item — what the prompt explicitly asks for |

⚠️ **Caveat:** it names the surroundings (*"on a patio"*) despite the prompt saying not to. Small models honour negative constraints less reliably. That's prompt-tunable and worth one iteration once descriptions are actually flowing — but it isn't perfect out of the box, and you should expect to tune.

## Headroom — measured, not predicted

```
bge-m3         0.62 GiB
qwen2.5-coder  4.58 GiB
qwen2.5vl:3b   2.79 GiB   <- the VLM (3.2 GB on disk, 2.79 resident)
---------------------------
total          7.99 GiB   of ~13 GiB  ->  ~4.2 GiB for Immich CLIP bursts
```

The earlier *"deliberately NOT 3"* reasoning was scoped to a third **7b-class** model (~10.7 GiB resident, ~2.3 GiB left — the 2026-05-18 VRAM-exhaustion zone). That still holds; this third model is far smaller. ~4.2 GiB is roughly double the incident configuration, but **tighter than the current 2-model layout**, so the inline comment names it as the first thing to reconsider if CLIP starts spilling to CPU.

## Not in this PR

Frigate's own config (`genai.base_url` + `model`) lives on the **PVC, not git**, and applying it needs a **frigate restart** — the provider only initialises at startup. Frigate is **Renee-facing**, so that waits for the Tuesday 02:00–04:00 window or explicit approval.

Until then this change is inert: the slot exists, the VLM is pulled, and nothing routes to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)