### PR TITLE
fix(docs): retract the "disk picture inverted" claim — it was one sample

### DIFF
--- a/docs/src/etcd_raft_timers.md
+++ b/docs/src/etcd_raft_timers.md
@@ -55,11 +55,21 @@ Four things that cost real time in this diagnosis:
   is per-member and resets when etcd restarts. Check
   `process_start_time_seconds` before drawing conclusions from a total,
   and compare *rates* after any rollout.
-- **The fsync histogram uses power-of-two buckets.** `p99` can read
-  identically on every member simply because they all land in the same
-  bucket. Identical values are *not* evidence the disks are equal. Use a
-  10 m window and compare against a known-good baseline, and cross-check
-  with `etcd_disk_backend_commit_duration_seconds`.
+- **Never judge disk latency from an instant query.** Two failure modes
+  bite here. First, the fsync histogram uses power-of-two buckets, so
+  `p99` can read identically on every member simply because they all
+  land in the same bucket — identical values are *not* evidence the
+  disks are equal. Second, a single sample is easily unrepresentative:
+  a member that has just restarted looks fast because it is idle. Use a
+  median over hours, and cross-check `wal_fsync` against
+  `backend_commit`:
+
+  ```promql
+  quantile_over_time(0.5,
+    (histogram_quantile(0.99,
+      sum by (instance,le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket[10m]))))[9h:15m])
+  ```
+
 - **The etcd image is distroless.** `kubectl exec … -- env ETCDCTL_API=3
   etcdctl` fails with ``executable file `env` not found``. Call
   `etcdctl` directly; API v3 is the default since etcd 3.4.
@@ -191,37 +201,35 @@ If they do not improve, raft timing was not the binding constraint.
 
 ## Where the real problem is
 
-Raising the timers buys headroom; it does not make the disks faster. The
-disk picture has **inverted** since the 2026-05-05 measurements in
+Raising the timers buys headroom; it does not make the disks faster.
+master1 remains the slow voter, essentially unchanged since the
+2026-05-05 measurements in
 [master1 etcd-Disk Swap Plan](master1_etcd_disk_swap.md):
 
-| p99 over 10 m | master1 | master2 | master3 |
+| p99, median over 9 h | master1 | master2 | master3 |
 |---|---|---|---|
 | `wal_fsync` — May | **31 ms** | 17 ms | 16 ms |
-| `wal_fsync` — Aug | 29 ms | 28 ms | 29 ms |
+| `wal_fsync` — Aug | **30.5 ms** | 15.6 ms | 15.6 ms |
 | `backend_commit` — May | **103 ms** | 29 ms | 27 ms |
-| `backend_commit` — Aug | **32 ms** | 54 ms | **62 ms** |
+| `backend_commit` — Aug | **97 ms** | 24 ms | 26 ms |
 
-Two things follow:
+master1's sync-write path is roughly **2× slower on fsync and 4× slower
+on commit** than the other two voters, and has been for months. etcd
+wants `wal_fsync` p99 well under 10 ms; none of the three meet that, but
+master1 is the outlier.
 
-1. **master1 is no longer the slow voter.** It is now the *fastest* on
-   `backend_commit`. The disk-swap plan targeting it is no longer the
-   highest-value fix.
-2. **The whole control plane degraded.** `wal_fsync` p99 converged
-   upward to ~29 ms on all three — etcd wants this well under 10 ms.
-   master2 and master3 roughly doubled.
+So the conclusion of the disk-swap plan stands: **replacing master1's
+root NVMe is still the highest-value fix.** Timer tuning is the stopgap
+that stops the flapping in the meantime.
 
