### PR TITLE
fix(ai): drop the tools filter — it was suppressing MCP tools

### DIFF
--- a/kubernetes/apps/ai/opencode/app/kustomization.yaml
+++ b/kubernetes/apps/ai/opencode/app/kustomization.yaml
@@ -18,6 +18,11 @@ configMapGenerator:
   #   1. mcp.lovenet-gateway.url -> internal broker svc (no Authelia JWT
   #      needed in-cluster; the public mcp.${SECRET_DOMAIN} route is what
   #      carries the SecurityPolicy JWT check). No Bearer header.
+  #   0. NO `tools` block. The gateway is disabled, so the old
+  #      `lovenet-gateway_*: false` guard had nothing to guard — and with it
+  #      present the model saw only built-in tools even though `opencode mcp
+  #      list` reported memory as connected. Removing it is the test for
+  #      whether that filter was suppressing MCP tools. (tools block removed)
   #   2. instructions[] points at the REPOS' own conventions
   #      (.agents/instructions/*.md, AGENTS.md) — not the workstation's
   #      personal vault files (~/.claude-personal/CLAUDE.md,

--- a/kubernetes/apps/ai/opencode/app/resources/opencode.json
+++ b/kubernetes/apps/ai/opencode/app/resources/opencode.json
@@ -40,10 +40,6 @@
   },
   "model": "vllm-driver/qwen3.6-35b-a3b",
   "small_model": "ollama-p40/qwen2.5-coder:7b",
-  "tools": {
-    "lovenet-gateway_*": false,
-    "memory_*": true
-  },
   "instructions": [
     ".agents/instructions/*.md",
     "AGENTS.md",


### PR DESCRIPTION
## Evidence

`opencode mcp list` **inside the pod**:

```text
●  ✓ memory            connected   http://memory-mcp.mcp-system.svc.cluster.local:8070/mcp
●  ○ lovenet-gateway   disabled    (as configured)
```

Yet the model enumerates only built-ins:

```text
apply_patch, bash, edit, glob, grep, question, read, skill, todowrite, webfetch, websearch, write
```

The only thing between a connected MCP server and the model was:

```json
"tools": { "lovenet-gateway_*": false, "memory_*": true }
```

The gateway is disabled, so that guard was guarding nothing. Removing it is the decisive test for whether the filter suppresses MCP tools.

## Reproduced locally

The workstation config carries the same `"lovenet-gateway_*": false`, and a local server shows the **identical** built-ins-only list — while `opencode mcp list` reports all 7 servers connected. So this is opencode behaviour, not a cluster or manifest problem.

## Acceptance

A prompt asking the agent to enumerate its tools must include `memory_*` entries. Anything less and the filter was not the cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)