### PR TITLE
fix(helm): five value blocks the charts silently ignore

### DIFF
--- a/kubernetes/apps/databases/pgadmin/app/helmrelease.yaml
+++ b/kubernetes/apps/databases/pgadmin/app/helmrelease.yaml
@@ -21,10 +21,12 @@ spec:
       PGADMIN_CONFIG_SERVER_MODE: "False"
       email: "${EMAIL}"
 
-    envFrom:
-      - secretRef:
-          name: *app
-
+    # NOTE: an `envFrom: [secretRef]` block was removed — this chart has
+    # no envFrom key (its equivalent is `envVarsFromSecrets`), so it was
+    # silently ignored. Nothing is lost: the password already arrives via
+    # `existingSecret` + the chart's default secretKeys.pgadminPasswordKey,
+    # and the address via `env.email`. pgadmin is Ready live, which is the
+    # evidence those two paths are sufficient on their own.
     existingSecret: *app
 
     persistentVolume:

--- a/kubernetes/apps/kube-system/cilium/app/values.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/values.yaml
@@ -2,12 +2,11 @@
 cni:
   exclusive: false # Needed to allow Cillium to work properly with Multus
 
-bgp:
-  enabled: false
-  announce:
-    loadbalancerIP: true
-    podCIDR: false
-
+# NOTE: the legacy `bgp:` block (enabled/announce.loadbalancerIP) was
+# removed here — the Cilium chart no longer has that key at all, so it
+# was silently ignored while sitting directly above the setting that
+# does work. BGP is driven by bgpControlPlane + the three CRs in
+# ../config/bgp.yaml (ClusterConfig / PeerConfig / Advertisement).
 bgpControlPlane:
   enabled: true
 

--- a/kubernetes/apps/kube-system/intel-device-plugin/gpu/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/intel-device-plugin/gpu/helmrelease.yaml
@@ -16,10 +16,9 @@ spec:
       hub: docker.io/intel
     name: intel-device-plugin-gpu
     nodeFeatureRule: true
-    resources:
-      requests:
-        cpu: 10m
-        memory: 64Mi
-      limits:
-        memory: 128Mi
+    # NOTE: a `resources:` block was removed — this chart renders a
+    # GpuDevicePlugin CR and exposes no resources key, so it never
+    # applied. Live, the DaemonSet runs the operator default (45Mi)
+    # rather than the 64Mi that was requested here. Setting it for real
+    # needs a kustomize patch on the DaemonSet, not a chart value.
     sharedDevNum: 3

--- a/kubernetes/apps/observability/exporters/blackbox-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/exporters/blackbox-exporter/app/helmrelease.yaml
@@ -11,8 +11,12 @@ spec:
 
   interval: 30m
   values:
-    allowIcmp: true
-
+    # NOTE: `allowIcmp: true` was removed — the chart has no such key
+    # (its documented ICMP switch is securityContext.capabilities.add:
+    # ["NET_RAW"]). It was silently ignored, yet ICMP probing works:
+    # the `devices` job uses the icmp module and probe_success is 1 for
+    # ~70 targets live. So this was a no-op, not a broken prober — do
+    # not "restore" it by adding NET_RAW without evidence it's needed.
     resources:
       requests:
         cpu: 10m

--- a/kubernetes/apps/observability/tempo/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/tempo/app/helmrelease.yaml
@@ -100,10 +100,20 @@ spec:
     tempoQuery:
       enabled: false
 
-    # Pod-level security context.
-    podSecurityContext:
+    # Pod-level security context. The key is `securityContext`, NOT
+    # `podSecurityContext` — that is what this block used, and the chart
+    # has no such key, so it was silently ignored. (The chart's own
+    # values comment labels this one "securityContext for container",
+    # which is wrong: the template renders it at pod scope.)
+    #
+    # UID/GID stay at the chart's 10001 rather than the 1000 the ignored
+    # block asked for — tempo's PVC is already owned by 10001, so
+    # changing it would break ownership on an existing volume. The one
+    # real addition is fsGroupChangePolicy, which skips the recursive
+    # chown when the volume root already matches.
+    securityContext:
       runAsNonRoot: true
-      runAsUser: 1000
-      runAsGroup: 1000
-      fsGroup: 1000
+      runAsUser: 10001
+      runAsGroup: 10001
+      fsGroup: 10001
       fsGroupChangePolicy: OnRootMismatch


### PR DESCRIPTION
`flate test` reports **"values not used by the chart"** for each of these. Helm accepts unknown keys without complaint, so they render fine and *read* as configuration while doing nothing. Each was checked against the actual chart **and** against live state — the point is that none of them mean what they appear to mean.

| App | Key | Verdict |
|---|---|---|
| tempo | `podSecurityContext` | **re-keyed** to `securityContext` |
| cilium | `bgp` | removed — chart dropped the key |
| blackbox-exporter | `allowIcmp` | removed — no-op, ICMP works anyway |
| intel-device-plugin-gpu | `resources` | removed — chart has no such key |
| pgadmin | `envFrom` | removed — redundant |

### tempo — the one real behaviour change

`podSecurityContext` isn't a key in this chart; the pod-level key is plain `securityContext`. (The chart's own values comment labels it *"securityContext for container"*, which is wrong — the template renders it at **pod** scope.)

UID/GID stay at the chart's **10001**, not the `1000` the ignored block asked for: tempo's PVC is already owned by 10001, and re-keying to 1000 would break ownership on an existing volume. `fsGroupChangePolicy: OnRootMismatch` is the one genuine addition.

Verified by rendering: pod `securityContext` = `{runAsNonRoot: true, 10001/10001/10001, fsGroupChangePolicy: OnRootMismatch}`.

### cilium — `bgp:`

The chart no longer has this key at all; only `bgpControlPlane` does. It sat **directly above** the setting that does work, so a reader could reasonably believe BGP announce config was live. BGP is actually driven by `bgpControlPlane` plus the three CRs in `config/bgp.yaml`.

### blackbox-exporter — `allowIcmp`

No such key; the chart's documented ICMP switch is `securityContext.capabilities.add: ["NET_RAW"]`.

Worth stating plainly: **ICMP probing works anyway.** The `devices` job uses the `icmp` module and `probe_success` is `1` for ~70 targets right now. This is a no-op, not a broken prober — I checked before filing it as critical, and it wasn't. **Do not "restore" it by granting NET_RAW** without evidence it's needed.

### intel-device-plugin-gpu — `resources`

The chart renders a `GpuDevicePlugin` CR and exposes no `resources` key. Live, the DaemonSet runs the operator default **45Mi**, not the 64Mi requested here.

### pgadmin — `envFrom`

No `envFrom` key in this chart (the equivalent is `envVarsFromSecrets`). Nothing is lost: the password already arrives via `existingSecret` + the chart-default `secretKeys.pgadminPasswordKey`, and the address via `env.email`. **pgadmin is Ready live**, which is the evidence those two paths suffice on their own.

## Verification

- `flate test all` → **477 passed**; all five warnings cleared (the remaining `reloader` warning is fixed separately in #13503)
- tempo rendered through the real chart to confirm pod-scope placement
- `pre-commit` clean on all five files

## Out of scope

The intel GPU plugin has **no resource requests at all** — fixing that needs a DaemonSet kustomize patch, not a chart value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)