### PR TITLE
fix(media): pip user-installs died because HOME is a read-only /

### DIFF
--- a/kubernetes/apps/media/stash/app/helmrelease.yaml
+++ b/kubernetes/apps/media/stash/app/helmrelease.yaml
@@ -75,6 +75,16 @@ spec:
 
             env:
               TZ: "America/New_York"
+              # Python plugins pip-install their own requirements at load.
+              # site-packages is root-owned, so pip falls back to a user
+              # install under $HOME — and HOME=/ here, a read-only root-owned
+              # dir — so every install died on "Permission denied: '/.local'"
+              # and the plugin then failed with ModuleNotFoundError. Point the
+              # user base at the config PVC instead: pip writes there and
+              # Python picks it up automatically via site.getusersitepackages().
+              # Deliberately not $HOME — Stash resolves its config as
+              # $HOME/.stash, so moving HOME would move config.yml.
+              PYTHONUSERBASE: /.stash/.python
               STASH_STASH: /media/
               STASH_GENERATED: /data/generated/
               STASH_METADATA: /data/metadata/


### PR DESCRIPTION
A media app's Python plugins pip-install their own requirements when they load. The image's site-packages is root-owned, so pip falls back to a user install under `$HOME` — and the image sets `HOME=/`, a root-owned `dr-xr-xr-x` dir, while the app runs as uid 1114. Every install failed with

```
OSError: [Errno 13] Permission denied: '/.local'
```

and the plugin then died on `ModuleNotFoundError` for its first import. Nothing tied the two together in the log, so it read as a missing dependency rather than an unwritable install target.

**Fix:** set `PYTHONUSERBASE` to a directory on the config PVC. pip writes there, Python adds it to `sys.path` automatically via `site.getusersitepackages()`, and the packages survive restarts instead of being re-fetched on every plugin load.

Deliberately *not* moving `HOME` — the app resolves its own config directory relative to `$HOME`, so a different `HOME` would move `config.yml` out from under it (the same path trap the persistence comment in this file already documents).

**Verification** (in the running pod, before the change): with `PYTHONUSERBASE` exported, `pip install --user -r requirements.txt` completes to the PVC and all three imports resolve. The requirements of the other plugin in that directory are a subset, so it's covered by the same install.

**Impact:** one pod restart when Flux rolls the StatefulSet. Not a Renee-facing service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)