### PR TITLE
fix(jellyfin): CNP selector matched zero pods; swiparr had no ingress

### DIFF
--- a/kubernetes/apps/media/jellyfin/app/cnp-allow.yaml
+++ b/kubernetes/apps/media/jellyfin/app/cnp-allow.yaml
@@ -37,10 +37,20 @@ spec:
               protocol: TCP
     # 3) In-cluster callers (janitorr → /Users/MediaSegments, etc.)
     #    reach jellyfin via cluster-DNS Service.
+    #
+    #    janitorr was split into janitorr-radarr + janitorr-sonarr, so
+    #    the old `app.kubernetes.io/name: janitorr` selector matched
+    #    zero live pods. Same-namespace traffic still flowed — the
+    #    baseline `allow-intra-namespace` CNP covers media internally
+    #    and Cilium rules are additive — so this was dead config, not an
+    #    outage. It still documented an intent it no longer enforced.
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: media
-            app.kubernetes.io/name: janitorr
+          matchExpressions:
+            - key: app.kubernetes.io/name
+              operator: In
+              values: ["janitorr-radarr", "janitorr-sonarr"]
       toPorts:
         - ports:
             - port: "8096"
@@ -51,6 +61,19 @@ spec:
         - matchLabels:
             io.kubernetes.pod.namespace: home
             app.kubernetes.io/name: home-assistant
+      toPorts:
+        - ports:
+            - port: "8096"
+              protocol: TCP
+    # 5) swiparr (collab ns) reaches jellyfin via
+    #    JELLYFIN_URL=http://jellyfin.media:8096. This one IS
+    #    cross-namespace, so allow-intra-namespace does not cover it —
+    #    swiparr declares the egress but there was no matching ingress
+    #    here, making it a genuine silent drop.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: collab
+            app.kubernetes.io/name: swiparr
       toPorts:
         - ports:
             - port: "8096"


### PR DESCRIPTION
Two problems in jellyfin's CNP ingress list, with **deliberately different severities** — I checked each rather than assuming both were outages.

## 1. Stale `janitorr` selector — dead config, *not* a live drop

Rule 3 selected `app.kubernetes.io/name: janitorr`. That app was split into `janitorr-radarr` and `janitorr-sonarr`, so the selector matches **zero live pods** (confirmed against the running pod list — there is no pod named plain `janitorr` in `media`).

But this is **not** currently dropping traffic. Both callers are in the `media` namespace, and the baseline `allow-intra-namespace` CNP has `endpointSelector: {}` with `fromEndpoints: [matchLabels: {}]` — all same-namespace traffic is already permitted, and Cilium rules are additive.

So it's dead config documenting an intent it no longer enforces. Worth fixing for correctness; nothing is broken today. *(An earlier pass of this audit called it an active outage — that was wrong, and the intra-namespace baseline is why.)*

## 2. Missing `swiparr` ingress — genuine silent drop

`swiparr` (collab ns) has `JELLYFIN_URL=http://jellyfin.media:8096` and declares the matching **egress** in its own CNP, but jellyfin had no corresponding **ingress** entry.

This one *is* cross-namespace, so `allow-intra-namespace` does not cover it — and jellyfin's ingress list has no `fromEntities: cluster` fallback either (the four existing rules are envoy, world, janitorr, home-assistant). Asymmetric policy → silent drop, no error anywhere.

## Verification

- Pod labels resolved against the live `media` namespace, not inferred from YAML
- `flate test all` → **477 passed**
- `yamllint` at the **CI invocation** (no `--strict`) → exit 0

## Two things this surfaced, not fixed here

- **Hubble is unreachable through the MCP surface** (`dial tcp [::1]:4245: connection refused`), so a live DROPPED verdict could not be obtained — this whole class has to be reasoned about instead of confirmed. Worth fixing before the next policy audit.
- **pre-commit and CI disagree on yamllint.** The hook passes `--strict` under a comment claiming it "mirrors the CI yamllint job"; CI does not. So `pre-commit run --all-files` fails on files CI happily accepts (this file has one such pre-existing warning, left untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)