### PR TITLE
feat(collab): roll out the PUMP audit fixes

### DIFF
--- a/kubernetes/apps/collab/pump-cv/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump-cv/app/helmrelease.yaml
@@ -95,7 +95,7 @@ spec:
           pump-cv:
             image:
               repository: ghcr.io/rwlove/pump-cv
-              tag: v0.6.2@sha256:8a90ea8e11a9bda157903928313e833556ce92583b3a75db361d6647871f16ab
+              tag: v0.6.3@sha256:ebeb0ac2e174590dea27f7e74a41f4f3d5585a3997d0ee6d801f4852c47d818f
 
             # Image's default ENTRYPOINT calls bare `python`, which doesn't
             # exist in PATH (only python3 is installed). Use the console-script

--- a/kubernetes/apps/collab/pump-voltra/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump-voltra/app/helmrelease.yaml
@@ -37,7 +37,7 @@ spec:
           pump-voltra:
             image:
               repository: ghcr.io/rwlove/pump-voltra
-              tag: v0.1.7@sha256:8c6ec13ff7bf4bdb4bd2b0fd16fac0d8a2dff327adb87a595861e09ec4d8af72
+              tag: v0.1.8@sha256:cebcafe82ff68dd554d8161e0f689d7ad979188bc8082c6dd63a4cd4c9c4de91
 
             env:
               VOLTRA_ENABLED: "true"

--- a/kubernetes/apps/collab/pump/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump/app/helmrelease.yaml
@@ -49,7 +49,7 @@ spec:
           pump:
             image:
               repository: ghcr.io/rwlove/pump
-              tag: v0.0.109@sha256:274688bef64210ea3068df3d7d69cada68f13901c9f1e18fe9b40e14e7998a8d
+              tag: v0.0.110@sha256:508489aa540fd8ec18e57a1ae2ec4afc0d5fc750e197b8035b714ee4e873188d
 
             env:
               # Activates the /api/cv/* proxy in pump (see internal/web/exercise.go).


### PR DESCRIPTION
| Component | From | To |
|---|---|---|
| `pump-voltra` | v0.1.7 | **v0.1.8** |
| `pump` | v0.0.109 | **v0.0.110** |
| `pump-cv` | v0.6.2 | **v0.6.3** |

A full audit of PUMP (upstream PRs #92–#96) found defects in all three components. The ones that matter operationally:

## pump-voltra — motor safety

Seven holes closed, **two critical**:

- A weight change **orphaned the keepalive task**, so the cable stayed under tension after UNLOAD — indefinitely — while the UI reported it slack. `unload()` only cancelled the newest task.
- The parameter read **returned stale cached values**, so both motor read-back gates could pass on data the device never sent. That made the central safety check a formality.

Motor control has still never run against real hardware. These land before it does.

## pump — security and data loss

- **Unauthenticated off-cluster read and delete of body-weight history.** Only `POST /api/weight` was gated; the Route that bypasses gateway auth matches the path prefix with no method restriction.
- Stored XSS on the workout page.
- Several data-loss paths, including one where **merely viewing a day scheduled a rewrite of it from the browser DOM** — destroying any set the browser hadn't seen.

## pump-cv — the clock stopped when nobody was in frame

Reported timestamp `0.0` for every empty frame, so **the last set of every workout never closed** and the kiosk could never be told to sleep.

Also bounds a pose buffer that grew without limit. Prometheus had this pod at **93% of its 2 GiB limit** with 139 MiB of headroom:

| | |
|---|---|
| Peak working set (4-day pod) | 1909 MiB |
| Limit | 2048 MiB |

And makes the Voltra skip **fail closed**, so a pump-cv that starts before pump-api is serving no longer double-logs every trainer set — a live exposure since `VOLTRA_ENABLED=true` went on.

## Rollout

No schema change, so no migration runs. **Ordering is not load-bearing here**: the armed/loaded gate already exists on both sides as of v0.0.109 / v0.1.7, so these upgrade in any order.

All three kustomizations build clean with the pinned digests resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)