### PR TITLE
fix(alerts): clear the two actionable firing alerts (konflate OOM, watchdog latch)

### DIFF
--- a/kubernetes/apps/home/windmill/app/watchdog-cronjob.yaml
+++ b/kubernetes/apps/home/windmill/app/watchdog-cronjob.yaml
@@ -31,6 +31,19 @@ spec:
       # No retries: a retry would let a transient blip mask a real outage
       # by refreshing last_successful_time. One shot, pass or fail.
       backoffLimit: 0
+      # Without a TTL, KubeJobFailed latches forever. That alert is just
+      # `kube_job_failed{condition="true"} > 0` with no time bound, so it
+      # fires for as long as a failed Job object exists — and with
+      # failedJobsHistoryLimit: 3, a failed Job is only evicted by three
+      # *more* failures. Because backoffLimit is 0, a single transient
+      # blip creates a failed Job; on 2026-08-02 one did, and the alert
+      # was still firing 6 days later while every run since had passed.
+      #
+      # 24h keeps a full day of forensics (the job runs every 5m, so
+      # that is ~288 runs of context) and re-scopes the alert to "failed
+      # recently" instead of "failed ever". A real outage still fires:
+      # each new failure creates a new Job and re-arms the alert.
+      ttlSecondsAfterFinished: 86400
       template:
         spec:
           restartPolicy: Never

--- a/kubernetes/apps/selfhosted/konflate/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/konflate/app/helmrelease.yaml
@@ -60,9 +60,28 @@ spec:
       enabled: false
     networkPolicy:
       enabled: false
+    # The memory limit is konflate's real tuning knob: it derives
+    # GOMEMLIMIT (90% of it) so the GC compresses render bursts before
+    # the kernel OOM-kills them. Render peaks legitimately allocate far
+    # above the ceiling — upstream measured ~2.7GiB uncapped on a
+    # routine PR set (home-operations/konflate#331) — so the limit has
+    # to leave the GC room to work, not just cover steady state.
+    #
+    # The chart default is 1Gi and its values.yaml says to raise it for
+    # very large clusters; this repo is ~170 HelmReleases. #12803's bulk
+    # resource backfill instead *halved* the default to 512Mi. That held
+    # on 0.4.3 (138Mi steady, 207Mi peak) but OOMKilled 0.5.0 75 times in
+    # 9h while rendering the repo-wide cilium 1.19.6→1.20.0 bump (#13381)
+    # — a sweeping render that fans out across every app in the repo.
+    #
+    # 2Gi is upstream's burst-headroom recommendation for exactly this
+    # PR class. If it ever recurs, the next levers are config
+    # `maxDiffConcurrency` (concurrent PR renders, auto-capped at 4) and
+    # `renderConcurrency` (reconcile goroutines *within* one render, auto
+    # = NumCPU*4 = 40 on a 10-core node, since no CPU limit is set here).
     resources:
       requests:
         cpu: 50m
         memory: 256Mi
       limits:
-        memory: 512Mi
+        memory: 2Gi


### PR DESCRIPTION
Clears the two firing alerts that had a fix in Git. Two files, no behaviour change beyond resource sizing and Job GC.

## 1. konflate OOMKilled + KubePodCrashLooping (critical)

75 OOMKills in 9h, 417 back-offs. This is a resource-sizing defect, not a workload change.

The chart ships `limits.memory: 1Gi` and its `values.yaml` says to raise it for very large clusters. #12803's bulk resource backfill across 25 HelmReleases instead **halved** it to 512Mi. That held on 0.4.3 but not on 0.5.0:

| image | memory | state |
|---|---|---|
| 0.4.3 `6f7b755e…` | 138Mi | healthy |
| 0.5.0 `5ddce5cf…` | 511.5Mi | OOMKill ×75 |

Evidence the workload is unchanged:

- The only open PR (#13381, cilium 1.19.6→1.20.0) has been open 8 days and rendered fine at 138Mi steady / 207Mi peak throughout.
- Peak is censored at exactly 511.72Mi — pinned to the ceiling.
- All 75 restarts fall inside the 9h since the 0.5.0 bump merged.

konflate's render bursts are *expected* to exceed the ceiling — upstream measured ~2.7GiB uncapped on a routine PR set (home-operations/konflate#331) — and rely on `GOMEMLIMIT` (90% of the limit) to compress them. So the limit has to leave the GC room, not track steady state. At 512Mi that budget was ~460Mi and the live set stopped fitting. #13381 is also the heaviest class konflate renders: a sweeping repo-wide bump re-rendered across every app at both merge-base and head.

**2Gi is upstream's burst-headroom recommendation for this PR class.**

Caveat: the true 0.5.0 peak is still censored — we know it exceeds 512Mi, not by how much. If it recurs, the next levers are `maxDiffConcurrency` and `renderConcurrency` (auto-derives to `NumCPU*4` = 40 goroutines within a single render, since no CPU limit is set on a 10-core node). Both are noted in the manifest comment.

## 2. windmill-watchdog KubeJobFailed latch

Firing since 2026-08-02 on a single transient failure. Every run since has passed.

`KubeJobFailed` is `kube_job_failed{condition="true"} > 0` with no time bound, so it fires as long as a failed Job object exists. The watchdog runs `backoffLimit: 0` by design (a retry would let a blip mask a real outage by refreshing `last_successful_time`), so any blip creates a failed Job — and with `failedJobsHistoryLimit: 3` and no TTL, that object is only evicted by three *more* failures. On a job this reliable that is effectively never, so one blip pins the alert permanently and the signal decays to noise.

`ttlSecondsAfterFinished: 86400` re-scopes it to "failed recently" instead of "failed ever", keeping a day of forensics (~288 runs at the `*/5` schedule). A real outage still fires: each new failure creates a new Job and re-arms the alert. Two sibling CronJobs in the media namespace already set this TTL.

## Not addressed here

- **The other `KubeJobFailed`** needs no change — that CronJob already carries the 24h TTL, so it self-clears around noon ET tomorrow. Its failure clustered with others at 15:00–16:00 UTC today, alongside today's Flux/image-pull incident; all have succeeded since.
- **`BlackboxIoTDeviceUnreachable`** is a genuinely offline sensor (dark 122h, since ~5:35 PM ET Aug 3). Its two siblings are up, so not network; HA independently reports the entity `unavailable`. Physical fix, nothing in Git.

## Validation

- `pre-commit run --files …` — all hooks pass (incl. the envsubst `$$`-escaping guard on the watchdog).
- `kubectl kustomize` builds clean for both apps; rendered output confirms `memory: 2Gi` and `ttlSecondsAfterFinished: 86400`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
