### PR TITLE
feat(media): move immichkiosk night blanking to ImmichFrame active-hours

### DIFF
--- a/kubernetes/apps/media/immichkiosk/app/helmrelease.yaml
+++ b/kubernetes/apps/media/immichkiosk/app/helmrelease.yaml
@@ -64,9 +64,14 @@ spec:
               KIOSK_BACKGROUND_BLUR: true
               KIOSK_THEME: fade
               KIOSK_LAYOUT: splitview
-              # Sleep mode
-              KIOSK_SLEEP_START: 22
-              KIOSK_SLEEP_END: 7
+              # Sleep mode — OWNED BY THE FRAMES, NOT KIOSK.
+              # Both ImmichFrame clients (v50+) run the app's own
+              # active-hours schedule (activeTimes=true, 07:00-22:00 daily),
+              # which blanks the display locally instead of kiosk serving a
+              # dark overlay to a lit screen. Leaving KIOSK_SLEEP_* set here
+              # too would just double up. immichkiosk-party keeps its
+              # KIOSK_SLEEP_* because its consumer is a TV with no
+              # ImmichFrame app to schedule itself.
               # Transistion options
               KIOSK_TRANSITION: cross-fade
               KIOSK_FADE_TRANSITION_DURATION: 1


### PR DESCRIPTION
## What

Removes `KIOSK_SLEEP_START: 22` / `KIOSK_SLEEP_END: 7` from **immichkiosk**. Night blanking now happens in the ImmichFrame app on each frame.

## Device-side work already done (not in this PR)

Both frames upgraded and configured:

| Frame | IP | Version | Active hours |
| --- | --- | --- | --- |
| familyroom | .23 | v49 → **v50** | `activeTimes=true`, 07:00–22:00 daily |
| basement | .20 | v49 → **v50** | `activeTimes=true`, 07:00–22:00 daily |

Schedule JSON (schema read from upstream `Helpers.parseActiveSchedule`, not guessed — `days` is `Calendar.DAY_OF_WEEK`, 1=Sunday):

```json
{"rules":[{"days":[1,2,3,4,5,6,7],"ranges":[{"start":"07:00","end":"22:00"}]}]}
```

Written directly to each app's `shared_prefs` over root ADB, preserving per-frame uid and SELinux context (they differ: `u0_a102` vs `u0_a103`). Prior prefs backed up first.

## Why app-side is better

ImmichFrame's inactive path stops the image and weather timers, loads `about:blank`, sets brightness to 0, clears `FLAG_KEEP_SCREEN_ON` so the panel can power down, and arms a wake alarm. Kiosk's version just served a dark page to a fully lit screen and kept fetching assets all night.

**Bonus:** the 07:00 wake calls `setFrameActive(true)` → `loadSettings()`, which reloads the webview. That's a daily self-heal — a frame whose webview dies during the day now recovers next morning instead of staying blank until someone notices.

## Verified, not assumed

Applied a deliberately inactive schedule and watched it take effect, then restored:

| State | screencap |
| --- | --- |
| Active window | 3,802,389 bytes (photo) |
| Forced inactive | **26,037 bytes** (blank) |
| Restored 07:00–22:00 | 4,352,224 bytes (photo) |

**Caveat:** `mScreenState` stays `ON`. A real power-off needs device-admin for `lockDeviceIfPossible()`, which isn't granted — the fallback is the brightness-0 overlay. So this is a visual/behavioural win and a daily-reload win, **not yet a power-saving win**. Granting device admin would complete that and can be a follow-up.

## Scope

`immichkiosk-party` **keeps** its `KIOSK_SLEEP_*` — its consumer is a TV with no ImmichFrame app to schedule itself. Confirmed `immichkiosk` currently serves only the two frames (1280×854 basement, 854×1280 familyroom; party had zero clients over 10 minutes).