### PR TITLE
feat(music-assistant): raise memory limit so Smart Fades can load

### DIFF
--- a/kubernetes/apps/media/music-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/media/music-assistant/app/helmrelease.yaml
@@ -165,9 +165,22 @@ spec:
             resources:
               requests:
                 cpu: 15m
-                memory: 1536Mi
+                # Raised 1536Mi -> 2Gi alongside the limit bump below: Smart
+                # Fades loads the Beat This! beat-tracking model, so steady
+                # state is no longer ~535Mi. A request far below real usage
+                # makes this pod the first eviction candidate under node
+                # memory pressure (worker3 requests sit ~78%).
+                memory: 2Gi
               limits:
-                memory: 3Gi
+                # Smart Fades gates itself on total available RAM and refuses
+                # to load below 4GB, reading the container's cgroup limit:
+                #   "Provider(instance) Smart Fades can not run on this system:
+                #    at least 4GB of RAM is required (3.0GB detected)"
+                # The old 3Gi limit was reported as 3.0GB, so the provider was
+                # permanently disabled -- not an upstream bug, just the cap.
+                # 6Gi clears the 4GB gate with headroom for the model rather
+                # than sitting exactly on the threshold.
+                memory: 6Gi
 
     service:
       app:


### PR DESCRIPTION
## Why Smart Fades is off

It gates itself on total available RAM and refuses to load below 4 GB, reading the container's **cgroup limit**:

```
WARNING  Provider(instance) Smart Fades can not run on this system:
         at least 4GB of RAM is required (3.0GB detected)
```

The limit was `3Gi`, which MA reports as `3.0GB`. So the provider has been permanently disabled. **There is no upstream fix to wait for — it's purely the cap.**

## Change

| | before | after |
|---|---|---|
| `limits.memory` | 3Gi | **6Gi** |
| `requests.memory` | 1536Mi | **2Gi** |

**6Gi, not 4Gi** — so it clears the gate with headroom for the Beat This! beat-tracking model it loads, rather than sitting exactly on the threshold.

**Request raised to match.** Steady state today is ~535Mi, but with Smart Fades actually loading a model that climbs, and a request far below real usage makes this pod the first eviction candidate under node memory pressure.

## Node headroom

MA runs on a worker with **62 GiB allocatable**; memory *requests* there sit ~78%, so +512Mi of request is affordable. The limit increase lands on an already-overcommitted limits figure (155%), which is normal and expected for limits.

## Note

Requires a pod restart to take effect — Renee-facing, ~3 min (image is cached, so this is a fast roll, not the 2.5 GB cold pull).

Unrelated to #13389 (the Voice PE / Sendspin issue); this one is purely local config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
