### PR TITLE
feat(immich): upgrade immich-server v3.0.2 → v3.1.0

### DIFF
--- a/kubernetes/apps/media/immich/app/helmrelease.yaml
+++ b/kubernetes/apps/media/immich/app/helmrelease.yaml
@@ -41,7 +41,7 @@ spec:
               # immich-server was invisible to Renovate and froze at v3.0.2
               # while immich-machine-learning kept auto-bumping.
               repository: ghcr.io/immich-app/immich-server
-              tag: v3.0.2@sha256:14390f3dc9512dc3273b12ccee6363d9be16c388699abc3f3fe0498bb9829937
+              tag: v3.1.0@sha256:b434cb9287eea1471c9974845914d4dd328c9c2d652e446ed4930f99944f0ceb
             env:
               DB_DATABASE_NAME: immich
 


### PR DESCRIPTION
## What

Bumps `immich-server` from **v3.0.2** (2026-07-09) to **v3.1.0** (2026-07-29), digest-pinned.

## Why

`immich-machine-learning` has been on **v3.1.0** since #13370, while the server stayed on v3.0.2 — two releases of skew running since 2026-07-29. The cause was that immich-server was invisible to Renovate (fixed in #13480); it never got offered the updates its ML sidecar was taking automatically. This converges them.

It also unblocks `immich-kiosk` 0.42.0, which hard-gates on Immich >= 3.0.3 and is currently pinned back to 0.41.0 by #13479. That pin carries a `# workaround:` annotation whose retirement condition — "Immich >= 3.0.3" — is satisfied by this PR.

## Risk

**Breaking changes across v3.0.3 + v3.1.0: one** — dropping iOS 14 support in the mobile app. Nothing server-side, and this deployment is Android-only, so no exposure.

Everything else is features/fixes: upload wakelock, undo archive, workflow filters by server filepath and EXIF, OIDC role-claim sync, session invalidation on password reset.

## Pre-upgrade backup

Immich runs **forward-only** schema migrations at startup — rolling the image back cannot un-run them. Fresh backup taken and verified before this change:

```
backup:   postgres-immich-pre-v310-20260808-1358
backupId: 20260808T175853
phase:    completed
window:   garage-immich lastSuccessfulBackupTime 2026-08-08T18:01:38Z
```

The prior automatic backup was 6 days old (`@weekly`); this one is minutes old.

The HelmRelease already sets `disableWait: true` on install and upgrade, so helm-controller will not enter the timeout-then-rollback cycle that makes forward-only migrations hazardous — the failure mode documented in #13383 and again in today's runbook (#13478).

## Expected impact

`immich-server` restarts and runs migrations. Photo library unavailable for the duration. Assets themselves live on NFS and are untouched; only the Postgres schema changes.