### PR TITLE
fix(konflate): the GitHub token expired an hour after every start

### DIFF
--- a/kubernetes/apps/selfhosted/konflate/README.md
+++ b/kubernetes/apps/selfhosted/konflate/README.md
@@ -32,6 +32,25 @@ PAT. The App's PEM comes from the 1Password `Github` item
 `github-app-pem` secret. konflate stays read-only (`prComments`/`statusChecks`
 off), so the App's write scope is unused.
 
+**The token expires after 1 hour, and the pod must be rolled to pick up a new
+one.** The chart wires `secret.existingSecret` in through `envFrom`, and a
+pod's environment variables are fixed at start — so konflate cannot re-read a
+rotated Secret in place. `deploymentAnnotations` therefore carries
+`reloader.stakater.com/auto: "true"`, and Reloader (kube-system) rolls the
+Deployment each time `konflate-secret` changes. Restart cadence equals the
+ExternalSecret's 30m `refreshInterval`.
+
+Without that annotation konflate authenticates for exactly one hour after
+each start and then 401s indefinitely, which is how it sat broken for 3.7
+days from 2026-08-08: probes are process-level and kept passing, the pod
+never restarted, and ESO reported `Ready=True` because minting the token
+had in fact succeeded. `app/prometheusrule.yaml` alerts on the two counters
+that did show it (`konflate_forge_list_errors_total`,
+`konflate_diff_jobs_total{result="error"}`).
+
+renovate-operator shares the same App and never hit this: it runs a Job per
+cycle, so each run starts a fresh pod that reads the current Secret.
+
 ## Provisioning (done)
 
 The out-of-Git secrets and the Authelia client were created on 2026-06-24:
@@ -67,3 +86,10 @@ No further manual 1Password steps are needed to deploy this app.
 - Swap the shared renovate App token for a dedicated read-only PAT or a
   konflate-scoped GitHub App (least privilege; the current token can write
   though konflate never does).
+- Ask upstream to support App auth on the **read** path. konflate already
+  mints and refreshes installation tokens internally when given
+  `config.appClientId` + `secret.appPrivateKey`, but the chart documents that
+  pair as the *write* identity — a read-only instance like this one can't use
+  it, which is why the read token has to arrive through a Secret and be
+  reloaded. Native read-path App auth would remove the expiry problem, and
+  with it the 30m restart cadence, entirely.

--- a/kubernetes/apps/selfhosted/konflate/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/konflate/app/helmrelease.yaml
@@ -40,6 +40,27 @@ spec:
     # Token supplied by the konflate ExternalSecret (key KONFLATE_TOKEN).
     secret:
       existingSecret: konflate-secret
+    # The chart wires existingSecret in via `envFrom`, and environment
+    # variables are fixed for the life of a pod. The GithubAccessToken
+    # generator mints a GitHub App *installation* token, which GitHub
+    # expires after 1 hour — so konflate authenticated for the first hour
+    # after each start and then 401'd forever, while ESO rotated the
+    # Secret underneath it (182 "secret updated" events over 2d17h, all
+    # into a void). Nothing looked wrong: probes are process-level, the
+    # pod never restarted, and ESO reported Ready=True the whole time.
+    # Only konflate's own counters showed it — 148 of 150 diff jobs
+    # erroring, both successes inside the first 20 minutes of uptime.
+    #
+    # renovate-operator shares this exact App (2931213) and is unaffected
+    # because it runs a Job per cycle: every run gets a fresh pod that
+    # reads the current Secret at startup. konflate is a long-lived
+    # Deployment, so it never re-reads.
+    #
+    # Reloader rolls the pod when konflate-secret changes, which is the
+    # remedy the chart itself documents on this value. Restart cadence
+    # therefore equals the ExternalSecret's 30m refreshInterval.
+    deploymentAnnotations:
+      reloader.stakater.com/auto: "true"
     service:
       port: 8080
     # State (flate caches + git mirror + rendered diffs) is regenerable

--- a/kubernetes/apps/selfhosted/konflate/app/kustomization.yaml
+++ b/kubernetes/apps/selfhosted/konflate/app/kustomization.yaml
@@ -8,4 +8,5 @@ resources:
   - ./helmrelease.yaml
   - ./httproute.yaml
   - ./ocirepository.yaml
