### PR TITLE
fix(collab): bump pump-voltra to v0.1.3

### DIFF
--- a/kubernetes/apps/collab/pump-voltra/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump-voltra/app/helmrelease.yaml
@@ -37,7 +37,7 @@ spec:
           pump-voltra:
             image:
               repository: ghcr.io/rwlove/pump-voltra
-              tag: v0.1.2@sha256:070e8141560ab41ad7c48123dd73884f4efb797a411c63ff837b662cc66899a9
+              tag: v0.1.3@sha256:b1982f051257f3d8ae4db6233b56c806e1610cc4dee215f88d57e3c9c9c4741c
 
             env:
               VOLTRA_ENABLED: "true"


### PR DESCRIPTION
Bumps `pump-voltra` `v0.1.2` → `v0.1.3`. Upstream: rwlove/PUMP#81.

**This is the root cause of the proxy "reverting" after each re-flash.**

`connect()` built an `APIClient` and returned only the `BleakClient`. Nothing ever closed the `APIClient`, so every 15 s retry stranded one on the ESP32. It accepts only a handful of concurrent API connections, so within hours it ran out and began dropping new clients right after the encrypted hello:

```
The connection dropped immediately after encrypted hello;
Try enabling encryption on the device or turning off encryption on the client
```

That reads as a wrong PSK, which is what sent me rebuilding firmware and re-flashing twice. The PSK was correct at all four hops the whole time — esphome `secrets.yaml`, 1Password, the k8s Secret, and the pod env were verified byte-identical.

The tell: a fresh client connected fine while the long-running sidecar failed, and each device reboot restored service for a while before it degraded again.

`connect()` now returns a `ProxyLink` covering both halves and closes the API client on every failure path. Retries back off 15 s → 120 s so an idle gym doesn't hammer the device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)