### PR TITLE
feat(observability): alert on admission-webhook call failures

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/kustomization.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
+  - ./prometheusrule-admission-webhooks.yaml
   - ./prometheusrule-cilium-drops.yaml
   - ./prometheusrule-egress-detection.yaml
   - ./prometheusrule-node-disk-io.yaml

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/prometheusrule-admission-webhooks.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/prometheusrule-admission-webhooks.yaml
@@ -1,0 +1,117 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: admission-webhooks
+spec:
+  groups:
+    # Admission-webhook availability. Nothing watched this before
+    # 2026-07-26, and the gap was expensive: kustomize-mutating-webhook
+    # accumulated 200 rejections (503 x 107, 429 x 93) while silently
+    # halting cluster-apps FOUR separate times over two days — tempo,
+    # goldilocks, memory-mcp and vector-agent. Each was diagnosed
+    # individually, from scratch, as "GitOps is stuck again". The counter
+    # had the answer the whole time; nothing was reading it.
+    #
+    # Metric: `apiserver_admission_webhook_rejection_count`, emitted by
+    # kube-apiserver. Two properties make it the right signal:
+    #   - it is APISERVER-side, so it records rejections and timeouts the
+    #     webhook pod itself never logs (see
+    #     reference_measure_admission_webhooks_from_apiserver);
+    #   - `error_type` separates infrastructure failure from policy.
+    #
+    # `error_type="calling_webhook_error"` is the whole reason this alert
+    # is not noisy. It means the apiserver could not get a usable answer —
+    # unreachable, 5xx, throttled, timed out. A validating webhook
+    # *correctly* denying a bad resource does NOT carry this error_type,
+    # so ordinary policy enforcement never fires this.
+    #
+    # Emitted per-apiserver instance, hence the sum by (name).
+    - name: admission-webhooks.availability
+      rules:
+        # Any webhook failing calls. Warning rather than critical because
+        # the blast radius depends on failurePolicy, which the metric does
+        # not expose: with Ignore the request proceeds unmutated (bad, but
+        # not an outage), with Fail the request is rejected outright.
+        # The runbook says to check that first.
+        - alert: AdmissionWebhookRejectingRequests
+          annotations:
+            summary: >-
+              Admission webhook {{ $labels.name }} is failing calls
+              ({{ $labels.rejection_code }})
+            description: |
+              kube-apiserver could not get a usable response from
+              admission webhook {{ $labels.name }} — rejection_code
+              {{ $labels.rejection_code }}, error_type
+              calling_webhook_error. Requests to the resources it
+              intercepts are being rejected or passed through unmutated.
+
+              First question, because it decides the severity:
+                `kubectl get mutatingwebhookconfiguration,validatingwebhookconfiguration
+                 -o custom-columns=NAME:.metadata.name,POLICY:.webhooks[*].failurePolicy`
+              failurePolicy=Fail means the intercepted operations are
+              hard-failing right now.
+
+              Common causes, in the order they actually occur here:
+                (1) 503 = no ready endpoint. A single-replica webhook
+                    returns this on every restart, eviction or brief
+                    unreadiness. Check replica count FIRST — this is
+                    exactly what bit kustomize-mutating-webhook.
+                (2) 429 = the webhook shedding load under burst; scale it
+                    out rather than up (latency is rarely the axis).
+                (3) cert expiry / SNI mismatch — check the webhook's
+                    Certificate and its caBundle.
+
+              Do NOT diagnose from the webhook pod's own logs alone; they
+              routinely omit the rejections the apiserver is counting.
+          expr: |-
+            sum by (name, rejection_code) (
+              increase(apiserver_admission_webhook_rejection_count{error_type="calling_webhook_error"}[10m])
+            ) > 0
+          for: 5m
+          labels:
+            severity: warning
+        # kustomize-mutating-webhook specifically, at critical. It gates
+        # EVERY Flux Kustomization apply (rules: kustomizations
+        # CREATE/UPDATE) with failurePolicy: Fail, so when it fails the
+        # entire GitOps reconcile loop stops — which is a different class
+        # of problem from one app's webhook misbehaving.
+        #
+        # Deliberately duplicates the generic alert above for this one
+        # webhook, matching the pattern used elsewhere in this repo
+        # (generic BlackboxProbeFailed plus app-specific wedge alerts with
+        # richer runbook). One root cause, two notifications, accepted.
+        - alert: FluxAdmissionWebhookDown
+          annotations:
+            summary: kustomize-mutating-webhook is rejecting Flux Kustomization applies
+            description: |
+              The webhook that injects postBuild substitutions into every
+              Flux Kustomization is failing calls
+              ({{ $labels.rejection_code }}). Because its failurePolicy is
+              Fail, GitOps reconciliation is stopped cluster-wide —
+              expect `flux get ks -A` to show a growing not-ready list and
+              cluster-apps stuck ReconciliationFailed.
+
+              Checks:
+              (1) `kubectl -n flux-system get deploy kustomize-mutating-webhook`
+                  — should be 3/3. At 1 replica any restart causes this.
+              (2) `kubectl -n flux-system get pdb` — minAvailable 1 should
+                  prevent a drain emptying the endpoint list.
+              (3) latency is usually NOT the cause; confirm with
+                  `apiserver_admission_webhook_admission_duration_seconds`
+                  before tuning resources (p95 is normally ~22ms).
+              (4) emergency only, with Rob: removing the
+                  MutatingWebhookConfiguration opens the admission path
+                  and lets Flux self-heal, at the cost of unsubstituted
+                  Kustomizations until it is restored.
+          expr: |-
+            sum by (rejection_code) (
+              increase(apiserver_admission_webhook_rejection_count{
+                name="kustomize-mutating-webhook.xunholy.com",
+                error_type="calling_webhook_error"
+              }[10m])
+            ) > 0
+          for: 5m
+          labels:
+            severity: critical


