### PR TITLE
feat(glance): surface cluster vitals from kromgo

### DIFF
--- a/kubernetes/apps/collab/glance/app/cnp-allow.yaml
+++ b/kubernetes/apps/collab/glance/app/cnp-allow.yaml
@@ -28,6 +28,17 @@ spec:
             - port: "8081"
               protocol: TCP
   egress:
+    # Cluster-vitals custom-api widget → kromgo:8080 (observability).
+    # Needs its own rule: the world-entity rule below only opens 80/443,
+    # and this is an in-cluster pod on 8080.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: observability
+            app.kubernetes.io/name: kromgo
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
     # Widgets pull from arbitrary upstreams configured in glance.yml
     # (RSS feeds, Reddit, Hacker News, weather, GitHub, Docker Hub,
     # Twitch, YouTube, calendar ICS, etc.). The widget set evolves

--- a/kubernetes/apps/collab/glance/app/resources/glance.yml
+++ b/kubernetes/apps/collab/glance/app/resources/glance.yml
@@ -20,6 +20,69 @@ pages:
             search-engine: https://search.${SECRET_DOMAIN}/search?q={QUERY}
             autofocus: true
 
+          # Cluster vitals from kromgo, which fronts a curated set of
+          # PromQL queries (kromgo/app/resources/config.yaml) so glance
+          # never needs Prometheus credentials or PromQL of its own.
+          #
+          # kromgo v0.10.0 serves `GET /<metric>` as shields.io endpoint
+          # JSON: `message` is the already-formatted value (the config's
+          # suffix is applied server-side) and `color` is the threshold
+          # bucket. So the template only formats — it never does math.
+          #
+          # The top-level `url` populates `.JSON`; the rest come from
+          # `newRequest`, which glance issues concurrently. Widen this by
+          # adding a metric to kromgo's config first, then a tile here.
+          #
+          # NOTE: kromgo's `cluster_alert_count` is deliberately NOT
+          # surfaced — its query reads grafana_alerting_alertmanager_alerts,
+          # which counts Grafana-managed alerts, not the kube-prometheus-stack
+          # Alertmanager that actually pages. It would render a confident
+          # "0" while alerts are firing. See the PR notes.
+          - type: custom-api
+            title: Cluster
+            cache: 1m
+            url: http://kromgo.observability.svc.cluster.local:8080/cluster_node_count
+            template: |
+              {{ $base := "http://kromgo.observability.svc.cluster.local:8080/" }}
+              {{ $pods := newRequest (concat $base "cluster_pod_count") | getResponse }}
+              {{ $cpu := newRequest (concat $base "cluster_cpu_usage") | getResponse }}
+              {{ $mem := newRequest (concat $base "cluster_memory_usage") | getResponse }}
+              {{ $power := newRequest (concat $base "cluster_power_usage") | getResponse }}
+              {{ $age := newRequest (concat $base "cluster_age_days") | getResponse }}
+              {{ $version := newRequest (concat $base "kubernetes_version") | getResponse }}
+              {{ $cpuColor := $cpu.JSON.String "color" }}
+              {{ $memColor := $mem.JSON.String "color" }}
+              {{ $powerColor := $power.JSON.String "color" }}
+              <div class="flex justify-between text-center">
+                <div>
+                  <div class="color-highlight size-h3">{{ .JSON.String "message" }}</div>
+                  <div class="size-h6 uppercase">Nodes</div>
+                </div>
+                <div>
+                  <div class="color-highlight size-h3">{{ $pods.JSON.String "message" }}</div>
+                  <div class="size-h6 uppercase">Pods</div>
+                </div>
+                <div>
+                  <div class="size-h3 {{ if eq $cpuColor "green" }}color-positive{{ else }}color-negative{{ end }}">{{ $cpu.JSON.String "message" }}</div>
+                  <div class="size-h6 uppercase">CPU</div>
+                </div>
+                <div>
+                  <div class="size-h3 {{ if eq $memColor "green" }}color-positive{{ else }}color-negative{{ end }}">{{ $mem.JSON.String "message" }}</div>
+                  <div class="size-h6 uppercase">Memory</div>
+                </div>
+                <div>
+                  <div class="size-h3 {{ if eq $powerColor "green" }}color-positive{{ else }}color-negative{{ end }}">{{ $power.JSON.String "message" }}</div>
+                  <div class="size-h6 uppercase">Power</div>
+                </div>
+                <div>
+                  <div class="color-highlight size-h3">{{ $age.JSON.String "message" }}</div>
+                  <div class="size-h6 uppercase">Uptime</div>
+                </div>
+              </div>
+              <div class="size-h6 color-subdue text-center margin-top-10">
+                Kubernetes {{ $version.JSON.String "message" }}
+              </div>
+
           # Auto-discovered apps split into one widget per glance/id
           # category. Each block renders as its own card on the page so
           # every link is visible without tabbing. Add a category by

--- a/kubernetes/apps/observability/kromgo/app/cnp-allow.yaml
+++ b/kubernetes/apps/observability/kromgo/app/cnp-allow.yaml
@@ -14,11 +14,22 @@ spec:
   ingress:
     # HTTPRoute on external gateway → kromgo:8080 (no oauth2-proxy,
     # exposes a curated subset of Prometheus queries publicly for
-    # external dashboards / glance widgets).
+    # external dashboards).
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: network
             app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+    # glance (collab) cluster-vitals widget, server-side fetched. Goes
+    # pod-to-pod rather than back out through the external gateway, so
+    # it needs its own rule — the envoy rule above does not cover it.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: collab
+            app.kubernetes.io/name: glance
       toPorts:
         - ports:
             - port: "8080"


### PR DESCRIPTION
## What

Adds a `custom-api` widget to the glance startpage rendering six cluster vitals — nodes, pods, CPU, memory, power, cluster age — plus the Kubernetes version, sourced from kromgo.

## Why

kromgo has been running as a curated Prometheus front-end since it was deployed, and its own CNP comment claimed it existed to feed *"external dashboards / glance widgets"*. glance never consumed it. Its only dynamic data was the glance-k8s-extension app/node lists; everything else on the page was static bookmarks. This makes the comment true and corrects it where it wasn't.

kromgo returns shields.io endpoint JSON, so `message` arrives already suffix-formatted and `color` already carries the threshold bucket. The template only lays out — no arithmetic, no PromQL, and no Prometheus credentials in glance.

## Network policy

Both directions need explicit rules, and both were missing:

- glance's existing egress rule only opens 80/443 to the `world` entity; this is an in-cluster pod on 8080.
- kromgo's ingress only admitted envoy. The widget is fetched server-side pod-to-pod, not back out through the external gateway.

## Deliberately omitted

kromgo's `cluster_alert_count` is **not** surfaced. Its query reads `grafana_alerting_alertmanager_alerts`, which counts Grafana-managed alerts rather than the kube-prometheus-stack Alertmanager that actually pages — so the tile would render a confident `0` while alerts were firing. Fixing that query is a separate change.

## Verification

- `kubectl kustomize` renders clean for both app dirs; widget lands in the ConfigMap.
- Go template parsed offline against `html/template` with the glance helper funcs stubbed.
- API shape and template functions checked against the **pinned** versions (kromgo v0.10.0, glance v0.8.5), not `main` — the two differ. kromgo `main` documents `/badges/{id}`; v0.10.0 serves `GET /{metric}`.
- Confirmed Flux's envsubst only expands braced `${VAR}`, so the template's bare `$base` / `$cpu` Go-template variables survive `postBuild` substitution untouched (verified with `flux envsubst --strict`). GNU envsubst *does* eat them — different implementation, and a misleading local test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)