### PR TITLE
fix(collab): bump pump-voltra to v0.1.2

### DIFF
--- a/kubernetes/apps/collab/pump-voltra/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump-voltra/app/helmrelease.yaml
@@ -37,7 +37,7 @@ spec:
           pump-voltra:
             image:
               repository: ghcr.io/rwlove/pump-voltra
-              tag: v0.1.1@sha256:122db595e770ea088c4803aa60cf218a56e171e6669f982abe51f12fd7610c30
+              tag: v0.1.2@sha256:070e8141560ab41ad7c48123dd73884f4efb797a411c63ff837b662cc66899a9
 
             env:
               VOLTRA_ENABLED: "true"


### PR DESCRIPTION
Bumps `pump-voltra` `v0.1.1` → `v0.1.2`. Upstream: rwlove/PUMP#80.

With the ESP32 proxy finally reachable, the sidecar got past authentication and immediately hit a bug in its own transport:

```
connect failed; retrying error="object ESPHomeClientData can't be used in 'await' expression"
```

`connect_scanner` is synchronous and was being awaited. It also assigns the caller three duties the code performed none of — `scanner.async_setup()`, registering the scanner with the habluetooth manager, and unregistering on disconnect. Without the registration the proxy authenticates and then yields no usable BLE client, which is a silent dead end rather than an error.

That path had never been exercised by committed code: the protocol spike used the workstation's own Bluetooth adapter, with no ESPHome in the loop.

Also required, separately from this image: the proxy itself needed `esphome clean` + a full rebuild + OTA. The cached build predated the current `secrets.yaml` key, so the first re-flash pushed a stale one. Encrypted connect to the proxy now succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)