### PR TITLE
feat(ai): keep Frigate's VLM warm — probe + OLLAMA_KEEP_ALIVE=30m

### DIFF
--- a/kubernetes/apps/ai/ollama/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/ollama/app/helmrelease.yaml
@@ -53,6 +53,25 @@ spec:
               # https://github.com/ollama/ollama/blob/main/docs/faq.md#how-can-i-set-the-quantization-type-for-the-kv-cache
               OLLAMA_KV_CACHE_TYPE: q8_0
               OLLAMA_FLASH_ATTENTION: 1
+              # Raised from ollama's 5m default on 2026-07-26. Frigate's
+              # GenAI VLM was aging out between detections, so real
+              # descriptions paid ~38s of cold load (vision projector
+              # included) against ~1.5s warm.
+              #
+              # This is GLOBAL — ollama has no per-model TTL — so it also
+              # pins bge-m3 and qwen2.5-coder for longer. That is the real
+              # cost: the resident FLOOR rises, where previously models
+              # decayed between bursts, and that floor eats Immich CLIP
+              # burst headroom on a GPU that also serves Renee's whisper.
+              # The measured ceiling is unchanged at 7.99 GiB.
+              #
+              # 30m rather than infinite: long enough that the 5-min
+              # ollama-vlm-warm probe always lands inside the window, short
+              # enough that a genuinely idle stretch still releases VRAM.
+              # The two are a PAIR — changing the probe cadence or this TTL
+              # without re-checking the other reintroduces the cold-load
+              # penalty (cadence must stay well inside TTL).
+              OLLAMA_KEEP_ALIVE: 30m
               # Tightened 2026-05-18 (Phase 0d audit caught CPU-spill from
               # P40 VRAM exhaustion): NUM_PARALLEL=4 × KV cache at 16384
               # context blew past 24 GiB VRAM headroom after immich-ml

--- a/kubernetes/apps/ai/ollama/app/prometheusrule.yaml
+++ b/kubernetes/apps/ai/ollama/app/prometheusrule.yaml
@@ -50,7 +50,44 @@ spec:
               (4) probe payload changed / model removed — check the
                   ollama-embed Probe + ollama_embed module definition.
           expr: |-
-            probe_success{instance=~"https?://ollama\\.ai\\.svc.*"} == 0
+            probe_success{instance=~"https?://ollama\\.ai\\.svc.*/api/embed"} == 0
           for: 5m
           labels:
             severity: critical
+        # Frigate's GenAI VLM path. Separate from the embed probe above
+        # because they fail independently — the embedder can be fine while
+        # the VLM is evicted, unloadable, or mid-cold-load — and because
+        # the runbooks differ.
+        #
+        # NOTE the embed alert's matcher was narrowed to `/api/embed` when
+        # this was added. It previously matched any probe against
+        # ollama.ai.svc, so this VLM probe would have fired it with
+        # embed-specific runbook text.
+        #
+        # The probe doubles as the keep-warm heartbeat: at a 5-min cadence
+        # inside a 30-min OLLAMA_KEEP_ALIVE it holds qwen2.5vl:3b resident,
+        # which is what keeps Frigate's descriptions at ~1.5s instead of
+        # the ~38s cold-load path. So a sustained failure here means both
+        # "no wedge detection" AND "descriptions have gone slow".
+        - alert: OllamaVlmWedged
+          annotations:
+            summary: ollama (P40) VLM probe failing (Frigate GenAI degraded)
+            description: |
+              The ollama-vlm-warm Probe (POST /api/generate against
+              qwen2.5vl:3b) has been failing for ≥10 minutes. Frigate
+              event descriptions will be missing or very slow. Checks:
+              (1) model present — `kubectl -n ai exec ollama-0 -c main --
+                  ollama list | grep qwen2.5vl`;
+              (2) VRAM pressure — three models plus Immich CLIP share the
+                  P40; `nvidia-smi` and see
+                  reference_p40_ollama_model_thrash_and_vram_budget;
+              (3) ollama worker hung — `kubectl -n ai rollout restart
+                  sts ollama`;
+              (4) if only latency degraded, confirm OLLAMA_KEEP_ALIVE is
+                  still longer than the probe interval, otherwise the
+                  model ages out between probes and every call cold-loads.
+          expr: |-
+            probe_success{instance=~"https?://ollama\\.ai\\.svc.*/api/generate"} == 0
+          for: 10m
+          labels:
+            severity: warning

--- a/kubernetes/apps/observability/exporters/blackbox-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/exporters/blackbox-exporter/app/helmrelease.yaml
@@ -80,6 +80,35 @@ spec:
             valid_status_codes: [200]
           prober: http
           timeout: 10s
