### PR TITLE
fix(home-assistant): 5m timeout + rollback on forward-only migrations

### DIFF
--- a/kubernetes/apps/home/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/home/home-assistant/app/helmrelease.yaml
@@ -10,6 +10,27 @@ spec:
     name: app-template
 
   interval: 1h
+  # Home Assistant runs forward-only recorder schema migrations at
+  # startup, so rolling the image back cannot un-migrate the database —
+  # the same shape that wedged romm for ~2h (#13383). This HelmRelease
+  # previously declared no install/upgrade block at all and inherited
+  # Helm's 5m default while waiting, with rollback remediation.
+  #
+  # The recorder DB measures 8.5 GiB live (the 120Gi elsewhere is the
+  # provisioned PVC, not the data). An ALTER TABLE on states/events at
+  # that size can still run past 5m, and this is Renee-facing — lights,
+  # locks and climate — so failing forward and staying visible as
+  # Ready=False beats reverting into a version that cannot read its own
+  # schema.
+  #
+  # retries: 0 is set in the cluster-apps exclusion patch, not here: the
+  # cluster-wide HelmRelease patch overrides any retries value declared
+  # at this level (see kubernetes/flux/cluster/ks.yaml).
+  install:
+    timeout: 30m
+  upgrade:
+    timeout: 30m
+    cleanupOnFail: true
   values:
     controllers:
       home-assistant:

--- a/kubernetes/flux/cluster/ks.yaml
+++ b/kubernetes/flux/cluster/ks.yaml
@@ -136,7 +136,7 @@ spec:
               target:
                 group: helm.toolkit.fluxcd.io
                 kind: HelmRelease
-                name: (romm|open-webui)
+                name: (romm|open-webui|home-assistant)
       target:
         group: kustomize.toolkit.fluxcd.io
         kind: Kustomization


### PR DESCRIPTION
Home Assistant runs **forward-only recorder schema migrations** at startup, so rolling the *image* back cannot un-migrate the *database*.

Its HelmRelease declared **no `install`/`upgrade` block at all** — inheriting Helm's 5m default while waiting, with rollback remediation and 2 retries. That's the exact shape that wedged romm for ~2h (#13383).

## Correcting a number from the audit

The recorder database measures **8.5 GiB** live, not 120Gi — that figure was the **provisioned PVC**, not the data.

So the exposure is real but smaller than it first looked. An `ALTER TABLE` on `states`/`events` at 8.5 GiB can still run past 5m, and this is **Renee-facing** (lights, locks, climate), so failing forward and staying visible as `Ready=False` beats reverting into a version that cannot read its own schema.

## The fix

- `install.timeout` / `upgrade.timeout`: **30m**
- `retries: 0` — set via the **cluster-apps exclusion patch, not the HelmRelease**

That second point matters: a `retries` value declared at the HelmRelease level is overridden by the cluster-wide patch (#13504). Setting it in the app's own file would have *looked* correct and done nothing — the same trap that left romm's fix half-live for a week.

## Verification

Rendered the full patch chain:

```
retries distribution: {2: 166, 0: 3, 3: 1}   (was {2: 167, 0: 2, 3: 1})
  home-assistant  retries=0  timeout=30m
  romm            retries=0  timeout=20m
  open-webui      retries=0  timeout=20m
```

`flate test all` → **475 passed**. Nothing else changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)