### PR TITLE
feat(cnpg): alert on stalled WAL archiving without flapping on idle clusters

### DIFF
--- a/kubernetes/apps/databases/cloudnative-pg/app/prometheusrule.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/app/prometheusrule.yaml
@@ -74,6 +74,54 @@ spec:
           for: 5m
           labels:
             severity: warning
+        # WALArchivingStalled — catches a stopped/stuck archiver that the CR's
+        # ContinuousArchiving condition cannot: that condition is a "has ever
+        # worked" flag, set True on first success and never re-evaluated for
+        # freshness (postgres-netbox has shown True since 2026-05-08 with no
+        # bearing on current state).
+        #
+        # DELIBERATELY NOT time-since-last-archive. An idle database (no
+        # writes) legitimately stops archiving forever: with nothing to flush,
+        # Postgres never forces a WAL segment switch even with archive_timeout
+        # set (confirmed on postgres-netbox: 0 writes since ~2026-06-23,
+        # archive_timeout=300s, failed_count=0, pg_current_wal_lsn() sitting
+        # exactly on a segment boundary — this is correct, healthy behaviour,
+        # not staleness). A "last_archived_time older than N hours" alert
+        # fires permanently on every quiet cluster and trains the pager to be
+        # ignored. DO NOT convert this alert to that shape.
+        #
+        # Instead we watch cnpg_collector_pg_wal_archive_status{value="ready"}
+        # — the count of WAL segments sitting in pg_wal/archive_status marked
+        # .ready (produced, not yet archived). An idle cluster always reports
+        # 0 here: there's nothing pending, so there's nothing to fall behind
+        # on. A cluster whose archiver has genuinely stopped keeps producing
+        # segments under any write load and the backlog grows monotonically.
+        # max by (job, namespace) collapses per-pod series (each replica in
+        # the Cluster reports its own value; only the primary actually
+        # archives, but this is agnostic to which pod is currently primary,
+        # including across a failover).
+        #
+        # Threshold and for: are set from a live 7d replay across all 22
+        # clusters (2026-07-26): every cluster's ready-count sits at 0
+        # almost always, with brief single-digit blips (max observed: 7,
+        # on postgres-home-assistant, the highest-write-volume cluster in
+        # the fleet) lasting on the order of one to a few 1-minute scrapes
+        # while the archiver catches up under burst load. Threshold of 10
+        # sits above that observed ceiling; for: 15m requires the backlog
+        # to stay elevated across ~15 consecutive scrapes, which a transient
+        # catch-up blip never does but a stopped archiver always will
+        # (segments keep accumulating instead of draining).
+        - alert: WALArchivingStalled
+          annotations:
+            description: Cluster {{ $labels.job }} in {{ $labels.namespace }} has 10+ WAL segments pending archival, sustained for 15+ minutes. This is a backlog under active write load, not an idle database (idle clusters report 0 pending). Check pg_stat_archiver and the archive command/plugin target.
+            summary: CNPG WAL archiver has a growing unarchived backlog.
+          expr: |-
+            max by (job, namespace) (
+              cnpg_collector_pg_wal_archive_status{value="ready"}
+            ) >= 10
+          for: 15m
+          labels:
+            severity: warning
         # BackupStale — no successful backup in too long, complementary to
         # BackupFailed (which catches recent explicit failures). Signal is
         # kube-state-metrics CRSM over Cluster.status.conditions: the metric


### PR DESCRIPTION
## Summary

- Adds `WALArchivingStalled` to the existing CNPG `PrometheusRule` (`kubernetes/apps/databases/cloudnative-pg/app/prometheusrule.yaml`), additive only — no existing rule or AlertManager routing touched.
- The CR's `ContinuousArchiving` status condition is a "has ever succeeded" flag that never re-evaluates freshness. `postgres-netbox` has reported it `True` since 2026-05-08 regardless of current archiver state — it would tell you nothing during a real WAL-archiving outage.
- The obvious fix (alert on `time() - last_archived_time > N`) is wrong: idle databases legitimately stop archiving forever, since Postgres never forces an empty WAL segment switch even with `archive_timeout` set. That shape would fire permanently on every quiet cluster in the fleet (confirmed against `postgres-netbox`: 0 writes since ~2026-06-23, `failed_count=0`, WAL position sitting exactly on a segment boundary — healthy, not stale).
- Instead this alerts on **pending, unarchived backlog**: `cnpg_collector_pg_wal_archive_status{value="ready"}`, the count of WAL segments produced but not yet archived. An idle cluster always reports 0 here — nothing pending, nothing to fall behind on. A stuck archiver accumulates backlog under any live write load.

## Validation

- Confirmed `cnpg_collector_pg_wal_archive_status` and the other `cnpg_pg_stat_archiver_*` metrics exist by port-forwarding a CNPG pod's `:9187/metrics` directly, then confirmed they're scraped into the cluster's Prometheus.
- Pulled a live 7-day range query across all 22 `databases` CNPG clusters for the `ready` series. Nearly all sit at 0 continuously. The few transient blips topped out at 7 (on `postgres-home-assistant`, the highest-write-volume cluster in the fleet) and cleared within a few 1-minute scrapes — normal archiver catch-up under burst load, not staleness.
- Threshold (`>= 10`) sits above that observed ceiling with margin; `for: 15m` requires ~15 consecutive scrapes above threshold, which the observed blips never came close to sustaining.
- Ran the exact `expr:` from the committed file against live Prometheus — returns empty right now (all 22 clusters healthy, including the idle `postgres-netbox`).
- `kubectl apply --dry-run=server` against the updated `PrometheusRule` passed API/webhook schema validation. Nothing was applied live.

## Routing

Matches the existing CNPG alerts in this same file (`severity: warning`) — no new routing path. This `AlertmanagerConfig` has no severity-tiered routes; every non-null-matched alert (this repo's existing `Watchdog`/`InfoInhibitor` null-routes aside) falls through to the root `pushover` receiver.

## Test plan

- [ ] Flux reconciles the `PrometheusRule` cleanly (`flux get kustomization -n databases` / `kubectl get prometheusrule -n databases cloudnative-pg-rules -o yaml`)
- [ ] `kubectl get prometheusrules -n databases cloudnative-pg-rules -o jsonpath='{.status}'` shows no rule-load errors
- [ ] In Prometheus UI, `ALERTS{alertname="WALArchivingStalled"}` shows the rule loaded and currently inactive across all 22 clusters
- [ ] (Optional, future validation) Simulate a stuck archiver on a disposable/non-prod-critical cluster (e.g. pause the archive command) and confirm the alert transitions pending → firing after ~15m, then clears on recovery — not required to merge but worth doing before trusting it in the next real incident

🤖 Generated with [Claude Code](https://claude.com/claude-code)