### PR TITLE
fix(renovate): two managers that silently tracked nothing

### DIFF
--- a/.github/renovate/customManagers.json5
+++ b/.github/renovate/customManagers.json5
@@ -11,6 +11,32 @@
         "oci://(?<depName>[^:]+):(?<currentValue>\\S+)",
       ],
       datasourceTemplate: "docker",
-    }
+    },
+    {
+      // Handles the inline annotation form:
+      //   # renovate: datasource=github-releases depName=owner/repo
+      //   someKey: v1.2.3
+      //
+      // Without this manager the annotation is inert — Renovate simply
+      // does not see the dependency, and there is no warning anywhere.
+      // That is exactly how immich-server froze at v3.0.2 for 10 days
+      // while immich-machine-learning kept auto-bumping (#13480). That
+      // fix worked around the hole by setting `repository:` explicitly;
+      // this closes it, so the next annotation anyone writes works.
+      //
+      // Regex is the one from home-operations/renovate-presets: it
+      // covers YAML values, quoted values, anchors, and KEY=value env
+      // lines.
+      customType: "regex",
+      description: "Process annotated dependencies",
+      managerFilePatterns: [
+        "/(^|/).+\\.ya?ml(?:\\.j2)?$/",
+      ],
+      matchStrings: [
+        "datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)( versioning=(?<versioning>\\S+))?\\n.+(:\\s|=)(&\\S+\\s)?[\"']?(?<currentValue>[^\"'\\s]+)[\"']?",
+      ],
+      datasourceTemplate: "{{#if datasource}}{{{datasource}}}{{else}}github-releases{{/if}}",
+      versioningTemplate: "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
+    },
   ]
 }

--- a/.github/renovate/grafanaDashboards.json5
+++ b/.github/renovate/grafanaDashboards.json5
@@ -9,13 +9,41 @@
   },
   customManagers: [
     {
+      // URL form: `.../dashboards/<id>/revisions/<rev>/download`.
+      // Currently matches nothing in the tree — every grafana.com
+      // dashboard here uses the chart-native gnetId/revision pair
+      // handled below. Kept because it is the upstream-idiomatic form
+      // and costs nothing if a url-style dashboard is ever added.
       customType: "regex",
-      description: "Process Grafana dashboards",
+      description: "Process Grafana dashboards (url form)",
       managerFilePatterns: ["/(^|/)kubernetes/.+\\.ya?ml$/"],
       matchStrings: [
         "dashboards\\/(?<depName>\\d+)\\/revisions\\/(?<currentValue>\\d+)\\/download",
       ],
       autoReplaceStringTemplate: "dashboards/{{depName}}/revisions/{{newValue}}/download",
+      datasourceTemplate: "custom.grafana-dashboards",
+      versioningTemplate: "regex:^(?<major>\\d+)$",
+    },
+    {
+      // Chart-native form, used by every grafana.com dashboard here:
+      //
+      //   gnetId: 15761
+      //   revision: 17
+      //
+      // The url-form manager above never matched any of them, so all
+      // 14 were invisible to Renovate and drifting silently. The
+      // `# renovate: dashboardName=...` comments sitting next to them
+      // looked like tracking but had no manager backing them.
+      //
+      // Deliberately no autoReplaceStringTemplate: letting Renovate
+      // replace the captured currentValue in place keeps this
+      // indentation-agnostic.
+      customType: "regex",
+      description: "Process Grafana dashboards (gnetId/revision form)",
+      managerFilePatterns: ["/(^|/)kubernetes/.+\\.ya?ml$/"],
+      matchStrings: [
+        "gnetId: (?<depName>\\d+)\\s+revision: (?<currentValue>\\d+)",
+      ],
       datasourceTemplate: "custom.grafana-dashboards",
       versioningTemplate: "regex:^(?<major>\\d+)$",
     },


### PR DESCRIPTION
Both of these are the same failure shape: config that **looks like** dependency tracking, produces no error, and matches **zero** dependencies. Renovate never warns about a manager that matches nothing.

## 1. Grafana dashboards were never tracked at all

`grafanaDashboards.json5` only had a manager for the **URL form** (`dashboards/<id>/revisions/<rev>/download`). Every grafana.com dashboard in this repo uses the **chart-native pair** instead:

```yaml
gnetId: 15761
revision: 17
```

Measured over the whole tree, not assumed:

| regex | matches in `kubernetes/**` |
|---|---|
| existing (url form) | **0** |
| `gnetId`/`revision` | **14** |

So the manager has never fired — and the eight `# renovate: dashboardName=...` comments sitting beside those dashboards *looked* like tracking while having nothing behind them. Several dashboards are multiple revisions behind upstream (e.g. Views/Nodes pinned at 32 vs 40, Views/Namespaces 41 vs 46).

Added a second manager for the chart-native form; kept the URL one since it's the upstream-idiomatic shape and costs nothing if a url-style dashboard is added later.

**Heads-up:** this newly tracks **14** dashboards, six of which had no annotation at all. Expect a batch of dashboard PRs on the next Renovate run. They automerge under the existing grafana-dashboard rule — low-risk here because a dashboard bump is a ConfigMap change with **no image pull**, so it can't reproduce the pull-saturation problem from the earlier merge wave.

## 2. The annotated-dependency form had no manager

`customManagers.json5` defined exactly one manager, for `oci://`. The inline form

```yaml
# renovate: datasource=github-releases depName=owner/repo
someKey: v1.2.3
```

was therefore **inert**.

This is not hypothetical — it's how `immich-server` froze at v3.0.2 for 10 days while `immich-machine-learning` kept auto-bumping (#13480). That fix worked *around* the hole by setting `repository:` explicitly rather than closing it, so **the next annotation anyone wrote would have failed the same silent way**.

Regex taken from `home-operations/renovate-presets`; it handles YAML values, quoted values, anchors, and `KEY=value` lines. No annotation in the tree uses this form today, so it adds no dependencies right now — it makes the form work when next used.

## Verification

- `renovate-config-validator` → passes on both files
- gnetId/revision regex run over `kubernetes/**` to **count** matches (14 vs 0) rather than assume

🤖 Generated with [Claude Code](https://claude.com/claude-code)