### PR TITLE
fix(renovate): the pump deploy chain covered one image and had a dead trigger

### DIFF
--- a/kubernetes/apps/renovate/renovate-operator/jobs/pump.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/jobs/pump.yaml
@@ -23,11 +23,17 @@ spec:
       value: enabled
     - name: RENOVATE_CACHE_PRIVATE_PACKAGES
       value: "true"
-    # Restrict Renovate to only the pump HelmRelease so a webhook-triggered
+    # Restrict Renovate to the three PUMP HelmReleases so a webhook-triggered
     # run skips the rest of the repo.
+    #
+    # This covered only the server until 2026-08-08, so pump-cv and
+    # pump-voltra digests were never bumped automatically even when the chain
+    # was working — both were rolled by hand every time.
     - name: RENOVATE_INCLUDE_PATHS
       value: >-
-        ["kubernetes/apps/collab/pump/app/helmrelease.yaml"]
+        ["kubernetes/apps/collab/pump/app/helmrelease.yaml",
+         "kubernetes/apps/collab/pump-cv/app/helmrelease.yaml",
+         "kubernetes/apps/collab/pump-voltra/app/helmrelease.yaml"]
     # Don't rewrite the global "Renovate Dashboard 🤖" issue from this
     # narrow run — the rwlove-home-ops job owns it.
     - name: RENOVATE_DEPENDENCY_DASHBOARD

--- a/kubernetes/apps/selfhosted/webhook/app/resources/github-rwlove-pump-package.sh
+++ b/kubernetes/apps/selfhosted/webhook/app/resources/github-rwlove-pump-package.sh
@@ -1,8 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Triggers the rwlove-pump RenovateJob, which is scoped to
-# kubernetes/apps/collab/pump/app/helmrelease.yaml only.
+# Triggers the rwlove-pump RenovateJob, which is scoped to the three PUMP
+# HelmReleases (pump, pump-cv, pump-voltra).
+#
+# Fired by the github-rwlove-pump-package hook on a `release: published`
+# event from rwlove/PUMP. That repo now creates a GitHub Release
+# automatically once an image is in GHCR (.github/workflows/release.yml);
+# before 2026-08-08 releases were made by hand, the habit lapsed on
+# 2026-07-03, and this chain went silent — every deploy since was manual.
 JOB="rwlove-pump"
 NAMESPACE="renovate"
 PROJECT="rwlove/home-ops"


### PR DESCRIPTION
Two independent faults in the automation that's supposed to bump the PUMP HelmRelease digests. Between them, **every PUMP deploy since 2026-07-03 has been done by hand** — 14 tags, including three today.

## 1. Scope — it only ever covered one of three images

`RENOVATE_INCLUDE_PATHS` listed only the server HelmRelease. `pump-cv` and `pump-voltra` were never in range, so even a perfectly working chain would have left two of three images manual. Now all three.

## 2. Trigger — it has been dead since 2026-07-03

The `github-rwlove-pump-package` hook fires on a **`release: published`** event from rwlove/PUMP. But that repo only ever gets **git tags** — releases were created by hand, and the practice stopped after `pump-cv-v0.6.1`.

Nothing automated them, so the chain went silent with no signal at all:

| | |
|---|---|
| Last GitHub Release | `pump-cv-v0.6.1`, 2026-07-03 |
| Tags shipped since | 14, all deployed manually |
| `rwlove-pump` RenovateJob runs, **ever** | **1** (2026-05-09) |
| PRs it has opened, **ever** | **0** |

rwlove/PUMP#98 now creates a release automatically once an image is in GHCR, fired on `workflow_run` so the event cannot arrive before the image exists — firing it in parallel would have Renovate find nothing and reproduce the same symptom.

**The hook's own trigger rule is correct and unchanged.** It simply never had an event to match.

## Verification

- `RENOVATE_INCLUDE_PATHS` renders as valid JSON with all three paths resolved; all three files exist.
- Jobs kustomization builds; script passes `bash -n`.

Also corrects the script's comment, which still described the old single-HelmRelease scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)