### PR TITLE
feat(opencode): set SERVER_USERNAME so the HTTPRoute works headlessly

### DIFF
--- a/kubernetes/apps/ai/opencode/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/opencode/app/externalsecret.yaml
@@ -14,9 +14,34 @@ spec:
     creationPolicy: Owner
     template:
       data:
-        # Belt-and-suspenders behind oauth2-proxy: opencode's own HTTP
-        # basic-auth guards the API/SDK surface even for callers that
-        # bypass the browser SSO path.
+        # Belt-and-suspenders behind extAuth (#12767, was oauth2-proxy):
+        # opencode's own HTTP basic-auth guards the API/SDK surface even for
+        # callers that bypass the browser SSO path. That second gate matters
+        # more than the comment implied: `allow-intra-namespace` in this ns
+        # is endpointSelector:{} / fromEndpoints:[{}] with no toPorts, so
+        # EVERY pod in `ai` can already reach opencode:4096 directly. This
+        # basic-auth is the only thing standing in front of a pod that runs
+        # `bash`, holds four git deploy keys and can reach the MCP broker's
+        # mutating surface. Do not remove it without replacing the boundary
+        # at the network layer.
+        #
+        # Both fields must hold the credentials of an LLDAP user in
+        # `group:lldap_admin` — the subject on the opencode.${SECRET_DOMAIN}
+        # rule in authelia's access_control (policy: one_factor). Because
+        # `one_factor` accepts HTTP Basic Auth, a single Authorization header
+        # then satisfies BOTH gates: Authelia at the gateway and opencode
+        # itself. That is what lets a headless client use the HTTPRoute:
+        #
+        #   opencode attach https://opencode.${SECRET_DOMAIN} -u <user> -p <pass>
+        #
+        # and is why the kubectl port-forward is no longer needed.
+        #
+        # USERNAME is not optional here. opencode defaults it to `opencode`
+        # when unset, which passes its own gate but fails Authelia's — the
+        # exact 401 seen while diagnosing this. Verified against the server:
+        # wrong-user + right-password returns 401, so the username is
+        # checked, not decorative.
+        OPENCODE_SERVER_USERNAME: "{{ .SERVER_USERNAME }}"
         OPENCODE_SERVER_PASSWORD: "{{ .SERVER_PASSWORD }}"
   dataFrom:
     - extract:


### PR DESCRIPTION
> **Draft — blocked on a 1Password change. See "Before merging" below.**
> Merging this before the 1Password item is updated will break opencode auth.

## Why the port-forward existed

The TUI reached the in-cluster server through `kubectl port-forward` because
`opencode.${SECRET_DOMAIN}` 302s to the Authelia portal and `opencode attach`
has no `--header` flag.

That forward is a silent SPOF. It exited on 2026-07-28 leaving a zombie child,
and the TUI spun for **four days** with no error, `0 tokens`, `$0.00 spent` —
because opencode enforced no liveness (fixed separately in #13341). It then
died a second time when merging #13341 bounced the opencode pod.

## It was never necessary

```yaml
- domain: ['opencode.${SECRET_DOMAIN}', …]
  policy: 'one_factor'
  subject: 'group:lldap_admin'
```

`one_factor` accepts HTTP Basic Auth. Confirmed by observed behaviour:

| Request | Result |
| --- | --- |
| No credentials | **302** → portal redirect |
| Credentials (any) | **401**, no redirect |

Authelia *validates* basic auth here rather than bouncing to a browser.

The only real blocker was that one `Authorization` header must satisfy two
gates and the usernames differed. `OPENCODE_SERVER_USERNAME` was unset, so
opencode defaulted it to `opencode` — which its own gate accepts and Authelia
rejects. That was the 401 seen while diagnosing.

Verified against a local `opencode serve`:

| Credentials | Result |
| --- | --- |
| none | 401 |
| `opencode` + correct password | **401** ← username enforced |
| correct user + correct password | **200** |
| correct user + wrong password | 401 |

## Change

Add `OPENCODE_SERVER_USERNAME` to the ExternalSecret template. Both fields then
hold an `lldap_admin` member's credentials, and one header passes both gates:

```
opencode attach https://opencode.${SECRET_DOMAIN} -u <user> -p <pass>
```

No SecurityPolicy change, no route carve-out, **no control removed.**
`envFrom` already pulls the whole secret, so no HelmRelease change is needed.

## Rejected alternative

Dropping opencode's own basic-auth and relying on extAuth + CNP was considered
and rejected. `allow-intra-namespace` in `ai` is `endpointSelector: {}` with
`fromEndpoints: [{}]` and no `toPorts`, so **every pod in `ai` can already
reach `opencode:4096` directly** — the per-app CNP's envoy-only rule is
additive and does not restrict that path. opencode's basic-auth is therefore
the only gate in front of a pod that runs `bash`, holds four git deploy keys,
has `world:443` egress, and can reach the MCP broker that `cnp-allow.yaml`
itself describes as fronting "mutating backends (kubectl/omada/ha) with no
per-tool authz."

`comfyui-spark` is the concrete concern: it installs third-party custom nodes
and pulls remote models, and shares that namespace.

## Before merging

1. In the 1Password `opencode` item, add **`SERVER_USERNAME`** and set
   **`SERVER_PASSWORD`** to the credentials of an LLDAP user in
   `group:lldap_admin`.
2. Confirm the pair authenticates end to end:
   ```
   curl -s -o /dev/null -w '%{http_code}\n' -u '<user>:<pass>' \
     https://opencode.${SECRET_DOMAIN}/config
   ```
   Expect **200**. A 401 means Authelia rejected the identity; a 302 means
   basic auth isn't being accepted and this PR's premise is wrong.
3. Then mark ready and merge. If `SERVER_USERNAME` is absent from the item,
   the template renders empty and auth breaks.

## After merging

The `kubectl port-forward` on 14096 can be retired permanently, along with the
zombie-child failure mode that started this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)