+        # Generation prober for Frigate's GenAI VLM on the P40. Serves two
+        # purposes at once, exactly as ollama_embed does for bge-m3: it is
+        # the wedge detector AND the keep-warm heartbeat that holds
+        # qwen2.5vl:3b resident, so Frigate's descriptions run at ~1.5s
+        # instead of the ~38s cold-load path.
+        #
+        # Deliberately TEXT-ONLY. A vision request would mean inlining a
+        # ~95 KB base64 image into these chart values, and it buys nothing:
+        # ollama loads the vision projector as part of the runner
+        # (`load_hparams: projector: qwen2.5vl_merger` appears even on a
+        # text-only load), so a text prompt keeps the whole model warm.
+        #
+        # 45s timeout absorbs a genuine cold load; warm calls return in
+        # about a second. num_predict=1 keeps the generated work trivial —
+        # the point is residency, not output.
+        ollama_generate:
+          http:
+            body: |-
+              {"model":"qwen2.5vl:3b","prompt":"ping","stream":false,"options":{"num_predict":1}}
+            fail_if_body_not_matches_regexp:
+              - "\"response\""
+            headers:
+              Content-Type: application/json
+            method: POST
+            preferred_ip_protocol: "ip4"
+            valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
+            valid_status_codes: [200]
+          prober: http
+          timeout: 45s
         tcp_connect:
           prober: tcp
           tcp:

--- a/kubernetes/apps/observability/exporters/blackbox-exporter/app/probes.yaml
+++ b/kubernetes/apps/observability/exporters/blackbox-exporter/app/probes.yaml
@@ -170,6 +170,35 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: Probe
 metadata:
+  name: ollama-vlm-warm
+spec:
+  # Frigate's GenAI VLM (qwen2.5vl:3b) on the P40. Wedge detector AND
+  # keep-warm heartbeat, the same dual role ollama-embed plays for bge-m3.
+  #
+  # 5m is chosen against OLLAMA_KEEP_ALIVE=30m, not independently: the
+  # probe only holds the model resident while its cadence stays well
+  # inside the TTL. If either value is changed, re-check the pair —
+  # cadence > TTL means the model ages out between probes and every
+  # Frigate description pays the ~38s cold load again.
+  #
+  # 50s scrapeTimeout against the module's 45s: the module must be the
+  # thing that times out, so a cold load surfaces as a slow success
+  # rather than a scrape error.
+  interval: 5m
+  scrapeTimeout: 50s
+  module: ollama_generate
+  prober:
+    url: blackbox-exporter.observability.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - http://ollama.ai.svc.cluster.local:11434/api/generate
+
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/probe_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
   name: tei-embed-spark-embed
 spec:
   # Wedge detector for tei-embed-spark, which took over RAG embeddings


### PR DESCRIPTION
## Why

Frigate's first real GenAI call measured **38.5 s** against **1.5 s** warm. The VLM was aging out of ollama's 5 m default between detections, so nearly every description paid a cold load — vision projector included.

## Two halves, deliberately paired

**1. `ollama-vlm-warm` Probe (5 m)** using a new `ollama_generate` blackbox module.

Same dual role `ollama-embed` already plays for bge-m3 — **wedge detector _and_ keep-warm heartbeat**. That's the established pattern in this cluster rather than a new mechanism; the existing probe's comment already describes itself as *"the heartbeat that prevents bge-m3 from being evicted."*

**Text-only on purpose.** A vision request would mean inlining a ~95 KB base64 image into the chart values, and it buys nothing — ollama loads the vision projector as part of the runner. Verified: `load_hparams: projector: qwen2.5vl_merger` appears on a *text-only* load, and a text call leaves `qwen2.5vl` resident.

**2. `OLLAMA_KEEP_ALIVE=30m`.**

⚠️ This is **global** — ollama has no per-model TTL — so it also pins bge-m3 and qwen2.5-coder longer. That's the real cost, and it's worth being explicit about:

| | before | after |
|---|---|---|
| resident **ceiling** | 7.99 GiB | 7.99 GiB (unchanged) |
| resident **floor** | decayed toward ~0 between bursts | ~3.4 GiB held (bge-m3 + VLM) |

The rising floor eats Immich CLIP burst headroom on a GPU that also serves Renee's whisper. **30 m rather than infinite** so a genuinely idle stretch still releases VRAM, while the 5-min probe always lands inside the window.

Cadence and TTL are a **pair** — both comments say so, because changing either alone silently restores the cold-load penalty.

## Fixes an overlap this would otherwise have created

The existing `OllamaWedged` matcher was `instance=~"https?://ollama\.ai\.svc.*"` — which would also match the new `/api/generate` probe and fire with **embed-specific runbook text**. Narrowed to `/api/embed`, and added `OllamaVlmWedged` for `/api/generate` at severity **warning** (descriptions degrade; inference doesn't stop).

Rendered exprs are now disjoint:

```
probe_success{instance=~"https?://ollama\\.ai\\.svc.*/api/embed"}    == 0
probe_success{instance=~"https?://ollama\\.ai\\.svc.*/api/generate"} == 0
```

## Verified before commit

Probe payload run verbatim against live ollama:

```
{"model":"qwen2.5vl:3b","prompt":"ping","stream":false,"options":{"num_predict":1}}
-> 692ms, "response" present, done=true, eval_count=1
```

Also: blackbox is **already** admitted to `ai/ollama` (the existing ollama-embed probe proves the path), so **no CNP change is needed** — checked rather than assumed, given three CNP asymmetries surfaced in this repo over the last two days.

`yamllint` clean, both kustomizations build, rendered output confirms `KEEP_ALIVE=30m`, the new module, and the new Probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)