### PR TITLE
feat(collab): bump pump-voltra to v0.1.7 — motor control

### DIFF
--- a/kubernetes/apps/collab/pump-voltra/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump-voltra/app/helmrelease.yaml
@@ -37,7 +37,7 @@ spec:
           pump-voltra:
             image:
               repository: ghcr.io/rwlove/pump-voltra
-              tag: v0.1.6@sha256:1e3a2897c0ba498b50a5c55869b691b1af79f4dbd1d1bfd5954490542dbf93a2
+              tag: v0.1.7@sha256:8c6ec13ff7bf4bdb4bd2b0fd16fac0d8a2dff327adb87a595861e09ec4d8af72
 
             env:
               VOLTRA_ENABLED: "true"
@@ -52,6 +52,12 @@ spec:
               # pending so the name gets corrected in the UI; normally the
               # name is inherited and this is unused.
               VOLTRA_DEFAULT_EXERCISE: Voltra
+              # Ceiling on any weight written to the motor; requests above it
+              # are clamped. Same as the image default — stated here because
+              # from v0.1.7 this sidecar commands the motor, and a physical
+              # safety limit should be reviewable in the manifest rather than
+              # inherited invisibly from the image.
+              VOLTRA_MAX_LOAD_LB: "130"
 
             envFrom:
               - secretRef:


### PR DESCRIPTION
`ghcr.io/rwlove/pump-voltra` **v0.1.6 → v0.1.7**

## What changes

Phase 2: the sidecar now drives the trainer's motor. PUMP holds intent (which set is armed, whether it should be loaded); the sidecar reconciles the hardware onto it and reports back what actually happened.

Reconciliation rather than a command queue — there's nothing to replay onto a machine the athlete has since walked away from after a reconnect.

Safety rules are enforced as preconditions in the sidecar:
- clamp every write to max load
- refuse unless the workout is active on the device
- disengage before any weight change
- verify by **read-back** before reporting engaged
- unload rather than leave the cable live if the state stream drops

## ⚠️ Merge order

**This must merge and roll out before the `pump` v0.0.109 bump.** That release gates trainer writes on the sidecar reporting `Loaded`; server-first would 409 every Voltra write until this lands.

## Blast radius

Single replica, `strategy: Recreate` — the trainer accepts one BLE central, so two replicas would fight over the connection. A restart drops the load rather than holding it, by design.

`VOLTRA_MAX_LOAD_LB` is stated explicitly at the image default of `130`. No behaviour change; from this version the sidecar can actually act on that limit, so it belongs somewhere reviewable rather than inherited invisibly from the image.

## Not changed

No network policy change. The new traffic is `/api/voltra/stream` and `/api/voltra/report` against `pump-api:8851`, already covered by the baseline intra-namespace allow; the `/32` hole to the BLE proxy on 6053 is untouched.

## Verification

- `kubectl kustomize kubernetes/apps/collab/pump-voltra/app` builds clean; tag and env render as expected.
- Digest taken from the GHCR packages API, matching the convention the existing pinned digests in this repo use (cross-checked against the v0.1.6 entry).
- Hardware still untested — motor control has not run against the real trainer yet. First real use is intended at low weight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)