### PR TITLE
feat(container): update image ghcr.io/home-operations/home-assistant ( 2026.7.4 → 2026.8.1 )

### DIFF
--- a/kubernetes/apps/home/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/home/home-assistant/app/helmrelease.yaml
@@ -60,7 +60,7 @@ spec:
           venv-reset:
             image:
               repository: ghcr.io/home-operations/home-assistant
-              tag: &hassImage 2026.7.4@sha256:17a97c2fc87b4311342c1a67b92ffa5d4b02cd64f514228d80385e96a888137e
+              tag: &hassImage 2026.8.1@sha256:e1f54eb0306d7ded8b3cdee70c21178413cd175aa3e526452af0e086a39ecc51
 
             args:
               - |


### PR DESCRIPTION
Supersedes the Renovate branch for this update.

## Why a hand-authored PR

The Renovate branch conflicted with the 2026.7.4 **digest** bump (#13432) from today's wave and could not be auto-rebased (`rebaseWhen: 'auto'` didn't fire; a follow-up run reported `updated: 0`). Clean commit off current `main` instead of force-pushing the bot branch.

## Digest provenance

Verified against the upstream ghcr manifest for tag `2026.8.1`:

```
ghcr.io/home-operations/home-assistant:2026.8.1
sha256:e1f54eb0306d7ded8b3cdee70c21178413cd175aa3e526452af0e086a39ecc51  ✓ matches upstream
```

Only the `&hassImage` anchor changes; the alias at the second use site follows automatically.

## Risk — please read

This is a **monthly** Home Assistant release (2026.7.x → 2026.8.x), the class most likely to carry breaking configuration changes, and HA is **Renee-facing**. Per `AGENTS.md` this would normally wait for the **Tuesday 02:00–04:00** window; it's being merged Saturday afternoon at Rob's explicit direction.

Recovery from a bad monthly is a **config fix, not an image rollback** — HA validates configuration at startup, so a breaking change surfaces as a failure to boot rather than a silent problem. The checked-in config lives in the separate `home-assistant-config` repo.

I'll watch the pod through its first boot and report the startup result.