### PR TITLE
feat(windmill): add a dead-man's switch for failure detection

### DIFF
--- a/kubernetes/apps/home/windmill/README.md
+++ b/kubernetes/apps/home/windmill/README.md
@@ -118,3 +118,57 @@ Workspace `lovenet` already created via API for this purpose.
 Source-of-truth workflows (to be migrated) live at
 
 namespace go away (Phase 3).
+
+## Failure detection
+
+Two layers, deliberately independent:
+
+1. **`windmill-failure-watcher`** (Windmill script, `*/5` cron) — polls the
+   jobs API and emails when a script exceeds its failure-rate threshold.
+   Rate-driven: catches flapping and sustained breakage.
+2. **`windmill-watchdog`** (k8s CronJob, `*/5`, `./app/watchdog-cronjob.yaml`)
+   — asserts layer 1 has *succeeded* recently. Presence-of-success, not
+   absence-of-failure: if the watcher stops running entirely there are no
+   failures for it to report, and nothing else would notice.
+
+Layer 2 lives outside Windmill on purpose. It only reads the jobs API and
+needs no Windmill scheduler, dispatch, or error handler to function — so it
+stays true when Windmill itself is the thing that broke.
+
+Alerting is `./app/prometheusrule.yaml`, keyed on
+`kube_cronjob_status_last_successful_time` (self-clearing) rather than
+`kube_job_failed` (which sticks at 1 until the failed Job is GC'd).
+`WindmillWatchdogMissing` covers the CronJob itself disappearing.
+
+### The workspace error handler does not work — do not re-add it
+
+Windmill's native **workspace error handler is inert on CE v1.771.0**.
+Tested 2026-07-26 with a correct configuration: handler script deployed and
+locked, `g/error_handler` group present, `ws_error_handler_muted: false` on
+every schedule, setting persisted (tried both `script/f/...` and bare
+`f/...` path forms). Result: **5 scheduled failures, 0 handler invocations**,
+nothing in the server logs. The workspace setting was reverted to unset — a
+handler that claims coverage but never fires is worse than none.
+
+Per-schedule `on_failure` was not tested and may work; it is a different
+code path. Verify it actually fires before relying on it.
+
+### Editing the watchdog script
+
+The container image's `date` is **busybox**: `-d "15 minutes ago"` is
+rejected, `-d @<epoch>` works. The epoch arithmetic is deliberate.
+
+Do not collapse the curl/jq steps into a single pipeline assignment.
+`set -e` does not fire there — the assignment inherits `jq`'s status, and
+`jq` succeeds on the empty input a failed `curl` produces. That shape was
+verified on 2026-07-26 to report `OK` while the API was unreachable.
+
+Exercise all four paths after any edit (extract the script from the
+manifest, mount it via ConfigMap, run it in-namespace):
+
+| case | expected |
+|---|---|
+| watcher healthy | exit 0 |
+| watcher stale / never ran | exit 1 |
+| Windmill API unreachable | exit 1 |
+| bad token (401) | exit 1 |

--- a/kubernetes/apps/home/windmill/app/kustomization.yaml
+++ b/kubernetes/apps/home/windmill/app/kustomization.yaml
@@ -10,4 +10,6 @@ resources:
   - ./externalsecret.yaml
   - ./externalsecret-workflows.yaml
   - ./helmrelease.yaml
+  - ./prometheusrule.yaml
   - ./securitypolicy.yaml
+  - ./watchdog-cronjob.yaml

--- a/kubernetes/apps/home/windmill/app/prometheusrule.yaml
+++ b/kubernetes/apps/home/windmill/app/prometheusrule.yaml
@@ -1,0 +1,63 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: windmill-watchdog-rules
+spec:
+  groups:
+    - name: windmill.watchdog
+      rules:
+        # Dead-man's switch. windmill-watchdog succeeds only when
+        # windmill-failure-watcher has had a successful run recently, so a
+        # stale last_successful_time means one of:
+        #   - the watcher stopped running or is erroring
+        #   - Windmill's scheduler is wedged
+        #   - the watchdog itself cannot reach the Windmill API
+        # All three mean the same thing operationally: Windmill failure
+        # detection is blind and nothing else will tell you.
+        #
+        # Alerting on absence-of-success rather than kube_job_failed is
+        # deliberate — a retained failed Job keeps kube_job_failed at 1
+        # after recovery, so that alert would stick until GC. This one
+        # self-clears on the next successful run.
+        - alert: WindmillFailureDetectionStale
+          annotations:
+            summary: Windmill failure detection is blind (watchdog stale {{ $value | humanizeDuration }})
+            description: |
+              windmill-watchdog has not completed successfully recently. Windmill
+              job failures are currently going undetected — the failure-watcher is
+              the only thing that surfaces them, and this alert means it is not
+              confirmed running.
+
+              Check in order:
+                kubectl -n home get cronjob windmill-watchdog
+                kubectl -n home logs job/$(kubectl -n home get job -o name | grep windmill-watchdog | tail -1 | cut -d/ -f2)
+                kubectl -n home get pods -l app.kubernetes.io/name=windmill
+
+              Note: the workspace error handler is NOT a fallback here. It was
+              tested on 2026-07-26 against Windmill CE v1.771.0 and does not fire.
+          expr: |
+            time() - kube_cronjob_status_last_successful_time{namespace="home",cronjob="windmill-watchdog"} > 900
+          for: 10m
+          labels:
+            severity: warning
+        # A dead-man's switch that can itself vanish silently is not a
+        # switch. This fires if the CronJob stops being reported at all
+        # (deleted, namespace pruned, kube-state-metrics not scraping it).
+        # Expected to fire briefly on first deploy until the first run
+        # succeeds — the 15m `for` covers three */5 attempts.
+        - alert: WindmillWatchdogMissing
+          annotations:
+            summary: windmill-watchdog CronJob is not reporting to kube-state-metrics
+            description: |
+              No kube_cronjob_status_last_successful_time series exists for
+              home/windmill-watchdog. The dead-man's switch guarding Windmill
+              failure detection is itself absent, so WindmillFailureDetectionStale
+              cannot fire. Verify the CronJob exists and has run at least once:
+                kubectl -n home get cronjob windmill-watchdog
+          expr: |
+            absent(kube_cronjob_status_last_successful_time{namespace="home",cronjob="windmill-watchdog"})
+          for: 15m
+          labels:
+            severity: warning

--- a/kubernetes/apps/home/windmill/app/watchdog-cronjob.yaml
+++ b/kubernetes/apps/home/windmill/app/watchdog-cronjob.yaml
@@ -1,0 +1,113 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/cronjob-batch-v1.json
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: windmill-watchdog
+spec:
+  # Dead-man's switch for the Windmill failure-detection layer.
+  #
+  # Why this exists outside Windmill: on 2026-07-26 a custom workspace
+  # error handler was configured correctly (script deployed, g/error_handler
+  # present, no schedule muted) and never fired — 5 scheduled failures, 0
+  # handler invocations, nothing in the server logs. Windmill's error
+  # dispatch can be silently inert, so anything that depends on it is not
+  # a safety net. This job only READS the jobs API; it needs no dispatch,
+  # no scheduler, and no error handler to work.
+  #
+  # It asserts presence-of-success, not absence-of-failure. That is the
+  # only signal that catches silent death: if windmill-failure-watcher
+  # stops running at all, a failure-triggered alert has nothing to fire on.
+  #
+  # k8tz transparently injects timeZone: America/New_York on this cluster,
+  # so the schedule below is local time (irrelevant here — it is a fixed
+  # interval, not a wall-clock time).
+  schedule: "*/5 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      # No retries: a retry would let a transient blip mask a real outage
+      # by refreshing last_successful_time. One shot, pass or fail.
+      backoffLimit: 0
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: watchdog
+              # Same image as the other home-ns maintenance jobs; carries
+              # curl + jq. NOTE: its `date` is busybox, which rejects
+              # `-d "15 minutes ago"` but accepts `-d @<epoch>`. The epoch
+              # arithmetic below is deliberate, not incidental.
+              image: docker.io/alpine/k8s:1.36.2@sha256:44ef4942e171939b9c665a4a84beb80e2dcdb9a24330d4651cfdfd2e9deecc47
+              env:
+                - name: WINDMILL_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: windmill-workflows-secret
+                      key: WINDMILL_TOKEN
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -eu
+
+                  BASE="http://windmill-app.home.svc.cluster.local:8000"
+                  WS="lovenet"
+                  WATCHED="f/lovenet/windmill-failure-watcher"
+                  # 15 min tolerates two consecutive misses of the
+                  # watcher's own */5 schedule before we call it stale.
+                  WINDOW_S=900
+
+                  NOW="$(date -u +%s)"
+                  SINCE="$(date -u -d "@$((NOW - WINDOW_S))" +%Y-%m-%dT%H:%M:%SZ)"
+                  # Guard: an empty SINCE would drop the started_after
+                  # filter and return the full job history, making this
+                  # check pass unconditionally — a silently dead switch.
+                  case "$SINCE" in
+                    ????-??-??T??:??:??Z) ;;
+                    *) echo "FATAL: bad window start '$SINCE'"; exit 1 ;;
+                  esac
+
+                  # Each step is checked separately and on its own line.
+                  # Do NOT collapse this into `N="$(curl ... | jq ...)"`:
+                  # the assignment would take its status from jq, which
+                  # succeeds on the empty input a failed curl produces, so
+                  # `set -e` never fires and N ends up empty. The empty
+                  # comparison then errors inside an `if` condition — which
+                  # `set -e` also exempts — and the script falls through to
+                  # OK. Verified 2026-07-26: that shape reported healthy
+                  # while the API was unreachable.
+                  RESP="$(curl -sSf --max-time 20 \
+                            -H "Authorization: Bearer ${WINDMILL_TOKEN}" \
+                            "${BASE}/api/w/${WS}/jobs/completed/list?per_page=100&started_after=${SINCE}")" || {
+                    echo "FATAL: Windmill API query failed — cannot verify detection health"
+                    exit 1
+                  }
+
+                  N="$(printf '%s' "$RESP" | jq --arg p "$WATCHED" \
+                        '[.[] | select(.script_path == $p and .success == true)] | length')" || {
+                    echo "FATAL: could not parse Windmill API response"
+                    exit 1
+                  }
+
+                  # A non-integer here means the response shape changed.
+                  # Treat "I do not understand the answer" as unhealthy.
+                  case "$N" in
+                    ''|*[!0-9]*) echo "FATAL: non-numeric run count '$N'"; exit 1 ;;
+                  esac
+
+                  echo "successful ${WATCHED} runs since ${SINCE}: ${N}"
+
+                  if [ "$N" -lt 1 ]; then
+                    echo "STALE: no successful run in the last ${WINDOW_S}s — Windmill failure detection is blind"
+                    exit 1
+                  fi
+                  echo "OK"
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  memory: 128Mi


