### PR TITLE
docs(agents): tell the agent to inspect the cluster via kubectl MCP, not bash

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,32 @@ always-load diet HOMELAB-SPEC applies to its own Layers 4-7.
 
 ---
 
+## Inspecting the live cluster — use the kubectl MCP tools, not `bash`
+
+When you need to see cluster state, call the `kubectl_*` MCP tools directly.
+Do **not** shell out to `kubectl` via `bash`. The MCP path is the intended
+one: it is the surface that is allowlisted, auditable, and read-only by
+construction. A `bash` call bypasses all of that, and in the in-cluster
+server there is no kubectl binary on PATH anyway.
+
+Reach for these first:
+
+| Need | Tool |
+|---|---|
+| What is running / failing | `kubectl_get_pods`, `kubectl_get_events`, `kubectl_get_pod_events` |
+| Why a pod is unhealthy | `kubectl_diagnose_pod_crash`, `kubectl_check_pod_health`, `kubectl_get_logs`, `kubectl_get_previous_logs` |
+| Node / capacity | `kubectl_get_nodes`, `kubectl_get_nodes_summary`, `kubectl_get_node_metrics` |
+| Storage | `kubectl_get_pvcs`, `kubectl_get_persistent_volumes`, `kubectl_get_storage_classes` |
+| Flux / GitOps state | `kubectl_gitops_apps_list_tool`, `kubectl_gitops_app_status_tool`, `kubectl_gitops_sources_list_tool` |
+| Metrics | `prom_execute_query`, `prom_execute_range_query` |
+| Network policy | `cilium_*`, `kubectl_analyze_network_policies` |
+
+The allowlist is **read-only**. There is no apply/patch/delete/scale/rollout,
+and `kubectl_get_secrets` / `kubectl_kubeconfig_view` are deliberately absent.
+If a task seems to need a mutating or credential tool, that is a signal to
+stop and propose the change as a Flux commit — not to look for a way around
+the gate. Git is canonical for cluster state.
+
 ## Repository guide
 
 This is a **Home Kubernetes cluster monorepo** managed with GitOps (Flux, Renovate, GitHub Actions).


### PR DESCRIPTION
## Observed behaviour

Asked to list storage classes, the in-cluster agent reached for `bash` first, and only called `lovenet-gateway_kubectl_get_storage_classes` after being corrected. It has the tools since #13315; it just doesn't reliably prefer them.

## Change

A short section near the top of `AGENTS.md` mapping tasks to the kubectl MCP tools, and stating plainly that shelling out to `kubectl` is wrong — the MCP path is the allowlisted, auditable, read-only-by-construction surface, and the in-cluster server has no `kubectl` binary on PATH anyway.

It also states the boundary: no apply/patch/delete/scale/rollout, and `kubectl_get_secrets` / `kubectl_kubeconfig_view` deliberately absent. Needing one is a signal to propose a Flux commit, not to route around the gate — Git is canonical for cluster state (HOMELAB-SPEC L2 #4).

## Cost

~378 tokens against ~15.9k headroom. AGENTS.md is loaded every session, so this was kept tight.

Every tool named in the new section was verified to exist in the live allowlist (20/20; the only two that don't resolve are `get_secrets` and `kubeconfig_view`, named precisely because they're excluded).

## Note

Separately: I flagged the `opencode.db` WAL as a VACUUM candidate. Checked it — `freelist_count = 0`, 568 pages, integrity `ok`. There is no bloat and VACUUM would reclaim nothing. The `VACUUM INTO` idea in my notes is about backup *consistency* under Longhorn snapshots, which is a real but separate item. No change made there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)