### PR TITLE
fix(home-assistant): stop the liveness probe killing HA mid-startup

### DIFF
--- a/kubernetes/apps/home/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/home/home-assistant/app/helmrelease.yaml
@@ -99,7 +99,52 @@ spec:
             envFrom: *envFrom
 
             probes:
-              liveness: &probes
+              # Liveness is DELIBERATELY far more forgiving than readiness.
+              # It previously shared one YAML anchor with readiness — period
+              # 10s, timeout 5s, failureThreshold 3 — so 30 seconds of slow
+              # responses killed the container. That is well inside normal
+              # behaviour for this instance: HA's post-startup phase blocks
+              # the event loop while setting up 400+ devices, so `/` can take
+              # longer than 5s for a minute at a time.
+              #
+              # The startup probe does NOT cover that window. It passes as
+              # soon as 8123 accepts connections (~40s, "Home Assistant
+              # initialized in 39.42s"), which is long before integration
+              # setup finishes — so liveness takes over during the single
+              # heaviest phase of the boot and kills it mid-work.
+              #
+              # Observed 2026-07-31: 3 restarts inside ~2 minutes, each
+              # "Liveness probe failed: context deadline exceeded" -> Killing
+              # -> exit 143. NOT OOM: memory was 946Mi against the 2Gi limit
+              # below (46%), and lastState reason was Error/143, not
+              # OOMKilled. Every restart flaps every Z-Wave / BLE / MQTT
+              # entity in the house `unavailable -> unknown -> off` for ~12s,
+              # so a spurious restart is a household-visible event.
+              #
+              # Now 120s of *sustained* unresponsiveness (12 x 10s) with a
+              # 10s per-probe timeout before a kill. A genuine hang still
+              # gets restarted; a busy event loop no longer does.
+              #
+              # Raising the timeout rather than switching to a lighter path
+              # is deliberate — the bottleneck is the blocked asyncio event
+              # loop, not response size, so no endpoint would answer faster.
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: 8123
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 10
+                  failureThreshold: 12
+              # Readiness stays tight on purpose. Pulling a genuinely
+              # unresponsive pod out of the LoadBalancer is cheap and
+              # reversible; restarting it is neither. Only the restart
+              # decision needed loosening, which is why the shared anchor
+              # had to go.
+              readiness:
                 enabled: true
                 custom: true
                 spec:
@@ -110,7 +155,6 @@ spec:
                   periodSeconds: 10
                   timeoutSeconds: 5
                   failureThreshold: 3
-              readiness: *probes
               startup:
                 enabled: true
                 custom: true


### PR DESCRIPTION
HA restarted **3 times in ~2 minutes** on 2026-07-31. The cause was its own liveness probe, not memory.

## What was wrong

Liveness shared a YAML anchor with readiness:

```yaml
liveness: &probes
  spec:
    periodSeconds: 10
    timeoutSeconds: 5
    failureThreshold: 3    # => 30s of slow responses kills the container
readiness: *probes
```

Thirty seconds is well inside normal behaviour for this instance. HA's post-startup phase blocks the asyncio event loop while setting up 400+ devices, and `/` can take longer than 5s for a minute at a time.

**The startup probe does not cover that window.** It passes as soon as 8123 accepts connections — logs show `Home Assistant initialized in 39.42s` — which is long before integration setup finishes. So liveness takes over during the single heaviest phase of the boot and kills it mid-work.

## Evidence it was the probe, not memory

```
Last State:  Terminated
  Reason:    Error
  Exit Code: 143          ← SIGTERM from the kubelet, not OOMKilled
Restart Count: 3
Events: Liveness probe failed: context deadline exceeded  (x4 over 2m8s)
        Container app failed liveness probe, will be restarted
```

Memory at the time: **946Mi against the 2Gi limit — 46%**, with real headroom. An older note in my memory claimed this pod ran at 95% of 2.5G; both figures were stale and have been corrected.

Worth stating plainly: **every restart flaps every Z-Wave / BLE / MQTT entity in the house `unavailable → unknown → off` for ~12s.** A spurious restart here is a household-visible event, not a log blip.

## The change

Split the anchor and give liveness its own budget:

| probe | period | timeout | threshold | tolerance |
|---|---|---|---|---|
| **liveness** | 10s | **10s** | **12** | **120s** (was 30s) |
| readiness | 10s | 5s | 3 | 30s — unchanged |
| startup | 5s | 5s | 60 | 300s — unchanged |

**Readiness stays tight deliberately.** Pulling an unresponsive pod out of the LoadBalancer is cheap and reversible; restarting it is neither. Only the restart decision needed loosening — which is exactly why the shared anchor had to go.

A genuine hang still gets restarted, just after 120s instead of 30s.

## Rejected alternative

Probing a lighter path than `/`. The bottleneck is the blocked event loop, not response size — no endpoint would answer faster while asyncio is saturated. Raising the timeout is the change that actually matches the failure mode.

## ⚠️ Service impact

Applying this rolls the StatefulSet, so it costs **one deliberate HA restart** and the ~12s entity flap that comes with it. Worth merging at a moment when a brief flap is acceptable — not during an evening dog walk or a delivery window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)