### PR TITLE
fix(opencode): declare the 131072 context now served by vllm-driver

### DIFF
--- a/kubernetes/apps/ai/opencode/app/resources/opencode.json
+++ b/kubernetes/apps/ai/opencode/app/resources/opencode.json
@@ -15,7 +15,7 @@
         "qwen3.6-35b-a3b": {
           "name": "Qwen3.6 35B-A3B (Spark vLLM, agentic driver)",
           "limit": {
-            "context": 65536,
+            "context": 131072,
             "output": 8192
           }
         }


### PR DESCRIPTION
Follow-up to #13319 — **without this, that change does nothing for opencode.**

## The gap

opencode budgets against the context limit declared in **its own config**, not what the server advertises. `vllm-driver-spark` now serves 131,072, but `opencode.json` still said:

```json
"limit": { "context": 65536, "output": 8192 }
```

So opencode would keep compacting at half the available window. This raises `limit.context` to 131072; `limit.output` stays 8192.

## Correcting #13319's capacity claim

That PR said the change "costs no additional GPU memory" on the basis of a 505,563-token KV cache. Total GPU allocation is unchanged — `gpu-memory-utilization` is still 0.36 — but the **KV cache itself shrank**:

| | before | after |
|---|---|---|
| GPU KV cache | 505,563 tokens | **369,384 tokens** |
| max concurrency | 7.71× | **2.82×** (predicted 3.86×) |

This is a **hybrid Mamba model**, and its conv/state cache scales with `max-model-len` — the difference comes out of KV. I predicted concurrency from the old cache size, which was wrong. 2.82× is still ample for a fleet running ~1–3 concurrent, so the decision stands, but the reasoning in #13319 was incomplete.

Rollout took 12 minutes, not the ~10 I estimated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)