### PR DESCRIPTION
feat(windmill): add a dead-man's switch for failure detection

Windmill failure detection had a single point of failure: if
`windmill-failure-watcher` stopped running, nothing noticed. All 7
schedules had `on_failure` unset and no workspace error handler was
configured, so the watcher was the entire detection layer — and it could
not report its own death.

The obvious fix — Windmill's native workspace error handler — does not
work. Tested on CE v1.771.0 with a correct configuration: handler script
deployed and locked, `g/error_handler` present, `ws_error_handler_muted:
false` on every schedule, setting persisted (both `script/f/...` and bare
`f/...` forms). Result: 5 scheduled failures, 0 handler invocations, no
error-handler activity in the server logs. The workspace setting was
reverted to unset rather than left claiming coverage it does not provide.
An initial negative was discarded as contaminated (Windmill was mid-
upgrade 1.770.0 -> 1.771.0) and the test re-run clean on the settled
version.

So the switch lives OUTSIDE Windmill. It only reads the jobs API — no
scheduler, dispatch, or error handler required — which is what makes it
trustworthy when Windmill is the thing that broke.

Design notes:
- Asserts presence-of-success, not absence-of-failure. If the watcher
  stops running entirely there are no failures to fire on.
- Alert keys on `kube_cronjob_status_last_successful_time`, not
  `kube_job_failed`: the latter stays at 1 after recovery until the failed
  Job is GC'd, which would leave a stuck alert.
- `WindmillWatchdogMissing` covers the switch itself disappearing.
- `backoffLimit: 0` — a retry could refresh last_successful_time and mask
  a real outage.
- severity `warning` reaches Pushover; Alertmanager null-routes only the
  `Watchdog` and `InfoInhibitor` alertnames, not by severity. (The comment
  in alertmanagerconfig claiming it "null-routes anything below critical"
  is inaccurate — not fixed here.)

Two failure modes found and fixed during testing, both of which would have
produced a silently dead switch:
- busybox `date` rejects `-d "15 minutes ago"`. An empty window start would
  drop the `started_after` filter, return all job history, and pass
  unconditionally. Now epoch arithmetic plus a format assertion.
- `N="$(curl ... | jq ...)"` reported OK while the API was unreachable:
  the assignment inherits jq's status, jq succeeds on empty input, and the
  resulting bad comparison sits inside an `if` condition, which `set -e`
  exempts. Now each step is checked separately.

Verified in-namespace against the real API and secret, all four paths:
  watcher healthy      -> exit 0
  watcher stale        -> exit 1
  API unreachable      -> exit 1
  bad token (401)      -> exit 1

Co-Authored-By: Claude <noreply@anthropic.com>
