### PR TITLE
fix(media): raise a memory ceiling that OOMKilled at 98.7% of limit

### DIFF
--- a/kubernetes/apps/media/stash/app/helmrelease.yaml
+++ b/kubernetes/apps/media/stash/app/helmrelease.yaml
@@ -97,7 +97,13 @@ spec:
                 cpu: 100m
                 memory: 256Mi
               limits:
-                memory: 512Mi
+                # Raised 512Mi -> 1Gi after an OOMKill on 2026-08-09.
+                # This is a spiky workload, not a steadily growing one:
+                # p99 over 30d is 89Mi, but the killed instance peaked at
+                # 505Mi — 98.7% of the old ceiling — during a scan. The
+                # request stays at 256Mi because the steady state really
+                # is small; only the ceiling needed room for the spike.
+                memory: 1Gi
 
     service:
       app:


### PR DESCRIPTION
An app in the media stack was **OOMKilled** on 2026-08-09 and restarted. Not a leak — a spike clipping a ceiling that was slightly too low.

| measurement | value |
|---|---|
| p99 working set over 30d | **89Mi** |
| killed instance peak | **505.5Mi** against a 512Mi limit (**98.7%**) |
| replacement instance now | ~158Mi |

So the steady state is genuinely small and the **request is correctly sized** at 256Mi — only the ceiling needed room for the scan-driven spike. Limit raised 512Mi → 1Gi; request unchanged.

Surfaced by a post-merge health check during the repo-wide review, not by an existing alert threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)