### PR TITLE
fix(romm): grow config volume 10Gi -> 20Gi before it fills

### DIFF
--- a/kubernetes/apps/media/romm/app/longhorn-pvc.yaml
+++ b/kubernetes/apps/media/romm/app/longhorn-pvc.yaml
@@ -12,7 +12,17 @@ spec:
   volumeMode: Filesystem
   resources:
     requests:
-      storage: 10Gi
+      # Grown 10Gi -> 20Gi on 2026-08-02: KubePersistentVolumeFillingUp fired
+      # with 12.94% free and a ~4-day projection. Effectively all of it is
+      # /romm/resources (8.7G) -- romm's downloaded box art / metadata assets,
+      # which grow with the library. /romm/library is NFS and unaffected.
+      #
+      # Online expansion works because romm-config-storage-class exists
+      # in-cluster with allowVolumeExpansion=true; a static-volumeHandle PV
+      # cannot be resized without that (see memory
+      # feedback_longhorn_static_pv_resize). Both the PVC request AND the PV
+      # capacity below must move together for a statically-bound pair.
+      storage: 20Gi
   volumeName: romm-config-pv
   storageClassName: romm-config-storage-class
 ---
@@ -27,7 +37,7 @@ metadata:
     recurring-job-group.longhorn.io/weekly-backup: enabled
 spec:
   capacity:
-    storage: 10Gi
+    storage: 20Gi
   volumeMode: Filesystem
   accessModes:
     - ReadWriteOnce


### PR DESCRIPTION
`KubePersistentVolumeFillingUp` fired for `romm-config-pvc` — **12.94% available, ~4 days to full**. Confirmed live:

```
/dev/longhorn/romm-config-xfs   9.9G   8.7G   1.3G   87%   /romm/resources
```

## What's consuming it

Effectively all of it is **`/romm/resources`** — romm's downloaded box art and metadata assets, which grow with the library. The other mounts are irrelevant:

| Mount | Backing | Size |
|---|---|---|
| `/romm/resources` | **romm-config-pvc** (Longhorn) | **8.7G** ← the growth |
| `/romm/config` | romm-config-pvc | 4.0K |
| `/romm/assets` | romm-config-pvc | empty |
| `/romm/library` | NFS on beast, 75T | unaffected |

## Change

Grow **both** the PVC request and the PV capacity to 20Gi. For a statically-bound pair these must move together — unlike a dynamically provisioned PVC where only the claim is edited.

**Why online expansion works here:** `romm-config-storage-class` already exists in-cluster with `allowVolumeExpansion: true` and `provisioner: driver.longhorn.io`. A static-`volumeHandle` PV *cannot* be resized without that — both the k8s resize controller and Longhorn's admission webhook resolve the referenced StorageClass on every attempt. (Memory: `feedback_longhorn_static_pv_resize`.)

**Why 20Gi:** roughly a month of headroom at the observed fill rate; `numberOfReplicas: 2` means the real cost is 40Gi; and further online growth is cheap if the artwork cache keeps climbing. Node headroom is not a constraint — every Longhorn node reports 740Gi+ free.

## Not claimed

Whether today's 5.0.0 → 5.1.0 upgrade (#13383) caused the growth. The `0103_roms_facets_provider_ids` migration touches provider IDs and could plausibly have triggered a metadata refetch, but there's no before/after measurement, so I'm not asserting it.

## Related, deliberately out of scope

**5 Longhorn StorageClasses exist in-cluster and 0 are defined in Git** — `longhorn`, `longhorn-static` (both chart-provided), plus `romm-config-storage-class`, `obsidian-data-storage-class`, `wg-easy-config-storage-class` (hand-created). A cluster rebuild loses the latter three and re-breaks every static-PV resize. Codifying them was explicitly declined on 2026-05-14, so this PR doesn't touch it — noting only that the gap is still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
