### PR TITLE
fix(opencode): enforce stream liveness so stalled turns fail instead of hanging

### DIFF
--- a/kubernetes/apps/ai/opencode/app/resources/opencode.json
+++ b/kubernetes/apps/ai/opencode/app/resources/opencode.json
@@ -9,7 +9,10 @@
       "name": "vLLM Driver (Spark / GB10)",
       "options": {
         "baseURL": "http://vllm-driver-spark.ai.svc.cluster.local:8000/v1",
-        "apiKey": "vllm"
+        "apiKey": "vllm",
+        "timeout": false,
+        "headerTimeout": 120000,
+        "chunkTimeout": 300000
       },
       "models": {
         "qwen3.6-35b-a3b": {
@@ -26,7 +29,10 @@
       "name": "Ollama (P40)",
       "options": {
         "baseURL": "http://ollama.ai.svc.cluster.local:11434/v1",
-        "apiKey": "ollama"
+        "apiKey": "ollama",
+        "timeout": false,
+        "headerTimeout": 60000,
+        "chunkTimeout": 120000
       },
       "models": {
         "qwen2.5:7b": {


### PR DESCRIPTION
## Problem

opencode never bounds a stream. Once a request is open, an upstream stall is
indistinguishable from work in progress — the TUI spins, `0 tokens`, `$0.00
spent`, and no error is ever surfaced.

Two unrelated faults produced that identical signature:

1. **Dead transport** — the `kubectl port-forward` backing the local TUI's
   attach endpoint exited (leaving a zombie child). Nothing listened on the
   port; every submit got `ECONNREFUSED`. Went unnoticed for **four days**.
2. **Wedged engine** — `vllm-driver-spark-0` admitted two requests, issued a
   first token for each, then froze mid-decode: `generation_tokens_total` and
   `prompt_tokens_total` static, `num_requests_running=2`, `waiting=0`,
   `finished_reason=error|abort` both `0`, all 130 EngineCore threads sleeping
   at 0% CPU while the GPU reported 96%. No exception raised, so the request
   was held open indefinitely.

Neither is an opencode bug in itself. The opencode-level defect is that
**nothing enforces liveness**, so both are invisible.

## Change

Per-provider liveness bounds on `provider.*.options`:

| | vllm-driver | ollama-p40 |
| --- | --- | --- |
| `timeout` | `false` | `false` |
| `headerTimeout` | 120000 | 60000 |
| `chunkTimeout` | 300000 | 120000 |

`timeout: false` is deliberate — agentic turns are legitimately long and a
wall-clock cap would kill real work. What is enforced instead is that the
stream keeps *producing*: per the config schema, if no SSE chunk arrives
within `chunkTimeout`, the request is aborted.

`chunkTimeout` is generous on the driver (5 min) because prefill on the GB10
under a large MCP tool payload is genuinely slow, and a false abort on real
work costs more than a five-minute wait. ollama runs tighter (2 min) since the
7b responds fast.

## Validation

- `pre-commit run --files …` — `check-json`, `gitleaks`, `detect-private-key`, `readme-drift` all pass
- `kubectl kustomize kubernetes/apps/ai/opencode/app` renders; `chunkTimeout` present for both providers
- Confirmed the `stage-config` init container uses `cp -f`, so the regenerated
  ConfigMap overwrites the PVC copy on restart — the reloader hash env
  (`STAKATER_OPENCODE_CONFIG_CONFIGMAP`) triggers that restart automatically.
  No manual step needed after merge.

## Not addressed here

The wedged engine itself still needs a pod restart to clear, and the root
cause is unpinned — `py-spy` is in the image but lacks `CAP_SYS_PTRACE`, so no
stack dump was possible. Suspects from the engine's own startup log: DeepGemm
auto-disabled on Blackwell for `qwen3_5_moe_text` (CUTLASS fallback), a
mid-inference Triton JIT of `_count_expert_num_tokens`, and a dev build
(`v0.25.2.dev0+g752a3a504`) rather than a tagged release. Follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)