### PR TITLE
feat(kubectl-mcp): read-only RBAC for the API groups audits keep hitting

### DIFF
--- a/kubernetes/apps/mcp-system/kubectl-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/kubectl-mcp/app/helmrelease.yaml
@@ -143,6 +143,50 @@ spec:
             - apiGroups: ["barmancloud.cnpg.io"]
               resources: ["objectstores"]
               verbs: ["get", "list", "watch"]
+            # Added 2026-08-09. Each of these blocked a verification
+            # during the repo-wide audit, forcing findings to be reasoned
+            # about from YAML instead of confirmed against live state —
+            # which is exactly how this cluster's three silent-drop
+            # incidents went unnoticed in the first place. All read-only.
+            #
+            # cilium.io: resolve a CNP endpointSelector against real
+            # endpoints. A selector matching zero pods is a silent drop
+            # with nothing in any log; it cannot be caught by reading
+            # the manifest.
+            - apiGroups: ["cilium.io"]
+              resources: ["ciliumnetworkpolicies", "ciliumclusterwidenetworkpolicies", "ciliumendpoints", "ciliumidentities", "ciliumnodes"]
+              verbs: ["get", "list", "watch"]
+            # ceph.rook.io: read CephCluster health. Needed to confirm
+            # the rook-ceph-cluster health gate; had to be inferred by
+            # rendering the chart instead.
+            - apiGroups: ["ceph.rook.io"]
+              resources: ["cephclusters", "cephblockpools", "cephfilesystems", "cephobjectstores"]
+              verbs: ["get", "list", "watch"]
+            # longhorn.io: recurring-job coverage lives on the Volume CR,
+            # NOT the PV — the PV's labels never propagate. Without this
+            # there is no way to tell a backed-up volume from an
+            # unprotected one.
+            - apiGroups: ["longhorn.io"]
+              resources: ["volumes", "backups", "snapshots", "recurringjobs", "nodes"]
+              verbs: ["get", "list", "watch"]
+            # monitoring.coreos.com: confirm a ServiceMonitor/Probe
+            # actually selects something, and that a PrometheusRule is
+            # loaded rather than merely present in Git.
+            - apiGroups: ["monitoring.coreos.com"]
+              resources: ["servicemonitors", "podmonitors", "probes", "prometheusrules", "scrapeconfigs", "alertmanagerconfigs"]
+              verbs: ["get", "list", "watch"]
+            # source.toolkit.fluxcd.io: the other half of Flux state —
+            # kustomizations/helmreleases above are useless for
+            # diagnosing a stalled source without these.
+            - apiGroups: ["source.toolkit.fluxcd.io"]
+              resources: ["ocirepositories", "gitrepositories", "helmrepositories", "helmcharts", "buckets"]
+              verbs: ["get", "list", "watch"]
+            # admissionregistration.k8s.io: a failurePolicy:Fail webhook
+            # gates every apply in the cluster (#13292). Reading the
+            # configs is how you find out which one.
+            - apiGroups: ["admissionregistration.k8s.io"]
+              resources: ["validatingwebhookconfigurations", "mutatingwebhookconfigurations"]
+              verbs: ["get", "list", "watch"]
         kubectl-mcp-write-restricted:
           type: Role
           rules:


### PR DESCRIPTION
Six API groups were missing from the `kubectl-mcp` ClusterRole, and **each one blocked a verification during this repo-wide audit** — forcing findings to be reasoned about from YAML instead of confirmed against live state.

That is precisely how this cluster's three silent-drop incidents went unnoticed: the manifest looked fine, and nothing could check whether it matched reality.

All additions are `get/list/watch`. **No secrets, no kubeconfig, no mutating verbs** — the deliberate omissions in this role are untouched.

| API group | what it unblocks |
|---|---|
| `cilium.io` | Resolve a CNP `endpointSelector` against real endpoints. A selector matching zero pods is a silent drop with nothing in any log. **Blocked the network audit**, which fell back to pod-label inference. |
| `ceph.rook.io` | Read `CephCluster` health. Blocked confirming the rook-ceph health gate — the CephCluster name had to be recovered by rendering the chart. |
| `longhorn.io` | Backup coverage lives on the **Volume CR**, not the PV, and PV labels never propagate. Without this you cannot tell a backed-up volume from an unprotected one — the exact trap that left one volume **85 days stale**. |
| `monitoring.coreos.com` | Confirm a ServiceMonitor/Probe actually selects something, and that a PrometheusRule is *loaded* rather than merely present in Git. |
| `source.toolkit.fluxcd.io` | Kustomizations/HelmReleases are readable, but diagnosing a stalled source without the source objects is guesswork (cf. the source-controller `Recreate` wedge). |
| `admissionregistration.k8s.io` | A `failurePolicy: Fail` webhook gates **every apply** in the cluster (#13292). Reading the configs is how you find out which one. |

## Not fixed here

**Hubble relay is unreachable** through the MCP surface (`dial tcp [::1]:4245: connection refused`). That's network reachability, not RBAC, so it needs a separate change — and it's the single biggest remaining gap for *confirming* drops rather than inferring them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)