+  - ./prometheusrule.yaml
   - ./securitypolicy.yaml

--- a/kubernetes/apps/selfhosted/konflate/app/prometheusrule.yaml
+++ b/kubernetes/apps/selfhosted/konflate/app/prometheusrule.yaml
@@ -1,0 +1,94 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: konflate-rules
+spec:
+  groups:
+    - name: konflate.forge
+      rules:
+        # konflate can fail completely while every conventional signal stays
+        # green: /healthz and /readyz are process-level and keep passing, the
+        # pod never restarts so KubePodCrashLooping is quiet, and ESO reports
+        # Ready=True because minting the token succeeded — the token just
+        # never reaches the running process. That combination hid a total
+        # outage for 3.7 days (see the deploymentAnnotations comment in
+        # helmrelease.yaml). These counters were in Prometheus the whole
+        # time; nothing consumed them. That gap is what this file closes.
+        #
+        # 401 Bad credentials is the expected shape here, but any forge-side
+        # failure (rate limit, network, repo renamed) lands in this counter
+        # and means the same thing operationally: konflate no longer knows
+        # what PRs exist, so it is reviewing nothing.
+        - alert: KonflateForgeListFailing
+          annotations:
+            summary: konflate cannot list PRs from the forge ({{ $value | printf "%.1f" }}/h failing)
+            description: |
+              konflate's periodic refresh is failing to enumerate open PRs, so
+              it is not reviewing anything new. The UI keeps serving whatever
+              it last rendered, which makes this invisible from the browser.
+
+              Check the error first — the log line carries the HTTP status:
+                kubectl -n selfhosted logs deploy/konflate | grep 'list PRs failed'
+
+              "401 Bad credentials" means the installation token is stale.
+              That token is minted by the GithubAccessToken generator and
+              expires 1h after issue, so the pod must be rolled whenever the
+              Secret rotates — verify Reloader is doing that:
+                kubectl -n selfhosted get externalsecret konflate
+                kubectl -n selfhosted describe deploy konflate | grep -i reloader
+                kubectl -n kube-system get pods -l app=reloader-reloader
+          # Scaled to per-hour so $value reads as "2.0/h" rather than the
+          # raw per-second rate (0.0006), which rounds to 0.0 in the summary.
+          expr: |
+            sum(rate(konflate_forge_list_errors_total{namespace="selfhosted"}[1h])) * 3600 > 0
+          for: 1h
+          labels:
+            severity: warning
+        # The render path fails independently of the list path — a valid
+        # token still enumerates PRs while every render errors (bad manifest,
+        # unreachable chart source, OOM mid-render). Ratio rather than a raw
+        # count so an occasional broken PR doesn't page. If no jobs run at
+        # all the denominator is 0, the expression is NaN, and this stays
+        # silent by design; KonflateForgeListFailing covers that case.
+        - alert: KonflateDiffJobsFailing
+          annotations:
+            summary: konflate is failing most render jobs ({{ $value | humanizePercentage }} erroring)
+            description: |
+              More than half of konflate's diff jobs are erroring, so its PR
+              diffs are stale or absent even though the service is up.
+
+                kubectl -n selfhosted logs deploy/konflate | grep -i error
+
+              Check whether renders are being killed rather than failing —
+              konflate's peak memory is workload-dependent and a sweeping PR
+              renders far more than a narrow one:
+                kubectl -n selfhosted describe pod -l app.kubernetes.io/name=konflate | grep -A3 'Last State'
+          expr: |
+            sum(rate(konflate_diff_jobs_total{namespace="selfhosted",result="error"}[1h]))
+              /
+            sum(rate(konflate_diff_jobs_total{namespace="selfhosted"}[1h]))
+              > 0.5
+          for: 1h
+          labels:
+            severity: warning
+        # Both alerts above are evaluated against konflate's own metrics, so
+        # they go silent precisely when konflate stops being scraped. Without
+        # this guard the failure mode that started all of it — everything
+        # green, nothing reporting — would still be undetectable.
+        - alert: KonflateMetricsMissing
+          annotations:
+            summary: konflate is not reporting metrics to Prometheus
+            description: |
+              No `up` series exists for the konflate ServiceMonitor target, so
+              KonflateForgeListFailing and KonflateDiffJobsFailing cannot fire.
+              konflate may be down, or its ServiceMonitor may have been
+              dropped or mislabelled.
+                kubectl -n selfhosted get pods -l app.kubernetes.io/name=konflate
+                kubectl -n selfhosted get servicemonitor konflate
+          expr: |
+            absent(up{job="konflate",namespace="selfhosted"})
+          for: 30m
+          labels:
+            severity: warning


