### PR TITLE
fix(collab): bump pump-voltra to v0.1.5

### DIFF
--- a/kubernetes/apps/collab/pump-voltra/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump-voltra/app/helmrelease.yaml
@@ -37,7 +37,7 @@ spec:
           pump-voltra:
             image:
               repository: ghcr.io/rwlove/pump-voltra
-              tag: v0.1.4@sha256:e509615b626427b9dd778c5d2fab1765394943a294d3a9c984f5d81ce89daa36
+              tag: v0.1.5@sha256:1cfdbb6462408d787ef76ddba3003f5f5cd724713945de6f0db57635793c7986
 
             env:
               VOLTRA_ENABLED: "true"


### PR DESCRIPTION
Bumps `pump-voltra` `v0.1.4` → `v0.1.5`. Upstream: rwlove/PUMP#83.

The ESP32 allows **one advertisement subscriber at a time** and silently refuses a replacement while a prior connection still holds the slot. The sidecar tore its whole proxy session down every time the trainer wasn't found — which an empty gym did constantly — so the replacement subscription was usually refused without an error, the scanner heard nothing, and the trainer looked permanently offline.

The proxy session is now long-lived and survives the trainer being switched off. Only the BLE half is torn down between sessions.

This also invalidates the "the proxy's BLE radio sees nothing" reading that prompted the re-flash and power-cycle: a second API client probing for advertisements is refused for the same reason, and the two known-good proxies measure zero identically because Home Assistant holds their slot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)