### PR TITLE
feat(observability): emit the first traces into the idle Tempo pipeline

### DIFF
--- a/kubernetes/apps/ai/tei-embed-spark/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/tei-embed-spark/app/cnp-allow.yaml
@@ -62,3 +62,15 @@ spec:
         - ports:
             - port: "443"
               protocol: TCP
+    # OTLP trace export to the collector in observability. Without this
+    # the export is a silent drop — TEI logs nothing and no span ever
+    # reaches Tempo, the same failure shape as the blackbox-exporter
+    # label trap in #13264.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: observability
+            app.kubernetes.io/name: opentelemetry-collector
+      toPorts:
+        - ports:
+            - port: "4317"
+              protocol: TCP

--- a/kubernetes/apps/ai/tei-embed-spark/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/tei-embed-spark/app/helmrelease.yaml
@@ -81,6 +81,21 @@ spec:
               # Truncate over-long inputs rather than 413 the client.
               AUTO_TRUNCATE: "true"
               JSON_OUTPUT: "true"
+              # OTLP traces → the collector in observability. TEI bridges
+              # its whole `tracing` instrumentation to OTel, so handler
+              # spans carry tokenization_time / queue_time /
+              # inference_time — which is the point: this is the hop the
+              # RAG path most often stalls on.
+              #
+              # gRPC ONLY. The exporter is hardcoded to `.tonic()`; there
+              # is no protocol switch and port 4318 will not work.
+              #
+              # NOTE: TEI's sampler is Sampler::AlwaysOn with no knob, so
+              # this traces 100% of requests. A bulk re-embed emits one
+              # span per document. If Tempo gets noisy, sample at the
+              # collector rather than looking for a TEI-side setting.
+              OTLP_ENDPOINT: http://opentelemetry-collector.observability.svc.cluster.local:4317
+              OTLP_SERVICE_NAME: tei-embed-spark
 
             probes:
               liveness:

--- a/kubernetes/apps/ai/tei-spark/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/tei-spark/app/cnp-allow.yaml
@@ -38,3 +38,15 @@ spec:
         - ports:
             - port: "443"
               protocol: TCP
+    # OTLP trace export to the collector in observability. Without this
+    # the export is a silent drop — TEI logs nothing and no span ever
+    # reaches Tempo, the same failure shape as the blackbox-exporter
+    # label trap in #13264.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: observability
+            app.kubernetes.io/name: opentelemetry-collector
+      toPorts:
+        - ports:
+            - port: "4317"
+              protocol: TCP

--- a/kubernetes/apps/ai/tei-spark/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/tei-spark/app/helmrelease.yaml
@@ -79,6 +79,15 @@ spec:
               # Default-true upstream; pinned here for clarity.
               AUTO_TRUNCATE: "true"
               JSON_OUTPUT: "true"
+              # OTLP traces → the collector in observability. Same
+              # mechanics as tei-embed-spark: gRPC only (the exporter is
+              # hardcoded to `.tonic()`, so 4318 will not work) and a
+              # fixed Sampler::AlwaysOn with no sampling knob.
+              #
+              # Rerank volume is far below embed volume — this only fires
+              # once per RAG query, not once per indexed document.
+              OTLP_ENDPOINT: http://opentelemetry-collector.observability.svc.cluster.local:4317
+              OTLP_SERVICE_NAME: tei-spark
 
             probes:
               liveness:

--- a/kubernetes/apps/ai/vllm-driver-spark/app/cnp-allow.yaml
+++ b/kubernetes/apps/ai/vllm-driver-spark/app/cnp-allow.yaml
@@ -50,3 +50,15 @@ spec:
         - ports:
             - port: "443"
               protocol: TCP
+    # OTLP trace export to the collector in observability. Without this
+    # the export is a silent drop — vLLM logs nothing and no span ever
+    # reaches Tempo, the same failure shape as the blackbox-exporter
+    # label trap in #13264.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: observability
+            app.kubernetes.io/name: opentelemetry-collector
+      toPorts:
+        - ports:
+            - port: "4317"
+              protocol: TCP

--- a/kubernetes/apps/ai/vllm-driver-spark/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/vllm-driver-spark/app/helmrelease.yaml
@@ -151,6 +151,33 @@ spec:
               - --tool-call-parser
               - qwen3_xml
               - --enable-auto-tool-choice
