### PR TITLE
fix(schemas): move off the mirror that 200s on any path

### DIFF
--- a/.agents/instructions/schema.correction.md
+++ b/.agents/instructions/schema.correction.md
@@ -15,8 +15,15 @@ Whenever requested to fix or correct schemas, follow these instructions:
 - **verify a schema URL by its body, not its status code.** Some mirrors
   serve their SPA index with HTTP 200 for *any* path, so a status check
   says a schema exists when it does not — `kubernetes-schemas.pages.dev`
-  does exactly this. Confirm the response starts with `{`, and run a
-  known-bogus path as a negative control before trusting a new host.
+  does exactly this (re-measured 2026-08-09: a bogus path returns HTTP
+  200 with 68 KB of HTML). Confirm the response starts with `{`, and run
+  a known-bogus path as a negative control before trusting a new host.
+- **prefer `k8s-schemas.home-operations.com` for CRD schemas.** It
+  returns a real 404 for a missing path, so a typo is detectable. The
+  repo migrated off `kubernetes-schemas.pages.dev` for exactly that
+  reason. `k8s-schemas.bjw-s.dev` also 404s correctly and is fine where
+  already used; canonical `raw.githubusercontent.com/datreeio/...` and
+  `yannh/...` URLs stay as they are.
 - known-dead hosts, do not reintroduce: `kube-schemas.pages.dev` (whole
   host 404s) and `raw.githubusercontent.com/ishioni/CRDs-catalog`.
   Prefer canonical `raw.githubusercontent.com/datreeio/CRDs-catalog/main/…`
@@ -105,7 +112,7 @@ Whenever requested to fix or correct schemas, follow these instructions:
 | `monitoring.coreos.com/v1` | `PrometheusRule` | `https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/prometheusrule_v1.json` |
 | `monitoring.coreos.com/v1alpha1` | `AlertmanagerConfig` | `https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/alertmanagerconfig_v1alpha1.json` |
 | `monitoring.coreos.com/v1alpha1` | `ScrapeConfig` | `https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/scrapeconfig_v1alpha1.json` |
-| `observability.giantswarm.io/v1alpha2` | `Silence` | `https://kubernetes-schemas.pages.dev/observability.giantswarm.io/silence_v1alpha2.json` |
+| `observability.giantswarm.io/v1alpha2` | `Silence` | `https://k8s-schemas.home-operations.com/observability.giantswarm.io/silence_v1alpha2.json` |
 
 ### Storage / Database
 

--- a/kubernetes/apps/databases/pgadmin/app/httproute.yaml
+++ b/kubernetes/apps/databases/pgadmin/app/httproute.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.networking.k8s.io/httproute_v1.json
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/kubernetes/apps/flux-system/flux-instance/app/externalsecret.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/externalsecret.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:

--- a/kubernetes/apps/flux-system/flux-instance/app/github/webhooks/externalsecret.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/github/webhooks/externalsecret.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:

--- a/kubernetes/apps/flux-system/flux-instance/app/github/webhooks/httproute.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/github/webhooks/httproute.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.networking.k8s.io/httproute_v1.json
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/kubernetes/apps/flux-system/flux-instance/app/github/webhooks/receiver.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/github/webhooks/receiver.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/notification.toolkit.fluxcd.io/receiver_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/notification.toolkit.fluxcd.io/receiver_v1.json
 apiVersion: notification.toolkit.fluxcd.io/v1
 kind: Receiver
 metadata:

--- a/kubernetes/apps/flux-system/flux-instance/app/podmonitor.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/podmonitor.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/podmonitor_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/podmonitor_v1.json
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:

--- a/kubernetes/apps/flux-system/flux-instance/app/prometheusrule.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/prometheusrule.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/prometheusrule_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/prometheusrule_v1.json
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/kubernetes/apps/home/netbox/app/httproute.yaml
+++ b/kubernetes/apps/home/netbox/app/httproute.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.networking.k8s.io/httproute_v1.json
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/kubernetes/apps/kube-system/cilium/app/httproute.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/httproute.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.networking.k8s.io/httproute_v1.json
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/kubernetes/apps/media/beets/app/externalsecret.yaml
+++ b/kubernetes/apps/media/beets/app/externalsecret.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:

