### PR TITLE
perf(vllm-driver): drop fp8 kv-cache to restore prefix caching

### DIFF
--- a/kubernetes/apps/ai/vllm-driver-spark/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/vllm-driver-spark/app/helmrelease.yaml
@@ -118,10 +118,31 @@ spec:
               # memory and the coder failed to init.
               - --gpu-memory-utilization
               - "0.36"
-              # FP8 KV cache — halves KV footprint, key to fitting two
-              # instances (per the vLLM Qwen3.6 recipe).
-              - --kv-cache-dtype
-              - fp8
+              # FP8 KV cache REMOVED 2026-07-31. It halved the KV footprint to
+              # fit two instances, but vllm-coder-spark has been parked at
+              # replicas:0 since 2026-07-23 (Qwen3.6-27B cannot co-reside with
+              # the driver on the GB10) — so there is no second instance and
+              # the footprint saving buys nothing. Measured KV cache usage on
+              # a live agentic session was 2.4–9.5%.
+              #
+              # What it cost: fp8 kv-cache is incompatible with prefix caching,
+              # so vLLM silently set enable_prefix_caching=False and every
+              # request reported "Prefix cache hit rate: 0.0%". The driver's
+              # workload is an agentic tool-calling loop that re-sends an
+              # ~85k-token prefix on every step, which is the best possible
+              # case for prefix caching; instead each step re-prefilled the
+              # whole context (observed: +95,993 prompt tokens per step at
+              # ~9.9k tok/s, so ~10s of pure prefill before any output).
+              #
+              # It also silenced correctness: the engine warned "Using
+              # uncalibrated q_scale 1.0 and/or prob_scale 1.0 with fp8
+              # attention. This may cause accuracy issues" because the
+              # checkpoint ships no q/prob scaling factors. Removing this
+              # drops that risk too, and is a suspect (unproven) in the
+              # decode-hang tracked in #13342.
+              #
+              # Restore ONLY if a second instance is genuinely co-scheduled
+              # here, and re-measure prefix hit rate before accepting it.
               # Reasoning + tool-calling parsers (vLLM Qwen3.6 recipe).
               # tool-call support is the whole point of the driver role —
               # opencode/LightRAG drive tools through it.


### PR DESCRIPTION
Refs #13342

## Problem

`--kv-cache-dtype fp8` is incompatible with prefix caching, so vLLM silently
set `enable_prefix_caching=False`. Every request logs:

```
Prefix cache hit rate: 0.0%
```

The driver serves an agentic tool-calling loop that re-sends an ~85k-token
prefix on **every** step — the single best case for prefix caching. Instead
each step re-prefills the whole context. Measured on a live session:

| Observation | Value |
| --- | --- |
| Prompt tokens per agentic step | **+95,993** |
| Prefill throughput | ~9.9k tok/s → ~10s pure prefill before any output |
| Generation throughput | 7–12 tok/s |
| GPU utilization | 96% |
| Prefix cache hit rate | **0.0%** (every sample) |
| GPU KV cache usage | **2.4–9.5%** |

## The flag's rationale no longer holds

It was added to halve the KV footprint, *"key to fitting two instances."* But
`vllm-coder-spark` has been parked at `replicas:0` since 2026-07-23 because
Qwen3.6-27B cannot co-reside with the driver on the GB10 — confirmed still
`0/0`. There is no second instance, and KV usage is under 10%. The saving buys
nothing while costing the largest available win for this workload.

## Secondary benefit

Removes an accuracy risk the engine warns about at startup:

```
Using uncalibrated q_scale 1.0 and/or prob_scale 1.0 with fp8 attention.
This may cause accuracy issues.
```

The checkpoint ships no q/prob scaling factors. Uncalibrated fp8 attention is
also an **unproven** suspect in the decode hang tracked in #13342.

## Scope

Model weights stay FP8 (`Qwen3.6-35B-A3B-FP8`) — only the KV cache dtype
changes. The KV pool is still sized from `--gpu-memory-utilization`, so this
does **not** increase memory use: per-token cost doubles and token capacity
halves, amply covered at under 10% utilization.

Rendered args, diff confirmed to be the two removed lines only:

```
vllm serve Qwen/Qwen3.6-35B-A3B-FP8 --served-model-name qwen3.6-35b-a3b
  --host 0.0.0.0 --port 8000 --max-model-len 131072 --max-num-seqs 32
  --gpu-memory-utilization 0.36 --reasoning-parser qwen3
  --tool-call-parser qwen3_xml --enable-auto-tool-choice
```

## Validation

- `pre-commit run --files …` — all applicable hooks pass
- `kubectl kustomize` renders; `kv-cache-dtype` occurrences: **0**; all other args intact

## Verify after merge — the claim is untested

This is reasoned from the 0% hit rate and the access pattern, **not** from a
before/after benchmark. After the restart, confirm:

1. `Prefix cache hit rate` climbs well above `0.0%` across agentic steps
2. Per-step prompt tokens drop far below `+95,993`
3. Startup no longer emits the uncalibrated `q_scale`/`prob_scale` warning

**If the hit rate stays at 0%**, something else is disabling prefix caching,
this bought nothing, and the flag should be restored — it did have a real (if
currently unused) purpose.

## Blast radius

Restarts the driver: ~10 min for model load, graph compile and CUDA capture.
Shared inference substrate — nothing else can reach a model during that window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)