-The structural difference: master1 runs on bare-metal NVMe
-(`/dev/nvme0n1p3`, non-rotational), while **master2 and master3 are QEMU
-VMs on virtio disks** (`/dev/vda2`, 200 GB, reported rotational). They
-are also the smaller nodes at 3 CPU / 10 GiB each — and one of them holds
-the etcd leader, which is precisely the member that was missing its
-heartbeats.
-
-That points at the plan already recorded in the disk-swap runbook: retire
-the control-plane VMs in favour of bare-metal nodes, per
-[Promote Worker to Control Plane](promote_worker_to_control_plane.md).
-Timer tuning is the stopgap until then.
+> **Measure over a representative window.** An earlier revision of this
+> page claimed the disk picture had "inverted" and that master1 was now
+> the *fastest* voter. That was wrong. It came from a single 10-minute
+> sample taken minutes after the etcd restarts, when master1 had just
+> come up idle and the other two were still catching up. A 9-hour median
+> at 15-minute resolution shows the opposite, and matches May almost
+> exactly. Use `quantile_over_time(0.5, (…)[9h:15m])`, not a bare
+> instant query, before concluding anything about disk latency.
 
 ## Change log
 
@@ -230,3 +238,20 @@ Timer tuning is the stopgap until then.
   Rolled followers first, leader last; each node diff-gated with
   `kubeadm --dry-run` and health-gated between nodes. Recorded in
   `init/clusterconfiguration.yaml`.
+
+- **2026-08-10, +10 h** — result measured:
+
+  | metric | before | after 10 h |
+  |---|---|---|
+  | leader changes | ~11.6/day on master1 | **0** since the rollout |
+  | `heartbeat_send_failures` (leader) | ~83/h | **7.6/h** (−91 %) |
+  | `slow_apply` | ~1 297/h on master1 | ~1 890/h on master1 |
+
+  `etcdHighNumberOfLeaderChanges` cleared and has not re-fired. The
+  flapping stopped outright — the two leader changes master1 shows are
+  the rollout's own restarts, and there have been none since.
+
+  `slow_apply` did not improve, which is the expected result: it is
+  bound by disk, not by raft timing, and master1's disk is unchanged.
+  Note master1 is now the leader, so it is doing more work than it was
+  as a follower — the comparison is not like-for-like.


### PR DESCRIPTION
The etcd runbook merged in #13532 claimed the control-plane disk picture had **inverted** since May, that master1 was now the *fastest* voter, and therefore that the master1 NVMe swap was no longer the highest-value fix.

**That is wrong, and the recommendation built on it was wrong.**

It came from a **single 10-minute instant query** taken minutes after the etcd restarts — when master1 had just come up idle and the other two were still catching up.

## Measured properly (median over 9 h at 15 m resolution)

| p99 | master1 | master2 | master3 |
|---|---|---|---|
| `wal_fsync` — May | **31 ms** | 17 ms | 16 ms |
| `wal_fsync` — Aug | **30.5 ms** | 15.6 ms | 15.6 ms |
| `backend_commit` — May | **103 ms** | 29 ms | 27 ms |
| `backend_commit` — Aug | **97 ms** | 24 ms | 26 ms |

**Nothing inverted. Nothing degraded.** master1 is still the slow voter — ~2× on fsync, ~4× on commit — and has been for months. The disk-swap plan in `master1_etcd_disk_swap.md` **stands** as the highest-value fix.

## Fixed the advice that caused the error

The "Traps" section previously said *"use a 10 m window"* — which is precisely the mistake I then made. It now says never to judge disk latency from an instant query, gives the `quantile_over_time(0.5, (…)[9h:15m])` form, and names the second failure mode: **a just-restarted member looks fast because it is idle.**

## And the actual result of the timer change (+10 h)

| metric | before | after 10 h |
|---|---|---|
| leader changes | ~11.6/day on master1 | **0** since the rollout |
| `heartbeat_send_failures` (leader) | ~83/h | **7.6/h** (−91 %) |
| `slow_apply` | ~1297/h on master1 | ~1890/h on master1 |

`etcdHighNumberOfLeaderChanges` **cleared and has not re-fired.** The flapping stopped outright — the two leader changes master1 shows are the rollout's own restarts.

`slow_apply` not improving is the **expected** result: it's disk-bound, not timing-bound, and the disk is unchanged. master1 is also the leader now, so it's doing more work than it was as a follower — not a like-for-like comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)