### PR TITLE
fix(ci): a green gate that never ran, and a dashboard that never wrote

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -17,11 +17,13 @@ on:
       - README.md
       - .github/workflows/docs.yaml
 
+# Deployment uses peaceiris/actions-gh-pages with a GitHub App token
+# (see the Deploy step), pushing to the gh-pages branch — it does not
+# use the Pages OIDC deployment API. So actions/id-token/pages write
+# were all unused, and `actions: write` (cancel or re-run workflows,
+# delete artifacts) applied to the PR-triggered path too.
 permissions:
-  actions: write
   contents: read
-  id-token: write
-  pages: write
 
 jobs:
   publish:

--- a/.github/workflows/image-registry-check.yaml
+++ b/.github/workflows/image-registry-check.yaml
@@ -151,7 +151,16 @@ jobs:
 
   image-registry-check-success:
     if: ${{ !cancelled() }}
+    # `check-new-images` alone is not enough. If `filter-changes` or
+    # `extract-images` fails, this job is SKIPPED — result "skipped",
+    # not "failure" — so `contains(needs.*.result, 'failure')` stayed
+    # false and the gate went green with the registry policy never
+    # having run. Depending on all three closes that hole while still
+    # allowing the legitimate skip (no image changes on the PR), where
+    # the upstream jobs succeed and nothing reports failure.
     needs:
+      - filter-changes
+      - extract-images
       - check-new-images
     name: Image registry check successful
     runs-on: ubuntu-latest

--- a/.github/workflows/lychee.yaml
+++ b/.github/workflows/lychee.yaml
@@ -36,6 +36,15 @@ jobs:
         env:
           GITHUB_TOKEN: "${{ steps.generate-token.outputs.token }}"
         with:
+          # `output` defaults to lychee/out.md at this pinned SHA, but the
+          # Update Issue step below reads results.md — so the dashboard
+          # file never existed and that step errored on a missing path.
+          output: results.md
+          # `fail` also defaults to true, and neither issue step is
+          # `if: always()`. So when links WERE broken the job aborted here
+          # and the dashboard was skipped too. Broken links are reported
+          # via the issue + job summary, not by failing a weekly cron.
+          fail: false
           args: >
             --verbose
             --no-progress

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,6 +6,6 @@
         "redhat.vscode-yaml",
         "samuelcolvin.jinjahtml",
         "bluebrown.yamlfmt",
-        "nefrob.vscode-just-syntax",
+        "nefrob.vscode-just-syntax"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,5 @@
 {
-  "prettier.configPath": ".prettierrc.yaml",
-  "prettier.ignorePath": ".prettierignore",
   "yaml.schemas": {
     "kubernetes": ["kubernetes/*.yml", "kubernetes/*.yaml"]
-  },
+  }
 }


### PR DESCRIPTION
Four independent CI defects. The first two both produce a **passing or silent** result while doing nothing, which is why neither was noticed.

## 1. `image-registry-check`'s success gate could go green with the policy never evaluated

The job graph is `filter-changes → extract-images → check-new-images → image-registry-check-success`, but the gate declared `needs: [check-new-images]` **only**.

If `filter-changes` or `extract-images` **fails**, `check-new-images` is **skipped** — and a skipped job's result is `"skipped"`, not `"failure"`. So `contains(needs.*.result, 'failure')` stayed false and **the gate passed**.

A PR adding a non-allowlisted registry could merge with the check never having run. And `extract-images` does network work (`flate get images`, with retries), so failing is a realistic outcome rather than a hypothetical.

Gate now depends on all three. The *legitimate* skip — no image changes on the PR — still passes, because there the upstream jobs succeed and nothing reports failure.

## 2. The Link Checker Dashboard could never be written

Two independent reasons, both verified against `action.yml` at the pinned SHA (`fail` default `True`, `output` default `'lychee/out.md'`):

- the workflow passes `content-filepath: results.md`, but the action writes `lychee/out.md` — the file never existed, so `create-issue-from-file` errored on a missing path;
- `fail` defaults to `true` and neither issue step is `if: always()` — so when links **were** broken, the job aborted at the scan step and skipped the issue steps too.

Clean run or broken run, **the dashboard was never populated in either branch**. Fixed with `output: results.md` + `fail: false` — broken links are reported via the issue and job summary, which is the point of a weekly cron, rather than by failing the run.

## 3. `docs.yaml` over-privileged `GITHUB_TOKEN`

Requested `actions: write`, `id-token: write`, `pages: write` and used **none** of them — deployment is `peaceiris/actions-gh-pages` with a GitHub App token pushing to the `gh-pages` branch, not the Pages OIDC API. `actions: write` is the notable one (cancel/re-run workflows, delete artifacts) and it applied on the PR-triggered path too. Reduced to `contents: read`.

## 4. `.vscode/*.json` broke `pre-commit run --all-files`

Trailing commas, and the `check-json` hook uses Python `json.load`, not a JSONC parser. `.pre-commit-config.yaml` documents `pre-commit run --all-files` as *the bootstrap step* — and it **failed on a clean checkout**.

Also removed `prettier.configPath` / `prettier.ignorePath`, which point at `.prettierrc.yaml` and `.prettierignore`; neither file exists.

## Verification

- both workflows parse; both `.vscode` files parse as **strict** JSON
- `pre-commit run check-json --all-files` → **now passes**
- actionlint + all other hooks clean on the changed files

## Left alone deliberately

`.vscode/settings.json`'s `yaml.schemas` glob `kubernetes/*.yaml` is non-recursive and matches nothing under `kubernetes/apps/**`. Making it recursive would apply a blanket kubernetes schema to files that already carry their own `# yaml-language-server: $schema=` line — which this repo standardises on. That's an editor-behaviour call worth making deliberately rather than folding into a CI fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)