### PR TITLE
fix(observability): node-exporter needs hostNetwork or network metrics are wrong

### DIFF
--- a/kubernetes/apps/observability/exporters/node-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/exporters/node-exporter/app/helmrelease.yaml
@@ -23,7 +23,16 @@ spec:
       - --collector.filesystem.mount-points-exclude=^/(dev|proc|run/credentials/.+|sys|var/lib/docker/.+|var/lib/containers/storage/.+|var/lib/kubelet/pods/.+)($|/)
       - --collector.filesystem.fs-types-exclude=^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|erofs|sysfs|tracefs)$
 
-    hostNetwork: false
+    # hostNetwork MUST be true (also the chart default) or the network
+    # collector reports the POD's netns, not the host's: every node showed
+    # only eth0+lo with a ~253MB lifetime counter, so every per-node network
+    # rate() read ~0. CPU/memory/disk were unaffected (hostPath /proc), which
+    # is why this went unnoticed — the metric was silently WRONG, not missing,
+    # so any node-network panel or alert would never fire. Found 2026-08-08
+    # while trying to measure bandwidth during the source-controller outage.
+    # dnsPolicy pairs with hostNetwork so the pod still resolves cluster DNS.
+    hostNetwork: true
+    dnsPolicy: ClusterFirstWithHostNet
     image:
       registry: quay.io
       repository: prometheus/node-exporter


### PR DESCRIPTION
## The bug

The standalone `node-exporter` DaemonSet runs with **`hostNetwork: false`** — an explicit override of the chart's own default (`true`). It has `hostPID: true` but no host network namespace, so the network collector reports the **pod's** interfaces rather than the host's.

Every cluster node exposes only `eth0` + `lo`, with `eth0` at a ~253 MB lifetime counter:

| Target | Devices | Sample |
| --- | --- | --- |
| worker3 (this DaemonSet) | **2** — `eth0`, `lo` | `eth0` = 253 MB lifetime |
| beast (host-level exporter) | 14 — `eno1`, `eno2`, `virbr0`, … | `eno1` = 33 TB lifetime |

## Why it matters

Every per-node network `rate()` reads **~0**. That's worse than a missing metric — it is **silently wrong**, so any dashboard panel or alert on node network throughput sits at zero and can never fire.

CPU / memory / disk are unaffected (those come from hostPath `/proc` mounts), which is why this went unnoticed.

Found 2026-08-08 while testing a bandwidth-saturation theory during the source-controller outage (#13478): all 11 nodes returned `0.0 MB/s`, while beast and brain — host-level exporters, not k8s nodes — correctly showed 367 and 82 MB/s. That line of investigation had to be abandoned mid-incident.

## Change

```yaml
hostNetwork: true                      # was false; also the chart default
dnsPolicy: ClusterFirstWithHostNet     # so the pod still resolves cluster DNS
```

## Risk check done before proposing

The `false` was deliberate, not an oversight, so I looked for a reason before changing it:

- `git blame` traces only to a mass alphabetical-sort commit and a file move — no commit explains the value
- The chart's own default is `hostNetwork: true`
- **No hostNetwork pod anywhere in the cluster claims port 9100**
- Cluster nodes have **no host-level `node_exporter` being scraped** — their only series come from this DaemonSet. beast / brain / security-storage do have host exporters, but none of those are k8s nodes, so there's nothing to collide with

**Residual risk:** if a node turns out to run an unscraped `node_exporter` on `:9100`, that pod fails to bind and CrashLoops. It's a DaemonSet rolling update, so it would show up immediately and reverting restores the current (wrong-but-stable) state. Losing node metrics briefly is the worst case; no data is at risk.

## Verifying after merge

`node_network_receive_bytes_total` for a cluster node should list real NICs (`eno*`/`enp*`) with realistic counters instead of just `eth0` + `lo`.