### PR TITLE
docs(konflate): annotate the 2Gi memory limit as a tracked workaround

### DIFF
--- a/kubernetes/apps/selfhosted/konflate/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/konflate/app/helmrelease.yaml
@@ -74,11 +74,20 @@ spec:
     # 9h while rendering the repo-wide cilium 1.19.6→1.20.0 bump (#13381)
     # — a sweeping render that fans out across every app in the repo.
     #
-    # 2Gi is upstream's burst-headroom recommendation for exactly this
-    # PR class. If it ever recurs, the next levers are config
-    # `maxDiffConcurrency` (concurrent PR renders, auto-capped at 4) and
-    # `renderConcurrency` (reconcile goroutines *within* one render, auto
-    # = NumCPU*4 = 40 on a 10-core node, since no CPU limit is set here).
+    # Going back to the chart's 1Gi default is plain sizing — that part
+    # just undoes #12803. The headroom ABOVE 1Gi is the workaround: at
+    # 2Gi the render burst measured 1120MiB working set / 833MiB heap
+    # before reclaiming to 360MiB, so 0.5.0 no longer renders a sweeping
+    # PR inside the shipped default. Caveat kept deliberately: GOMEMLIMIT
+    # scales with the limit, so that burst is partly Go spending headroom
+    # it was handed. It does NOT prove 1Gi would fail — only that we have
+    # not risked it while the upstream question is open.
+    # workaround: https://github.com/home-operations/konflate/issues/434 — remove when a konflate release renders a sweeping PR within the chart's 1Gi default
+    #
+    # If it recurs, the next levers are config `maxDiffConcurrency`
+    # (concurrent PR renders, auto-capped at 4) and `renderConcurrency`
+    # (reconcile goroutines *within* one render, auto = NumCPU*4 = 40 on
+    # a 10-core node, since no CPU limit is set here).
     resources:
       requests:
         cpu: 50m


### PR DESCRIPTION
Follow-up to #13498. Comment-only — `kustomize build` output is unchanged.

#13498 raised konflate's memory limit to `2Gi` to stop a 75×-in-9h OOMKill loop. That change compensates for an upstream gap, so per `.agents/instructions/workarounds.md` it needs a `# workaround:` annotation with a specific upstream link and a checkable removal condition. At the time it was merged neither existed, so the annotation was deliberately deferred rather than written against a dead link — the instructions are explicit that a workaround without an upstream link "is not a workaround, it's an unjustified hack."

Both now exist:

- **Upstream:** home-operations/konflate#434
- **Tracking:** #13499 (`workaround` label), so `upstream-watcher` picks it up

## Scoping

Only the headroom **above the chart's 1Gi default** is annotated as the workaround. Moving from `512Mi` up to `1Gi` is plain sizing — it undoes #12803's bulk backfill, which halved the chart default across 25 HelmReleases. Annotating the whole limit would imply the correct value is `512Mi`, which it never was.

## Removal condition

> remove when a konflate release renders a sweeping PR within the chart's 1Gi default

Checkable, per the instruction's requirement that "eventually" is not a condition.

## Caveat recorded alongside the numbers

The annotation includes the measured burst (1120 MiB working set / 833 MiB heap, reclaiming to 360 MiB) **and** the reason not to over-read it: `GOMEMLIMIT` derives from the limit, so at `2Gi` Go defers collection and spends headroom it was handed. That burst does not prove `1Gi` would fail, and no regression multiplier should be inferred from peaks measured under different limits. Keeping that next to the figures is the point — the numbers are the kind that invite a wrong conclusion later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)