### PR TITLE
fix(flux): make kustomize-mutating-webhook HA (1 → 3 replicas)

### DIFF
--- a/kubernetes/apps/flux-system/kustomize-mutating-webhook/app/values.yaml
+++ b/kubernetes/apps/flux-system/kustomize-mutating-webhook/app/values.yaml
@@ -2,7 +2,30 @@
 image:
   repository: ghcr.io/xunholy/kustomize-mutating-webhook
   tag: 0.12.0@sha256:004c1d33626891260ded4d826848a3451792bbcd02824250d7a1fbda08192c20
-replicas: 1
+# Raised 1 -> 3 on 2026-07-26. This webhook is a hard dependency of every
+# Flux Kustomization apply (rules: kustomizations CREATE/UPDATE, and
+# failurePolicy: Fail), so a single replica made it a single point of
+# failure for ALL GitOps. It failed four separate times on 2026-07-25/26
+# — tempo, goldilocks, memory-mcp, vector-agent — each surfacing as
+#   "failed calling webhook ...: the server has received too many
+#    requests and has asked us to try again later"
+# and each halting cluster-apps until it happened to succeed on retry.
+#
+# Measured before changing anything, so this is not a guess:
+#   702 mutations / 30 min, median 0.70s, max 4.92s (timeout is 10s)
+#   CPU usage 2.7 millicores, CFS throttling 0.14%
+# Near-zero CPU at 0.7s latency means it is blocked on I/O, not compute —
+# so more CPU would have done nothing. The webhook reads cluster-config
+# and cluster-secrets per mutation, and client-go's default rate limiter
+# (QPS 5 / burst 10) is per-process. Under a ~167-Kustomization reconcile
+# wave, requests queue behind that limiter until they pass the 10s
+# webhook timeout.
+#
+# Replicas are therefore the correct lever: each pod carries its own
+# client-go limiter and its own informer cache, so N replicas multiply
+# the aggregate ceiling. 3 also means a node drain or rolling update no
+# longer takes the whole admission path down.
+replicas: 3
 certManager:
   enabled: true
 configMaps:
@@ -12,15 +35,28 @@ secrets:
   - create: false
     name: cluster-secrets
 env:
-  LOG_LEVEL: debug
+  # debug -> info on 2026-07-26. At debug this logs the ENTIRE generated
+  # patch on every mutation — a ~2 KB JSON blob, 702 times per 30 min —
+  # which is both latency on the hot path and a large amount of Loki
+  # ingestion for no steady-state value. Raise it back temporarily when
+  # actually debugging substitution behaviour.
+  LOG_LEVEL: info
 # Chart NP egress uses ipBlock 0.0.0.0/0 for 443/6443, which Cilium does
 # not match against the kube-apiserver (host-network identity, separate
 # from `world`). With it enabled, the 0.11.0 informer hangs on its
 # initial LIST/WATCH and /ready never returns 200.
 networkpolicy:
   create: false
+# Re-enabled 2026-07-26, restoring the chart default (enabled,
+# minAvailable: 1). It was almost certainly disabled *because* replicas
+# was 1: minAvailable 1 against a single replica makes that node
+# permanently undrainable, which is worse than having no PDB. At 3
+# replicas the same setting is correct — it allows draining two at once
+# while guaranteeing the admission path never reaches zero pods, which
+# matters a lot here because failurePolicy is Fail.
 podDisruptionBudget:
-  enabled: false
+  enabled: true
+  minAvailable: 1
 resources:
   requests:
     cpu: 25m


### PR DESCRIPTION
## The problem

This webhook gates **every** Flux Kustomization apply — `rules: kustomizations CREATE/UPDATE` with **`failurePolicy: Fail`** — so at one replica it was a single point of failure for *all* GitOps.

It failed **four separate times** on 2026-07-25/26:

| when | victim |
|---|---|
| session start | `tempo` |
| midday | `goldilocks` |
| during a merge | `memory-mcp` (stalled it ~1 hour) |
| this evening | `vector-agent` |

Each surfaced as:

```
failed calling webhook ...: the server has received too many requests
and has asked us to try again later
```

…halting `cluster-apps` until a retry happened to land.

## Diagnosis — measured, and it killed my first hypothesis

| metric | value |
|---|---|
| mutations | **702 / 30 min** |
| latency | median **0.70 s**, max **4.92 s** (timeout 10 s) |
| CPU usage | **2.7 millicores** |
| CFS throttling | **0.14 %** |

I expected CPU starvation — the pod requests only 25m. **It isn't throttled and barely uses CPU.** Near-zero CPU at 0.7 s latency means it's blocked on **I/O, not compute**, so adding CPU would have done nothing.

The webhook reads `cluster-config` and `cluster-secrets` per mutation, and **client-go's default rate limiter (QPS 5 / burst 10) is per-process**. Under a ~167-Kustomization reconcile wave, requests queue behind that limiter until they pass the 10 s webhook timeout.

**That makes replicas the lever that actually applies** — each pod carries its own client-go limiter and informer cache, so N replicas multiply the aggregate ceiling.

## Changes

1. **`replicas: 1 → 3`.** Worth noting the chart's own default is `replicas: 2` — this deployment had explicitly opted *out* of upstream's HA posture. 3 leaves two serving during a rolling update.

2. **PodDisruptionBudget re-enabled** (chart default, `minAvailable: 1`). It was almost certainly disabled *because* replicas was 1 — `minAvailable: 1` against a single replica makes that node **permanently undrainable**, which is worse than no PDB. At 3 replicas the same setting is correct and guarantees the admission path never reaches zero pods, which matters precisely because `failurePolicy: Fail`.

3. **`LOG_LEVEL: debug → info`.** At debug it logs the *entire generated patch* on every mutation — 702 times per 30 min. That's latency on the hot path and substantial Loki ingestion for no steady-state value.

## Verified

`helm template` dry-run against the pinned 0.12.0 chart renders `Deployment replicas: 3` and a `PodDisruptionBudget` with `minAvailable: 1`. `yamllint` clean, kustomization builds.

## ⚠️ Risk

Because this component gates Kustomization applies, **a failed rollout would prevent Git from reverting itself.** Mitigating factors: the image is unchanged (only replica count, log level, PDB), `RollingUpdate` holds the old pod until new ones are Ready, and the HelmRelease already has rollback remediation configured.

Escape hatch if ever needed: remove the `MutatingWebhookConfiguration` to open the admission path, then reconcile.

Worth watching the first reconcile wave after this lands to confirm the 429s stop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)