--- a/kubernetes/apps/media/immich/app/httproute.yaml
+++ b/kubernetes/apps/media/immich/app/httproute.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.networking.k8s.io/httproute_v1.json
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/kubernetes/apps/observability/exporters/blackbox-exporter/app/httproute.yaml
+++ b/kubernetes/apps/observability/exporters/blackbox-exporter/app/httproute.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.networking.k8s.io/httproute_v1.json
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/kubernetes/apps/observability/exporters/blackbox-exporter/app/probes.yaml
+++ b/kubernetes/apps/observability/exporters/blackbox-exporter/app/probes.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/probe_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/probe_v1.json
 apiVersion: monitoring.coreos.com/v1
 kind: Probe
 metadata:
@@ -78,7 +78,7 @@ spec:
         - bathroom-mmwave
 
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/probe_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/probe_v1.json
 apiVersion: monitoring.coreos.com/v1
 kind: Probe
 metadata:
@@ -95,7 +95,7 @@ spec:
         - security-storage:2049
 
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/probe_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/probe_v1.json
 apiVersion: monitoring.coreos.com/v1
 kind: Probe
 metadata:
@@ -123,7 +123,7 @@ spec:
         - wled-bush
 
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/probe_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/probe_v1.json
 apiVersion: monitoring.coreos.com/v1
 kind: Probe
 metadata:
@@ -144,7 +144,7 @@ spec:
         - http://ollama.ai.svc.cluster.local:11434/api/embed
 
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/probe_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/probe_v1.json
 apiVersion: monitoring.coreos.com/v1
 kind: Probe
 metadata:
@@ -173,7 +173,7 @@ spec:
         - http://ollama.ai.svc.cluster.local:11434/api/generate
 
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/probe_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/probe_v1.json
 apiVersion: monitoring.coreos.com/v1
 kind: Probe
 metadata:

--- a/kubernetes/apps/observability/goldilocks/app/httproute.yaml
+++ b/kubernetes/apps/observability/goldilocks/app/httproute.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.networking.k8s.io/httproute_v1.json
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/alertmanagerconfig.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/alertmanagerconfig.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/alertmanagerconfig_v1alpha1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/alertmanagerconfig_v1alpha1.json
 apiVersion: monitoring.coreos.com/v1alpha1
 kind: AlertmanagerConfig
 metadata:

--- a/kubernetes/apps/observability/netdata/app/httproute.yaml
+++ b/kubernetes/apps/observability/netdata/app/httproute.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.networking.k8s.io/httproute_v1.json
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/kubernetes/apps/observability/silence-operator/silences/beast-mass-storage-pvc.yaml
+++ b/kubernetes/apps/observability/silence-operator/silences/beast-mass-storage-pvc.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/observability.giantswarm.io/silence_v1alpha2.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/observability.giantswarm.io/silence_v1alpha2.json
 #
 # All these PVCs are NFS subpaths of beast.${SECRET_DOMAIN}:/mnt/mass_storage,
 # so they all report the same fill % and trigger one alert each for a single
@@ -19,7 +19,7 @@ spec:
       value: comfyui-output-pvc|frigate-exports-pvc|gonic-music-pvc|immich-external-library-pvc|immich-managed-library-pvc|jellyfin-movies-pvc|jellyfin-music-pvc|lidarr-media|music-assistant-music-pvc|radarr-media|soularr-music-pvc|stash-media-pvc|videodupfinder-scan-pvc
 
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/observability.giantswarm.io/silence_v1alpha2.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/observability.giantswarm.io/silence_v1alpha2.json
 apiVersion: observability.giantswarm.io/v1alpha2
 kind: Silence
 metadata:

