### PR TITLE
fix(prometheus): raise memory ceiling to 4G and correct the CPU request

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -158,12 +158,34 @@ spec:
           sha: df67ff1dc7094940e9d62e9bc318b02e4e35f539893dec5cc6b72d4fee4d8f21
         podMonitorSelectorNilUsesHelmValues: false
         probeSelectorNilUsesHelmValues: false
+        # Sized from measured behaviour rather than round numbers.
+        #
+        # Memory: the 7d peak was 2.64Gi against the old 3G (2.79Gi)
+        # ceiling — 94%. That held across three separate container
+        # generations (2.34 / 2.36 / 2.64Gi), so it was a routine
+        # near-miss, not one spike. p95 is only ~1.7Gi, so what needs
+        # covering is query/compaction burst, not steady state. 4G puts
+        # the observed peak at ~71%. Revisit if peak/limit climbs back
+        # over ~80% — Prometheus memory tracks active series, so this
+        # moves with cluster growth.
+        #
+        # Keeping memory request == limit is deliberate: kubelet ranks
+        # eviction by usage *above request*, so a pod that can never
+        # exceed its request sits at the bottom of the kill list. That
+        # matters here — everything else's alerting depends on this pod.
+        #
+        # CPU request follows measured 248m sustained; the previous 100m
+        # under-requested by 2.5x, which both misinforms the scheduler
+        # and weakens the CFS share under node contention. Still NO cpu
+        # limit, deliberately: throttling bursty rule evaluation would be
+        # worse than the contention it avoids, and matches the repo norm
+        # (only 23 of 158 HelmReleases set one).
         resources:
           limits:
-            memory: 3G
+            memory: 4G
           requests:
-            cpu: 100m
-            memory: 3G
+            cpu: 300m
+            memory: 4G
         retention: 14d
         retentionSize: 100GB
         ruleSelectorNilUsesHelmValues: false


### PR DESCRIPTION
## ⚠️ Merging this restarts Prometheus — please pick the window

Single replica, no HA. Merging triggers a Flux reconcile, the StatefulSet rolls, and alerting + scraping are blind until it is back and has replayed its WAL. **I could not measure the replay time** — this fork does not expose `prometheus_tsdb_wal_replay_duration_seconds` — so I am not going to guess at a duration against a 110Gi / 14d TSDB.

Per `AGENTS.md`, observability is "Routine: any night, 02:00–05:00" Eastern. This is not urgent (see "not an incident" below), so **holding for the window is the low-risk default.** Merge now only if you would rather not carry it.

## Memory: 3G → 4G

Peak was **2.64Gi against a 2.79Gi ceiling — 94%**, and it repeated across three separate container generations in 7 days:

| container generation | peak | p95 |
|---|---|---|
| 1 | 2.34 Gi | 1.57 Gi |
| 2 | 2.36 Gi | 1.63 Gi |
| 3 | 2.64 Gi | 1.73 Gi |

So it is a routine near-miss, not a single spike, on the one pod whose failure silences every other alert. p95 is only ~1.7Gi, so the headroom covers query/compaction burst rather than steady state. 4G puts the observed peak at ~71%.

**Request stays equal to the limit deliberately.** Kubelet ranks eviction by usage *above request*; a pod that can never exceed its request sits at the bottom of the kill list. (Note this does not make it Guaranteed — that needs a CPU limit too, and the pod is Burstable today. For memory-pressure eviction the request==limit property is what actually matters.)

## CPU request: 100m → 300m

Measured sustained usage is **248m** — the old request under-shot by 2.5×, which misinforms the scheduler and weakens the CFS share under node contention. **No CPU limit added**, deliberately: throttling bursty rule evaluation is worse than the contention it would prevent, and 135 of 158 HelmReleases here set no CPU limit either.

Bundled with the memory change on purpose — separating them would mean restarting the alerting backbone twice. Say the word and I will drop it.

## Capacity checked first

The node has **62.18Gi allocatable vs 53.51Gi** of running-pod requests, so +1G fits with ~7.7Gi to spare; CPU has ~1.07 cores free against +200m.

An earlier version of this check said the node was over-committed by 3Gi. That was wrong — it summed requests across *all* pod phases, including completed Jobs. Filtering to Running pods gives the numbers above.

## What this is not

The four restarts in 30d were **not** OOMKills, and I am not presenting this as an incident fix:

- Last termination was a graceful shutdown — `Rule manager stopped` → `err=stopped`, which surfaces to Kubernetes as `reason=Error`.
- The mass `query timed out in expression evaluation` lines ~9s earlier are in-flight queries being cancelled by that shutdown (they arrive alongside `context canceled`), not evidence of CPU starvation. I initially read them the other way and discarded that theory.
- Rule evaluation is healthy right now: slowest group runs at **5.5% of its interval**, 2 evaluation failures in 24h.

This is headroom on a component with an outsized blast radius, not a response to a failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)