### PR TITLE
fix(home): let frigate's snapshot sidecar reach github — it never could

### DIFF
--- a/kubernetes/apps/home/frigate/app/cnp-allow.yaml
+++ b/kubernetes/apps/home/frigate/app/cnp-allow.yaml
@@ -139,3 +139,28 @@ spec:
         - ports:
             - port: "11434"
               protocol: TCP
+    # SSH to github.com for the `snapshot` NATIVE SIDECAR that runs inside
+    # frigate-0 (initContainers.snapshot, restartPolicy: Always). It is a
+    # different pod from the nightly CronJob, so it does NOT inherit
+    # frigate-snapshot-allow — that policy selects
+    # `app.kubernetes.io/name: frigate-snapshot`, while the sidecar lives
+    # under `app.kubernetes.io/name: frigate` and lands here.
+    #
+    # Without this the sidecar has never worked. Its git clone was denied,
+    # so there was no .git, so every later git call failed with "not a git
+    # repository" and it gave up after 5 attempts — then slept forever by
+    # design ("so the pod stays Ready"), which is why the pod looked
+    # healthy while the startup snapshot silently did nothing. The feature
+    # it exists for — capturing a version-bump auto-migration the moment
+    # it happens, before the daily CronJob overwrites that state with a
+    # later edit — has therefore never once run.
+    #
+    # Same destination and port the CronJob already reaches, so this
+    # widens frigate-0's egress no further than the snapshot path already
+    # had cluster-wide.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "22"
+              protocol: TCP


### PR DESCRIPTION
## What's broken

`frigate-0` runs a **native sidecar** (`initContainers.snapshot`, `restartPolicy: Always`) that pushes `config.yml` to git on every pod startup — so a version-bump auto-migration is captured *the moment it happens*, rather than being overwritten by whatever the daily CronJob sees later.

**It has never worked.**

| CNP | selector | has `world:22` |
|---|---|---|
| `frigate-snapshot-allow` | `name: frigate-snapshot` (the **CronJob**) | ✅ |
| `frigate-allow` | `name: frigate` (frigate-0 **and its sidecar**) | ❌ |

The sidecar lives inside `frigate-0`, so it's selected by `frigate-allow` — not by the policy that actually carries the SSH rule. The CronJob could reach GitHub; the sidecar never could.

## Why it stayed invisible

Two things stacked:

```
fatal: not a git repository (or any of the parent directories): .git
ERROR: push failed after 5 attempts
Snapshot attempt failed (rc=1).
Sidecar mode: sleeping forever so pod stays Ready.
```

1. The denied `git clone` left **no `.git`**, so every later git call failed with a misleading *"not a git repository"* — nothing network-shaped in the logs.
2. The sidecar then **sleeps forever by design** so the pod stays Ready. A pod reporting healthy while one of its containers has permanently given up.

## How it surfaced

`FrigateUnauthorizedEgressAttempt` fired. Following **that alert's own runbook** produced the destination in one command:

```
home/frigate-0:33096 <> 140.82.112.4:22 (world) Policy denied DROPPED (SYN)
```

`140.82.112.4` is GitHub. Nice validation of that runbook — it said "grab Hubble flows within ~30s before the ring buffer rotates", and that's exactly what identified it.

Two Frigate restarts today made a restart-triggered failure visible that otherwise only fires during the weekly Tuesday restart cron.

## The fix

Adds the same `world:22` egress the CronJob already has.

**Blast radius:** none meaningful. It's the identical destination and port the snapshot path already reaches from this namespace. The alternative — relabelling the sidecar so it matches `frigate-snapshot-allow` — would fight the chart's pod labelling for no security gain.

## Verified

`yamllint` clean · kustomization builds · rendered `frigate-allow` now shows `toEntities=['world'] ports=['22']` alongside the existing `1935` (RTMP) rule.

Effect is visible on the **next** frigate restart — the sidecar should clone and push instead of failing, and the alert should stop firing on restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)