### PR TITLE
feat(apps): PodDisruptionBudgets for the seven multi-replica apps

### DIFF
--- a/kubernetes/apps/auth/lldap/app/helmrelease.yaml
+++ b/kubernetes/apps/auth/lldap/app/helmrelease.yaml
@@ -32,6 +32,11 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
 
+        # Two replicas with topology spread expresses HA intent, but
+        # without a PDB a node drain can take both at once.
+        podDisruptionBudget:
+          minAvailable: 1
+
         replicas: 2
         strategy: RollingUpdate
 

--- a/kubernetes/apps/collab/atuin/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/atuin/app/helmrelease.yaml
@@ -31,6 +31,11 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
 
+        # Two replicas with topology spread expresses HA intent, but
+        # without a PDB a node drain can take both at once.
+        podDisruptionBudget:
+          minAvailable: 1
+
         replicas: 2
         type: statefulset
 

--- a/kubernetes/apps/media/theme-park/app/helmrelease.yaml
+++ b/kubernetes/apps/media/theme-park/app/helmrelease.yaml
@@ -26,6 +26,11 @@ spec:
                 matchLabels:
                   app.kubernetes.io/name: *app
 
+        # Two replicas with topology spread expresses HA intent, but
+        # without a PDB a node drain can take both at once.
+        podDisruptionBudget:
+          minAvailable: 1
+
         replicas: 2
 
         type: statefulset

--- a/kubernetes/apps/network/cloudflared/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cloudflared/app/helmrelease.yaml
@@ -30,6 +30,11 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
 
+        # Two replicas with topology spread expresses HA intent, but
+        # without a PDB a node drain can take both at once.
+        podDisruptionBudget:
+          minAvailable: 1
+
         replicas: 2
         strategy: RollingUpdate
         containers:

--- a/kubernetes/apps/observability/kromgo/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kromgo/app/helmrelease.yaml
@@ -29,6 +29,11 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
 
+        # Two replicas with topology spread expresses HA intent, but
+        # without a PDB a node drain can take both at once.
+        podDisruptionBudget:
+          minAvailable: 1
+
         replicas: 2
         strategy: RollingUpdate
 

--- a/kubernetes/apps/observability/vector/aggregator/helmrelease.yaml
+++ b/kubernetes/apps/observability/vector/aggregator/helmrelease.yaml
@@ -36,6 +36,11 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
 
+        # Two replicas with topology spread expresses HA intent, but
+        # without a PDB a node drain can take both at once.
+        podDisruptionBudget:
+          minAvailable: 1
+
         replicas: 2
 
         strategy: RollingUpdate

--- a/kubernetes/apps/selfhosted/webhook/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/webhook/app/helmrelease.yaml
@@ -21,6 +21,11 @@ spec:
             runAsUser: 2000
         annotations:
           reloader.stakater.com/auto: "true"
+        # Two replicas with topology spread expresses HA intent, but
+        # without a PDB a node drain can take both at once.
+        podDisruptionBudget:
+          minAvailable: 1
+
         replicas: 2
         strategy: RollingUpdate
         containers:


### PR DESCRIPTION
Every app-template controller running `replicas: 2` had **no PodDisruptionBudget**.

Six of the seven also carry `topologySpreadConstraints` with `whenUnsatisfiable: DoNotSchedule`, so the HA intent is explicit — the pods are deliberately kept on separate nodes. Without a PDB, though, nothing stops a drain, a descheduler eviction, or a rolling node reboot from taking **both** at once. The spread constraint doesn't help, because both nodes can be drained in sequence faster than a replacement becomes Ready.

| app | namespace | why it matters |
|---|---|---|
| `cloudflared` | network | **public ingress path** |
| `lldap` | auth | **auth path behind Authelia** |
| `atuin` | collab | shell history sync |
| `kromgo` | observability | |
| `theme-park` | media | |
| `vector-aggregator` | observability | log pipeline |
| `webhook` | selfhosted | (only one without topology spread) |

## Why now

The only PDBs anywhere in the repo today come from upstream charts' own values (cert-manager, external-secrets, kustomize-mutating-webhook). **None** of the 110 app-template apps used the chart's native `controllers.<name>.podDisruptionBudget`, which exists in the pinned 5.0.1 — both in `values.schema.json` and as a real template at `charts/common/templates/classes/_podDisruptionBudget.tpl`.

`minAvailable: 1` on a 2-replica controller permits exactly one voluntary disruption at a time, which is what rolling node maintenance needs.

## Verification

- Parsed all **110** app-template HelmReleases for controllers with `replicas >= 2` — these seven are the complete set, and none had a `podDisruptionBudget` key
- Rendered `lldap` through the real chart: emits `PodDisruptionBudget/lldap` with `minAvailable: 1` and the controller-scoped selector
- `flate test all` → **475 passed**

## Operational note

A `minAvailable: 1` PDB will now **block a node drain while the other replica is unhealthy**, instead of letting the drain proceed and drop the service. That's the intended trade — but it does mean `kubectl drain` can hang where it previously succeeded. Check the sibling replica is Ready first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)