### PR TITLE
fix(collab): bump pump-voltra to v0.1.4

### DIFF
--- a/kubernetes/apps/collab/pump-voltra/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump-voltra/app/helmrelease.yaml
@@ -37,7 +37,7 @@ spec:
           pump-voltra:
             image:
               repository: ghcr.io/rwlove/pump-voltra
-              tag: v0.1.3@sha256:b1982f051257f3d8ae4db6233b56c806e1610cc4dee215f88d57e3c9c9c4741c
+              tag: v0.1.4@sha256:e509615b626427b9dd778c5d2fab1765394943a294d3a9c984f5d81ce89daa36
 
             env:
               VOLTRA_ENABLED: "true"


### PR DESCRIPTION
Bumps `pump-voltra` `v0.1.3` → `v0.1.4`. Upstream: rwlove/PUMP#82.

The scanner was being registered and connected to in the same breath, so it had heard nothing yet:

```
No backend with an available connection slot that can reach address ... was found:
unknown (never seen by any scanner); 1 scanner(s) registered, 1 scanning, 1 connectable
```

BLE devices are only reachable once they advertise, so this failed every time even with the trainer switched on. Now polls until a scanner has actually seen the address, then uses `bleak_retry_connector.establish_connection()` — which bleak had been asking for on every attempt, and which takes a `BLEDevice` rather than an address precisely because you're meant to discover first.

A discovery timeout is logged at **info**, not as an error. An empty gym is this service's normal state; warning about it hourly would bury real failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)