### PR TITLE
fix(media): pin immich-kiosk to 0.41.0 — 0.42.0 requires Immich >= 3.0.3

### DIFF
--- a/kubernetes/apps/media/immichkiosk-party/app/helmrelease.yaml
+++ b/kubernetes/apps/media/immichkiosk-party/app/helmrelease.yaml
@@ -27,7 +27,11 @@ spec:
           app:
             image:
               repository: ghcr.io/damongolding/immich-kiosk
-              tag: 0.42.0@sha256:96909e1c7f52323e4cd742cc14d2650d9a421fdbf85699f64e065f6aa6fbaa89
+              # workaround: https://github.com/damongolding/immich-kiosk/releases/tag/v0.42.0 — remove when Immich is upgraded to >= 3.0.3
+              # kiosk 0.42.0 hard-gates on Immich >= 3.0.3 and exits 1 at startup
+              # against our 3.0.2 ("ERRO Immich version not supported"). Renovate
+              # bumped the consumer ahead of its dependency; pin until Immich moves.
+              tag: 0.41.0@sha256:ee6145ac6bd5a5492a746d019bf01bbe25559def1cbc2e79f61b0871b8933cf6
 
             env:
               # Required settings

--- a/kubernetes/apps/media/immichkiosk/app/helmrelease.yaml
+++ b/kubernetes/apps/media/immichkiosk/app/helmrelease.yaml
@@ -27,7 +27,11 @@ spec:
           app:
             image:
               repository: ghcr.io/damongolding/immich-kiosk
-              tag: 0.42.0@sha256:96909e1c7f52323e4cd742cc14d2650d9a421fdbf85699f64e065f6aa6fbaa89
+              # workaround: https://github.com/damongolding/immich-kiosk/releases/tag/v0.42.0 — remove when Immich is upgraded to >= 3.0.3
+              # kiosk 0.42.0 hard-gates on Immich >= 3.0.3 and exits 1 at startup
+              # against our 3.0.2 ("ERRO Immich version not supported"). Renovate
+              # bumped the consumer ahead of its dependency; pin until Immich moves.
+              tag: 0.41.0@sha256:ee6145ac6bd5a5492a746d019bf01bbe25559def1cbc2e79f61b0871b8933cf6
 
             env:
               # Required settings


### PR DESCRIPTION
## Problem

`immich-kiosk` 0.42.0 (merged in #13461) **cannot start** against our Immich server. It hard-gates on the server version and exits 1 immediately:

```
Version 0.42.0
13:45:44 ERRO Immich version not supported  Immich version=3.0.2  supported version=3.0.3
```

Both kiosk HelmReleases CrashLooped through their remediation retries and rolled back. Renovate bumped the **consumer** ahead of the dependency it gates on, so this upgrade can never succeed until Immich moves — retrying just loops.

Captured live by forcing the upgrade and tailing the container during the CrashLoop backoff; the earlier failures only surfaced as `timeout waiting for: [StatefulSet ... 'InProgress']`, which looked like the day's registry contention and hid the real cause.

## Change

Pin both `immichkiosk` and `immichkiosk-party` back to `0.41.0`, annotated per [`.agents/instructions/workarounds.md`](.agents/instructions/workarounds.md) so `upstream-watcher` can retire it:

```yaml
# workaround: https://github.com/damongolding/immich-kiosk/releases/tag/v0.42.0 — remove when Immich is upgraded to >= 3.0.3
```

## Follow-up (not in this PR)

Immich **3.0.3** (2026-07-15) and **3.1.0** (2026-07-29) are both available upstream; we're on **3.0.2** (2026-07-09) and Renovate has proposed neither. Worth understanding why before upgrading — upgrading Immich is the real fix and unblocks kiosk 0.42.0.

## Urgency

Both kiosk StatefulSets are currently down. Merging this restores them to the working 0.41.0.