### PR TITLE
fix(bootstrap): repo config would rebuild kube-proxy and a second CoreDNS

### DIFF
--- a/init/clusterconfiguration.yaml
+++ b/init/clusterconfiguration.yaml
@@ -51,7 +51,12 @@ controllerManager:
   extraArgs:
   - name: bind-address
     value: 0.0.0.0
-dns: {}
+# kubeadm must NOT deploy CoreDNS: it is Flux-managed via the coredns
+# HelmRelease (chart coredns-1.47.0). The live kubeadm-config ConfigMap
+# already carries `disabled: true`; this file had drifted to `{}`, so a
+# rebuild from it would install a second, conflicting CoreDNS.
+dns:
+  disabled: true
 encryptionAlgorithm: RSA-2048
 etcd:
   local:
@@ -66,7 +71,12 @@ networking:
   dnsDomain: cluster.local
   podSubnet: 10.42.0.0/16
   serviceSubnet: 10.43.0.0/16
-proxy: {}
+# kubeadm must NOT deploy kube-proxy: Cilium replaces it
+# (kubeProxyReplacement: true in cilium/app/values.yaml), and there is no
+# kube-proxy DaemonSet in the live cluster. As above, the live ConfigMap
+# already says `disabled: true` and only this file had drifted.
+proxy:
+  disabled: true
 scheduler:
   extraArgs:
   - name: bind-address


### PR DESCRIPTION
`init/clusterconfiguration.yaml` had drifted from the live `kubeadm-config` ConfigMap in two places that **only matter during a rebuild** — which is exactly when nobody is in a position to notice.

| field | repo file | live ConfigMap |
|---|---|---|
| `dns` | `{}` | `disabled: true` |
| `proxy` | `{}` | `disabled: true` |

## The live values are the correct ones

Confirmed against the cluster, not inferred:

- **No `kube-proxy` DaemonSet exists at all** — Cilium replaces it (`kubeProxyReplacement: true`, `cilium/app/values.yaml:20`)
- **CoreDNS is Flux/Helm-managed** — the Deployment carries `helm.toolkit.fluxcd.io` labels and chart `coredns-1.47.0`

## Why it matters

A DR rebuild from this file would have kubeadm deploy **its own kube-proxy** alongside Cilium's replacement, and **its own CoreDNS** alongside the Flux-managed one. Two conflicting DNS providers plus a kube-proxy that shouldn't exist — on a cluster being rebuilt under pressure.

## How it surfaced

Side effect of validating the etcd timer rollout (#13530): comparing the repo's bootstrap config against the live ConfigMap turned this up. Nothing prompted it and nothing would have — **this file is bootstrap-only and never reconciled**, so drift is invisible until the rebuild that depends on it.

## Verification

The `ClusterConfiguration` in this file is now **byte-identical** to the live `kubeadm-config` ConfigMap.

## Follow-up worth considering

A CI check diffing this file against the live ConfigMap would catch the next drift. It can't run from GitHub-hosted CI (no cluster access), but the in-cluster ARC runners could.

🤖 Generated with [Claude Code](https://claude.com/claude-code)