### PR TITLE
fix(renovate): let the webhook app reach the operator's schedule endpoint

### DIFF
--- a/kubernetes/apps/renovate/renovate-operator/app/cnp-allow.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/app/cnp-allow.yaml
@@ -16,10 +16,13 @@ spec:
     ingress: false
   ingress:
     # HTTPRoute on internal gateway → renovate-operator:8081 (named
-    # "http"). renovate.${SECRET_DOMAIN} is the webhook endpoint used
-    # by GitHub repository webhook deliveries that arrive via
-    # cloudflared → envoy → here. Port 8082 is the operator's metrics
-    # port; the baseline allow-monitoring-scrape covers Prometheus.
+    # "http"). renovate.${SECRET_DOMAIN} is the endpoint GitHub repository
+    # webhook deliveries reach via cloudflared → envoy → here.
+    #
+    # Port numbering, since a previous version of this comment had it wrong
+    # and the mistake cost a working deploy chain: the container exposes
+    # metrics=8080, http=8081, webhook=8082. 8082 is NOT metrics. The
+    # baseline allow-monitoring-scrape covers Prometheus on 8080.
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: network
@@ -27,6 +30,18 @@ spec:
       toPorts:
         - ports:
             - port: "8081"
+              protocol: TCP
+    # The in-cluster webhook app POSTs /webhook/v1/schedule on 8082 to
+    # trigger a RenovateJob — that is how a PUMP release becomes a
+    # HelmRelease digest-bump PR. Nothing allowed it, so the call was
+    # silently dropped and the chain had never worked end to end.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: selfhosted
+            app.kubernetes.io/name: webhook
+      toPorts:
+        - ports:
+            - port: "8082"
               protocol: TCP
   egress:
     # GitHub API: operator polls api.github.com for repo discovery and

--- a/kubernetes/apps/selfhosted/webhook/app/cnp-allow-to-renovate.yaml
+++ b/kubernetes/apps/selfhosted/webhook/app/cnp-allow-to-renovate.yaml
@@ -1,0 +1,40 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: webhook-allow-to-renovate-operator
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: webhook
+  # Additive — the default-deny CNP from network-policy/default-deny is what
+  # triggers the lockdown; this punches one hole through it.
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  egress:
+    # Both hook scripts POST to the renovate-operator's schedule endpoint to
+    # trigger a RenovateJob:
+    #
+    #   github-renovate-operator.sh      → dependency-dashboard checkbox flow
+    #   github-rwlove-pump-package.sh    → PUMP release → HelmRelease digest bump
+    #
+    # The webhook pod had no egress rule at all, so both calls were dropped:
+    # a POST from here to renovate-operator:8082 timed out rather than being
+    # refused, which is why nothing surfaced in any log. The hook reported
+    # "triggered successfully" — that only means the script was executed, not
+    # that its curl reached anything.
+    #
+    # Port 8082 is the operator's *webhook* port, not metrics. The container
+    # exposes http=8081, metrics=8080, webhook=8082, and the service maps
+    # webhook→8082. The matching ingress rule (and a comment that had this
+    # wrong) live in renovate/renovate-operator/app/cnp-allow.yaml.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: renovate
+            app: renovate-operator
+      toPorts:
+        - ports:
+            - port: "8082"
+              protocol: TCP

--- a/kubernetes/apps/selfhosted/webhook/app/kustomization.yaml
+++ b/kubernetes/apps/selfhosted/webhook/app/kustomization.yaml
@@ -7,6 +7,7 @@ components:
 resources:
   - ./securitypolicy-public.yaml
   - ./cnp-allow-from-gateway.yaml
+  - ./cnp-allow-to-renovate.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
 configMapGenerator:


### PR DESCRIPTION
The last broken link in the PUMP deploy chain — and the reason it has **never** worked end to end.

## What was wrong

Both hook scripts POST `/webhook/v1/schedule` to `renovate-operator:8082` to trigger a RenovateJob. That's how a PUMP release becomes a HelmRelease digest-bump PR.

**Nothing permitted the call.** The webhook app had no egress rule at all, and the operator's ingress allowed only the gateway on 8081. So the request was *dropped* rather than refused — it timed out.

Verified from inside the webhook pod:

```
webhook → renovate-operator:8082   timeout (exit 124)
webhook → renovate-operator:8081   timeout (exit 124)
```

## Why it stayed hidden

Nothing surfaced in any log. The hook records **"triggered successfully"** — which only means the script was *executed*, not that its curl reached anything. The script doesn't check curl's exit status either.

And the operator's own comment claimed:

> Port 8082 is the operator's metrics port

That's wrong, and is probably how the gap survived review. The container exposes:

| Port | Name |
|---|---|
| 8080 | metrics |
| 8081 | http |
| **8082** | **webhook** |

Corrected, with the numbering spelled out so the next reader can't repeat it.

## The change

Two additive rules, each scoped to one pod pair and one port:

- **egress** — `selfhosted/webhook` → `renovate/renovate-operator:8082`
- **ingress** — the matching rule on the operator

No other namespace is touched, and nothing goes near core network infrastructure.

## This completes the chain

Three breaks in series, all now fixed:

1. No GitHub Releases since 2026-07-03 → rwlove/PUMP#98 *(verified: the hook now fires)*
2. Scope covered 1 of 3 images → #13494
3. **Webhook couldn't reach the operator** → this PR

The job has run once in its life (2026-05-09) and opened zero PRs, so the next release will be the real proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)