### PR TITLE
feat(collab): deploy pump-voltra; bump pump v0.0.107 + pump-cv v0.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ _Production-grade Kubernetes for a household._
 
 <br/>
 
-![apps](https://img.shields.io/badge/apps-159-blue?style=for-the-badge)
-![helmreleases](https://img.shields.io/badge/HelmReleases-171-326CE5?style=for-the-badge&logo=helm&logoColor=white)
+![apps](https://img.shields.io/badge/apps-160-blue?style=for-the-badge)
+![helmreleases](https://img.shields.io/badge/HelmReleases-172-326CE5?style=for-the-badge&logo=helm&logoColor=white)
 ![nodes](https://img.shields.io/badge/k8s_nodes-11-326CE5?style=for-the-badge&logo=kubernetes&logoColor=white)
 ![cnpg](https://img.shields.io/badge/Postgres_clusters-22-336791?style=for-the-badge&logo=postgresql&logoColor=white)
-![secrets](https://img.shields.io/badge/secrets-91-0572EC?style=for-the-badge&logo=1password&logoColor=white)
+![secrets](https://img.shields.io/badge/secrets-92-0572EC?style=for-the-badge&logo=1password&logoColor=white)
 ![age](https://img.shields.io/badge/cluster_age-5%2B_years-success?style=for-the-badge)
 
 </div>

--- a/kubernetes/apps/collab/kustomization.yaml
+++ b/kubernetes/apps/collab/kustomization.yaml
@@ -28,6 +28,7 @@ resources:
   - ./paperless/ks.yaml
   - ./pump/ks.yaml
   - ./pump-cv/ks.yaml
+  - ./pump-voltra/ks.yaml
   - ./searxng/ks.yaml
   # startpunkt-oauth2-proxy retired in favour of glance-user at
   # start.${SECRET_DOMAIN}. Directory remains on disk and the Authelia

--- a/kubernetes/apps/collab/pump-cv/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump-cv/app/helmrelease.yaml
@@ -95,7 +95,7 @@ spec:
           pump-cv:
             image:
               repository: ghcr.io/rwlove/pump-cv
-              tag: v0.6.1@sha256:6afac3a6fb0dd7f4a005a0192e85edf3e6aa185a8b29612be8443ac6f2046652
+              tag: v0.6.2@sha256:8a90ea8e11a9bda157903928313e833556ce92583b3a75db361d6647871f16ab
 
             # Image's default ENTRYPOINT calls bare `python`, which doesn't
             # exist in PATH (only python3 is installed). Use the console-script
@@ -110,6 +110,18 @@ spec:
             env:
               PYTHONPATH: /app
               PUMP_API_BASE_URL: http://pump-api:8851
+              # VOLTRA_ENABLED is deliberately NOT set yet.
+              #
+              # Setting it makes pump-cv stop writing sets for exercises
+              # flagged "Uses Voltra trainer" in PUMP, on the basis that
+              # pump-voltra owns them. Until that sidecar is confirmed logging
+              # a real set, turning this on means those sets get written by
+              # nobody. v0.6.2 already reads the flag from GET /api/exercises,
+              # so with this unset it just keeps the existing opaque-load
+              # behaviour (pending, weight=0) as the fallback.
+              #
+              # Flip it to "true" once pump-voltra has logged a set from the
+              # trainer for real.
               # Read the rendered config that the init container produced.
               PUMP_CV_CONFIG: /config/default.yaml
               # Per-set clip mp4s land here (shared with pump via the

--- a/kubernetes/apps/collab/pump-voltra/app/cnp-allow.yaml
+++ b/kubernetes/apps/collab/pump-voltra/app/cnp-allow.yaml
@@ -1,0 +1,40 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: pump-voltra-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: pump-voltra
+  # Additive — collab's default-deny is what triggers the lockdown; this
+  # rule punches the one hole through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  egress:
+    # Intra-ns pump-api:8851 (PUMP_API_BASE_URL, and the /api/sets/stream SSE
+    # subscription) is covered by baseline allow-intra-namespace, so the one
+    # rule below is the whole of this sidecar's external reach.
+    #
+    # The ESPHome native API on bluetooth-proxy-gym (M5Stack ATOM Lite,
+    # 10.10.20.69, IoT VLAN), Noise-encrypted, TCP 6053. This is the whole
+    # of the sidecar's external reach.
+    #
+    # Pinned to a /32 rather than the VLAN /24 that pump-cv uses for the
+    # camera pair: this path can open a GATT session that commands a motor,
+    # so the blast radius stays one host. If the DHCP reservation ever
+    # moves, this and VOLTRA_PROXY_HOST in the HelmRelease change together.
+    #
+    # Routed egress via the pod network, not macvlan. The other IoT-VLAN
+    # consumers (home-assistant, esphome, matter-server) take net-attach
+    # because they need multicast/mDNS discovery and inbound connections;
+    # this is a plain outbound TCP dial to a known address, so it needs
+    # neither, and skipping macvlan avoids burning a static IP.
+    - toCIDR:
+        - 10.10.20.69/32
+      toPorts:
+        - ports:
+            - port: "6053"
+              protocol: TCP

--- a/kubernetes/apps/collab/pump-voltra/app/externalsecret.yaml
+++ b/kubernetes/apps/collab/pump-voltra/app/externalsecret.yaml
@@ -1,0 +1,34 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: pump-voltra
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: pump-voltra-secret
+    template:
+      engineVersion: v2
+      data:
+        # Same API_KEY the pump-cv sidecar uses — one server, one key.
+        PUMP_API_KEY: "{{ .API_KEY }}"
+        # ESPHome native-API encryption key for bluetooth-proxy-gym. That
+        # proxy is the only one of the three with an encrypted API, because
+        # it is an active-connection path to a device that can command a
+        # motor. The value is `bluetooth_proxy_gym_api_key` in the ESPHome
+        # secrets.yaml on the esphome PVC.
+        #
+        # Add a "VOLTRA_PROXY_PSK" field to the 1Password "pump" item with
+        # that value — the ExternalSecret will not resolve until you do.
+        VOLTRA_PROXY_PSK: "{{ .VOLTRA_PROXY_PSK }}"
+        # The trainer's BLE MAC. Site-specific and deliberately kept out of
+        # git — the PUMP repo is public and the sidecar's own README says so.
+        #
+        # Add a "VOLTRA_ADDRESS" field to the 1Password "pump" item.
+        VOLTRA_ADDRESS: "{{ .VOLTRA_ADDRESS }}"
+  dataFrom:
+    - extract:
+        key: pump

--- a/kubernetes/apps/collab/pump-voltra/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump-voltra/app/helmrelease.yaml
@@ -1,0 +1,94 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app pump-voltra
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+
+  interval: 30m
+  install:
+    disableWait: true
+  upgrade:
+    disableWait: true
+  values:
+    controllers:
+      pump-voltra:
+        annotations:
+          reloader.stakater.com/auto: "true"
+
+        # The Voltra accepts exactly ONE BLE central. Two replicas — or a
+        # RollingUpdate that briefly runs old and new together — would fight
+        # over the connection and neither would log reliably. Recreate is
+        # load-bearing, not a preference.
+        replicas: 1
+        strategy: Recreate
+
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+
+        containers:
+          pump-voltra:
+            image:
+              repository: ghcr.io/rwlove/pump-voltra
+              tag: v0.1.0@sha256:c6397f340332c47627de2b57a075e755b7437dc1f6a4a53cfa425a400765367d
+
+            env:
+              VOLTRA_ENABLED: "true"
+              # The ESPHome bluetooth_proxy bridging gym-BLE to LAN-TCP
+              # (M5Stack ATOM Lite, bluetooth-proxy-gym, IoT VLAN). Addressed
+              # by IP rather than hostname so the pod needs no egress to
+              # brain's DNS — the cnp-allow rule pins the same /32.
+              VOLTRA_PROXY_HOST: 10.10.20.69
+              PUMP_API_BASE_URL: http://pump-api:8851
+              # Written on sets logged before the athlete has logged any set
+              # for a Voltra-flagged exercise that day. Such sets are marked
+              # pending so the name gets corrected in the UI; normally the
+              # name is inherited and this is unused.
+              VOLTRA_DEFAULT_EXERCISE: Voltra
+
+            envFrom:
+              - secretRef:
+                  name: pump-voltra-secret
+
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: 8080
+                  initialDelaySeconds: 15
+                  periodSeconds: 30
+                  failureThreshold: 3
+              # Readiness is deliberately DISABLED. /readyz reports 503
+              # whenever the trainer isn't connected, which is the normal
+              # state of an empty gym — wiring it would leave the pod
+              # NotReady most of the day and make a healthy service look
+              # broken. Nothing routes traffic to this pod, so readiness
+              # buys nothing. Connection state is observable on /metrics
+              # (pump_voltra_connected).
+              readiness:
+                enabled: false
+
+            resources:
+              requests:
+                cpu: 25m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+              seccompProfile:
+                type: RuntimeDefault

--- a/kubernetes/apps/collab/pump-voltra/app/kustomization.yaml
+++ b/kubernetes/apps/collab/pump-voltra/app/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../../../components/repos/app-template
+
+resources:
+  - ./cnp-allow.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/collab/pump-voltra/ks.yaml
+++ b/kubernetes/apps/collab/pump-voltra/ks.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app pump-voltra
+  labels:
+    substitution.flux.home.arpa/enabled: "true"
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: collab
+  path: ./kubernetes/apps/collab/pump-voltra/app
+  interval: 30m
+  timeout: 3m
+  wait: false
+  dependsOn:
+    # pump ships the exercises.voltra column (migration v11) that this
+    # sidecar reads from GET /api/exercises, and the VOLTRA_AUTOLOG gate
+    # that lets its writes through. Ordering matters on a cold bootstrap.
+    - name: pump

--- a/kubernetes/apps/collab/pump/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump/app/helmrelease.yaml
@@ -49,7 +49,7 @@ spec:
           pump:
             image:
               repository: ghcr.io/rwlove/pump
-              tag: v0.0.106@sha256:4f255412ab46d6b147d25b49fcf5e05d0ab2dad024fb8dc5642f93a32f18591f
+              tag: v0.0.107@sha256:92e26eda125cc35089fa8924ee5fd222f1b3c47f8bfc63dc4fe6e5f24c98b941
 
             env:
               # Activates the /api/cv/* proxy in pump (see internal/web/exercise.go).
@@ -71,6 +71,16 @@ spec:
               TREADMILL_MQTT_BROKER: tcp://emqx-headless.home.svc.cluster.local:1883
               TREADMILL_MQTT_TOPIC: zwave/Gym/Treadmill/50/0/value/66049
               TREADMILL_WATTS_THRESHOLD: "100"
+              # Accept set writes from the pump-voltra sidecar, which reads
+              # rep count and real resistance off the Beyond Power VOLTRA I
+              # over BLE. Without this pump 403s every Source: "voltra" write.
+              #
+              # It also flips the workout page to per-set saves. That matters:
+              # in bulk mode the page rewrites the whole day from the browser
+              # DOM, which would delete sidecar-written sets on the next
+              # autosave. Env-only — there is no Settings toggle for it, unlike
+              # CVAutoLog.
+              VOLTRA_AUTOLOG: "true"
 
             envFrom:
               - secretRef:


### PR DESCRIPTION
Deploys the **pump-voltra** sidecar and bumps the two existing PUMP images.

pump-voltra reads set number, rep count and real resistance off the Beyond Power VOLTRA I over BLE — via the `bluetooth-proxy-gym` ESPHome proxy — and logs each set. The trainer's resistance is electronic and invisible to pump-cv's plate detection, so today every Voltra set needs its weight typed in by hand.

Upstream: rwlove/PUMP#74 (sidecar + migration v11), #75 (pre-tag ritual), #78 (CI fix).

## Changes

| | |
|---|---|
| `pump` | `v0.0.106` → **`v0.0.107`**, adds `VOLTRA_AUTOLOG: "true"` |
| `pump-cv` | `v0.6.1` → **`v0.6.2`** (no env change — see below) |
| `pump-voltra` | **new app**: ks, HelmRelease, ExternalSecret, CiliumNetworkPolicy |

⚠️ **`pump` v0.0.107 runs migration v11** on first boot — `ALTER TABLE exercises ADD COLUMN IF NOT EXISTS voltra BOOLEAN NOT NULL DEFAULT FALSE`. Additive and idempotent, verified against a local restore of the prod DB on the fresh, v10→v11 and v1→v11 paths with sets and exercises checksums unchanged. Every existing exercise defaults to unflagged, which is correct.

## Three choices worth calling out

**`replicas: 1` + `strategy: Recreate`.** The Voltra accepts exactly one BLE central. A RollingUpdate briefly runs old and new pods together and they'd fight over the connection.

**Readiness probe deliberately disabled.** `/readyz` reports 503 whenever the trainer isn't connected — the normal state of an empty gym. Wiring it would leave the pod NotReady most of the day and make a healthy service look broken. Nothing routes traffic here. Connection state is observable as `pump_voltra_connected` on `/metrics`.

**Routed egress on a `/32`, not macvlan.** The other IoT-VLAN consumers (home-assistant, esphome, matter-server) take `net-attach` because they need multicast discovery and inbound connections. This is a plain outbound TCP dial to a known address, so it needs neither, and skipping macvlan avoids burning a static IP. Pinned to `10.10.20.69/32` rather than the VLAN `/24` that pump-cv uses for the cameras, because this path can open a GATT session that commands a motor.

## `VOLTRA_ENABLED` is intentionally NOT set on pump-cv

Setting it makes pump-cv stop writing sets for Voltra-flagged exercises, on the basis that pump-voltra owns them. Until the sidecar is confirmed logging a real set, that would mean **nobody** writes them. v0.6.2 already reads the flag, so leaving it unset just preserves the current opaque-load fallback. Flip it in a follow-up once the trainer has logged a set for real.

## Blocking prerequisite

The ExternalSecret will **not resolve** until two fields are added to the 1Password `pump` item:

- **`VOLTRA_PROXY_PSK`** — the value of `bluetooth_proxy_gym_api_key` from the ESPHome `secrets.yaml` on the esphome PVC. (`bluetooth-proxy-gym` is the only one of the three proxies with an encrypted API, precisely because it's an active-connection path to a motor.)
- **`VOLTRA_ADDRESS`** — the trainer's BLE MAC. Kept out of git because the PUMP repo is public.

## Also outstanding

**The gym smoke test.** Passive-listener telemetry has never been observed on hardware — every protocol test so far engaged the motor from software. The sidecar assumes the athlete starts the workout on the trainer's own controls and telemetry then flows to a listener. Worth watching the first session's logs.

**BLE central contention.** `bluetooth-proxy-gym` is a general proxy and will likely be adopted into Home Assistant. The proxy has 3 connection slots, but *the trainer* accepts one central — so if HA is ever pointed at the Voltra too, it and pump-voltra will fight. Fine today; worth knowing before that adoption.

## Verification

`kubectl kustomize` renders both the app and the full `collab` namespace (37 resources). All repo pre-commit hooks pass, including yamllint, secret detection and the README badge drift check (apps 159→160, HelmReleases 171→172, secrets 91→92). Probe, `strategy` and ExternalSecret syntax match existing apps in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)