+              # OTLP traces → the collector in observability. One
+              # `llm_request` span per request, backdated to arrival time,
+              # carrying time_to_first_token / time_in_queue /
+              # time_in_model_prefill / time_in_model_decode and prompt +
+              # completion token counts. That queue-vs-prefill-vs-decode
+              # split is the whole reason to trace this hop: it is the
+              # difference between "the model is slow" and "the request
+              # waited". Inbound W3C traceparent is honoured, so an
+              # open-webui span links straight through to this one.
+              #
+              # `grpc://` per vLLM's own examples. The exporter hardcodes
+              # insecure=True on the gRPC path, so no TLS opt-out is
+              # needed here (unlike open-webui).
+              #
+              # VERIFIED BEFORE ENABLING: this flag is startup-FATAL if
+              # the OTel packages are missing —
+              # ObservabilityConfig._validate_otlp_traces_endpoint raises
+              # rather than degrading. Upstream bundles them in
+              # requirements/common.txt, but this image is a third-party
+              # GB10 rebuild, so it was checked in-container:
+              # opentelemetry-exporter-otlp 1.42.0, Required-by: vllm.
+              # Re-check on any image bump that changes the base.
+              #
+              # NOT adding --collect-detailed-traces: upstream warns it
+              # involves "possibly costly and or blocking operations".
+              - --otlp-traces-endpoint
+              - grpc://opentelemetry-collector.observability.svc.cluster.local:4317
 
             env:
               # HF Hub cache on the PVC so the ~35 GB FP8 download survives
@@ -158,6 +185,11 @@ spec:
               # default-deny without the world:443 egress in cnp-allow).
               HF_HOME: &cachePath /data
               VLLM_LOGGING_LEVEL: INFO
+              # Read by the OTel SDK itself, not by vLLM — vLLM sets no
+              # service name of its own, so without this every span lands
+              # in Tempo as `unknown_service` and cannot be told apart
+              # from any other uninstrumented producer.
+              OTEL_SERVICE_NAME: vllm-driver-spark
 
             probes:
               # /health returns 200 once the engine is up and the model is

--- a/kubernetes/apps/collab/open-webui/app/cnp-allow.yaml
+++ b/kubernetes/apps/collab/open-webui/app/cnp-allow.yaml
@@ -122,5 +122,17 @@ spec:
         - ports:
             - port: "10443"
               protocol: TCP
+    # OTLP trace export to the collector in observability. Without this
+    # the export is a silent drop — Open WebUI logs nothing and no span
+    # reaches Tempo, the same failure shape as the blackbox-exporter
+    # label trap in #13264.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: observability
+            app.kubernetes.io/name: opentelemetry-collector
+      toPorts:
+        - ports:
+            - port: "4317"
+              protocol: TCP
 # Intra-ns to searxng:8080 (SEARXNG_QUERY_URL) is covered by
 # baseline allow-intra-namespace.

--- a/kubernetes/apps/collab/open-webui/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/open-webui/app/helmrelease.yaml
@@ -162,6 +162,38 @@ spec:
               VECTOR_DB: qdrant
               AUDIO_OPENAI_API_BASE_URL: https://piper.${SECRET_DOMAIN}/v1
               AUDIO_OPENAI_API_KEY: sk-111111111111 # fake key needed to make ui happy
+              # OpenTelemetry traces → the collector in observability,
+              # which batches and forwards to Tempo. Tempo and the
+              # collector have been deployed and idle since they landed;
+              # this is the first real trace producer in the cluster.
+              #
+              # BOTH gates are required. ENABLE_OTEL only gates the
+              # import in main.py; ENABLE_OTEL_TRACES separately gates
+              # tracer setup. Setting one alone silently produces no
+              # spans and logs nothing.
+              ENABLE_OTEL: true
+              ENABLE_OTEL_TRACES: true
+              OTEL_EXPORTER_OTLP_ENDPOINT: http://opentelemetry-collector.observability.svc.cluster.local:4317
+              # MANDATORY for a plaintext collector — the `http://` above
+              # is NOT sufficient on its own. Open WebUI always passes
+              # `insecure=` to the SDK as a real bool, which dead-codes
+              # the SDK's own scheme-based auto-detection. Left at its
+              # default of false, the exporter opens a TLS channel
+              # against a cleartext listener and every export fails.
+              OTEL_EXPORTER_OTLP_INSECURE: true
+              # Protocol selector. NOT the standard
+              # OTEL_EXPORTER_OTLP_PROTOCOL — Open WebUI never reads
+              # that one. If ever switched to `http`, the endpoint above
+              # must also gain an explicit `/v1/traces` path: Open WebUI
+              # passes `endpoint=` straight through, which makes the SDK
+              # skip appending the signal path, and a bare host 404s.
+              OTEL_OTLP_SPAN_EXPORTER: grpc
+              OTEL_SERVICE_NAME: open-webui
+              # Metrics and logs deliberately left off — Prometheus
+              # already scrapes this pod and logs reach Loki via Vector.
+              # ENABLE_OTEL_LOGS in particular builds its exporter at
+              # import time, so a bad endpoint there surfaces at first
+              # log write rather than at startup.
               # OIDC SSO via Authelia
               ENABLE_OAUTH_SIGNUP: true
               OAUTH_MERGE_ACCOUNTS_BY_EMAIL: true

