### PR TITLE
docs(observability): correct the alert-routing comments

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/alertmanagerconfig.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/alertmanagerconfig.yaml
@@ -22,9 +22,17 @@ spec:
           - name: alertname
             value: InfoInhibitor
             matchType: "="
-  # All other severity=critical alerts fall through to the root
-  # receiver (pushover) above — HolmesGPT/windmill-investigate
-  # enrichment was removed 2026-07-06 (no value delivered).
+  # Routing is by ALERTNAME, not by severity. The two routes above are
+  # the only suppression: everything else — critical, warning, and info
+  # alike — falls through to the root `pushover` receiver and notifies.
+  # If you want an alert to page, no severity label change is needed; if
+  # you want one silenced, add an alertname route here.
+  #
+  # (HolmesGPT/windmill-investigate enrichment on critical was removed
+  # 2026-07-06 — no value delivered.)
+  #
+  # The inhibitRule below is the one severity-aware behaviour: a firing
+  # critical suppresses a warning sharing the same alertname+namespace.
   inhibitRules:
     - equal: ["alertname", "namespace"]
       sourceMatch:

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -57,12 +57,19 @@ spec:
       # NFS export. The replacement keeps per-PVC granularity for
       # non-NFS PVCs and adds per-nfs_server aggregation.
       disabled:
-        # InfoInhibitor only exists as a source for an Alertmanager
-        # inhibit_rule that suppresses info-severity alerts. We don't
-        # have any info-severity alerts in this cluster (and the
-        # alertmanagerconfig already null-routes anything below
-        # `critical`), so the rule provides no value and just shows
-        # up as constant firing in the Prometheus/AM UIs.
+        # InfoInhibitor only exists as a source for an upstream
+        # inhibit_rule that suppresses info-severity alerts. Our
+        # alertmanagerconfig defines no such inhibit_rule (its only
+        # inhibitRule is critical -> warning), so InfoInhibitor is an
+        # unreferenced source that just shows up as constant firing in
+        # the Prometheus/AM UIs. Disabling it is still correct.
+        #
+        # The previous version of this comment was wrong twice and is
+        # corrected here: this cluster DOES have info-severity alerts
+        # (GPUPowerSustainedHigh, HostRequiresReboot), and the
+        # alertmanagerconfig does NOT null-route below `critical` — it
+        # null-routes exactly two alertnames. See the routing note in
+        # ./alertmanagerconfig.yaml.
         InfoInhibitor: true
         KubePersistentVolumeFillingUp: true
         KubePersistentVolumeInodesFillingUp: true


### PR DESCRIPTION
docs(observability): correct the alert-routing comments

A comment in kube-prometheus-stack's helmrelease claimed the
alertmanagerconfig "null-routes anything below `critical`". It does not.
Routing is by ALERTNAME: exactly two routes (`Watchdog`, `InfoInhibitor`)
go to the null receiver, and everything else — critical, warning and info
alike — falls through to the root pushover receiver and notifies.

This matters because it is load-bearing for alert design. Anyone reading
it would conclude a `severity: warning` rule cannot page, and either
inflate severities to be heard or assume a warning-level alert is
effectively disabled. The repo has 58 warning-severity alerts and two
were pending at the time of writing, so warnings very much notify.

The same comment also asserted the cluster has no info-severity alerts.
It has two: GPUPowerSustainedHigh (snmp-exporter/apc-ups) and
HostRequiresReboot (node-exporter addon). Both route to pushover.

Disabling InfoInhibitor remains correct, but for a different reason than
stated: our alertmanagerconfig defines no info-suppressing inhibit_rule
(its only inhibitRule is critical -> warning), so InfoInhibitor is an
unreferenced source that just shows as constantly firing.

Comments only — both files parse to identical YAML before and after, so
Alertmanager's and Prometheus's configuration is untouched.

Found while designing the windmill-watchdog alert (#13318), where the
claim would have pushed the severity up for the wrong reason.

Co-Authored-By: Claude <noreply@anthropic.com>
