### PR TITLE
ci(flate): cache chart blobs between runs to stop ghcr.io 429s

### DIFF
--- a/.github/workflows/flate.yaml
+++ b/.github/workflows/flate.yaml
@@ -63,6 +63,17 @@ jobs:
 
       - name: Setup flate
         uses: home-operations/flate/action@bf3405a189626478b0aa6ec98dc4d6f7d419df17 # v0.4.12
+        with:
+          # Restore/save flate's XDG cache (sources, helm charts, git mirrors,
+          # blobs) between runs. Without it every run re-fetches all 52 chart
+          # OCIRepositories cold from upstream registries, and GitHub-hosted
+          # runners share an egress pool, so anonymous ghcr.io pulls hit
+          # `429 toomanyrequests`. That failed main twice on 2026-07-31 --
+          # both times on ghcr.io/immich-app/immich-charts, both times with
+          # the tree itself valid (`flate test all` passed locally, 475/475).
+          # Chart refs are digest-pinned and change rarely, so the cache hits
+          # on nearly every run; requests not made can't be rate-limited.
+          cache: true
 
       # `test all` reconciles every Kustomization + HelmRelease (Helm rendering
       # is on by default) starting from the Flux entrypoint and following each
@@ -110,6 +121,12 @@ jobs:
 
       - name: Setup flate
         uses: home-operations/flate/action@bf3405a189626478b0aa6ec98dc4d6f7d419df17 # v0.4.12
+        with:
+          # Same rationale as the `test` job above -- cache chart blobs between
+          # runs so anonymous ghcr.io pulls from shared GitHub egress IPs stop
+          # tripping 429s. This job renders twice (PR tree + default-branch
+          # baseline), so it fetches roughly double and benefits more.
+          cache: true
 
       # flate's changed-only mode (--path-orig baseline = the default-branch
       # checkout) reconciles just the subtree the PR touches. FLATE_BASE="" so


### PR DESCRIPTION
## Problem

`Setup flate` was invoked with **no inputs**, so the action's `cache` defaulted to `false`. Every CI run therefore re-fetched **all 52 chart OCIRepositories cold** from upstream registries. GitHub-hosted runners share an egress pool, so those anonymous `ghcr.io` pulls compete with every other project's — and the run trips `429 toomanyrequests`.

This failed `main` **twice on 2026-07-31**, both on `ghcr.io/immich-app/immich-charts`:

```
✗  OCIRepository   media/immich-charts   429 toomanyrequests
✗  HelmRelease     media/immich          (chart source not ready)
   469 passed · 2 failed · 4 blocked
```

**Neither failure was a repo problem.** Against the same commit, `flate test all` passed locally with **475/475**, and the third CI attempt succeeded with no code change once the limit reset.

## Fix

Enable the action's own cache on both jobs:

```yaml
- name: Setup flate
  uses: home-operations/flate/action@bf3405a…  # v0.4.12
  with:
    cache: true
```

Per the action's docs it restores/saves flate's XDG cache — *"sources, helm charts, git mirrors, blobs"* — between runs. Chart refs here are digest-pinned and change rarely, so it should hit on nearly every run. Requests that are never made cannot be rate-limited.

The `diff` job renders twice (PR tree + default-branch baseline), so it fetches roughly double and benefits more.

## Alternatives deliberately not taken

**Route chart OCIRepositories through the in-cluster ZOT cache.** #12692 moved them off ZOT on purpose — plain-HTTP hop, `insecure: true`, a foundational-chart cold-boot exception, and flate/konflate couldn't render them. ZOT does now have an HTTPS gateway endpoint (`zot.${SECRET_DOMAIN}` via `internal`/`https`), which eases the plain-HTTP objection — but the cold-boot coupling remains, and it wouldn't help here regardless, because GitHub-hosted runners can't reach an internal-gateway hostname.

**Move these jobs back to self-hosted ARC runners.** #12696 moved them to `ubuntu-latest` precisely because charts no longer need in-cluster access.

**Authenticate to ghcr.io.** flate honours `~/.docker/config.json` for `OCIRepository` auth, so a `docker/login-action` step would raise the limit. Held in reserve — doing both at once would make it impossible to tell which change fixed it.

## Verification

`actionlint` passes; workflow parses and both `Setup flate` steps resolve to `cache: true`. Real signal is the next few runs: cache restore should appear in the setup step and chart-fetch time should drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
