### PR TITLE
fix(open-webui): don't revert the image out from under a migrated schema

### DIFF
--- a/kubernetes/apps/collab/open-webui/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/open-webui/app/helmrelease.yaml
@@ -10,13 +10,35 @@ spec:
     name: app-template
   interval: 30m
   install:
+    timeout: 20m
     remediation:
       retries: 3
   upgrade:
+    # Open WebUI runs forward-only Alembic migrations at startup against the
+    # SQLite DB in open-webui-data-pvc, so rolling back the *image* cannot
+    # un-migrate the *schema*. Combined with Helm's 5m default timeout (this
+    # release does not set disableWait), a slow image pull is enough to fail
+    # the upgrade, trigger remediation, and leave an older image running
+    # against a newer schema.
+    #
+    # That is exactly how romm wedged on 2026-07-31: the 5.0.0 -> 5.1.0 bump
+    # timed out behind a queued image pull, Flux rolled back, and 5.0.0 could
+    # not locate the Alembic revision 5.1.0 had already written. Every
+    # subsequent remediation re-applied the same unstartable version. See
+    # #13383.
+    #
+    # timeout: 20m stops a slow pull from being read as a failure.
+    # retries: 0 disables reversion -- for forward-only migrations, failing
+    # forward and surfacing Ready=False is strictly safer than returning to a
+    # version that can no longer read its own schema.
+    #
+    # Note: immich, khoj and prowlarr also pair rollback remediation with a
+    # database, but all three set disableWait: true, so Helm never waits, never
+    # times out, and remediation cannot trip. They are deliberately unchanged.
+    timeout: 20m
     cleanupOnFail: true
     remediation:
-      retries: 3
-      strategy: rollback
+      retries: 0
   values:
     controllers:
       open-webui:


### PR DESCRIPTION
Follow-up to #13383. Audits the whole repo for the failure mode that took romm down today, and fixes the one other release exposed to it.

## The pattern

An app that runs **forward-only migrations at startup** cannot be safely reverted by Helm — rolling back the *image* does not un-migrate the *schema*. If remediation reverts it, the older image starts against a newer schema and fails permanently. romm proved this today:

```
Version: 5.0.0
Running database migrations
FAILED: Can't locate revision identified by '0103_roms_facets_provider_ids'
```

Crucially, **no application bug is required to trigger it.** Helm's 5m default timeout plus a slow image pull is enough. Today's large Renovate wave supplied the slowness — a 4.7 MB busybox layer took 20m41s to pull.

## Audit

All **168** HelmReleases parsed. **30** remediate by reverting. The deciding factor turned out to be `disableWait`:

| App | reverts | waits? | schema | verdict |
|---|---|---|---|---|
| **open-webui** | retries 3 | **yes** | Alembic on SQLite in PVC | **at risk — fixed here** |
| immich | retries -1 | no (`disableWait`) | Postgres | safe, unchanged |
| khoj | retries 3 | no (`disableWait`) | Postgres | safe, unchanged |
| prowlarr | retries -1 | no (`disableWait`) | Postgres | safe, unchanged |

`disableWait: true` means Helm never waits for readiness, so it never times out and remediation cannot trip. romm did **not** set it — that is exactly why it waited, timed out, and reverted. immich, khoj and prowlarr are structurally immune despite pairing reversion with a database, so they are deliberately left alone.

That leaves **open-webui** as the only genuine match: reversion enabled, Helm waits, 5m default timeout, and a migrating schema.

## Change

| Field | Why |
|---|---|
| `install.timeout: 20m` / `upgrade.timeout: 20m` | Latency alone no longer reads as failure. |
| `upgrade.remediation.retries: 0` | Disables reversion. For forward-only migrations, failing forward and surfacing `Ready=False` beats returning to a version that cannot read its own schema. Flux still retries on its normal interval. |

Precautionary, not a live outage — unlike romm, open-webui has not detonated. It is one slow pull away from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