### PR DESCRIPTION
## What was wrong

konflate has been unable to reach the GitHub API since 2026-08-08. Its own counters:

| Metric | Value |
|---|---|
| `konflate_diff_jobs_total{result="error"}` | 148 |
| `konflate_diff_jobs_total{result="success"}` | 2 |
| `konflate_forge_list_errors_total` | 171 |

Both successes landed within ~20 minutes of pod start; the counter then froze for 3.7 days. Every 30m refresh logged:

```
"refresh: list PRs failed"
error: github: list PRs: GET .../pulls?...&state=open: 401 Bad credentials []
```

It was reviewing nothing.

## Root cause

The chart wires `secret.existingSecret` in through `envFrom`, and a pod's environment variables are fixed at start. The `GithubAccessToken` generator mints a GitHub App **installation** token, which GitHub expires after 1 hour.

So konflate authenticated for the first hour after each start and then 401'd indefinitely, while external-secrets rotated `konflate-secret` underneath it — **182 "secret updated" events over 2d17h**, none of which the running process could see.

renovate-operator shares the same App (`2931213`) and is unaffected: it runs a Job per cycle, so every run starts a fresh pod that reads the current Secret. konflate is a long-lived Deployment and never re-reads.

## Why nothing alerted

Every conventional signal was green, and each for a legitimate reason:

| Signal | Status | Why it missed |
|---|---|---|
| `/healthz`, `/readyz` | passing | Process-level; a 401 from GitHub isn't a health failure |
| `KubePodCrashLooping` | quiet | Pod up 3.7d, zero restarts |
| ExternalSecret `Ready` | `True` | ESO's job succeeded — minting the token worked |
| konflate error counters | 148 errors | **No rules attached** |

There were no konflate alert rules in the repo at all. The metrics were being scraped the whole time; nothing consumed them.

## Changes

- **`helmrelease.yaml`** — `deploymentAnnotations: reloader.stakater.com/auto: "true"`. This is the remedy the chart documents on that value, and Reloader already runs in kube-system. Restart cadence now equals the ExternalSecret's 30m `refreshInterval`.
- **`prometheusrule.yaml`** (new) — three alerts: forge-list failures, a render-job error ratio, and an `absent()` guard so the first two can't go silent by vanishing.
- **`README.md`** — documents the expiry/reload requirement and why renovate-operator is immune.

## Verification

Rendered with `kubectl kustomize`; all pre-commit hooks pass. Expressions checked against live Prometheus rather than assumed:

- `absent(up{job="konflate",namespace="selfhosted"})` → **empty** (selector matches a real series, so the guard won't false-fire)
- render-job error ratio → **1** (fires correctly, threshold 0.5)
- forge-list rate → **2.0/h** (scaled `* 3600`; the raw per-second rate rounds to `0.0` in the summary)
- `helm template` confirms the chart renders `deploymentAnnotations` onto the Deployment rather than silently ignoring the key

## Deliberately not included

The **2Gi memory limit is untouched.** Upstream (home-operations/konflate#434) traced the 0.5.0 OOMKills to a full-cluster render triggered by the old `path: ./` Kustomization, and advised the limit could come back down now that #13502 removed it. That reasoning holds, but right-sizing needs a real render workload to measure — and konflate hasn't had one. Current memory readings (361 MiB peak, 137 MiB heap) are from a process fast-failing almost every job in under a second, so they prove nothing. That follows once this has run.

## Known tradeoff

Reloader rolls the pod on every Secret rotation, so konflate restarts ~48×/day. Worth watching whether that inflates render volume, since it interacts with the open sizing question above. The durable fix is native App auth on konflate's **read** path — it already mints and refreshes its own installation tokens for `config.appClientId` + `secret.appPrivateKey`, but the chart scopes that pair to the *write* identity, which a read-only instance can't use. Noted as a follow-up in the README.