### PR TITLE
fix(collab): bump pump-voltra to v0.1.1

### DIFF
--- a/kubernetes/apps/collab/pump-voltra/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump-voltra/app/helmrelease.yaml
@@ -37,7 +37,7 @@ spec:
           pump-voltra:
             image:
               repository: ghcr.io/rwlove/pump-voltra
-              tag: v0.1.0@sha256:c6397f340332c47627de2b57a075e755b7437dc1f6a4a53cfa425a400765367d
+              tag: v0.1.1@sha256:122db595e770ea088c4803aa60cf218a56e171e6669f982abe51f12fd7610c30
 
             env:
               VOLTRA_ENABLED: "true"


### PR DESCRIPTION
Bumps `pump-voltra` `v0.1.0` → `v0.1.1`. Upstream: rwlove/PUMP#79.

Caught in the pod logs minutes after the initial deploy — it was reconnecting to `/api/sets/stream` every ~15 s:

```
[warning] sse stream dropped; reconnecting error=
```

The stream was healthy. httpx applied the client's 10 s timeout as a **read** timeout, and an SSE connection is idle by design between events — PUMP's keepalive is every **25 s** — so the read timeout always won. The empty error was `httpx.ReadTimeout`, which stringifies to `""`.

Set logging was never affected (it reconnected and re-seeded the naming anchor each time), but it churned a connection every 15 s and buried anything real in the log.

Image is unchanged in every other respect. Still blocked on the `bluetooth-proxy-gym` ESP32 being powered on — see the note on #13402.

🤖 Generated with [Claude Code](https://claude.com/claude-code)