--- a/kubernetes/apps/observability/silence-operator/silences/ceph-pool-growth.yaml
+++ b/kubernetes/apps/observability/silence-operator/silences/ceph-pool-growth.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/observability.giantswarm.io/silence_v1alpha2.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/observability.giantswarm.io/silence_v1alpha2.json
 #
 # CephPoolGrowthWarning is a predictive alert shipped by the rook-ceph
 # cluster chart (monitoring.createPrometheusRules: true). Its expression is

--- a/kubernetes/apps/observability/silence-operator/silences/ceph.yaml
+++ b/kubernetes/apps/observability/silence-operator/silences/ceph.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/observability.giantswarm.io/silence_v1alpha2.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/observability.giantswarm.io/silence_v1alpha2.json
 apiVersion: observability.giantswarm.io/v1alpha2
 kind: Silence
 metadata:

--- a/kubernetes/apps/observability/silence-operator/silences/frigate-media-pvc.yaml
+++ b/kubernetes/apps/observability/silence-operator/silences/frigate-media-pvc.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/observability.giantswarm.io/silence_v1alpha2.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/observability.giantswarm.io/silence_v1alpha2.json
 apiVersion: observability.giantswarm.io/v1alpha2
 kind: Silence
 metadata:
@@ -12,7 +12,7 @@ spec:
       value: frigate-recordings-pvc
 
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/observability.giantswarm.io/silence_v1alpha2.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/observability.giantswarm.io/silence_v1alpha2.json
 apiVersion: observability.giantswarm.io/v1alpha2
 kind: Silence
 metadata:
@@ -25,7 +25,7 @@ spec:
       value: frigate-recordings-pvc
 
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/observability.giantswarm.io/silence_v1alpha2.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/observability.giantswarm.io/silence_v1alpha2.json
 apiVersion: observability.giantswarm.io/v1alpha2
 kind: Silence
 metadata:
@@ -38,7 +38,7 @@ spec:
       value: frigate-clips-pvc
 
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/observability.giantswarm.io/silence_v1alpha2.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/observability.giantswarm.io/silence_v1alpha2.json
 apiVersion: observability.giantswarm.io/v1alpha2
 kind: Silence
 metadata:

--- a/kubernetes/apps/observability/silence-operator/silences/prometheus.yaml
+++ b/kubernetes/apps/observability/silence-operator/silences/prometheus.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/observability.giantswarm.io/silence_v1alpha2.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/observability.giantswarm.io/silence_v1alpha2.json
 apiVersion: observability.giantswarm.io/v1alpha2
 kind: Silence
 metadata:
@@ -13,7 +13,7 @@ spec:
       matchType: "=~"
 
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/observability.giantswarm.io/silence_v1alpha2.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/observability.giantswarm.io/silence_v1alpha2.json
 apiVersion: observability.giantswarm.io/v1alpha2
 kind: Silence
 metadata:
@@ -27,7 +27,7 @@ spec:
       matchType: "=~"
 
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/observability.giantswarm.io/silence_v1alpha2.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/observability.giantswarm.io/silence_v1alpha2.json
 apiVersion: observability.giantswarm.io/v1alpha2
 kind: Silence
 metadata:

--- a/kubernetes/apps/observability/silence-operator/silences/security-storage-diskspace.yaml
+++ b/kubernetes/apps/observability/silence-operator/silences/security-storage-diskspace.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/observability.giantswarm.io/silence_v1alpha2.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/observability.giantswarm.io/silence_v1alpha2.json
 #
 # security-storage holds Frigate's recordings/clips, which run by design at the
 # top of their XFS quotas: Frigate fills the filesystem and garbage-collects the

--- a/kubernetes/apps/observability/silence-operator/silences/security-storage-memory.yaml
+++ b/kubernetes/apps/observability/silence-operator/silences/security-storage-memory.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/observability.giantswarm.io/silence_v1alpha2.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/observability.giantswarm.io/silence_v1alpha2.json
 #
 # security-storage is a RAM-starved Core 2 box (7.4 GiB) whose steady state is
 # >90% memory used: the Frigate recording write path keeps page cache pegged.

