### PR TITLE
fix(glance): the k8s-extension sidecar had no resource bounds at all

### DIFF
--- a/kubernetes/apps/collab/glance/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/glance/app/helmrelease.yaml
@@ -74,7 +74,17 @@ spec:
                   httpGet:
                     path: /healthz
                     port: 8080
-            resources: {}
+            # Was `resources: {}` — the only main container in the repo
+            # with no requests and no limits. It contributed nothing to
+            # the pod's scheduling footprint while being free to grow
+            # until it caused node memory pressure and started evicting
+            # neighbours. Sized off measured usage: 92Mi peak over 14d.
+            resources:
+              requests:
+                cpu: 10m
+                memory: 128Mi
+              limits:
+                memory: 256Mi
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true


### PR DESCRIPTION
`resources: {}` on the `k8s-extension` container — **the only main container in the repo with neither requests nor limits** (checked across all 144).

Two consequences:

- the scheduler accounted **nothing** for it when placing the pod
- it had **no memory ceiling**, so a leak could grow until it triggered node memory pressure and started evicting neighbours on worker5

## Sizing

From measured usage, not a guess: **92Mi peak working set over 14d** → `128Mi` request / `256Mi` limit. `cpu: 10m` request matches the house pattern (no CPU limits anywhere in this repo, deliberately).

## Verification

- `flate test all` → **475 passed**
- `pre-commit` clean

## Related finding I deliberately did *not* act on

`av1corrector` and `videodupfinder` both set `startup: enabled: false` with a 120s liveness budget — the only two DB-backed apps that turn the startup gate off, and the inverse of what `romm` adopted after being bitten by exactly that.

But **neither shows any restarts**, so I have no evidence the budget is actually too tight. Changing probe config on healthy apps to fix a theoretical problem is how you cause the outage you were trying to prevent. Flagging it for a decision rather than patching it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)