### PR TITLE
fix(immich): make immich-server image trackable by Renovate

### DIFF
--- a/kubernetes/apps/media/immich/app/helmrelease.yaml
+++ b/kubernetes/apps/media/immich/app/helmrelease.yaml
@@ -33,8 +33,15 @@ spec:
         containers:
           main:
             image:
-              # renovate: datasource=github-releases depName=immich-app/immich
-              tag: "v3.0.2@sha256:14390f3dc9512dc3273b12ccee6363d9be16c388699abc3f3fe0498bb9829937"
+              # repository is explicit (not left to the chart default) so
+              # Renovate's standard helm-values manager tracks this image.
+              # The previous `# renovate: datasource=github-releases`
+              # annotation required a customManager regex that does not
+              # exist in .github/renovate/customManagers.json5, so
+              # immich-server was invisible to Renovate and froze at v3.0.2
+              # while immich-machine-learning kept auto-bumping.
+              repository: ghcr.io/immich-app/immich-server
+              tag: v3.0.2@sha256:14390f3dc9512dc3273b12ccee6363d9be16c388699abc3f3fe0498bb9829937
             env:
               DB_DATABASE_NAME: immich
 


### PR DESCRIPTION
## Problem

`immich-server` was tracked by an inline annotation rather than a normal image pair:

```yaml
# renovate: datasource=github-releases depName=immich-app/immich
tag: "v3.0.2@sha256:..."
```

That form requires a matching **customManager** regex. `.github/renovate/customManagers.json5` defines exactly one rule — for `oci://` URLs — so **nothing matched it**. immich-server has been invisible to Renovate and hasn't moved since it was hand-bumped to v3.0.2 in #12956 on 2026-07-09.

## Consequence: the components are skewed

`immich-machine-learning` has a normal `repository:` + `tag:` pair, so it kept auto-bumping:

| Component | Version | How it got there |
| --- | --- | --- |
| immich-server | **v3.0.2** (2026-07-09) | hand-bumped #12956, frozen since |
| immich-machine-learning | **v3.1.0** (2026-07-29) | #13067 → v3.0.3, #13370 → v3.1.0 |

They've been running two releases apart since 2026-07-29. Upstream v3.0.3 and v3.1.0 images both exist and are pullable — we simply were never offered them.

This also blocks `immich-kiosk` 0.42.0, which hard-gates on Immich >= 3.0.3 (see #13479).

## Change

Set `repository: ghcr.io/immich-app/immich-server` explicitly so Renovate's standard `helm-values` manager tracks it, with a comment recording why it isn't left to the chart default.

## Verification

`helm template` against chart 0.13.1 with the values before and after produces **byte-identical output** — this is purely a tracking fix, no version change and no runtime effect. The explicit repository matches what the pod already runs (`ghcr.io/immich-app/immich-server:v3.0.2@sha256:14390f…`).

## Follow-up (not in this PR)

Once merged, Renovate will start proposing v3.0.3 / v3.1.0 for the server. Converging server and ML onto one version is a deliberate decision — Immich is Renee-facing and major bumps carry DB migrations — so it should be its own change rather than an automerge.