### PR TITLE
fix(tooling): local pre-submit validated with a different gate than CI

### DIFF
--- a/.agents/skills/pre-submit.md
+++ b/.agents/skills/pre-submit.md
@@ -16,10 +16,18 @@ independent agent).
 
 ## Checks
 
-1. **Flux render diff** — run `flux-local diff` (or the repo's
-   wrapper) against `main` and verify the rendered manifest changes
-   match what you expect. Unexpected diffs usually mean an upstream
-   chart bumped under you.
+1. **Flux render + diff** — run `flate test all --path kubernetes/flux`
+   and confirm it passes, then `flate diff` against `main` and verify
+   the rendered manifest changes match what you expect. Unexpected
+   diffs usually mean an upstream chart bumped under you.
+
+   `flate test` also reports "values not used by the chart", which is
+   how a HelmRelease tells you a values block is being silently
+   ignored — treat any new warning there as a failure.
+
+   (This step used to say `flux-local diff`. CI has rendered with flate
+   since #12962; validating locally with the retired engine is not the
+   same gate.)
 2. **YAML schema validation** — every YAML in `kubernetes/` should
    have the right `# yaml-language-server: $schema=` comment on line
    2 per `.agents/instructions/schema.correction.md`. Open each

--- a/.github/workflows/.kubeconform-ignore
+++ b/.github/workflows/.kubeconform-ignore
@@ -1,1 +1,0 @@
-./bootstrap

--- a/.mise.toml
+++ b/.mise.toml
@@ -8,4 +8,15 @@ MINIJINJA_CONFIG_FILE = "{{config_root}}/.minijinja.toml"
 "aqua:astral-sh/uv" = "latest"
 "aqua:google/yamlfmt" = "latest"
 "aqua:rhysd/actionlint" = "latest"
-"pipx:flux-local" = "latest"
+
+# flux-local removed: CI has rendered with flate since #12962, so
+# installing the retired engine here meant validating locally with a
+# different tool than the one gating the merge. flate is not added as a
+# [tools] entry because the correct mise backend/version string for it
+# could not be verified from this checkout (mise is not installed here)
+# — install it the way flate.yaml does, or add a verified entry.
+#
+# Note also that every pin here is "latest" while actionlint is
+# separately pinned to v1.7.12 in .pre-commit-config.yaml and to
+# whatever bjw-s/action-actionlint bundles in CI. A silent bump makes a
+# local run disagree with the gate that blocks the merge.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,12 @@ repos:
     rev: v1.38.0
     hooks:
       - id: yamllint
-        args: [--strict, --config-file, .yamllint.yaml]
+        # No --strict: CI runs plain `yamllint --config-file
+        # .yamllint.yaml` (lint.yaml), where warnings exit 0. With
+        # --strict this hook failed on files CI accepts, so
+        # `pre-commit run --all-files` disagreed with the gate it is
+        # supposed to mirror.
+        args: [--config-file, .yamllint.yaml]
 
   # Markdown lint — mirrors `.github/workflows/lint.yaml` markdownlint
   # job; uses `.markdownlint.yaml` in repo root. The cli2 variant


### PR DESCRIPTION
HOMELAB-SPEC Inv #6 says *"the PR is the artifact of a passing local run"*. Four places where the local run and the merge gate disagreed.

## 1. pre-commit's yamllint didn't mirror CI, despite saying so

The hook passed `--strict` under a comment claiming it *"mirrors the CI yamllint job"*. CI runs plain `yamllint --config-file .yamllint.yaml`, where warnings exit **0**.

So the hook **failed on files CI accepts** — `pre-commit run --all-files` did not pass on a clean checkout. That makes the documented bootstrap step untrustworthy and trains people to skip it.

Dropped `--strict`. `pre-commit run yamllint --all-files` now passes repo-wide, matching CI.

## 2. `.mise.toml` installed the retired render engine

It installed `pipx:flux-local`. CI has rendered with **flate** since #12962 — so the documented local tool was validating with a *different renderer* than the one gating the merge. Removed.

**Deliberately not adding flate to `[tools]`:** mise isn't installed in this checkout, so I could not verify the correct backend/version string, and an unverified entry would break `mise install` for everyone. Left a comment pointing at how `flate.yaml` installs it.

Same reason the three `"latest"` pins are **flagged but not changed** — actionlint is separately pinned to `v1.7.12` in `.pre-commit-config.yaml` and to whatever `bjw-s/action-actionlint` bundles, so a silent bump desyncs local from CI. But I couldn't confirm the aqua version-string format without mise to test against, and guessing would just move the breakage.

## 3. The pre-submit skill named the retired engine

`.agents/skills/pre-submit.md` step 1 still said run `flux-local diff`. Updated to `flate test all` + `flate diff`.

Also added the point that **`flate test` reports "values not used by the chart"** — that warning is how a HelmRelease tells you a values block is being silently ignored, which this review found in **six** separate apps (#13503, #13507). A new one should be treated as a failure, not noise.

## 4. Orphaned `.kubeconform-ignore`

Removed `.github/workflows/.kubeconform-ignore`. Orphaned since 2023, zero references repo-wide, and no kubeconform job exists to read it.

## Verification

- `pre-commit run yamllint --all-files` → **passes**
- `.mise.toml` parses as TOML
- all hooks clean on the changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)