### PR TITLE
fix(collab): bump pump to v0.0.108 — workout page double-add

### DIFF
--- a/kubernetes/apps/collab/pump/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump/app/helmrelease.yaml
@@ -49,7 +49,7 @@ spec:
           pump:
             image:
               repository: ghcr.io/rwlove/pump
-              tag: v0.0.107@sha256:92e26eda125cc35089fa8924ee5fd222f1b3c47f8bfc63dc4fe6e5f24c98b941
+              tag: v0.0.108@sha256:edf637d449fe08e4b09cee7e19a2c3736d540dcaffe28263669857fcfb8f79ff
 
             env:
               # Activates the /api/cv/* proxy in pump (see internal/web/exercise.go).


### PR DESCRIPTION
Bumps `pump` `v0.0.107` → `v0.0.108`. Upstream: rwlove/PUMP#85.

Clicking **+** on an exercise added it twice, and deleting one removed both — two DOM nodes aliasing a single database row, because the server published the SSE `add` before writing the HTTP response, so the echo beat the client learning the row's id.

Browsers now send `X-Client-Id` on mutating calls and the broker withholds a client's own events. Sidecar writes (`pump-cv`, `pump-voltra`) carry no client id and still reach every browser — there's a test for that, since over-suppressing would silently break live auto-logged sets.

**Regression I introduced in v0.0.107**: `VOLTRA_AUTOLOG` enabled the page's per-set save mode and SSE for the first time on this deployment (`CVAutoLog` is false here), exposing a race that had been latent in the CV auto-log path.

**Data impact was loss, not duplication.** Both visible rows `PATCH`ed the same record, so differing values overwrote each other, and deleting a "duplicate" deleted the real set. ~6 sets went on 08-07/08-08 (id gaps 4828/4831/4832 and 4837–4840). WAL archiving is healthy with a 2026-08-02 base backup, so PITR recovery is being tracked separately.

No schema change. No new environment variables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)