### PR TITLE
fix(romm): stop rollback wedging the release on a forward-only migration

### DIFF
--- a/kubernetes/apps/media/romm/app/helmrelease.yaml
+++ b/kubernetes/apps/media/romm/app/helmrelease.yaml
@@ -11,13 +11,32 @@ spec:
 
   interval: 1h
   install:
+    timeout: 20m
     remediation:
       retries: 3
   upgrade:
+    # RomM runs forward-only Alembic migrations at startup, so a rollback of
+    # the *image* cannot un-migrate the *database*. On 2026-07-31 the 5.0.0 ->
+    # 5.1.0 bump exceeded Helm's 5m default timeout (image pulls were queued
+    # behind a 40-PR Renovate wave), Flux remediated with strategy: rollback,
+    # and 5.0.0 came back up against a DB already stamped at 5.1.0's revision
+    # `0103_roms_facets_provider_ids`. It could not locate that revision, so it
+    # crashlooped -- and every subsequent rollback attempt re-applied the same
+    # unstartable version. The release wedged permanently and needed a spec
+    # change to escape.
+    #
+    # timeout: 20m gives the pull + migration room so remediation is not
+    # triggered by slowness alone.
+    #
+    # retries: 0 disables remediation entirely. For an app with forward-only
+    # migrations, failing forward and staying on the new version is strictly
+    # safer than rolling back to a version that can no longer read its own
+    # database. A failed upgrade stays visible as Ready=False instead of
+    # silently reverting into an unrecoverable state.
+    timeout: 20m
     cleanupOnFail: true
     remediation:
-      retries: 3
-      strategy: rollback
+      retries: 0
   values:
     defaultPodOptions:
       securityContext:


### PR DESCRIPTION
Fixes a live outage: `romm` has been in CrashLoopBackOff for ~95 minutes and cannot recover on its own.

## What happened

#13378 bumped RomM 5.0.0 → 5.1.0. The upgrade exceeded Helm's **5 minute default timeout** — image pulls were queued behind a large Renovate wave (a 4.7 MB busybox layer took **20m41s** to pull on the same node). Flux remediated with `strategy: rollback`, reverting the image to 5.0.0.

But 5.1.0 had **already run its migrations**. 5.0.0 came back up against a database stamped at a revision it has never heard of:

```
Version: 5.0.0
Running database migrations
FAILED: Can't locate revision identified by '0103_roms_facets_provider_ids'
ERROR: Failed to run database migrations
```

Rolling back an **image** cannot un-migrate a **database**. Every subsequent remediation re-applied that same unstartable version, so the release could never converge. Re-triggering reconciliation by hand did not clear it either — the stored remediation state still targeted the earlier revision, and only a spec change bumps the generation enough for Flux to attempt the Git-declared 5.1.0 again.

Git has said `5.1.0` the whole time. Only the cluster was stuck.

## The fix

| Change | Why |
|---|---|
| `install.timeout: 20m` / `upgrade.timeout: 20m` | A slow pull or long migration no longer trips remediation on latency alone. |
| `upgrade.remediation.retries: 0` | Disables automatic reversion for this release. For forward-only migrations, failing forward and staying put is strictly safer than returning to a version that cannot read its own database. A failed upgrade now stays visible as `Ready=False` instead of silently reverting into an unrecoverable state. |

Merging this should unstick the release: the generation bump makes Flux perform a fresh upgrade to 5.1.0, which understands revision `0103_roms_facets_provider_ids` and should start cleanly.

## Wider note

This trap is not unique to romm. **Any app that runs forward-only DB migrations at startup and carries `upgrade.remediation.strategy: rollback` has the same failure mode** — it just stays latent until something makes an upgrade slow enough to time out. `paperless` hit the same timeout in the same window (it recovered, having no incompatible migration). Worth an audit as a follow-up; deliberately out of scope here to keep this PR small and reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
