### PR TITLE
chore(windmill): retire dead langgraph-dlq-watcher reference from failure-watcher

### DIFF
--- a/kubernetes/apps/home/windmill/workflows/windmill-failure-watcher.ts
+++ b/kubernetes/apps/home/windmill/workflows/windmill-failure-watcher.ts
@@ -19,9 +19,11 @@
 // invoked via setState/getState helpers from npm:windmill-client).
 //
 // Self-recursion risk: if this watcher itself fails, no one knows.
-// Mitigation: BlackboxProbe on windmill /api/version catches the
-// "Windmill is down" case; the watcher's own failures show up in
-// `wmill flows runs` and the langgraph-dlq-watcher Pushover.
+// Partial mitigation: the BlackboxProbe on windmill /api/version
+// catches the "Windmill is down" case. It does NOT catch "Windmill is
+// up but this script is erroring" — the langgraph-dlq-watcher Pushover
+// that used to cover that was removed with the fleet (2026-07-06), so
+// today that case surfaces only on manual `wmill flows runs` inspection.
 
 import * as wmill from "npm:windmill-client@1.527.0";
 
@@ -44,9 +46,10 @@ const NOTIFY_COOLDOWN_S = 3600;
 // Scripts we expect to fail occasionally (DLQ scans, smoke probes) —
 // surface them only if failure rate stays >90% over the window, to
 // avoid flapping when one bad poll trips the regular threshold.
-const TOLERANT_PATHS = new Set([
-    "f/lovenet/langgraph-dlq-watcher",
-]);
+// Currently empty: the only entry was langgraph-dlq-watcher, removed
+// with the fleet (2026-07-06). Kept as a policy hook — add a path here
+// rather than raising FAILURE_RATE_THRESHOLD for everything.
+const TOLERANT_PATHS = new Set<string>([]);
 const TOLERANT_THRESHOLD = 0.9;
 
 type WatcherState = {


### PR DESCRIPTION
chore(windmill): retire dead langgraph-dlq-watcher reference from failure-watcher

Two leftovers from the langgraph fleet decommission (2026-07-06):

1. `TOLERANT_PATHS` held `f/lovenet/langgraph-dlq-watcher`, a script that
   no longer exists in the lovenet workspace (confirmed against the live
   scripts list). Harmless — the set-membership check simply never
   matched — but it made the tolerance mechanism look wired up when it
   was inert. The set is now empty and kept as a policy hook.

2. The self-recursion-risk header claimed the watcher's own failures
   "show up in ... the langgraph-dlq-watcher Pushover." That mitigation
   no longer exists. Rewritten to state the residual gap honestly: the
   BlackboxProbe catches "Windmill is down" but NOT "Windmill is up and
   this script is erroring," which today surfaces only on manual
   inspection.

Synced to Windmill, not just committed. This file's own header documents
the failure mode where a git change never reaches Windmill (PR #11894,
2026-05-21), so a git-only edit would have reproduced exactly the drift
this watcher exists to catch.

Verification:
- Pre-edit: live Windmill content diffed byte-identical to git (no
  pre-existing drift).
- Deployed via scripts/create, parent 1566b5cdd60b70d8 -> d1594b746d5b1b02.
- Post-deploy: lock generated, lock_error_logs null, deployed content
  matches this file exactly.
- Executed once: success=true, checked_n=16, issues_n=0.

Co-Authored-By: Claude <noreply@anthropic.com>
