### PR TITLE
feat(longhorn): alert on stale backups — four volumes had none

### DIFF
--- a/kubernetes/apps/longhorn-system/longhorn/app/kustomization.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn/app/kustomization.yaml
@@ -7,4 +7,5 @@ resources:
   - ./helmrelease.yaml
   - ./httproute.yaml
   - ./ocirepository.yaml
+  - ./prometheus-rule.yaml
   - ./servicemonitor.yaml

--- a/kubernetes/apps/longhorn-system/longhorn/app/prometheus-rule.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn/app/prometheus-rule.yaml
@@ -1,0 +1,48 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: longhorn-backup-rules
+spec:
+  groups:
+    - name: longhorn-backup.rules
+      rules:
+        # Longhorn is the cluster's durable-through-cluster-destruction
+        # tier (see .agents/instructions/storage-class.instructions.md),
+        # but nothing watched whether a backup actually happened. On
+        # 2026-08-09 four volumes were found with no recovery point —
+        # three of them 86 days old — and no alert had ever fired:
+        #
+        #   mealie-config-xfs      85.9d   detached
+        #   beets-config-xfs       85.9d   detached
+        #   n8n-data-xfs           85.9d   detached
+        #   comfyui-workspace-xfs  22.9d   detached
+        #
+        # The cause is structural, not a misconfiguration: Longhorn
+        # cannot back up a DETACHED volume — there is no engine to read
+        # from. Any CronJob-driven or scaled-to-zero workload therefore
+        # misses its backup window silently, and the recurring job
+        # reports nothing wrong because it never had a volume to act on.
+        #
+        # 14d threshold = two missed weekly cycles (weekly-backups runs
+        # Sat 00:00), so a single skipped run does not page.
+        #
+        # `longhorn_volume_last_backup_at > 0` guards the false positive
+        # a naive version would have: a freshly created volume reports 0
+        # until its first backup, which would otherwise read as ~56
+        # years stale and fire immediately.
+        - alert: LonghornVolumeBackupStale
+          annotations:
+            summary: Longhorn volume has no recent backup.
+            description: >-
+              Volume {{ $labels.volume }} (pvc {{ $labels.pvc_namespace }}/{{ $labels.pvc }})
+              last completed a backup {{ $value | humanizeDuration }} ago. If the volume is
+              detached it cannot be backed up at all — check whether its workload is a CronJob
+              or scaled to zero, in which case this will not self-resolve.
+          expr: |
+            (time() - longhorn_volume_last_backup_at) > 14 * 86400
+              and longhorn_volume_last_backup_at > 0
+          for: 1h
+          labels:
+            severity: warning


### PR DESCRIPTION
Longhorn is this cluster's **durable-through-cluster-destruction** tier, and nothing watched whether a backup actually happened. There were **no Longhorn PrometheusRules in the repo at all**.

Four volumes currently have no recent recovery point, and **no alert has ever fired** for any of them:

| volume | stale | state |
|---|---|---|
| `mealie-config-xfs` | **85.9d** | detached |
| `beets-config-xfs` | **85.9d** | detached |
| `n8n-data-xfs` | **85.9d** | detached |
| `comfyui-workspace-xfs` | 22.9d | detached |

All three 86-day volumes stopped on the **same date**, which is what makes this a class rather than four coincidences.

## The cause is structural

Longhorn **cannot back up a detached volume** — there's no engine to read from. Any CronJob-driven or scaled-to-zero workload misses its window silently, and the recurring job reports nothing wrong because it never had a volume to act on.

## Why an alert rather than four fixes

The storage audit caught `beets` and `comfyui` but **missed `mealie` and `n8n` entirely**. Querying `longhorn_volume_last_backup_at` across all 44 volumes found all four. An alert doesn't miss two of them.

## Design

- **14d threshold** = two missed weekly cycles (`weekly-backups` runs Sat 00:00), so one skipped run doesn't page
- **`longhorn_volume_last_backup_at > 0`** guards a real false positive: a freshly created volume reports `0` until its first backup, which without the guard reads as ~56 years stale and fires immediately

I hit both that trap and a **units error** while drafting this — the metric is in **seconds**, not milliseconds. Validated against live Prometheus before committing: the expression returns exactly those four series and correctly excludes `zwavejs2mqtt-config-xfs` (8.9d, *attached*, one cycle behind) and every healthy volume at ~1.9d.

## Expect it to fire on merge

For four volumes — and that's correct, they genuinely have no recovery point. **Deliberately not silenced**: the remediation (accept and document, retime the job, or back the config up another way) is a per-volume decision, and a silence would put this straight back where it started.

🤖 Generated with [Claude Code](https://claude.com/claude-code)