### PR TITLE
docs: retire langgraph-agents from present-tense comments

### DIFF
--- a/kubernetes/apps/ai/ollama/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/ollama/app/cnp-allow.yaml
@@ -30,8 +30,8 @@ spec:
     #   media/suggestarr      — LLM-driven recommendation enrichment
     #   collab/open-webui     — primary OLLAMA_BASE_URL
     #   mcp-system/*          — some MCP servers may proxy ollama calls
-    # Intra-ns callers (langgraph-agents, khoj, comfyui prompt eval) are
-    # covered by baseline allow-intra-namespace.
+    # Intra-ns callers (khoj, comfyui prompt eval) are covered by
+    # baseline allow-intra-namespace.
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: home

--- a/kubernetes/apps/ai/opencode/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/opencode/app/cnp-allow.yaml
@@ -42,8 +42,8 @@ spec:
     # dropped by mcp-gateway-broker-allow — which is why MCP was silently
     # dead here. In-cluster clients hit mcp-gateway-istio.mcp-system:8080 by
     # DNS, which mcp-gateway-istio-allow permits via `fromEntities: cluster`.
-    # Namespace-wide selector matches the langgraph-agents precedent (the
-    # reference in-cluster MCP client named in that policy's comment).
+    # Namespace-wide selector matches the convention that policy already
+    # uses for cluster-internal MCP clients.
     #
     # 8070 is memory-mcp, addressed DIRECTLY rather than through the broker.
     # It predates the gateway being usable and is kept because it is cheap

--- a/kubernetes/apps/databases/qdrant/app/cnp-allow.yaml
+++ b/kubernetes/apps/databases/qdrant/app/cnp-allow.yaml
@@ -13,11 +13,13 @@ spec:
   enableDefaultDeny:
     egress: false
     ingress: false
+  # qdrant single-pod, no cluster gossip. Egress only DNS + apiserver
+  # (baseline).
   ingress:
     # Known consumer (`http://qdrant.databases.svc.cluster.local:6333`):
     #   collab/open-webui   — VECTOR_DB=qdrant, QDRANT_URI
     # Use fromEntities: cluster on the HTTP+GRPC pair — vector DB tends
-    # to attract new consumers (LangGraph, additional RAG agents) and a
+    # to attract new consumers (additional RAG agents) and a
     # missed enumeration silently breaks RAG. Tighten in follow-up once
     # the consumer set stabilizes.
     - fromEntities:
@@ -28,5 +30,3 @@ spec:
               protocol: TCP
             - port: "6334"  # gRPC API
               protocol: TCP
-  # qdrant single-pod, no cluster gossip. Egress only DNS + apiserver
-  # (baseline).

--- a/kubernetes/apps/mcp-system/mcp-gateway/app/cnp-allow.yaml
+++ b/kubernetes/apps/mcp-system/mcp-gateway/app/cnp-allow.yaml
@@ -63,8 +63,8 @@ spec:
         - ports:
             - port: "8080"
               protocol: TCP
-    # Cluster-internal MCP clients (langgraph-agents, etc.)
-    # hit the istio Service directly by DNS; their source pods live
+    # Cluster-internal MCP clients (ai/opencode, collab/open-webui,
+    # etc.) hit the istio Service directly by DNS; their source pods live
     # in various namespaces. Allow from any namespace on 8080 — these
     # are MCP tool invocations gated by Authelia JWT at the envoy
     # SecurityPolicy layer (per project_mcp_gateway_auth_done.md).

--- a/kubernetes/apps/observability/opentelemetry-collector/app/cnp-allow.yaml
+++ b/kubernetes/apps/observability/opentelemetry-collector/app/cnp-allow.yaml
@@ -13,8 +13,8 @@ spec:
     egress: false
     ingress: false
   ingress:
-    # Cluster-wide OTLP ingress. Any pod (langgraph-agents, MCP
-    # backends, future OTel-instrumented apps) can push spans to the
+    # Cluster-wide OTLP ingress. Any pod (MCP backends, future
+    # OTel-instrumented apps) can push spans to the
     # collector at :4317 (gRPC) or :4318 (HTTP). The k8sattributes
     # processor in the pipeline tags every span with source pod
     # metadata, so we don't lose attribution by accepting from

--- a/kubernetes/apps/observability/tempo/app/cnp-allow.yaml
+++ b/kubernetes/apps/observability/tempo/app/cnp-allow.yaml
@@ -23,9 +23,9 @@ spec:
             - port: "3200"
               protocol: TCP
     # OTel collector (also in observability ns) pushes spans via OTLP
