### PR TITLE
feat(vllm-driver): raise max-model-len 65536 -> 131072

### DIFF
--- a/kubernetes/apps/ai/vllm-driver-spark/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/vllm-driver-spark/app/helmrelease.yaml
@@ -73,12 +73,29 @@ spec:
               # Qwen3.6's hybrid Gated-DeltaNet (Mamba) layers profiled to only
               # 1.44x KV concurrency + 95 Mamba cache blocks at 128k — under the
               # default max_num_seqs (256), so CUDA graph capture failed to init.
-              # 65536 is 2.6x opencode's ~24.5k-token agent scaffolding (fixes
-              # the old 32k overflow) with far more KV + Mamba headroom. Coder
-              # was dropped so this is single-tenant; effectively no memory cost.
-              # Native max is 262144.
+              # 131072. Native max is 262144, and the KV cache already
+              # allocated at gpu-memory-utilization 0.36 holds 505,563 tokens
+              # (vLLM startup log), so this costs no additional memory — 65536
+              # was leaving 4x on the table.
+              #
+              # Sized from measurement, not guesswork. opencode's in-cluster
+              # baseline is 39,821 tokens with the read-only kubectl MCP set
+              # (49,582 with tools loaded). 65536 leaves ~16k to work in and
+              # cannot fit an operator persona's domain tools at all: ha is
+              # ~57k, omada ~53k. At 131072 the ml-, storage- and
+              # observability-operator personas fit whole (~98-102k each).
+              #
+              # Cost is prefill latency: ~5,070 tok/s measured, so a full
+              # context is ~26s to first token (vs ~13s at 65536). Concurrency
+              # drops 7.71x -> 3.86x, still ample for a ~1-3 concurrent fleet.
+              # max-num-seqs stays 32, under the Mamba cache-block limit of 95
+              # at this length.
+              #
+              # 262144 would additionally fit network- and smart-home-operator
+              # but doubles prefill to ~52s. Not worth it until a persona
+              # actually needs omada_*/ha_* in-cluster.
               - --max-model-len
-              - "65536"
+              - "131072"
               # Cap concurrent sequences well under the Mamba cache-block limit
               # (95 at 128k, more at 65k). 32 is ample for this low-traffic
               # fleet (~1-3 concurrent) and lets CUDA graph capture proceed.


### PR DESCRIPTION
## Free capacity, not new hardware

```
model max_position_embeddings : 262,144   (native, rope_scaling: None)
GPU KV cache size             : 505,563 tokens   (at current 0.36 util)
--max-model-len               :  65,536  ->  131,072
```

The KV cache already holds 505k tokens. 65,536 was an arbitrary cap leaving **4× unused**. This costs no additional GPU memory.

## Why 131072

opencode's in-cluster baseline is **39,821** tokens (49,582 with the read-only kubectl MCP set). That leaves ~16k to work in, and cannot fit any operator persona's domain tools — `ha` is ~57k, `omada` ~53k, `immich` ~23k.

| `--max-model-len` | concurrency | prefill (full ctx) | unlocks |
|---|---|---|---|
| 65,536 (now) | 7.71× | ~13s | read-only kubectl only |
| **131,072** | **3.86×** | **~26s** | **ml-, storage-, observability-operator whole** |
| 262,144 | 1.93× | ~52s | + network-, smart-home-operator |

Not going to 262,144 until a persona actually needs `omada_*`/`ha_*` in-cluster — it doubles prefill for capability nobody is using.

`max-num-seqs` stays 32, still under the Mamba cache-block limit of 95 at this length (per the existing comment in this file).

## ⚠️ Blast radius — please read before merging

**This restarts shared inference.** Last boot: **488s loading weights + 134s engine init ≈ 10 minutes** serving nothing.

Consumers that go down for that window:
- `ai/opencode` — this workstream
- `ai/lightrag` — RAG ingest
- **`collab/open-webui` — chat backend points at vllm-driver-spark**

That third one is the reason I'm flagging rather than merging. Open WebUI is a **Renee-facing surface** (HOMELAB-SPEC L7), and L3 says Renee-facing services get the most downtime protection. A ~10 minute outage of the chat model mid-evening may not be what you want.

Prefill latency is also only paid in proportion to what's sent — today's 49.5k sessions are unaffected. Nothing degrades at the current usage level.

## Untested

Whether long-context *quality* holds at 131k. Native support is not the same as staying coherent, and I have no measurement. Worth a real task at length before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)