### PR TITLE
fix(flux): stop the cluster-wide patch overriding per-resource intent

### DIFF
--- a/kubernetes/flux/cluster/ks.yaml
+++ b/kubernetes/flux/cluster/ks.yaml
@@ -43,10 +43,15 @@ spec:
   deletionPolicy: WaitForTermination
   patches:
     # Inject sourceRef and prune defaults into every child Kustomization.
-    # Strategic-merge sets these on KSes that omit them; for KSes that
-    # already carry the same values the patch is a no-op.  wait/interval/
-    # timeout are intentionally NOT included here — they vary per-KS
-    # (e.g. 79 KSes have wait:true, interval splits 30m/1h, timeout 3m/5m).
+    #
+    # NOTE: strategic-merge is patch-WINS, not fill-in-the-blanks. A value
+    # set here OVERRIDES whatever the child KS declares — it is not "a
+    # no-op for KSes that already carry the same values". Anything this
+    # patch sets can no longer be overridden per-KS, so keep the list
+    # minimal and add an explicit exclusion below when a KS must differ.
+    # wait/interval/timeout are deliberately NOT set here — they vary
+    # per-KS (79 KSes have wait:true, interval splits 30m/1h, timeout
+    # 3m/5m) and would all be flattened.
     - patch: |-
         apiVersion: kustomize.toolkit.fluxcd.io/v1
         kind: Kustomization
@@ -61,6 +66,23 @@ spec:
       target:
         group: kustomize.toolkit.fluxcd.io
         kind: Kustomization
+    # Exclusion: these two opt out of pruning. Both carry `prune: false`
+    # in their own ks.yaml with a "never delete this" comment, but the
+    # blanket patch above was silently flipping them back to true —
+    # leaving cluster DNS and CSR approval exposed to garbage collection
+    # if a refactor ever dropped a resource from their path. Patches
+    # apply in order, so this one wins.
+    - patch: |-
+        apiVersion: kustomize.toolkit.fluxcd.io/v1
+        kind: Kustomization
+        metadata:
+          name: _
+        spec:
+          prune: false
+      target:
+        group: kustomize.toolkit.fluxcd.io
+        kind: Kustomization
+        name: (coredns|kubelet-csr-approver)
     # Add Kustomization defaults for all child Kustomizations
     - patch: |-
         apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -94,6 +116,27 @@ spec:
               target:
                 group: helm.toolkit.fluxcd.io
                 kind: HelmRelease
+            # Exclusion: apps whose startup runs forward-only DB
+            # migrations. Rolling the *image* back cannot un-migrate the
+            # *database*, so remediation turns a slow upgrade into an
+            # unrecoverable one — this is the #13383 romm outage. Both
+            # HelmReleases already declare `retries: 0` with a comment
+            # explaining why, but the blanket patch above was overriding
+            # it back to 2, so only the `timeout: 20m` half of that fix
+            # was ever live. Patches apply in order; this one wins.
+            - patch: |-
+                apiVersion: helm.toolkit.fluxcd.io/v2
+                kind: HelmRelease
+                metadata:
+                  name: _
+                spec:
+                  upgrade:
+                    remediation:
+                      retries: 0
+              target:
+                group: helm.toolkit.fluxcd.io
+                kind: HelmRelease
+                name: (romm|open-webui)
       target:
         group: kustomize.toolkit.fluxcd.io
         kind: Kustomization


### PR DESCRIPTION
## The defect

The `cluster-apps` patches in `kubernetes/flux/cluster/ks.yaml` are **strategic-merge, which is patch-wins**. The comment above them claimed they were *"a no-op for KSes that already carry the same values"* — that is not how strategic merge works. Anything the patch sets **cannot be overridden downstream**, and two deliberate, commented safety settings were being silently discarded.

Verified offline and deterministically with `flate build ks`, which renders the same patch chain Flux applies. No inference from reading YAML.

### 1. `upgrade.remediation.retries` — the #13383 romm fix was only half-live

**169 of 170** HelmReleases render `retries: 2`. The single exception is `reflector` — the one HelmRelease in the repo with no governing `ks.yaml`, so the patch never reaches it. A clean natural experiment confirming the mechanism.

`romm` and `open-webui` each declare `retries: 0` beneath a comment explaining that their startup runs **forward-only Alembic migrations**, so rolling the *image* back cannot un-migrate the *database*. Both were rendering `retries: 2`.

So only the `timeout: 20m` half of the #13383 fix was ever in effect. The half that prevents the **unrecoverable** state was not. A slow upgrade would reproduce the original 2-hour outage.

### 2. `prune` — cluster DNS was exposed to garbage collection

`coredns` and `kubelet-csr-approver` both carry `prune: false` with *"Never delete this"* / *"never should be deleted"* comments. Both render `prune: true`.

Commit `265f381189` explicitly recorded that these overrides were *"intentional and left untouched"* — the patch had been nullifying them the entire time. Any refactor that dropped a resource from `coredns/app` would have let Flux garbage-collect cluster DNS, with the documented safety net not actually present.

## The fix

Two **targeted exclusion patches** rather than removing the global defaults. Patches apply in order, so a later, narrower `target.name` wins. Blast radius is exactly the four resources that documented wanting something different:

| | before | after |
|---|---|---|
| `retries` | `{2: 169, 3: 1}` | `{2: 167, **0: 2**, 3: 1}` |
| `prune` | `{true: 230}` | `{true: 228, **false: 2}` |

The other 29 HelmReleases that declare a `retries` value are deliberately left alone — they either ask for `3` (vs the `2` they get, immaterial) or `-1` while also setting `disableWait: true`, which means Helm never waits so remediation cannot trip regardless.

The misleading comment is corrected in place so the next reader doesn't repeat the assumption.

## Verification

- `flate build ks` before/after — distributions above; `romm`/`open-webui` → `retries: 0`, `coredns`/`kubelet-csr-approver` → `prune: false`, all 396 other resources byte-identical
- `flate test all` → **477 passed**

## Not addressed here

`home-assistant` has a 120Gi database, no `timeout` override, and waits — same exposure class. Left out because picking the right timeout deserves a decision rather than a guess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)