### PR TITLE
fix(rook-ceph): the Ceph health gate could never trip

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/ks.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/ks.yaml
@@ -43,13 +43,31 @@ spec:
   targetNamespace: rook-ceph
   path: ./kubernetes/apps/rook-ceph/rook-ceph/cluster
   interval: 30m
-  timeout: 5m
-  wait: true
+  # Raised 5m -> 15m: the gate below now actually waits on Ceph coming
+  # up, and a cold boot takes longer than 5m to reach HEALTH_OK.
+  timeout: 15m
+  # `wait` MUST stay false here. Upstream: "when .spec.wait is enabled,
+  # .spec.healthChecks is ignored." The CephCluster is created by the
+  # HelmRelease, so it is not in this Kustomization's inventory and
+  # `wait: true` never looked at it — the healthCheckExprs below could
+  # not trip, and this KS went Ready as soon as the HelmRelease did.
+  # Listing the objects explicitly is the only way to health-check a
+  # resource the Kustomization does not own.
+  wait: false
   dependsOn:
     - name: rook-ceph
       namespace: rook-ceph
     - name: prometheus-operator-crds
       namespace: observability
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: rook-ceph-cluster
+      namespace: rook-ceph
+    - apiVersion: ceph.rook.io/v1
+      kind: CephCluster
+      name: rook-ceph
+      namespace: rook-ceph
   healthCheckExprs:
     - apiVersion: ceph.rook.io/v1
       kind: CephCluster


### PR DESCRIPTION
> **Draft on purpose.** This changes behaviour on the cluster's most critical dependency path — everything including CNPG is ordered behind it. Wants your call rather than an auto-merge.

## The defect

`rook-ceph-cluster` declares `failed: status.ceph.health == 'HEALTH_ERR'`, which reads as *"don't let dependents proceed into a broken Ceph"*. **It cannot fire.**

Two reasons, both confirmed:

1. The `CephCluster` is created by the **HelmRelease**, so it isn't in the Kustomization's inventory. Live `.status.inventory` contains only the HelmRelease and the OCIRepository.
2. `wait: true` doesn't help — and actively prevents the obvious fix. Upstream documents: **"when `.spec.wait` is enabled, `.spec.healthChecks` is ignored."** So simply adding a `healthChecks` entry alongside `wait: true` would have been *another no-op fix*.

Net effect today: `rook-ceph-cluster` reports Ready the moment the HelmRelease is Ready, whatever Ceph's actual health. Everything gated behind it proceeds regardless — `cloudnative-pg` and all **22 CNPG clusters** on `ceph-block`.

## The fix

Stop using `wait` here and health-check the two objects explicitly — the only way to assess a resource the Kustomization doesn't own.

Coverage is **not** reduced: `wait: true` previously covered the HelmRelease and OCIRepository, and the HelmRelease is now listed explicitly.

Timeout raised 5m → 15m because the gate now genuinely waits on Ceph.

## The trade — please weigh this

This turns a decorative gate into a real one, **and a real gate can block.**

On a cold boot or DR rebuild, `cloudnative-pg` and every CNPG cluster will now wait for Ceph to reach `HEALTH_OK`/`HEALTH_WARN` instead of racing ahead. That's the intended behaviour and strictly safer for data — but it converts a silent success into a **visible stall on the path that gates the databases**.

15m should cover a normal cold start. If Ceph routinely takes longer here, raise it before merging.

## Note

`CephCluster` name/namespace (`rook-ceph`/`rook-ceph`) was obtained by **rendering the pinned chart** — the `kubectl-mcp` ServiceAccount has no RBAC on `ceph.rook.io`, so it couldn't be read from the live cluster. That RBAC gap also blocked the `cilium.io` checks in this audit and is worth closing separately.

## Verification

- `flate test all` → **475 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)