--- a/kubernetes/apps/istio-system/istio/app/istiod/helmrelease.yaml
+++ b/kubernetes/apps/istio-system/istio/app/istiod/helmrelease.yaml
@@ -15,6 +15,33 @@ spec:
   values:
     # https://artifacthub.io/packages/helm/istio-official/istiod
     # https://github.com/istio/istio/blob/master/manifests/charts/istio-control/istio-discovery/values.yaml
+    #
+    # Declares the OTLP trace sink. This only makes the provider
+    # AVAILABLE — nothing is traced until a Telemetry CR selects it,
+    # which happens in mcp-system only (mcp-gateway/app/telemetry.yaml).
+    # Config ships over xDS, so no pod restart or re-injection.
+    meshConfig:
+      enableTracing: true
+      extensionProviders:
+        - name: otel-tracing
+          opentelemetry:
+            # Must be an FQDN that resolves in Istio's service registry.
+            # An ordinary in-cluster Service qualifies — the observability
+            # namespace does NOT need to be meshed, and no ServiceEntry
+            # is required.
+            #
+            # Lookup failure here is SILENT: no error, no log at default
+            # level. The tell is istiod's
+            # `provider_lookup_cluster_failures{provider="opentelemetry"}`
+            # counter, not anything in the sidecar.
+            service: opentelemetry-collector.observability.svc.cluster.local
+            port: 4317
+            # gRPC is the default transport when `http` is omitted. The
+            # collector Service already carries `appProtocol: grpc` on
+            # 4317 (chart default), which is what lets Istio negotiate
+            # HTTP/2 for the export cluster.
+            resourceDetectors:
+              environment: {}
     pilot:
       autoscaleMin: 2
       resources:

--- a/kubernetes/apps/mcp-system/mcp-gateway/app/kustomization.yaml
+++ b/kubernetes/apps/mcp-system/mcp-gateway/app/kustomization.yaml
@@ -16,3 +16,4 @@ resources:
   - ./rotator-cronjob.yaml
   - ./rotator-rbac.yaml
   - ./securitypolicy.yaml
+  - ./telemetry.yaml

--- a/kubernetes/apps/mcp-system/mcp-gateway/app/telemetry.yaml
+++ b/kubernetes/apps/mcp-system/mcp-gateway/app/telemetry.yaml
@@ -1,0 +1,49 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/telemetry.istio.io/telemetry_v1.json
+apiVersion: telemetry.istio.io/v1
+kind: Telemetry
+metadata:
+  name: otel-tracing
+spec:
+  tracing:
+    # Must string-match an `extensionProviders[].name` declared in the
+    # istiod meshConfig (istio-system/istio/app/istiod/helmrelease.yaml).
+    # Only ONE provider may be listed per tracing rule.
+    - providers:
+        - name: otel-tracing
+      # Set EXPLICITLY. The published API reference claims unset means
+      # 0%, which is wrong: the field is a DoubleValue wrapper, so unset
+      # falls back through meshConfig to PILOT_TRACE_SAMPLING, whose
+      # registered default is 1%. Relying on the default would silently
+      # sample 1 request in 100 and look like a broken pipeline.
+      #
+      # 100% is right for this namespace: mcp-system carries interactive
+      # tool calls at human rates, not bulk traffic, and a sampled-away
+      # trace is exactly the one being investigated. Revisit if span
+      # volume becomes a problem.
+      randomSamplingPercentage: 100
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: mcp-system-allow-otlp-export
+spec:
+  # Namespace-wide on purpose: every pod here carries a sidecar, and it
+  # is the SIDECAR that exports spans, not the app container. Scoping
+  # this to mcp-gateway alone would trace one pod and silently drop the
+  # other twenty backends — which is precisely the fan-out this exists
+  # to make visible.
+  endpointSelector: {}
+  enableDefaultDeny:
+    egress: false
+    ingress: false
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: observability
+            app.kubernetes.io/name: opentelemetry-collector
+      toPorts:
+        - ports:
+            - port: "4317"
+              protocol: TCP


### PR DESCRIPTION
## What

Turns on OTLP trace export for the two request paths where tracing answers a question metrics cannot: the MCP gateway fan-out, and the RAG path.

