### PR TITLE
fix(reloader): three value blocks sat at the wrong nesting level

### DIFF
--- a/kubernetes/apps/kube-system/reloader/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/reloader/app/helmrelease.yaml
@@ -10,14 +10,18 @@ spec:
     name: reloader
   interval: 30m
   values:
-    deployment:
-      resources:
-        limits:
-          memory: 512Mi
-        requests:
-          cpu: 5m
-          memory: 320Mi
-    podMonitor:
-      enabled: true
+    # Every one of these lives under `reloader:` in the chart. At the top
+    # level Helm accepts them silently and the chart never reads them —
+    # `flate test` reports "values not used by the chart".
+    reloader:
+      deployment:
+        resources:
+          limits:
+            memory: 512Mi
+          requests:
+            cpu: 5m
+            memory: 320Mi
+      podMonitor:
+        enabled: true
 
-    reloadStrategy: annotations
+      reloadStrategy: annotations


### PR DESCRIPTION
## What

Moves `deployment`, `podMonitor`, and `reloadStrategy` under the `reloader:` key, where the stakater chart actually reads them.

## Why

All three sat at the top level of `spec.values`. Helm accepts unknown top-level keys silently, so this looked correct and rendered without error — the chart simply never read any of them. `flate test` names it:

```
HelmRelease kube-system/reloader: values not used by the chart
  deployment, podMonitor, reloadStrategy
```

Each was confirmed against **live cluster state**, not inferred from the manifest:

| Setting | Intended | Actual |
|---|---|---|
| `deployment.resources` | 320Mi req / 512Mi limit | **no requests or limits at all** |
| `podMonitor.enabled` | `true` | no reloader scrape target in Prometheus |
| `reloadStrategy` | `annotations` | chart default (`default`, env-var strategy) |

The resources one is the reason this is worth a PR rather than a tidy-up. `kube_pod_container_resource_requests` returns no series for reloader and its cgroup path is `kubepods-besteffort` — so the controller that restarts half the cluster on a ConfigMap change is running **BestEffort QoS**, first in line for eviction under node memory pressure. Measured peak over 7d is **263Mi**, so the 320Mi/512Mi that was written is correctly sized. It just never took effect.

Second-order: `podMonitor` being inert means there has never been any visibility into whether reloads succeed.

## Verification

Rendered the chart at the pinned version with the corrected values:

- `PodMonitor` — now present (was absent)
- `--reload-strategy=annotations` — now on the container args
- container resources — `{limits: {memory: 512Mi}, requests: {cpu: 5m, memory: 320Mi}}`
- `flate test all` — reloader warning gone, **475 passed**

## Impact

Rolls the reloader deployment once. No dependent service disruption — reloader is a controller; a brief gap only delays annotation-driven reloads, it doesn't drop them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)