### PR TITLE
feat(observability): actionable alert for a wedged Omada controller

### DIFF
--- a/kubernetes/apps/observability/exporters/omada-exporter/app/kustomization.yaml
+++ b/kubernetes/apps/observability/exporters/omada-exporter/app/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - ./dashboard
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./prometheusrule.yaml

--- a/kubernetes/apps/observability/exporters/omada-exporter/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/exporters/omada-exporter/app/prometheusrule.yaml
@@ -1,0 +1,45 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: omada-exporter-rules
+spec:
+  groups:
+    - name: omada-exporter.rules
+      rules:
+        # The generic TargetDown rule already catches this, and it DID page
+        # (only Watchdog + InfoInhibitor are null-routed; everything else
+        # reaches pushover on a 6h repeat). The 2026-08-01 outage went
+        # unactioned for ~22h anyway, because "TargetDown / omada-exporter"
+        # does not tell you the controller is wedged or what to do about it.
+        # This alert exists for the annotation, not for the signal.
+        - alert: OmadaControllerUnreachable
+          annotations:
+            summary: Omada controller management plane is unreachable — restart it on brain.
+            description: >-
+              omada-exporter cannot reach the Omada controller at brain:8043.
+              The controller process is usually still ALIVE when this fires —
+              APs and switches keep forwarding and stay adopted — but its web
+              connectors have deadlocked, so the UI, API, exporter and MCP
+              tooling are all dead. Confirm with `ss -lnt | grep :8043` on
+              brain: a full accept queue (Recv-Q at or above the backlog of
+              100) is the signature. Fix is a restart, NOT a rebuild:
+              back up first with
+              `tar czf /root/omada-backups/pre-hang-restart-$(date +%Y%m%d-%H%M%S).tgz -C /opt/omada data`,
+              then `systemctl restart omada.service`, then wait ~60s for
+              Java+Mongo. Runbook and history:
+              rwlove/lovenet-network-configuration#51
+          # up==0 rather than absent(): the exporter pod stays Running and
+          # serving, but it collects on scrape, so a hung upstream makes
+          # Prometheus' scrape time out. That is what actually flipped on
+          # 2026-08-01 14:00 and it is the earliest available signal —
+          # the accept-queue depth that would lead it is not exported.
+          expr: up{job="omada-exporter"} == 0
+          # 10m: longer than a controller restart (~60-120s for Java+Mongo,
+          # plus image pull on a version bump) so a planned restart or the
+          # omada-upgrade skill does not page, short enough to catch a wedge
+          # within the hour rather than the next day.
+          for: 10m
+          labels:
+            severity: critical


### PR DESCRIPTION
Adds `OmadaControllerUnreachable` after the 2026-08-01 outage, where the Omada controller's web connectors deadlocked after ~6 days uptime and sat broken for ~22h.

## Detection was never the problem

`TargetDown` fired **and notified**. Only `Watchdog` and `InfoInhibitor` are null-routed, so everything else reaches pushover on a 6h repeat — meaning this paged roughly four times and was still not actioned.

Because *"TargetDown / omada-exporter"* tells you nothing about what broke or what to do about it.

**So this alert exists for its annotation, not for a new signal.** It names the failure mode, gives the one-command confirmation, and links the runbook.

## What it says when it fires

> Omada controller management plane is unreachable — restart it on brain.
>
> The controller process is usually still **ALIVE** when this fires — APs and switches keep forwarding and stay adopted — but its web connectors have deadlocked, so UI, API, exporter and MCP tooling are all dead. Confirm with `ss -lnt | grep :8043` on brain: a full accept queue (Recv-Q at or above the backlog of 100) is the signature. Fix is a restart, **not** a rebuild: back up first, then `systemctl restart omada.service`, then wait ~60s for Java+Mongo. Runbook: rwlove/lovenet-network-configuration#51

## Design

| Choice | Why |
|---|---|
| `up == 0`, not `absent()` | The exporter pod stays **Running and serving** throughout. It collects on scrape, so a hung upstream makes Prometheus' own scrape time out — this is the metric that actually flipped at 14:00 on 2026-08-01. The accept-queue depth that *leads* it isn't exported by anything. |
| `for: 10m` | Above a legitimate restart (Java+Mongo needs 60–120s, more behind an image pull) so a planned restart or an `omada-upgrade` run doesn't page — while still catching a wedge within the hour instead of the next day. |
| `severity: critical` | Matches the repo convention that routing is by alertname, not severity. |

**This duplicates TargetDown by design.** The point is that one of the two tells you what to do.

## Validation

- `up{job="omada-exporter"} == 0` → **empty** against live Prometheus (correctly not firing)
- `up{job="omada-exporter"}` → **1** — so the selector matches a real target, not a typo'd job name
- `flate test all` → 475 passed, 0 failed

## Not included

A blackbox probe against `brain:8043` would be a more direct check than the exporter's liveness, and would survive the exporter itself being broken. Deliberately left out — it needs a new probe target plus CNP egress, and the CNP label trap for blackbox (`app.kubernetes.io/name: prometheus-blackbox-exporter`, not `blackbox-exporter`) makes a wrong rule a **silent drop**. Worth doing separately, with care.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