-    # gRPC 4317 and HTTP 4318. Cross-ns ingestion from ai/ namespace
-    # (langgraph-agents direct-OTLP path) covered by the same
-    # endpoint-selector match; we intentionally allow OTLP from any
+    # gRPC 4317 and HTTP 4318. Cross-ns direct-OTLP ingestion is
+    # covered by the same endpoint-selector match; we intentionally
+    # allow OTLP from any
     # pod in the cluster to simplify Phase 3.K rollout. Tighten when
     # the OTel collector becomes the canonical path.
     - fromEntities:

--- a/kubernetes/apps/observability/tempo/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/tempo/app/helmrelease.yaml
@@ -28,9 +28,9 @@ spec:
       # short enough that the PVC stays sized at 50Gi.
       retention: 336h
 
-      # OTLP receivers — Phase 3.K propagates `trace_id` from
-      # langgraph-agents (and any other OTel-instrumented workload)
-      # via the OTel collector deployed alongside (2.J2). Tempo accepts
+      # OTLP receivers — Phase 3.K propagates `trace_id` from any
+      # OTel-instrumented workload via the OTel collector deployed
+      # alongside (2.J2). Tempo accepts
       # OTLP directly so a single-app pipeline (skip-collector) also
       # works for early debugging.
       receivers:


### PR DESCRIPTION
The langgraph-agents fleet was decommissioned 2026-07-06. Seven comments
still name it as a **current** traffic source or a **future** consumer. Two
of them sit directly above broad `fromEntities: cluster` rules, so a
decommissioned workload reads as live justification for a wide policy.

## Zero-risk by construction

Comments only. Every touched file parses to byte-identical YAML before and
after:

```
for f in $(git diff --name-only main); do
  diff <(git show main:$f | yq -o=json -P) <(yq -o=json -P $f)
done   # empty for all 7
```

Flux sees no change. **No policy is narrowed here** — retiring the example
does not change who the rules admit. Tightening the `fromEntities: cluster`
rules on qdrant / tempo / otel-collector / mcp-gateway is a separate,
deliberate call and not smuggled into a docs PR.

## Changed

| File | Was |
|---|---|
| `ai/ollama/cnp-allow.yaml` | listed langgraph-agents as a current intra-ns caller |
| `ai/opencode/cnp-allow.yaml` | cross-referenced mcp-gateway's now-reworded comment |
| `databases/qdrant/cnp-allow.yaml` | named LangGraph as a future consumer |
| `mcp-system/mcp-gateway/cnp-allow.yaml` | "MCP clients (langgraph-agents, etc.)" → the real ones |
| `observability/tempo/cnp-allow.yaml` | "langgraph-agents direct-OTLP path" |
| `observability/tempo/helmrelease.yaml` | "propagates trace_id from langgraph-agents" |
| `observability/opentelemetry-collector/cnp-allow.yaml` | "Any pod (langgraph-agents, …)" |

Plus: qdrant's trailing egress note moves above `ingress:`, under the
`enableDefaultDeny` block it actually explains. It tripped a **pre-existing**
yamllint `comments-indentation` warning — present on `main`, surfaced here
only because the file got staged. No indent clears it at EOF; the rule wants
a comment to precede content.

## Deliberately left alone

- **Historical-precedent notes** (`tei-spark`, `open-webui` "matches the
  langgraph-agents convention") — these stay true after the fleet is gone.
  Rewriting them would destroy provenance.
- **`prometheusrule-pod-pending.yaml`**'s 2026-05-18 incident reference —
  dated history, not a stale claim.
- **Everything naming `postgres-langgraph-memory`.** Despite the name this is
  *not* fleet residue — it backs `memory-mcp` (`memory-mcp/ks.yaml` dependsOn,
  helmrelease credential ref, cnp-allow selector) and is actively serving a
  healthy 3-instance cluster on 42Gi of ceph-block. Do not delete it; the name
  is the only thing wrong with it.
- **`alertmanagerconfig.yaml`** and **`ml-operator.md`** — both already
  document the 2026-07-06 removal correctly.

## Known follow-up, not in this PR

`home/windmill/workflows/windmill-failure-watcher.ts` still lists the dead
flow `f/lovenet/langgraph-dlq-watcher` in `TOLERANT_PATHS` (harmless — the set
membership check never matches), and its self-recursion-risk header cites "the
langgraph-dlq-watcher Pushover" as a mitigation that no longer exists. Left
out on purpose: that file's own header documents that git edits don't reach
Windmill without `wmill sync`, so changing it here would create exactly the
git↔Windmill drift the watcher was built to catch. Wants its own PR plus the
sync step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
