### PR TITLE
fix(music-assistant): publish Sendspin :8927 so the Voice satellites reconnect

### DIFF
--- a/kubernetes/apps/media/music-assistant/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/music-assistant/app/cnp-allow.yaml
@@ -33,6 +33,12 @@ spec:
     # (control). These arrive from `reserved:world`. Brain's iot-policy
     # firewall must also allow 10.10.20.{26,30,31} → 10.45.0.20 tcp
     # 3483+8097 (see lovenet-network-configuration iot-policy.xml).
+    #
+    # :8927 is Sendspin, which the three Home Assistant Voice PE satellites
+    # (10.10.20.{58,60,65}) use to reach MA. They dial the LoadBalancer VIP
+    # because MA advertises base_url at the VIP, so they arrive as
+    # `reserved:world` exactly like the SlimProto clients. Brain's iot-policy
+    # needs the matching 10.10.20.{58,60,65} → 10.45.0.20 tcp 8927 rule.
     - fromEntities:
         - world
       toPorts:
@@ -44,6 +50,8 @@ spec:
             - port: "8095"
               protocol: TCP
             - port: "8097"
+              protocol: TCP
+            - port: "8927"
               protocol: TCP
     # Home Assistant integration: HA music_assistant integration polls
     # + sends commands via the local music-assistant Service:8095.

--- a/kubernetes/apps/media/music-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/media/music-assistant/app/helmrelease.yaml
@@ -189,6 +189,20 @@ spec:
           # SlimProto clients; the in-cluster squeezelite players were removed.
           streamserver:
             port: 8097
+          # Sendspin — the protocol the three Home Assistant Voice PE
+          # satellites use to reach MA. Their Universal Player wrappers
+          # (up20f83b*) link to protocol players on the `sendspin` provider,
+          # and MA binds the Sendspin server on 0.0.0.0:8927.
+          #
+          # MA advertises itself at the LoadBalancer VIP (base_url =
+          # http://${SVC_MUSIC_ASSISTANT_ADDR}:8095), so the satellites dial
+          # the VIP — not the macvlan IoT address. With 8927 unpublished they
+          # had no path in: after the 2.10.0b6 -> b9 roll on 2026-08-01 the
+          # Sendspin server logged zero inbound connections and all three
+          # players sat `available: false`, while the WiiM players were
+          # unaffected because their Sendspin bridges are created pod-locally.
+          sendspin:
+            port: 8927
 
     route:
       app:


### PR DESCRIPTION
Fixes the one regression from the b6 → b9 roll: all three **Home Assistant Voice PE satellites** went `available: false` and stayed there. Their Universal Player wrappers registered fine but had nothing behind them.

## Root cause — a missing port, not lost config

```
10:27:52  Sendspin server started successfully on 0.0.0.0:8927
          … zero inbound connections, ever
```

- The three wrappers (`up20f83b091f98` / `up20f83b0a5315` / `up20f83b093cf1`) link to protocol players `20:F8:3B:{09:1F:98,0A:53:15,09:3C:F1}` — all `provider=sendspin, enabled=true`.
- MA advertises itself at the **LoadBalancer VIP** (`base_url = http://10.45.0.20:8095`), so the satellites dial the VIP, not MA's macvlan IoT address. That's why MA's `net1` ARP table shows only the SlimProto trio and none of the `20:F8:3B` devices — the traffic is routed to the VIP and never crosses the IoT segment at L2.
- The Service published `8095/1780/3483/8097`; the CNP allowed the same four from `reserved:world`. **8927 was in neither.**

WiiM players were unaffected because MA creates their Sendspin bridges **pod-locally** (`spb_*`), so they never traverse the Service.

## Ruled out

| Hypothesis | Evidence against |
|---|---|
| b9 dropped their config | `settings.json` vs MA's own pre-migration `settings.json.backup` are **identical** for all three — same `linked_protocol_ids`, same `enabled`/`hide_in_ui` |
| Devices offline | All three answer the ESPHome native API on **tcp/6053** at `10.10.20.{60,58,65}` |
| Stale firmware | Pinned to `home-assistant-voice-pe@26.6.0` — the **newest** release (2026-06-18), notes cover Sendspin explicitly |
| Schema migration damage | 52 → 55 completed in **8s**, no error; all three WiiM players intact **including the wiim-pool → wiim-deck sync link** |

## Change

Adds `8927` to the Service and to the CNP world-ingress list. **Service/policy only — the pod template is untouched, so this should not restart Music Assistant again.**

## Follow-up outside this repo

Brain's iot-policy needs a matching `10.10.20.{58,60,65} → 10.45.0.20 tcp 8927` rule alongside the existing 3483+8097 entries (`lovenet-network-configuration` → `iot-policy.xml`). Without it the satellites are still blocked upstream of Cilium.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
