### PR TITLE
fix(vllm-driver): add SYS_PTRACE so a wedged EngineCore can be diagnosed

### DIFF
--- a/kubernetes/apps/ai/vllm-driver-spark/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/vllm-driver-spark/app/helmrelease.yaml
@@ -55,6 +55,14 @@ spec:
               #   bump deliberately, validate on-box before merging.
               # Base image has no entrypoint (Cmd=bash), so `command`
               # below invokes vLLM explicitly.
+              #
+              # NOTE: the tag says v0.25.1 but the engine inside reports
+              # v0.25.2.dev0+g752a3a504 — the community image ships a dev
+              # build, not the tagged release. The digest below is the real
+              # pin; treat the tag as a label, not a version. Confirmed
+              # 2026-07-31 from the running EngineCore banner. Relevant when
+              # correlating behaviour against upstream issues: match on the
+              # dev SHA, not on v0.25.1.
               repository: ghcr.io/timothystewart6/vllm-gb10
               tag: v0.25.1-cu13.2-torch2.11-gb10.3@sha256:30e70a376ff076f4dc3e1e5fd5ee5f99f36a8ba274f6f590fa1d7894045a66d8
 
@@ -193,6 +201,21 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 drop: ["ALL"]
+                # workaround: https://github.com/vllm-project/vllm/issues/41725
+                #   — remove when the GB10 (sm_121) CUDA kernel hang is fixed
+                #   upstream and py-spy is no longer needed to diagnose it.
+                #   py-spy ships in the image but needs ptrace to attach.
+                #   Without it a wedged EngineCore can't be introspected: on
+                #   2026-07-31 the engine held two requests with the GPU pinned
+                #   at 96%, all 130 threads sleeping and every token counter
+                #   frozen, and `py-spy dump` failed with EPERM — leaving the
+                #   hang unpinned and a pod restart as the only recourse.
+                #   #41725 is the closest upstream match (same platform, same
+                #   GPU-pinned-96%-no-error signature) but is NOT confirmed to
+                #   be the same bug: that repro is 2-node TP=2 NVFP4/marlin,
+                #   ours is single-node TP=1 FP8 with CUDA graphs enabled.
+                #   Scoped to ptrace only; allowPrivilegeEscalation stays false.
+                add: ["SYS_PTRACE"]
               seccompProfile:
                 type: RuntimeDefault
 


### PR DESCRIPTION
Refs #13342

## Why

On 2026-07-31 `vllm-driver-spark-0` wedged and could not be diagnosed:

| Signal | Value |
| --- | --- |
| `num_requests_running` / `waiting` | 2 / 0 |
| `generation_tokens_total`, `prompt_tokens_total` | frozen |
| `time_to_first_token_count` vs `success{stop}` | 85 vs 82 — 2 stalled mid-decode |
| `finished_reason=error` / `abort` | 0 / 0 — nothing ever thrown |
| GPU utilization | pinned 96%, sole compute proc `VLLM::EngineCore` |
| EngineCore threads | 130 total, **0 running, 130 sleeping**, 0.0% CPU |

Host threads blocked while the GPU reports busy is the signature of a stuck
CUDA kernel — the engine is parked in a stream synchronize on a kernel that
never returns. Because no exception is raised, the request is held open
indefinitely rather than failed.

`py-spy` is present in the image, but the pod drops `ALL` capabilities so
`py-spy dump --pid <engine>` returns `EPERM`. The hang went unpinned and a pod
restart was the only recourse — which destroys the evidence along with the
requests.

## Change

`add: ["SYS_PTRACE"]`, annotated per `.agents/instructions/workarounds.md`.

Hardening otherwise unchanged:

- `allowPrivilegeEscalation: false`
- `drop: ["ALL"]` retained
- `seccompProfile: RuntimeDefault`

Also documents that the image ships **v0.25.2.dev0+g752a3a504** despite its
`v0.25.1` tag — the digest is the real pin, and upstream correlation must match
the dev SHA, not the tag. (No pin change needed: the image was already
digest-pinned.)

## Upstream

Closest match https://github.com/vllm-project/vllm/issues/41725 — recurring
CUDA kernel hang on DGX Spark (GB10, sm_12.1), GPU locked 96–99%, no log
errors, onset after healthy serving. Same platform, same fingerprint, but
**not confirmed the same bug**: that repro is 2-node TP=2 NVFP4/marlin with
NCCL collectives, ours is single-node TP=1 FP8 with CUDA graphs and no
collectives.

## Validation

- `pre-commit run --files …` — all applicable hooks pass (`check-yaml`, `yamllint`, `gitleaks`, `cnp-empty-rules`, `envsubst-shell-vars`, `literal-credentials`)
- `kubectl kustomize kubernetes/apps/ai/vllm-driver-spark/app` renders with `SYS_PTRACE` present alongside `drop: [ALL]`

## Blast radius

Merging restarts the driver — ~10 min for model load, graph compile and CUDA
capture. It is the shared inference substrate, so nothing else can use a model
during that window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)