### PR TITLE
feat(collab): bump pump to v0.0.109 — group-based colors, Voltra phase 2 server

### DIFF
--- a/kubernetes/apps/collab/pump/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump/app/helmrelease.yaml
@@ -49,7 +49,7 @@ spec:
           pump:
             image:
               repository: ghcr.io/rwlove/pump
-              tag: v0.0.108@sha256:edf637d449fe08e4b09cee7e19a2c3736d540dcaffe28263669857fcfb8f79ff
+              tag: v0.0.109@sha256:274688bef64210ea3068df3d7d69cada68f13901c9f1e18fe9b40e14e7998a8d
 
             env:
               # Activates the /api/cv/* proxy in pump (see internal/web/exercise.go).


### PR DESCRIPTION
`ghcr.io/rwlove/pump` **v0.0.108 → v0.0.109**

## ⚠️ Merge order

**Merge rwlove/home-ops#13483 (`pump-voltra` v0.1.7) first and let it roll out.**

This release gates trainer writes on the sidecar reporting `Loaded`. The v0.1.6 sidecar never reports it, so deploying this first would 409 every Voltra write until the sidecar catches up.

## What changes

**Exercise colours by muscle group.** Colours were assigned by a global golden-angle rotation that ignored the exercise's group, so members of a group landed at arbitrary points on the wheel. Each group now owns a 60° sector, with its exercises as shades in a 28° band. Two Legs exercises had drifted to `#000000` — invisible on the dark theme.

**Voltra phase 2, server side.** The arm/load state machine, the `/api/voltra` endpoints, and the source gate described above.

## Database

No schema change — no migration runs on start, and no rollback concern.

The exercise colour rows, and the denormalized copy of the colour on `sets`, were corrected in the database ahead of this deploy. The palette is therefore already live and does not depend on this image; the image governs colours for **newly created** exercises.

## Blast radius

Single Renee-facing service. Rolling update, no PVC or schema involvement, so rollback is a digest revert. The Voltra endpoints are inert unless an exercise is flagged and a sidecar is connected.

## Verification

- `kubectl kustomize kubernetes/apps/collab/pump/app` builds clean; tag renders as expected.
- `VOLTRA_AUTOLOG: "true"` is already set, so the source gate is active on arrival.
- Digest from the GHCR packages API, matching the convention of the existing pinned digests (cross-checked against the v0.0.108 entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)