### PR DESCRIPTION
## Why

Nothing watched admission webhooks. The gap was expensive: `kustomize-mutating-webhook` accumulated **200 rejections** (503 × 107, 429 × 93) while silently halting `cluster-apps` **four separate times** in two days — tempo, goldilocks, memory-mcp, vector-agent.

Each was diagnosed from scratch as *"GitOps is stuck again."* **The counter held the answer the whole time and nothing was reading it.**

## Two rules

Mirrors the generic-plus-specific pattern this repo already uses for blackbox probes.

| Alert | Scope | Severity |
|---|---|---|
| `AdmissionWebhookRejectingRequests` | every webhook | warning |
| `FluxAdmissionWebhookDown` | `kustomize-mutating-webhook` | **critical** |

Generic is *warning* because blast radius depends on `failurePolicy`, which **the metric doesn't expose** — `Ignore` means the request proceeds unmutated (bad, not an outage), `Fail` means outright rejection. The runbook makes that the first check.

The Flux-specific one is *critical* because that webhook gates every Kustomization apply with `failurePolicy: Fail`, so its failure stops reconciliation cluster-wide — a different class of problem from one app's webhook misbehaving.

## What keeps it from being noisy

One label does the work: **`error_type="calling_webhook_error"`**. It means the apiserver couldn't get a usable answer — unreachable, 5xx, throttled, timed out. A validating webhook *correctly denying a bad resource* does **not** carry that error_type, so ordinary policy enforcement never fires this.

## Validated against live Prometheus, not assumed

```
10m window (now):  empty          -> silent post-fix, as it should be
6h window:         5 rejections   -> on kustomize-mutating-webhook
```

So the query **matches real data and would have fired during the incidents**, while staying quiet now. That's the check that matters for a new alert.

Two other webhooks already carry series — `mutator.longhorn.io` and `validate.externalsecret.external-secrets.io` — so the generic rule earns its place rather than being speculative.

## Runbooks encode what today actually cost

- **Check replica count first.** 503 = "no ready endpoint", which a single replica guarantees on any restart. That was the real cause and it took four incidents to find.
- **Scale out, not up, for 429.** Latency was never the axis — p95 admission is ~22 ms.
- **Don't diagnose from the webhook pod's own logs.** They omit the rejections the apiserver counts, and here they actively pointed the wrong way.

## Checks

`yamllint` clean, kustomization builds, both alerts render, rules validated well-formed (expr / for / severity present).

> Note: a `python3 -c yaml.safe_load_all` pass over the *combined* render errors on `matchType: =` in the pre-existing `alertmanagerconfig.yaml` — PyYAML reads a bare `=` as the YAML 1.1 value tag. Unrelated to this PR and harmless to Kubernetes; noting it so the next person doesn't chase it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)