### PR TITLE
feat(renovate): watch the PUMP source repository

### DIFF
--- a/kubernetes/apps/renovate/renovate-operator/jobs/kustomization.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/jobs/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./cnp-allow.yaml
   - ./home-ops.yaml
   - ./pump.yaml
+  - ./pump-repo.yaml

--- a/kubernetes/apps/renovate/renovate-operator/jobs/pump-repo.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/jobs/pump-repo.yaml
@@ -1,0 +1,65 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/renovate-operator.mogenius.com/renovatejob_v1alpha1.json
+#
+# Renovate against the PUMP *source* repository.
+#
+# Not to be confused with jobs/pump.yaml, which despite its name watches
+# rwlove/home-ops and only bumps the pump HelmRelease digest here. That is the
+# deploy side. This is the source side: Go modules, Python deps for both
+# sidecars, Dockerfile base images, and above all the GitHub Actions pins.
+#
+# Every `uses:` in rwlove/PUMP is pinned to a 40-character commit SHA with a
+# `# vX.Y.Z` comment. Pinning is what stops a hijacked mutable tag executing in
+# a job that holds packages: write against a public registry — but a pin nobody
+# updates is just an old version with extra steps, and that is the job this
+# runs. The repo carries its own .github/renovate.json5.
+#
+# PREREQUISITE: the Renovate GitHub App must be installed on rwlove/PUMP.
+# Autodiscover only returns repositories the App can see — as of writing that
+# is home-ops, lovenet-network-configuration and containers, so PUMP was
+# invisible and this job will discover nothing until the installation is
+# widened. github.com/settings/installations → Renovate → Repository access.
+apiVersion: renovate-operator.mogenius.com/v1alpha1
+kind: RenovateJob
+metadata:
+  name: rwlove-pump-repo
+  namespace: renovate
+spec:
+  discoveryFilters:
+    - "rwlove/PUMP"
+  extraEnv:
+    - name: LOG_LEVEL
+      value: "info"
+    - name: RENOVATE_ENDPOINT
+      value: https://api.github.com/
+    - name: RENOVATE_PLATFORM
+      value: github
+    - name: RENOVATE_PLATFORM_COMMIT
+      value: disabled  # Matches rwlove-home-ops; enabled trips a repo-changed abort.
+    - name: RENOVATE_REDIS_URL
+      value: redis://dragonfly.databases.svc.cluster.local:6379
+    - name: RENOVATE_REPOSITORY_CACHE
+      value: enabled
+    - name: RENOVATE_CACHE_PRIVATE_PACKAGES
+      value: "true"
+    # The three release lines (pump-v*, pump-cv-v*, pump-voltra-v*) are tagged
+    # by hand after a pre-tag ritual, so Renovate opens PRs and never pushes.
+    - name: RENOVATE_DEPENDENCY_DASHBOARD
+      value: "true"
+  image: ghcr.io/renovatebot/renovate:44.14.12@sha256:160125831b82ae05c734870b9f65094e0f8699a0e44f3274bacc7b36a9041047
+  parallelism: 1
+  provider:
+    name: github
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+  # Daily rather than hourly: this repo's dependencies move far more slowly
+  # than the cluster's container images, and action-digest churn is noise if
+  # it arrives every hour.
+  schedule: 30 6 * * *
+  secretRef: github-auth-token-secret
+  webhook:
+    enabled: true
+    authentication:
+      enabled: false


### PR DESCRIPTION
Adds a RenovateJob for **`rwlove/PUMP` itself**.

Not to be confused with `jobs/pump.yaml`, which despite the name watches `rwlove/home-ops` and only bumps the pump HelmRelease digest here — that's the *deploy* side. This is the *source* side: Go modules, Python dependencies for both sidecars, Dockerfile base images, and above all the **GitHub Actions pins**.

## Why now

Every `uses:` in rwlove/PUMP was just pinned from a mutable major tag to a 40-character commit SHA (rwlove/PUMP#97). That closes a real hole — four of those workflows hold `packages: write` against a public registry, so a hijacked tag could push a backdoored image.

But a pin nobody updates is only an old version with extra steps. **This job is what keeps them current.** The repo carries its own `.github/renovate.json5` describing what to group and how.

## Choices

- **Daily, not hourly** (`30 6 * * *`). This repo's dependencies move far more slowly than the cluster's container images, and action-digest churn arriving every hour is noise.
- **PRs only, never pushes.** The three release lines are tagged by hand after the pre-tag ritual in the repo's AGENTS.md.
- **No network policy change needed.** `renovate-jobs-allow` already matches any pod carrying a `batch.kubernetes.io/job-name` label in this namespace — which is exactly what that selector was widened to after the 2026-06 discovery-egress outage.

## ⚠️ Not yet effective — needs one manual step

The Renovate GitHub App **is not installed on rwlove/PUMP**, and autodiscover only returns repositories the App can see:

```
$ kubectl logs -n renovate rwlove-home-ops-discovery-<...>
["rwlove/home-ops","rwlove/lovenet-network-configuration","rwlove/containers"]
```

Until the installation is widened, this job discovers nothing — it is inert, not broken. Widen it at **github.com/settings/installations → Renovate → Repository access**.

`kubectl kustomize` renders all three jobs with the right discovery filters:

```
rwlove-home-ops     rwlove/*
rwlove-pump         rwlove/home-ops
rwlove-pump-repo    rwlove/PUMP
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)