### PR TITLE
fix(collab): bump pump-voltra to v0.1.6

### DIFF
--- a/kubernetes/apps/collab/pump-voltra/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump-voltra/app/helmrelease.yaml
@@ -37,7 +37,7 @@ spec:
           pump-voltra:
             image:
               repository: ghcr.io/rwlove/pump-voltra
-              tag: v0.1.5@sha256:1cfdbb6462408d787ef76ddba3003f5f5cd724713945de6f0db57635793c7986
+              tag: v0.1.6@sha256:1e3a2897c0ba498b50a5c55869b691b1af79f4dbd1d1bfd5954490542dbf93a2
 
             env:
               VOLTRA_ENABLED: "true"


### PR DESCRIPTION
Bumps `pump-voltra` `v0.1.5` → `v0.1.6`. Upstream: rwlove/PUMP#84.

Discovery **succeeded** against the real trainer for the first time, then immediately failed on a wrong attribute name:

```
22:42:32  waiting for the trainer   (asleep)
22:43:29  connect failed  'BluetoothScannerDevice' object has no attribute 'device'   ← FOUND
22:43:48  connect failed  ... same
22:44:20  connect failed  ... same
22:46:20  waiting for the trainer   (asleep again — window gone)
```

habluetooth's `BluetoothScannerDevice` is `(scanner, ble_device, advertisement)`. The wrong name only ever runs on the success path, so every earlier run took the timeout branch and never reached it.

The trainer advertises only briefly after being woken, so those three retries consumed the whole window and the log went back to reporting it absent — reading as "never found" rather than "found and thrown away".

Discovery timeout also 60s → 300s: the proxy session is long-lived now, so waiting is free, and a short window needlessly misses a device that wakes between polls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)