--- a/kubernetes/apps/observability/silence-operator/silences/spark-memory.yaml
+++ b/kubernetes/apps/observability/silence-operator/silences/spark-memory.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/observability.giantswarm.io/silence_v1alpha2.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/observability.giantswarm.io/silence_v1alpha2.json
 #
 # spark is the GB10 / Grace-Blackwell inference node. Its memory is unified:
 # models warm-pinned in ollama-spark / comfyui (e.g. qwen2.5-coder:32b, ~38 GB,

--- a/kubernetes/apps/observability/silence-operator/silences/zot-data-pvc.yaml
+++ b/kubernetes/apps/observability/silence-operator/silences/zot-data-pvc.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/observability.giantswarm.io/silence_v1alpha2.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/observability.giantswarm.io/silence_v1alpha2.json
 apiVersion: observability.giantswarm.io/v1alpha2
 kind: Silence
 metadata:

--- a/kubernetes/apps/storage/garage/app/externalsecret.yaml
+++ b/kubernetes/apps/storage/garage/app/externalsecret.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:

--- a/kubernetes/components/alerts/github-status/alert.yaml
+++ b/kubernetes/components/alerts/github-status/alert.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/notification.toolkit.fluxcd.io/alert_v1beta3.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/notification.toolkit.fluxcd.io/alert_v1beta3.json
 apiVersion: notification.toolkit.fluxcd.io/v1beta3
 kind: Alert
 metadata:

--- a/kubernetes/components/alerts/github-status/externalsecret.yaml
+++ b/kubernetes/components/alerts/github-status/externalsecret.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:

--- a/kubernetes/components/alerts/github-status/provider.yaml
+++ b/kubernetes/components/alerts/github-status/provider.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/notification.toolkit.fluxcd.io/provider_v1beta3.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/notification.toolkit.fluxcd.io/provider_v1beta3.json
 apiVersion: notification.toolkit.fluxcd.io/v1beta3
 kind: Provider
 metadata:


### PR DESCRIPTION
29 files pointed `# yaml-language-server: $schema=` at `kubernetes-schemas.pages.dev`.

That host serves its SPA index with **HTTP 200 for *any* path** — so a typo'd or removed schema URL is **undetectable**. A status check says the schema exists, and yamlls silently stops validating.

Re-measured today, all three hosts with the same bogus path `/TOTALLY-BOGUS/nope_v1.json`:

| host | result |
|---|---|
| `kubernetes-schemas.pages.dev` | **HTTP 200**, 68,544 B of HTML |
| `k8s-schemas.bjw-s.dev` | HTTP 404 ✅ |
| `k8s-schemas.home-operations.com` | HTTP 404 ✅ |

`.agents/instructions/schema.correction.md` already warned about this host **by name**; the repo just hadn't moved off it. It's the same class as the six dead schema URLs found by hand in #13491 — and that sweep only caught them because someone checked *bodies* rather than status codes.

## What changed

All 29 files rewritten to `k8s-schemas.home-operations.com`.

**Every one of the 10 distinct schema paths in use was fetched from the new host first** and confirmed to return HTTP 200 with a body starting `{` — **10/10**. No guessing, and no path left pointing at a 404.

Also updated `schema.correction.md`: the `Silence` mapping still pointed at the retired host, and the guidance now names a host that fails loudly.

## Left alone deliberately

- `k8s-schemas.bjw-s.dev` (12 files) — **404s correctly**, so it isn't the trap this fixes; churning it buys nothing
- canonical `raw.githubusercontent.com/datreeio/...` and `yannh/...` URLs — the instruction file already prefers these

## Verification

- `flate test all` → **475 passed**
- `pre-commit` clean
- `grep` for the old host → **0 remaining**

🤖 Generated with [Claude Code](https://claude.com/claude-code)