### PR TITLE
fix(opencode): disable MCP gateway again — in-cluster context budget

### DIFF
--- a/docs/src/mcp_tool_authz_design.md
+++ b/docs/src/mcp_tool_authz_design.md
@@ -13,8 +13,15 @@ Last updated: 2026-07-26
 > ≈ 334k tokens. Measurement showed opencode applies its `tools` filter
 > **client-side, before the model call** — an allowlisted agent sends ~12k
 > tokens of schemas, and a filtered agent's request measured 18.8k input
-> tokens with the entire gateway attached. The gateway is therefore enabled
-> for `ai/opencode` as of 2026-07-26 with a read-only allowlist.
+> tokens with the entire gateway attached.
+>
+> **However, enabling it in-cluster on 2026-07-26 still failed** and was
+> reverted the same day. The 18.8k figure came from a local `--pure` run
+> with plugins disabled. In-cluster the `oh-my-openagent` plugin injects
+> six further MCP servers, and the baseline was already 53-57k input tokens
+> before any gateway tools; ~12k of allowlisted kubectl pushed it past
+> `max_model_len` and vLLM returned 400. The context budget must be cut at
+> the baseline before the gateway can be enabled at any allowlist size.
 >
 > Nothing in the threat model below changes. The allowlist is a
 > context-budget control that happens to narrow reach; a session can still

--- a/kubernetes/apps/ai/opencode/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/opencode/app/cnp-allow.yaml
@@ -50,13 +50,22 @@ spec:
     # (14 tools / ~3.2k tokens) and avoids paying the broker's full
     # tools/list fetch just to reach memory.
     #
-    # The gateway is now ENABLED (2026-07-26). Its tools/list is 1,266 tools
+    # The gateway is DISABLED again. It was enabled 2026-07-26 and reverted
+    # the same day: see the token-budget note below.
+    # Its tools/list is 1,266 tools
     # / 1.34 MB ≈ 334k tokens, far past vLLM's hard max_model_len of 65536 —
     # which is what silently killed every turn when it was last on. The fix
     # is opencode's own tools filter: it is applied CLIENT-SIDE BEFORE the
     # model call, so an allowlisted agent sends ~12k tokens of schemas, not
-    # 334k. Measured: a filtered agent's request was 18.8k input tokens with
+    # 334k. Measured LOCALLY (--pure, plugins off): 18.8k input tokens with
     # the whole gateway attached.
+    #
+    # That local figure does NOT hold in-cluster. Here the oh-my-openagent
+    # plugin injects six more MCP servers and the baseline is already
+    # 53-57k input tokens before any gateway tools. Adding ~12k of
+    # allowlisted kubectl exceeded max_model_len and vLLM returned 400 on
+    # every turn. The baseline must be cut before the gateway can be
+    # enabled at ANY allowlist size.
     #
     # This means broker-side filtering (Kuadrant AuthPolicy — see
     # docs/src/mcp_tool_authz_design.md) is NOT required to make the gateway

--- a/kubernetes/apps/ai/opencode/app/resources/opencode.json
+++ b/kubernetes/apps/ai/opencode/app/resources/opencode.json
@@ -121,7 +121,7 @@
     "lovenet-gateway": {
       "type": "remote",
       "url": "http://mcp-gateway-istio.mcp-system.svc.cluster.local:8080/mcp",
-      "enabled": true,
+      "enabled": false,
       "headers": {
         "x-mcp-virtualserver": "opencode-readonly"
       }


### PR DESCRIPTION
**Reverts the enable in #13297. The in-cluster agent is currently broken** — vLLM returns 400 on every turn and opencode auto-compacts.

## What I got wrong

I measured a filtered agent at **18.8k input tokens** with the whole gateway attached and concluded ~12k of kubectl tools would fit in 65,536. That measurement was taken **locally with `--pure`** — plugins disabled.

In-cluster, the `oh-my-openagent` plugin injects six more MCP servers. The baseline there was **already 53–57k input tokens** before any gateway tools — visible in the earlier `memory_search` run, which I had in hand and did not carry into the estimate. Adding ~12k exceeded `max_model_len`, and vLLM rejects rather than truncating.

Evidence: `POST /v1/chat/completions 400 Bad Request` from the opencode pod IP, repeatedly.

## Kept

These are correct and independent of the enable:

- The 69-rule read-only allowlist — inert while disabled, ready for when there's room.
- The six operator agents no longer requesting broad domain families. Each would have exceeded 65536 on its own (smart-home by 120k), so this is a latent bug fixed regardless.
- The finding that client-side filtering — not Kuadrant — is what makes the gateway usable *in principle*.

## Corrected

Docs and the CNP comment now say the gateway is usable in principle but does not fit this deployment's context budget.

## Next

Cut the 53–57k baseline; the plugin's six MCP servers are the obvious target. Trimming the kubectl allowlist further is pointless — at a 53–57k baseline there is no room at any allowlist size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)