### PR TITLE
feat(media): retire immich-kiosk 0.41.0 pin — Immich is now v3.1.0

### DIFF
--- a/kubernetes/apps/media/immichkiosk-party/app/helmrelease.yaml
+++ b/kubernetes/apps/media/immichkiosk-party/app/helmrelease.yaml
@@ -27,11 +27,7 @@ spec:
           app:
             image:
               repository: ghcr.io/damongolding/immich-kiosk
-              # workaround: https://github.com/damongolding/immich-kiosk/releases/tag/v0.42.0 — remove when Immich is upgraded to >= 3.0.3
-              # kiosk 0.42.0 hard-gates on Immich >= 3.0.3 and exits 1 at startup
-              # against our 3.0.2 ("ERRO Immich version not supported"). Renovate
-              # bumped the consumer ahead of its dependency; pin until Immich moves.
-              tag: 0.41.0@sha256:ee6145ac6bd5a5492a746d019bf01bbe25559def1cbc2e79f61b0871b8933cf6
+              tag: 0.42.0@sha256:96909e1c7f52323e4cd742cc14d2650d9a421fdbf85699f64e065f6aa6fbaa89
 
             env:
               # Required settings

--- a/kubernetes/apps/media/immichkiosk/app/helmrelease.yaml
+++ b/kubernetes/apps/media/immichkiosk/app/helmrelease.yaml
@@ -27,11 +27,7 @@ spec:
           app:
             image:
               repository: ghcr.io/damongolding/immich-kiosk
-              # workaround: https://github.com/damongolding/immich-kiosk/releases/tag/v0.42.0 — remove when Immich is upgraded to >= 3.0.3
-              # kiosk 0.42.0 hard-gates on Immich >= 3.0.3 and exits 1 at startup
-              # against our 3.0.2 ("ERRO Immich version not supported"). Renovate
-              # bumped the consumer ahead of its dependency; pin until Immich moves.
-              tag: 0.41.0@sha256:ee6145ac6bd5a5492a746d019bf01bbe25559def1cbc2e79f61b0871b8933cf6
+              tag: 0.42.0@sha256:96909e1c7f52323e4cd742cc14d2650d9a421fdbf85699f64e065f6aa6fbaa89
 
             env:
               # Required settings


### PR DESCRIPTION
## What

Reverts the pin from #13479, restoring both `immichkiosk` and `immichkiosk-party` to **0.42.0** and removing the `# workaround:` annotation.

## Why

That workaround's retirement condition was *"remove when Immich is upgraded to >= 3.0.3"*. Immich went to **v3.1.0** in #13481 and is running healthy (migrations applied, no schema drift), so the condition is satisfied.

Original failure, for reference:

```
Version 0.42.0
ERRO Immich version not supported  Immich version=3.0.2  supported version=3.0.3
```

0.42.0 is still the latest kiosk release (2026-08-04), so reverting the pin is the only way forward — there's no newer build to jump to.

## Known risk

Kiosk reported `supported version=3.0.3` and we're now on **3.1.0**. **If that check is an exact match rather than a minimum, 0.42.0 will fail again identically.** I could not confirm the comparison semantics from upstream source.

Verifying empirically rather than guessing, because failure here is cheap and non-destructive:

- the container exits 1 immediately on mismatch (no partial state, no migrations, no data touched)
- Helm rolls back to 0.41.0 automatically
- worst case is a few minutes of photo-frame downtime

If it does crashloop, the response is to re-pin to 0.41.0 and reopen the workaround noting the exact-match behaviour — which would then need an upstream issue, since it'd mean kiosk can never run against a newer Immich.

## Verification plan

Watch both StatefulSets through the roll; confirm the startup banner reports 0.42.0 without the version error and the pods reach Ready.