### PR TITLE
fix(observability): a UPS could drop out unseen; a sidecar was unscrapable

### DIFF
--- a/kubernetes/apps/collab/pump-voltra/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump-voltra/app/helmrelease.yaml
@@ -98,3 +98,35 @@ spec:
                   - ALL
               seccompProfile:
                 type: RuntimeDefault
+
+    # This app exposes /metrics (pump_voltra_connected) but had no
+    # Service at all, so nothing could reach it — the only signal for a
+    # sidecar that commands a motor under a physical load clamp was its
+    # liveness probe. Port 8080 is the same HTTP server the liveness
+    # probe hits (/healthz); the container declares no ports and the
+    # image is private, so this is inferred rather than read from
+    # source. Blast radius is nil (nothing routes here), and a wrong
+    # port shows up immediately as a down scrape target.
+    service:
+      app:
+        controller: pump-voltra
+        ports:
+          metrics:
+            port: 8080
+
+    serviceMonitor:
+      app:
+        endpoints:
+          - port: metrics
+            scheme: http
+            path: /metrics
+            interval: 1m
+            scrapeTimeout: 10s
+        serviceName: pump-voltra
+
+    # Deliberately NO alert on `pump_voltra_connected == 0`. Disconnected
+    # is the NORMAL state of an empty gym — the readiness probe is
+    # disabled for exactly that reason — so alerting on it would fire
+    # most of the day. The metric is for dashboards and post-hoc
+    # debugging; a useful alert would need to key off an active session,
+    # which there is no signal for yet.

--- a/kubernetes/apps/observability/exporters/snmp-exporter/app/apc-ups/prometheusrule.yaml
+++ b/kubernetes/apps/observability/exporters/snmp-exporter/app/apc-ups/prometheusrule.yaml
@@ -12,10 +12,29 @@ spec:
           annotations:
             description: APC UPS SNMP exporter has disappeared from Prometheus target discovery.
             summary: APC UPS SNMP exporter is down.
-          expr: absent(up{job=~".*snmp-exporter-apc-ups.*"} == 1)
+          # `absent(up{...})` — the whole job is gone from discovery,
+          # which is what the description above actually claims. The
+          # previous form, `absent(up{...} == 1)`, only fired when NO
+          # target reported up==1, i.e. when BOTH UPSes were down; a
+          # single UPS dropping out left it silent. Per-target coverage
+          # is the rule below.
+          expr: absent(up{job=~".*snmp-exporter-apc-ups.*"})
           for: 5m
           labels:
             severity: critical
+        - alert: SnmpExporterApcUpsTargetDown
+          annotations:
+            description: SNMP polling of UPS {{ $labels.instance }} has been failing for 10m; that UPS's battery, load and on-battery state are all unreadable.
+            summary: APC UPS SNMP target is not responding.
+          # Per-instance, so the firing alert names WHICH UPS. Both
+          # targets share job="snmp-exporter-apc-ups", so the absent()
+          # rule above cannot distinguish them. The chart-shipped
+          # TargetDown rule does catch this case, but only with generic
+          # text and no pointer to the UPS runbook.
+          expr: up{job=~".*snmp-exporter-apc-ups.*"} == 0
+          for: 10m
+          labels:
+            severity: warning
         - alert: UPSOnBattery
           annotations:
             description: UPS {{ $labels.target }} has lost power and is running on battery.


### PR DESCRIPTION
Two coverage gaps from the observability audit.

## 1. `SnmpExporterApcUpsAbsent` could not detect **one** UPS failing

Both UPS targets share `job="snmp-exporter-apc-ups"`, and the rule was `absent(up{job=~...} == 1)` — which only fires when **no** target reports `up==1`, i.e. when **both** UPSes are down. A single UPS dropping out left it silent.

Not hypothetical: during this audit `192.168.5.36` was failing SNMP polls while `.65` was fine, and the rule stayed `inactive` throughout. *(Both have since recovered.)*

- `absent()` rule changed to `absent(up{job=~...})` — which is what its own description already claims ("disappeared from target discovery")
- added per-instance **`SnmpExporterApcUpsTargetDown`** so the firing alert names **which** UPS

The chart's generic `TargetDown` does catch this, but with no UPS context and no pointer to the runbook.

## 2. `pump-voltra` exposed `/metrics` with no Service

**No Service existed at all** — the pod was reachable only by pod IP, which nothing uses. For a sidecar that commands a motor under a physical load clamp (`VOLTRA_MAX_LOAD_LB`), the only health signal was its liveness probe.

Added the chart-native `service` + `serviceMonitor`.

**On the port:** 8080 is the same HTTP server the liveness probe hits (`/healthz`). The container declares no ports and the image repo is private, so that's **inferred, not read from source** — and said so in the manifest. Blast radius is nil (nothing routes to this pod) and a wrong port shows up immediately as a down scrape target, so it's cheap to confirm and cheap to correct. I'll verify the target comes up after merge.

**Deliberately no alert on `pump_voltra_connected == 0`.** The audit suggested one — but disconnected is the *normal* state of an empty gym, which is exactly why the readiness probe is disabled here. That alert would fire most of the day and add to the noise this repo has worked to remove.

No CNP change needed: baseline `allow-monitoring-scrape` already permits the Prometheus pod on any port (same as atuin's metrics port in the same namespace).

## Verification

- `flate test all` → **475 passed**
- rendered through app-template 5.0.1: `Service pump-voltra [metrics/8080]` + ServiceMonitor with matching selector and `/metrics` path

🤖 Generated with [Claude Code](https://claude.com/claude-code)