### PR TITLE
fix(gpu-operator): make the readiness gate real instead of decorative

### DIFF
--- a/kubernetes/apps/kube-system/gpu-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/gpu-operator/app/helmrelease.yaml
@@ -15,10 +15,25 @@ spec:
   interval: 30m
   install:
     crds: CreateReplace
-    disableWait: true
+    # Was disableWait: true, which contradicted ks.yaml's `wait: true`.
+    #
+    # Eight GPU workloads declare dependsOn gpu-operator: comfyui,
+    # comfyui-spark, ollama, tei-spark, tei-embed-spark, vllm-coder-spark,
+    # vllm-driver-spark, wyoming-services. That gate only means something if
+    # the Kustomization goes Ready when the operator is actually serving.
+    # disableWait made it Ready as soon as Helm finished applying, so
+    # dependents could start before the device plugin had registered
+    # nvidia.com/gpu -- the gate was decorative.
+    #
+    # A generous timeout keeps the readiness signal while tolerating the slow
+    # part of a gpu-operator upgrade (driver / container-toolkit / validator
+    # DaemonSet rollouts). Verified 2026-07-31 that every gpu-operator
+    # DaemonSet is desired==ready in steady state, including the
+    # zero-scheduled mps-control-daemon, so Helm's wait passes today.
+    timeout: 20m
   upgrade:
     crds: CreateReplace
-    disableWait: true
+    timeout: 20m
   values:
     operator:
       cleanupCRD: false


### PR DESCRIPTION
`ks.yaml` sets `wait: true`. The HelmRelease set `disableWait: true`. Those contradict each other, and **`disableWait` wins** — the Kustomization reported Ready as soon as Helm finished applying, not when the operator was actually serving.

## Why it matters

Eight workloads declare `dependsOn: gpu-operator`:

`comfyui` · `comfyui-spark` · `ollama` · `tei-spark` · `tei-embed-spark` · `vllm-coder-spark` · `vllm-driver-spark` · `wyoming-services`

All eight were gating on a signal that carried no information — they could start before the device plugin had registered `nvidia.com/gpu`. Kubernetes recovers (pods stay `Pending` until the resource appears), so this was never an outage. But the gate was decorative, and `wait: true` implied a guarantee that wasn't there.

## Change

Replace `disableWait: true` with an explicit **`timeout: 20m`** on install and upgrade. This keeps the readiness signal while tolerating the genuinely slow part of a gpu-operator upgrade — the driver, container-toolkit and validator DaemonSet rollouts.

## Verified before changing

Every gpu-operator DaemonSet is `desired == ready` in steady state, so Helm's wait passes today rather than newly blocking the eight dependents:

```
gpu-feature-discovery                     2/2
nvidia-container-toolkit-daemonset        1/1
nvidia-crio-cdi-setup                     1/1
nvidia-dcgm-exporter                      2/2
nvidia-device-plugin-daemonset            2/2
nvidia-device-plugin-mps-control-daemon   0/0
nvidia-node-status-exporter               2/2
nvidia-operator-validator                 2/2
```

## Scope of the audit

All **170** HelmReleases checked; **23** use `disableWait`. Every other one pairs it with `wait: false` on its Kustomization — including `auth/authelia` (25 dependents), `media/immich` (4) and `ai/ollama` (3). Those are internally consistent: they claim no readiness gate, so `disableWait` removes nothing. **gpu-operator was the only contradiction in the repo.**

Deliberately not changed: the 22 consistent ones. Several are documented as needing `disableWait` for genuinely long startups (model downloads, large image pulls), and none of them make a readiness promise they don't keep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
