### PR TITLE
fix(renovate): scope the installation token to PUMP as well

### DIFF
--- a/kubernetes/apps/renovate/renovate-operator/auth/github-auth-token.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/auth/github-auth-token.yaml
@@ -7,10 +7,19 @@ metadata:
 spec:
   appID: "2931213"
   installID: "111956727"
+  # The installation token is scoped to exactly these repositories, which is
+  # narrower than the App installation itself. Renovate's autodiscover can
+  # only ever see what the token covers, so a repo missing here is invisible
+  # no matter what the App's Repository access says on github.com — that
+  # combination cost an afternoon: the App was widened to include PUMP and
+  # discovery still returned only the three below.
+  #
+  # Must match the case GitHub stores: the repo is "PUMP", not "pump".
   repositories: # optional
     - home-ops
     - containers
     - lovenet-network-configuration
+    - PUMP
   auth:
     privateKey:
       secretRef:


### PR DESCRIPTION
Renovate's autodiscover can only see what its **token** covers, and the `GithubAccessToken` generator pins the installation token to an explicit three-repository list:

```yaml
repositories:
  - home-ops
  - containers
  - lovenet-network-configuration
```

That is precisely the list discovery returns. PUMP was invisible to the operator regardless of anything set on github.com.

## Why this is worth spelling out

The two settings look interchangeable and are not. The App's **Repository access** was widened to include PUMP first — and discovery *still* returned only the three above.

- The **App installation** governs what a token *may* be minted for.
- This list governs what the token **actually is**.

Both have to include the repo.

## Evidence

Run directly against the job rather than inferred from a missing PR:

| Filter | Result |
|---|---|
| `rwlove/PUMP` (before) | `[]` |
| `rwlove/*` (before, after App widened) | `["rwlove/home-ops","rwlove/lovenet-network-configuration","rwlove/containers"]` |

The second run is the decisive one: with a wide-open filter and PUMP already added to the App, PUMP still didn't appear — which rules out my filter and points squarely here.

Case matters: GitHub stores the repository as **`PUMP`**. The webhook hook rules already carry a `^(?i)pump$` regex for the same reason.

The ExternalSecret refreshes every 30m, so the new token picks it up on the next refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)