### PR TITLE
chore(opencode): bump server image v1.18.5 -> v1.18.7

### DIFF
--- a/kubernetes/apps/ai/opencode/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/opencode/app/helmrelease.yaml
@@ -128,7 +128,7 @@ spec:
           stage-repos:
             image:
               repository: ghcr.io/rwlove/opencode-server
-              tag: v1.18.5@sha256:72ad9c904e501063818358766ac91dc1f02382ce27e3c459e8fc3b7a037742af
+              tag: v1.18.7@sha256:aaa60d423494b3645f5cb196aa51c80f77b3ab3625fbdba9ca25946c4e98fc8b
             command:
               - /bin/bash
               - -cu
@@ -227,7 +227,7 @@ spec:
               # bump to. Verified by A/B against a local 1.18.4 server, which
               # answered the identical prompt in ~20s.
               repository: ghcr.io/rwlove/opencode-server
-              tag: v1.18.5@sha256:72ad9c904e501063818358766ac91dc1f02382ce27e3c459e8fc3b7a037742af
+              tag: v1.18.7@sha256:aaa60d423494b3645f5cb196aa51c80f77b3ab3625fbdba9ca25946c4e98fc8b
             env:
               # No PORT/HOSTNAME_OVERRIDE: those were the community
               # entrypoint's contract. Our image has an explicit CMD binding


### PR DESCRIPTION
Picks up rwlove/containers#190 (`opencode-ai` 1.18.5 → 1.18.7), released as `opencode-server-v1.18.7`.

Both pins updated — the app container and the `stage-repos` initContainer share the image:

```
v1.18.5@sha256:72ad9c90…  ->  v1.18.7@sha256:aaa60d42…
```

Image verified published, public and amd64 before pinning. The build-time version assertion passed in CI, so the binary reports 1.18.7.

## After merge

**Re-measure rather than assume.** Today's tuning rests on an in-cluster baseline of **39,821** tokens (49,582 with the read-only kubectl set) against a **131,072** window. A runtime bump can move the system prompt or built-in tool schemas underneath both numbers.

## Related

Local `opencode run` hangs at `init` on 1.18.4 — reproducible with default config and `--pure`. I suspected the parked `vllm-coder` provider (503 all day); removed it from the local config and **the hang persisted**, so that theory is dead. If 1.18.7 fixes it, that's worth knowing before spending more on diagnosing the older client. `opencode attach` / the TUI are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)