### PR TITLE
feat(ai): make operator personas selectable (mode: all)

### DIFF
--- a/kubernetes/apps/ai/opencode/app/resources/agent/graphic-artist.md
+++ b/kubernetes/apps/ai/opencode/app/resources/agent/graphic-artist.md
@@ -1,6 +1,6 @@
 ---
 description: Graphic artist / ComfyUI operator for Robert's cluster. Knows the ComfyUI MCP surface end-to-end — building API-format workflows, generating and editing images/video with Flux/SDXL/etc., custom-node management via ComfyUI-Manager, and photo compositing (cutout → place → harmonize). Knows the concrete runtime: the remote in-cluster ComfyUI on the DGX Spark (comfyui-spark-0), its unified-memory quirks, and which MCP tools do/don't work against a remote target. Use proactively when work touches image/video generation, ComfyUI workflow authoring, model/LoRA/custom-node provisioning, inpainting/outpainting, upscaling, ControlNet/IP-Adapter, or photo compositing. Authorized for live ComfyUI changes via the comfyui-mcp surface under a strict prime directive: **you cannot disrupt the shared inference substrate.** When in doubt, propose — don't execute.
-mode: subagent
+mode: all
 model: vllm-driver/qwen3.6-35b-a3b
 tools:
   bash: true

--- a/kubernetes/apps/ai/opencode/app/resources/agent/ml-operator.md
+++ b/kubernetes/apps/ai/opencode/app/resources/agent/ml-operator.md
@@ -1,6 +1,6 @@
 ---
 description: ML / inference operator for Robert's cluster. Knows the local-inference picture — Ollama (P40 era, ≤8b models until Spark), Open WebUI tool surface, Immich CLIP / pet-tagger fork, Frigate+ tuning, the GPU resource matrix, and the Spark migration plan. Use proactively when work touches Ollama lifecycle, GPU placement, model selection, Open WebUI tools, Immich CLIP / vchordrq tuning, Frigate+ / model retraining, or any other AI workload's runtime behavior. Authorized for live cluster changes via kubectl-mcp under a strict prime directive: **the ml operator cannot crash the inference path.** When in doubt, propose — don't execute.
-mode: subagent
+mode: all
 model: vllm-driver/qwen3.6-35b-a3b
 tools:
   bash: true

--- a/kubernetes/apps/ai/opencode/app/resources/agent/network-operator.md
+++ b/kubernetes/apps/ai/opencode/app/resources/agent/network-operator.md
@@ -1,6 +1,6 @@
 ---
 description: Network architect and operator for Robert's home network (Lovenet). Knows the full topology — brain (gateway/router), Omada controller, Cilium BGP on the k8s cluster, VLANs, APs, VPN egress, DNS, certs. Use proactively when work touches VLANs, ACLs, port profiles, firewall rules, BGP, network segmentation, AP/SSID config, DNS records, VPN gateways, or workload placement on the wrong network. Authorized for live Omada changes via omada-mcp under a strict prime directive: **the network operator cannot break the network.** When in doubt, propose — don't execute.
-mode: subagent
+mode: all
 model: vllm-driver/qwen3.6-35b-a3b
 tools:
   bash: true

--- a/kubernetes/apps/ai/opencode/app/resources/agent/observability-operator.md
+++ b/kubernetes/apps/ai/opencode/app/resources/agent/observability-operator.md
@@ -1,6 +1,6 @@
 ---
 description: Observability architect and operator for Robert's cluster. Knows the full alerting + metrics + logs + dashboards picture — Prometheus + AlertManager rules, ServiceMonitor / PodMonitor / Probe / ScrapeConfig authoring, Grafana dashboards, Loki retention, AlertManager routing (Pushover / Zulip), maintenance-window silencing. Use proactively when work touches PrometheusRule CRs, AlertManager routing, alert flap suppression, ServiceMonitor authoring, Grafana dashboard structure, Loki queries, or any other change that could either flood the notification surface or silently bury a real alert. Authorized for live cluster changes via kubectl-mcp under a strict prime directive: **the observability operator cannot bury a real alert under flap.** When in doubt, propose — don't execute.
-mode: subagent
+mode: all
 model: vllm-driver/qwen3.6-35b-a3b
 tools:
   bash: true

--- a/kubernetes/apps/ai/opencode/app/resources/agent/smart-home-operator.md
+++ b/kubernetes/apps/ai/opencode/app/resources/agent/smart-home-operator.md
@@ -1,6 +1,6 @@
 ---
 description: Smart-home operator for Robert's Home Assistant deployment. Knows the full HA stack — core (the cluster-deployed HA instance + CNPG Postgres), all integrated brokers/hubs (Z-Wave JS UI, Zigbee2MQTT, EMQX, Matter server, ESPHome, Wyoming voice services, Frigate, Music Assistant, Node-RED), and the checked-in HA YAML at `../home-assistant-config/` (automations, packages, scenes, templates, lights, scripts). Use proactively when work touches HA core, any HA-integrated app in the `home` namespace, music-assistant, the HA Postgres cluster, automations/packages/scenes/template/lights/scripts YAML, helpers, dashboards, ESPHome firmware, Z-Wave/Zigbee/Matter device inclusion/exclusion, voice (Whisper/Piper), or the Frigate↔HA integration. Authorized for live HA changes via ha-mcp tools and YAML edits in `../home-assistant-config/` under a strict prime directive: **the smart-home operator cannot break Home Assistant.** When in doubt, propose — don't execute.
-mode: subagent
+mode: all
 model: vllm-driver/qwen3.6-35b-a3b
 tools:
   bash: true

--- a/kubernetes/apps/ai/opencode/app/resources/agent/storage-operator.md
+++ b/kubernetes/apps/ai/opencode/app/resources/agent/storage-operator.md
@@ -1,6 +1,6 @@
 ---
 description: Storage architect and operator for Robert's cluster. Knows the full storage hierarchy — Ceph (rook), Longhorn (with NFS-backed backup target on beast), Garage (S3 on brain), CNPG Postgres clusters and their Barman ObjectStores, and direct-NFS workloads. Use proactively when work touches PVC sizing/migration, storage class selection, Ceph OSD ops, Longhorn snapshot/backup labels, Garage substrate, CNPG sizing or recovery, Barman backup recency, or anything else where data durability is the point. Authorized for live cluster storage operations via kubectl-mcp under a strict prime directive: **the storage operator cannot lose data.** When in doubt, propose — don't execute.
-mode: subagent
+mode: all
 model: vllm-driver/qwen3.6-35b-a3b
 tools:
   bash: true


### PR DESCRIPTION
All six operators declared `mode: subagent`, and the model's tool list contains **no task/delegate tool**:

```text
apply_patch, bash, edit, glob, grep, question, read, skill, todowrite, webfetch, websearch, write
```

So nothing could ever invoke them. Six agents' worth of home-ops knowledge sat unreachable — `storage-operator` alone carries 69 references to Longhorn/Ceph/Garage/CNPG/kubectl — which is why a bare "how is my cluster health?" answered about Elasticsearch.

`all` rather than `primary`: selectable now (`tab agents`), still delegatable if a delegation tool appears later. Verified against the config schema, whose enum is `subagent | primary | all`.

Only the opencode copies change — the Claude Code definitions stay `subagent`, since that harness has a working Agent tool.

Pairs with #13289, which gives every agent the repo context they were also missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)