### PR TITLE
fix(flux): nine health gates were declared but never evaluated

### DIFF
--- a/kubernetes/apps/databases/cloudnative-pg/ks.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/ks.yaml
@@ -319,6 +319,7 @@ spec:
   path: ./kubernetes/apps/databases/cloudnative-pg/config/sparkyfitness
   interval: 30m
   timeout: 5m
+  wait: true
   dependsOn:
     - name: cloudnative-pg
       namespace: databases
@@ -518,6 +519,7 @@ spec:
   path: ./kubernetes/apps/databases/cloudnative-pg/config/lidarr
   interval: 30m
   timeout: 5m
+  wait: true
   dependsOn:
     - name: cloudnative-pg
       namespace: databases
@@ -550,6 +552,7 @@ spec:
   path: ./kubernetes/apps/databases/cloudnative-pg/config/sonarr
   interval: 30m
   timeout: 5m
+  wait: true
   dependsOn:
     - name: cloudnative-pg
       namespace: databases
@@ -582,6 +585,7 @@ spec:
   path: ./kubernetes/apps/databases/cloudnative-pg/config/radarr
   interval: 30m
   timeout: 5m
+  wait: true
   dependsOn:
     - name: cloudnative-pg
       namespace: databases
@@ -614,6 +618,7 @@ spec:
   path: ./kubernetes/apps/databases/cloudnative-pg/config/prowlarr
   interval: 30m
   timeout: 5m
+  wait: true
   dependsOn:
     - name: cloudnative-pg
       namespace: databases

--- a/kubernetes/apps/downloads/prowlarr/ks.yaml
+++ b/kubernetes/apps/downloads/prowlarr/ks.yaml
@@ -21,6 +21,8 @@ spec:
       namespace: longhorn-system
     - name: onepassword-connect
       namespace: external-secrets
+    - name: prowlarr
+      namespace: databases
   postBuild:
     substitute:
       APP: *app

--- a/kubernetes/apps/downloads/qbittorrent/ks.yaml
+++ b/kubernetes/apps/downloads/qbittorrent/ks.yaml
@@ -12,6 +12,7 @@ spec:
   path: ./kubernetes/apps/downloads/qbittorrent/secrets
   interval: 30m
   timeout: 5m
+  wait: true
   dependsOn:
     - name: authelia
       namespace: auth

--- a/kubernetes/apps/media/av1corrector/ks.yaml
+++ b/kubernetes/apps/media/av1corrector/ks.yaml
@@ -12,6 +12,7 @@ spec:
   path: ./kubernetes/apps/media/av1corrector/secrets
   interval: 30m
   timeout: 5m
+  wait: true
   dependsOn:
     - name: authelia
       namespace: auth

--- a/kubernetes/apps/media/kodi-playback-watcher/ks.yaml
+++ b/kubernetes/apps/media/kodi-playback-watcher/ks.yaml
@@ -12,6 +12,7 @@ spec:
   path: ./kubernetes/apps/media/kodi-playback-watcher/secrets
   interval: 30m
   timeout: 5m
+  wait: true
   dependsOn:
     - name: onepassword-connect
       namespace: external-secrets

--- a/kubernetes/apps/media/lidarr/ks.yaml
+++ b/kubernetes/apps/media/lidarr/ks.yaml
@@ -16,6 +16,8 @@ spec:
   dependsOn:
     - name: authelia
       namespace: auth
+    - name: lidarr
+      namespace: databases
     - name: longhorn
       namespace: longhorn-system
     - name: onepassword-connect

--- a/kubernetes/apps/media/radarr/ks.yaml
+++ b/kubernetes/apps/media/radarr/ks.yaml
@@ -20,6 +20,8 @@ spec:
       namespace: longhorn-system
     - name: onepassword-connect
       namespace: external-secrets
+    - name: radarr
+      namespace: databases
   postBuild:
     substitute:
       APP: *app

--- a/kubernetes/apps/media/sonarr/ks.yaml
+++ b/kubernetes/apps/media/sonarr/ks.yaml
@@ -20,6 +20,8 @@ spec:
       namespace: longhorn-system
     - name: onepassword-connect
       namespace: external-secrets
+    - name: sonarr
+      namespace: databases
   postBuild:
     substitute:
       APP: *app

--- a/kubernetes/apps/media/videodupfinder/ks.yaml
+++ b/kubernetes/apps/media/videodupfinder/ks.yaml
@@ -12,6 +12,7 @@ spec:
   path: ./kubernetes/apps/media/videodupfinder/secrets
   interval: 30m
   timeout: 5m
+  wait: true
   dependsOn:
     - name: onepassword-connect
       namespace: external-secrets


### PR DESCRIPTION
## The defect

`healthCheckExprs` only supplies custom health logic for objects that are *actually being health-checked* — i.e. `wait: true`, or the object is listed in `healthChecks`. **Nine Kustomizations declared the expression with neither**, so it never ran. The Kustomization goes Ready the moment its objects are **applied**, not when they are healthy.

The distribution makes it clear this is drift, not intent: of the 22 CNPG cluster Kustomizations, **17 set `wait: true` and 5 do not** — and the 5 are exactly the ones whose expression is inert.

| Kustomization | expression that never ran |
|---|---|
| `databases/{lidarr,sonarr,radarr,prowlarr,sparkyfitness}` | `status.phase in ['Cluster in healthy state']` |
| `media/av1corrector-secrets` | ExternalSecret `Ready` condition |
| `media/videodupfinder-secrets` | ExternalSecret `Ready` condition |
| `media/kodi-playback-watcher-secrets` | ExternalSecret `Ready` condition |
| `downloads/qbittorrent-secrets` | ExternalSecret `Ready` condition |

## Why the ExternalSecret half matters most

Three of those four paths are consumed by a `postBuild.substituteFrom` with `optional: false`. The dependency edge is satisfied when the ExternalSecret **object** is applied — not when ESO has **materialised the Secret**. So on a cold boot, an ESO restart, or a 1Password Connect blip, the dependent Kustomization fails with "Secret not found" and stalls for a retryInterval.

That is precisely the failure the gate was written to prevent.

## The CNPG half also needed the consumer side

`lidarr`, `sonarr`, `radarr` and `prowlarr` each point at `postgres-<app>-rw.databases.svc.cluster.local` (verified in their externalsecrets) but **none dependsOn its database** — so even a working gate had nothing waiting on it. On a cold boot or DB re-create, the apps start before Postgres exists and crashloop until they happen to retry into a live DB.

Added those four edges, matching the pattern `paperless` and the other 17 already use, alphabetically sorted per `flux.sorting.instructions.md`.

## Verification

- `flate test all` → **475 passed**
- Full dependency graph re-walked **after** the new edges: **no dangling `dependsOn`, no cycles**, 230 Kustomizations

## Not included

`rook-ceph-cluster` has `wait: true`, but its `CephCluster` is created by the HelmRelease and therefore is **not in the Kustomization's inventory** — its `failed: status.ceph.health == 'HEALTH_ERR'` expression can never trip. Everything gated behind it (including `cloudnative-pg` and all 22 CNPG clusters on `ceph-block`) proceeds into a degraded Ceph. That needs an explicit `healthChecks` entry and is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)