### PR TITLE
perf(opencode): stop double-loading instructions into every session

### DIFF
--- a/kubernetes/apps/ai/opencode/app/resources/opencode.json
+++ b/kubernetes/apps/ai/opencode/app/resources/opencode.json
@@ -112,8 +112,6 @@
     "lovenet-gateway_cilium_*": true
   },
   "instructions": [
-    ".agents/instructions/*.md",
-    "AGENTS.md",
     "/root/.config/opencode/instructions/HOMELAB-SPEC.md",
     "/root/.config/opencode/instructions/persona-base.md"
   ],


### PR DESCRIPTION
## Measured problem

A trivial `"Reply with exactly: OK"` prompt against the in-cluster agent costs **54,100 input tokens** — 83% of vLLM's 65,536 `max_model_len`, leaving ~11k for actual work.

| component | ~tokens |
|---|---|
| opencode core (system prompt + built-ins) | ~18,000 |
| **`instructions[]`** | **~22,700** |
| skills (7) | ~6,200 |
| MCP servers (websearch, context7, grep_app, memory) | ~5,200 |
| misc / agent prompt | ~2,000 |

The MCP servers were never the problem — all four together are 5.2k, under a quarter of what `instructions[]` costs.

## Three overlapping loads

`instructions[]` was `[".agents/instructions/*.md", "AGENTS.md", HOMELAB-SPEC, persona-base]`:

1. **opencode reads `AGENTS.md` natively** from the repo root — listing it explicitly loaded it twice (~5.2k).
2. **AGENTS.md inlines** `persona.md`, `worktree-isolation.md`, `data-classification.md` — the glob loaded those again (~2.9k). Verified by content match, not assumption.
3. **AGENTS.md indexes the other 9** under a heading that says *"Not inlined, to stay inside the context budget. Read the file when its subject comes up."* The glob force-loaded all 9 regardless (~10.3k), defeating the design.

## Change

`instructions[]` now carries only the two files that live **outside the repo** and are invisible to native AGENTS.md discovery: `HOMELAB-SPEC.md` and `persona-base.md`.

## Nothing becomes unreachable

All 12 files in `.agents/instructions/` are covered by AGENTS.md — 3 inlined, 9 indexed with an explicit read-on-demand instruction. Verified 12/12 referenced.

The 9 shift from always-resident to read-when-relevant, which is what AGENTS.md already said they were.

## Why now

Prerequisite for re-enabling the MCP gateway (reverted in the previous commit for this exact reason). The ~12k read-only kubectl allowlist has no room at a 54k baseline.

Expected new baseline ~36–41k. **I'll measure it after merge rather than predict it** — mis-predicting a baseline from the wrong environment is what caused the revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)