### PR TITLE
docs(grafana): record why anonymous-Admin cannot just be flipped off

### DIFF
--- a/kubernetes/apps/observability/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/grafana/app/helmrelease.yaml
@@ -290,6 +290,33 @@ spec:
         check_for_plugin_updates: false
         check_for_updates: false
         reporting_enabled: false
+      # SECURITY POSTURE — read before changing any of the three
+      # settings below; they are load-bearing together.
+      #
+      # Grafana on the internal gateway has no SecurityPolicy, no login
+      # form and no OIDC, and anonymous users are Admin. So any device
+      # on the LAN has full Grafana admin — datasources, users, the lot.
+      # That is a real privilege gap, but neither obvious fix is safe on
+      # its own, which is why this is a comment and not a change:
+      #
+      #   * Adding an extAuth SecurityPolicy WOULD BREAK Home Assistant.
+      #     ../home-assistant-config/dashboards/gpu.yaml iframes
+      #     grafana.${SECRET_DOMAIN}/d/Oxed_c6Wz/...?kiosk — an Authelia
+      #     redirect inside that iframe renders a broken panel. This is
+      #     also why GF_SECURITY_ALLOW_EMBEDDING is true.
+      #
+      #   * Dropping org_role to Viewer WOULD LOCK ADMIN OUT ENTIRELY.
+      #     disable_login_form is true, no OAuth/OIDC provider is
+      #     configured, and grafana-secret carries only Postgres
+      #     credentials — no admin user/password. Anonymous Admin IS the
+      #     administration path today.
+      #
+      # The safe order is therefore two steps, not one: first establish
+      # an authenticated admin path (re-enable the login form with an
+      # admin credential in the ExternalSecret, or wire Authelia OIDC),
+      # verify you can administer Grafana with it, and only then drop
+      # anonymous to Viewer — which keeps the HA iframe working, since
+      # viewing a dashboard needs Viewer, not Admin.
       auth:
         disable_login_form: true
       auth.anonymous:


### PR DESCRIPTION
Grafana on the internal gateway has **no SecurityPolicy, no login form, no OIDC — and anonymous users get `org_role: Admin`**. Any device on the LAN has full Grafana admin: datasources, users, everything.

The audit proposed *"flip `org_role` to Viewer, or add an extAuth SecurityPolicy."* **Both are wrong on their own**, and working out why took more digging than the finding did — so it's recorded in the file rather than left to be rediscovered.

## Why extAuth would break things

Home Assistant **iframes this Grafana**. `../home-assistant-config/dashboards/gpu.yaml` embeds:

```
https://grafana.${SECRET_DOMAIN}/d/Oxed_c6Wz/nvidia-dcgm-exporter-dashboard?kiosk
```

An Authelia redirect inside that iframe renders a broken panel. That's also why `GF_SECURITY_ALLOW_EMBEDDING: true` is set — the flag is **load-bearing, not leftover**.

## Why `org_role: Viewer` would lock you out

- `disable_login_form: true`
- no OAuth/OIDC provider configured
- `grafana-secret` carries **only Postgres credentials** — no admin user or password anywhere

**Anonymous Admin *is* the administration path today.** Flipping it to Viewer leaves no way to administer Grafana at all.

## The safe sequence

Two steps, not one:

1. Establish an authenticated admin path — re-enable the login form with an admin credential in the ExternalSecret, **or** wire Authelia OIDC
2. Verify you can administer Grafana with it
3. *Then* drop anonymous to `Viewer` — the HA iframe keeps working, because viewing a dashboard needs Viewer, not Admin

## No behaviour change in this PR

Comment only.

## Related, for the same decision

The **internal** gateway has no default extAuth SecurityPolicy — unlike **external**, which has `external-default-extauth` at the Gateway level. So `prometheus`, `alertmanager`, `longhorn`, `hubble`, `netdata`, `netbox`, `pgadmin` and `emqx` are unauthenticated on it too.

Grafana is the sharp one only because it grants **Admin** rather than read. (I also checked the Ceph dashboard, which an earlier pass flagged as a bypass — it has no HTTPRoute at all, so it is **not** exposed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)