### PR TITLE
fix(windmill): escape shell vars in watchdog so envsubst stops eating them

### DIFF
--- a/kubernetes/apps/home/windmill/app/prometheusrule.yaml
+++ b/kubernetes/apps/home/windmill/app/prometheusrule.yaml
@@ -32,7 +32,8 @@ spec:
 
               Check in order:
                 kubectl -n home get cronjob windmill-watchdog
-                kubectl -n home logs job/$(kubectl -n home get job -o name | grep windmill-watchdog | tail -1 | cut -d/ -f2)
+                kubectl -n home get jobs -l job-name --sort-by=.metadata.creationTimestamp | grep windmill-watchdog
+                kubectl -n home logs job/<newest-windmill-watchdog-job>
                 kubectl -n home get pods -l app.kubernetes.io/name=windmill
 
               Note: the workspace error handler is NOT a fallback here. It was

--- a/kubernetes/apps/home/windmill/app/watchdog-cronjob.yaml
+++ b/kubernetes/apps/home/windmill/app/watchdog-cronjob.yaml
@@ -50,6 +50,13 @@ spec:
               command:
                 - /bin/sh
                 - -c
+                # NOTE: every `$` below is doubled. Flux postBuild envsubst
+                # runs in STRICT mode over this manifest, so a bare ${VAR}
+                # is read as a Flux substitution variable and fails the
+                # whole Kustomization with "variable not set". `$$` survives
+                # as a literal `$` for the shell. Same convention as
+                # ai/opencode/app/helmrelease.yaml. Verified the hard way on
+                # 2026-07-26: unescaped ${WINDMILL_TOKEN} broke reconcile.
                 - |
                   set -eu
 
@@ -60,48 +67,48 @@ spec:
                   # watcher's own */5 schedule before we call it stale.
                   WINDOW_S=900
 
-                  NOW="$(date -u +%s)"
-                  SINCE="$(date -u -d "@$((NOW - WINDOW_S))" +%Y-%m-%dT%H:%M:%SZ)"
+                  NOW="$$(date -u +%s)"
+                  SINCE="$$(date -u -d "@$$((NOW - WINDOW_S))" +%Y-%m-%dT%H:%M:%SZ)"
                   # Guard: an empty SINCE would drop the started_after
                   # filter and return the full job history, making this
                   # check pass unconditionally — a silently dead switch.
-                  case "$SINCE" in
+                  case "$$SINCE" in
                     ????-??-??T??:??:??Z) ;;
-                    *) echo "FATAL: bad window start '$SINCE'"; exit 1 ;;
+                    *) echo "FATAL: bad window start '$$SINCE'"; exit 1 ;;
                   esac
 
                   # Each step is checked separately and on its own line.
-                  # Do NOT collapse this into `N="$(curl ... | jq ...)"`:
-                  # the assignment would take its status from jq, which
-                  # succeeds on the empty input a failed curl produces, so
-                  # `set -e` never fires and N ends up empty. The empty
-                  # comparison then errors inside an `if` condition — which
-                  # `set -e` also exempts — and the script falls through to
-                  # OK. Verified 2026-07-26: that shape reported healthy
-                  # while the API was unreachable.
-                  RESP="$(curl -sSf --max-time 20 \
-                            -H "Authorization: Bearer ${WINDMILL_TOKEN}" \
-                            "${BASE}/api/w/${WS}/jobs/completed/list?per_page=100&started_after=${SINCE}")" || {
+                  # Do NOT collapse this into one piped assignment: the
+                  # assignment would take its status from jq, which succeeds
+                  # on the empty input a failed curl produces, so `set -e`
+                  # never fires and N ends up empty. The empty comparison
+                  # then errors inside an `if` condition — which `set -e`
+                  # also exempts — and the script falls through to OK.
+                  # Verified 2026-07-26: that shape reported healthy while
+                  # the API was unreachable.
+                  RESP="$$(curl -sSf --max-time 20 \
+                            -H "Authorization: Bearer $${WINDMILL_TOKEN}" \
+                            "$${BASE}/api/w/$${WS}/jobs/completed/list?per_page=100&started_after=$${SINCE}")" || {
                     echo "FATAL: Windmill API query failed — cannot verify detection health"
                     exit 1
                   }
 
-                  N="$(printf '%s' "$RESP" | jq --arg p "$WATCHED" \
-                        '[.[] | select(.script_path == $p and .success == true)] | length')" || {
+                  N="$$(printf '%s' "$$RESP" | jq --arg p "$$WATCHED" \
+                        '[.[] | select(.script_path == $$p and .success == true)] | length')" || {
                     echo "FATAL: could not parse Windmill API response"
                     exit 1
                   }
 
                   # A non-integer here means the response shape changed.
                   # Treat "I do not understand the answer" as unhealthy.
-                  case "$N" in
-                    ''|*[!0-9]*) echo "FATAL: non-numeric run count '$N'"; exit 1 ;;
+                  case "$$N" in
+                    ''|*[!0-9]*) echo "FATAL: non-numeric run count '$$N'"; exit 1 ;;
                   esac
 
-                  echo "successful ${WATCHED} runs since ${SINCE}: ${N}"
+                  echo "successful $${WATCHED} runs since $${SINCE}: $${N}"
 
-                  if [ "$N" -lt 1 ]; then
-                    echo "STALE: no successful run in the last ${WINDOW_S}s — Windmill failure detection is blind"
+                  if [ "$$N" -lt 1 ]; then
+                    echo "STALE: no successful run in the last $${WINDOW_S}s — Windmill failure detection is blind"
                     exit 1
                   fi
                   echo "OK"


### PR DESCRIPTION
fix(windmill): escape shell vars in watchdog so envsubst stops eating them

#13318 broke reconciliation of the home/windmill Kustomization:

  post build failed for 'CronJob.v1.batch/windmill-watchdog':
  envsubst error: variable substitution failed:
  variable not set (strict mode): "WINDMILL_TOKEN"

Flux postBuild envsubst runs in strict mode over the built manifest, so
the shell's ${WINDMILL_TOKEN} inside the CronJob's inline script was read
as a Flux substitution variable, not shell syntax. Every `$` in a
manifest-embedded script must be doubled — the convention is already
documented at ai/opencode/app/helmrelease.yaml:136.

Fixed by escaping all shell references as $$. Also replaced a `$(kubectl
...)` command substitution in the PrometheusRule runbook text with a
plain placeholder; `{{ $value }}` / `{{ $labels }}` are left as-is, which
frigate's live rule confirms is safe.

Verified against the rendered output rather than by inspection:
- `kubectl kustomize` the app dir, parse the CronJob, regex for `$` not
  part of a `$$` pair -> 0 occurrences.
- The only genuine envsubst target left in the render is ${SECRET_DOMAIN},
  which is defined.
- Simulating envsubst ($$ -> $) reproduces a script byte-identical to the
  one tested in #13318 across all four paths (healthy / stale / API down /
  bad token), apart from one reflowed comment.

Note: CI's flate check passed on #13318, so it does not exercise strict
postBuild substitution. This class of breakage is not currently caught
before merge.

Co-Authored-By: Claude <noreply@anthropic.com>
