### PR TITLE
fix(container): update image ghcr.io/home-operations/esphome ( 2026.7.3 → 2026.7.4 )

### DIFF
--- a/kubernetes/apps/home/esphome/app/helmrelease.yaml
+++ b/kubernetes/apps/home/esphome/app/helmrelease.yaml
@@ -46,7 +46,7 @@ spec:
           app:
             image:
               repository: ghcr.io/home-operations/esphome
-              tag: 2026.7.3@sha256:06e37508f9db6ff6e2051b3b84bdcfa11f2fec9df50dacd9b2e86c39ff909ff4
+              tag: 2026.7.4@sha256:e17dae435f0a104c153c6258f5556f6fd90fc2fcd4b4396bb23c8d8231f2205a
 
 
             env:


### PR DESCRIPTION
Supersedes the Renovate branch for this update.

## Why a hand-authored PR

The Renovate branch conflicted with the 2026.7.3 **digest** bump (#13431) that merged first during today's wave, and it could not be auto-rebased — `rebaseWhen: 'auto'` didn't fire, and a follow-up Renovate run reported `updated: 0, unchanged: 1`. Rather than force-push the bot branch, this is a clean commit off current `main`.

## Digest provenance

The digest was **verified against the upstream ghcr manifest** for tag `2026.7.4`, not copied from the conflicted branch:

```
ghcr.io/home-operations/esphome:2026.7.4
sha256:e17dae435f0a104c153c6258f5556f6fd90fc2fcd4b4396bb23c8d8231f2205a  ✓ matches upstream
```

## Impact

ESPHome dashboard restart only. Already-flashed devices keep running and reconnect on their own — this does not reflash anything.