| Producer | Spans |
|---|---|
| Istio sidecars, `mcp-system` only | Every hop of the gateway → 20-backend fan-out |
| open-webui | HTTP handlers, SQLAlchemy, Redis, outbound httpx |
| tei-embed-spark / tei-spark | `tokenization_time`, `queue_time`, `inference_time` |
| vllm-driver-spark | One `llm_request` span: queue vs prefill vs decode, TTFT, token counts |

## Why now

Tempo and the OpenTelemetry collector have been deployed, wired to each other, and registered as a Grafana datasource — with **zero producers**. The OTLP receivers were open cluster-wide and nothing ever sent a span. The Tempo datasource even has `tracesToLogsV2` / `tracesToMetrics` correlation configured against logs and metrics that had no traces to correlate to.

## Three traps, each of which yields a silently-dead pipeline

1. **Istio sampling.** The published API reference says an unset `randomSamplingPercentage` means 0%. It is a `DoubleValue` wrapper, so unset actually falls through to `PILOT_TRACE_SAMPLING`'s **1%** default. Either reading gives near-zero spans that look like a broken export rather than a setting. Set explicitly.
2. **open-webui needs two gates.** `ENABLE_OTEL` gates only the import; `ENABLE_OTEL_TRACES` gates the tracer. Either alone produces nothing and logs nothing. `OTEL_EXPORTER_OTLP_INSECURE=true` is load-bearing, not cosmetic — open-webui passes `insecure=` to the SDK as a real bool, dead-coding the SDK's scheme-based detection, so `http://` alone still opens TLS against a cleartext listener.
3. **Sidecars export, not app containers.** The mcp-system CNP is namespace-wide (`endpointSelector: {}`) for that reason. Scoping it to mcp-gateway would have traced one pod and silently dropped the other twenty backends — the exact fan-out this exists to reveal.

Every producer gets an explicit CNP egress rule. All affected namespaces run `default-deny`, and a missing rule is a silent drop with nothing in any log — same shape as the blackbox-exporter label trap in #13264.

## Excluded, with reasons

- **Windmill** — OTLP tracing is compiled out of the Community Edition binary; `otel` and `enterprise` are both absent from the `features=ce` build that produces the public image, and `tracing_init.rs` resolves the tracer to a compile-time `None`. Upstream docs imply only inbound trace connection and metrics export are Enterprise-gated; the Cargo feature wiring disagrees. Would need the `-ee` image plus a license.
- **Qdrant** — the opentelemetry crates are not a dependency at any version; upstream qdrant#3839 is still open. No config enables it. The RAG trace will show open-webui → TEI → vLLM with a qdrant-shaped gap.
- **Envoy Gateway** — deliberately out of scope; it would roll all ingress and belongs in its own change.

## Rollout impact

Not free. Recommend a routine window (any night 02:00–05:00); nothing here is on the household-facing voice path, which runs on the P40 rather than vLLM.

| Change | Effect |
|---|---|
| istiod `meshConfig` | Ships over xDS — no sidecar restart, no re-injection. istiod itself rolls; injection webhook briefly unavailable, existing traffic unaffected. |
| Telemetry CR + CNPs | Pure additions, no restart |
| open-webui | Pod restart, seconds |
| tei-embed-spark, tei-spark | Pod restart + model reload from cache PVC |
| **vllm-driver-spark** | **StatefulSet restart → ~35 GB FP8 model reload, several minutes with no chat LLM.** Also affects opencode and LightRAG. |

## Pre-flight check already done

vLLM's `--otlp-traces-endpoint` is **startup-fatal** when the OTel packages are absent — `ObservabilityConfig._validate_otlp_traces_endpoint` raises rather than degrading — and this cluster runs a third-party GB10 rebuild, so upstream's bundling guarantee does not automatically hold. Verified in-container before enabling: `opentelemetry-exporter-otlp 1.42.0`, `Required-by: vllm`. Worth re-checking on any image bump that changes the base.

## How to verify after merge

1. `provider_lookup_cluster_failures{provider="opentelemetry"}` on istiod must stay `0`. A registry-lookup failure there is completely silent — no error, no log at default level. This is the only signal.
2. Grafana → Tempo, search by service name: `open-webui`, `tei-embed-spark`, `tei-spark`, `vllm-driver-spark`, plus the injected mcp-system services.
3. A single RAG query should produce **one linked trace** across open-webui → tei-embed → vLLM (all three honour inbound W3C `traceparent`). Separate traces instead of one means context propagation is broken even though export works.

## Follow-up

`tempo/app/helmrelease.yaml` has `metricsGenerator` disabled. With spans now flowing, enabling it derives per-service RED metrics — likely more valuable day-to-day than reading individual traces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)