### PR TITLE
fix(loki): Loki has never been scraped, so its alert rules are inert

### DIFF
--- a/kubernetes/apps/observability/loki/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/loki/app/helmrelease.yaml
@@ -110,7 +110,14 @@ spec:
     resultsCache:
       enabled: false
 
-    # Disable bundled monitoring/canary/test for homelab
+    # Disable bundled canary/test/self-monitoring for homelab, but the
+    # ServiceMonitor has to stay ON. This app ships its own hand-written
+    # prometheus-rule.yaml (LokiRequestErrors, LokiRequestPanics,
+    # LokiRequestLatency + 12 recording rules); with no scrape target
+    # those rules evaluate against an empty input set — permanently
+    # inactive rather than erroring, so they read as healthy while
+    # catching nothing. `rules.enabled: false` suppresses the chart's
+    # own bundled rules; it does not gate ours.
     monitoring:
       dashboards:
         annotations:
@@ -118,7 +125,7 @@ spec:
       rules:
         enabled: false
       serviceMonitor:
-        enabled: false
+        enabled: true
         metricsInstance:
           enabled: false
       selfMonitoring:


### PR DESCRIPTION
## The defect

`monitoring.serviceMonitor.enabled` was `false`, so **no Loki scrape target has ever existed** — `up{job=~".*loki.*"}` returns zero series live.

That matters because this app *also* ships its own hand-written `prometheus-rule.yaml`: `LokiRequestErrors`, `LokiRequestPanics`, `LokiRequestLatency`, plus 12 recording rules. Those are **not** gated by the chart's `monitoring.rules.enabled: false` flag — they ship unconditionally via `kustomization.yaml`.

With no input series they sit at `state: inactive, health: ok, lastError: None` forever.

This is the failure mode worth fixing: not a broken rule that surfaces an error, but **three `severity: critical` rules that look perfectly healthy while being structurally incapable of firing**. Loki could OOM, panic, or 5xx every log query and nothing would page. The only current Loki liveness signal is indirect — Grafana Explore returning no data.

## Verification

Rendered the chart at the pinned 7.2.0:

- The ServiceMonitor template is gated on `Capabilities.APIVersions.Has "monitoring.coreos.com/v1/ServiceMonitor"`. A plain `helm template` therefore renders **nothing** and looks like the fix failed — worth knowing for anyone re-checking this. Supplying that api-version (what the cluster actually presents) renders it correctly.
- Selector resolves to **exactly one** Service: `loki`, port `http-metrics:3100`, path `/metrics`.
- `loki-headless` also matches the label selector, but the chart labels it `prometheus.io/service-monitor: "false"` and the ServiceMonitor excludes it via `matchExpressions` → **no double scrape**.
- Prometheus sets `serviceMonitorSelectorNilUsesHelmValues: false`, so it is picked up with no selector change.
- Scrape is permitted: baseline `allow-monitoring-scrape` allows the observability Prometheus pod on any port, and loki's own CNP sets `enableDefaultDeny.ingress: false`.
- `flate test all` → **477 passed**

## Scope

Canary, self-monitoring, `metricsInstance` and the chart's bundled rules stay **disabled**. Only the ServiceMonitor is enabled — Loki's `/metrics` cardinality is negligible at homelab log volume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)