### PR TITLE
fix(konflate): authenticate as the App so the credential renews itself

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ _Production-grade Kubernetes for a household._
 ![helmreleases](https://img.shields.io/badge/HelmReleases-172-326CE5?style=for-the-badge&logo=helm&logoColor=white)
 ![nodes](https://img.shields.io/badge/k8s_nodes-11-326CE5?style=for-the-badge&logo=kubernetes&logoColor=white)
 ![cnpg](https://img.shields.io/badge/Postgres_clusters-22-336791?style=for-the-badge&logo=postgresql&logoColor=white)
-![secrets](https://img.shields.io/badge/secrets-92-0572EC?style=for-the-badge&logo=1password&logoColor=white)
+![secrets](https://img.shields.io/badge/secrets-91-0572EC?style=for-the-badge&logo=1password&logoColor=white)
 ![age](https://img.shields.io/badge/cluster_age-5%2B_years-success?style=for-the-badge)
 
 </div>

--- a/kubernetes/apps/selfhosted/konflate/README.md
+++ b/kubernetes/apps/selfhosted/konflate/README.md
@@ -24,29 +24,47 @@ konflate ──renders──▶ ZOT (kube-system/zot:5000) + api.github.com + ch
 
 ## GitHub auth
 
-konflate authenticates to GitHub with a **short-lived App installation token**,
-minted by a `GithubAccessToken` generator from the same GitHub App
-(`2931213`) renovate-operator uses — see `app/externalsecret.yaml`. No standing
-PAT. The App's PEM comes from the 1Password `Github` item
-(`renovate_app_private_key`), replicated into this namespace as the
-`github-app-pem` secret. konflate stays read-only (`prComments`/`statusChecks`
-off), so the App's write scope is unused.
+konflate authenticates to GitHub **as the App itself**, using the same App
+(`2931213`) renovate-operator uses. `config.appClientId` is set in the
+HelmRelease and the PEM arrives as `KONFLATE_APP_PRIVATE_KEY` from the
+1Password `Github` item (`renovate_app_private_key`) — see
+`app/externalsecret.yaml`. No standing PAT.
 
-**The token expires after 1 hour, and the pod must be rolled to pick up a new
-one.** The chart wires `secret.existingSecret` in through `envFrom`, and a
-pod's environment variables are fixed at start — so konflate cannot re-read a
-rotated Secret in place. `deploymentAnnotations` therefore carries
-`reloader.stakater.com/auto: "true"`, and Reloader (kube-system) rolls the
-Deployment each time `konflate-secret` changes. Restart cadence equals the
-ExternalSecret's 30m `refreshInterval`.
+konflate mints its own installation tokens from that key and re-mints them a
+minute before each expires, so **no credential has to reach the running
+process after startup**. The installation is auto-detected from the repo, so
+no installation id is configured. A configured App is konflate's identity for
+reads as well as writes (`newGitHubReadClient` precedence: App →
+`KONFLATE_TOKEN` → anonymous), which is why no token is supplied at all.
 
-Without that annotation konflate authenticates for exactly one hour after
-each start and then 401s indefinitely, which is how it sat broken for 3.7
-days from 2026-08-08: probes are process-level and kept passing, the pod
-never restarted, and ESO reported `Ready=True` because minting the token
-had in fact succeeded. `app/prometheusrule.yaml` alerts on the two counters
-that did show it (`konflate_forge_list_errors_total`,
-`konflate_diff_jobs_total{result="error"}`).
+konflate stays read-only (`prComments`/`statusChecks` off), so the App's write
+scope is unused; upstream AND-gates both features on those flags
+(`StatusChecksEnabled` / `PRCommentsEnabled`), so supplying the PEM does not
+by itself enable write-back.
+
+### Why not the installation token
+
+The original design minted the installation token *outside* the pod, via a
+`GithubAccessToken` generator. That token expires after 1 hour, and the chart
+delivers `secret.existingSecret` through `envFrom` — a pod's environment is
+fixed at start, so konflate could never see a rotated value. It authenticated
+for one hour after each start and then 401'd for 3.7 days from 2026-08-08,
+while ESO rotated the Secret 182 times into a void.
+
+Nothing caught it: probes are process-level and kept passing, the pod never
+restarted, and ESO reported `Ready=True` because minting the token had in
+fact succeeded. Only konflate's own counters showed it — 148 of 150 diff jobs
+erroring. `app/prometheusrule.yaml` now alerts on them
+(`konflate_forge_list_errors_total`, `konflate_diff_jobs_total{result="error"}`),
+plus an `absent()` guard so that pair cannot go quiet by vanishing.
+
+`deploymentAnnotations` still carries `reloader.stakater.com/auto: "true"`,
+now as a safety net rather than the fix: the PEM does not expire, so it fires
+approximately never, but a manual key rotation still needs a pod restart to
+take effect.
+
+renovate-operator shares the same App and never hit any of this — it runs a
+Job per cycle, so each run starts a fresh pod that reads the current Secret.
 
 renovate-operator shares the same App and never hit this: it runs a Job per
 cycle, so each run starts a fresh pod that reads the current Secret.
@@ -83,13 +101,14 @@ No further manual 1Password steps are needed to deploy this app.
 
 ## Hardening follow-ups
 
-- Swap the shared renovate App token for a dedicated read-only PAT or a
-  konflate-scoped GitHub App (least privilege; the current token can write
-  though konflate never does).
-- Ask upstream to support App auth on the **read** path. konflate already
-  mints and refreshes installation tokens internally when given
-  `config.appClientId` + `secret.appPrivateKey`, but the chart documents that
-  pair as the *write* identity — a read-only instance like this one can't use
-  it, which is why the read token has to arrive through a Secret and be
-  reloaded. Native read-path App auth would remove the expiry problem, and
-  with it the 30m restart cadence, entirely.
+- Swap the shared renovate App for a konflate-scoped one (least privilege —
+  konflate now holds the same PEM renovate does, which carries write scope it
+  never uses). This is the remaining over-grant; the credential's *lifecycle*
+  is no longer a problem.
+- Consider enabling `statusChecks` — **not** to duplicate CI, which already
+  posts the diff as a sticky comment and gates merges on the required
+  `flate successful` check, but because konflate surfaces blast-radius and
+  danger-lint signals CI does not, and those currently live only in an
+  SSO-gated UI someone has to remember to open. If added, leave it
+  *non-required*: konflate is a single-instance in-cluster service, and a
+  required check would couple merging to cluster health.

--- a/kubernetes/apps/selfhosted/konflate/app/externalsecret.yaml
+++ b/kubernetes/apps/selfhosted/konflate/app/externalsecret.yaml
@@ -1,59 +1,41 @@
 ---
-# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/generators.external-secrets.io/githubaccesstoken_v1alpha1.json
-apiVersion: generators.external-secrets.io/v1alpha1
-kind: GithubAccessToken
-metadata:
-  name: konflate-github-token
-spec:
-  # Reuses the existing GitHub App (the one renovate-operator authenticates
-  # with) to mint a short-lived, auto-rotating installation token scoped to
-  # rwlove/home-ops — no standing PAT to mint or store. konflate reads PRs
-  # with this; it stays read-only (prComments/statusChecks disabled), so the
-  # App's write scope is unused.
-  appID: "2931213"
-  installID: "111956727"
-  repositories:
-    - home-ops
-  auth:
-    privateKey:
-      secretRef:
-        name: github-app-pem
-        key: private_key_pem
----
-# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
-apiVersion: external-secrets.io/v1
-kind: ExternalSecret
-metadata:
-  name: github-app-pem
-spec:
-  refreshInterval: 1h
-  secretStoreRef:
-    kind: ClusterSecretStore
-    name: onepassword-connect
-  target:
-    name: github-app-pem
-  data:
-    - secretKey: private_key_pem
-      remoteRef:
-        key: Github
-        property: renovate_app_private_key
----
 # yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: konflate
 spec:
-  refreshInterval: 30m
+  # Only the App PEM, which does not expire — so unlike the installation
+  # token this replaced, the value konflate reads at startup stays valid for
+  # the life of the pod. 1h is just a drift check, not a liveness dependency.
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
   target:
     name: konflate-secret
     template:
       engineVersion: v2
       data:
-        KONFLATE_TOKEN: "{{ .token }}"
-  dataFrom:
-    - sourceRef:
-        generatorRef:
-          apiVersion: generators.external-secrets.io/v1alpha1
-          kind: GithubAccessToken
-          name: konflate-github-token
+        # Paired with config.appClientId in the HelmRelease. konflate mints
+        # its own installation tokens from this key and re-mints them a minute
+        # before each expires, so no credential has to reach the running
+        # process after startup.
+        #
+        # This replaced a GithubAccessToken generator that minted the
+        # installation token *outside* the pod. That token expires after 1h
+        # while the chart delivers it through envFrom — and a pod's
+        # environment is fixed at start — so konflate authenticated for one
+        # hour and then 401'd for 3.7 days while ESO rotated the Secret 182
+        # times into a void (#13541).
+        #
+        # The App's write scope is unused: konflate keeps prComments and
+        # statusChecks off, and both are AND-gated on those flags upstream
+        # (config.go StatusChecksEnabled / PRCommentsEnabled), so supplying
+        # the PEM does not by itself enable any write-back.
+        KONFLATE_APP_PRIVATE_KEY: "{{ .privateKey }}"
+  data:
+    - secretKey: privateKey
+      remoteRef:
+        key: Github
+        property: renovate_app_private_key

--- a/kubernetes/apps/selfhosted/konflate/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/konflate/app/helmrelease.yaml
@@ -29,36 +29,38 @@ spec:
       logLevel: info
       # Periodic re-render backstop (no inbound webhook wired yet).
       refreshInterval: 30m
+      # GitHub App client id, paired with KONFLATE_APP_PRIVATE_KEY from the
+      # ExternalSecret. konflate treats a configured App as its forge identity
+      # for *reads* as well as writes — newGitHubReadClient's precedence is
+      # App, then KONFLATE_TOKEN, then anonymous — and re-mints the
+      # installation token a minute before expiry, in process. That is what
+      # makes the credential self-sustaining; the token path could not be,
+      # because envFrom freezes the environment at pod start.
+      #
+      # Not a secret: a client id is a public identifier (the PEM is the
+      # secret), and the App/installation ids were already committed here.
+      appClientId: Iv23li1DTAALxhOLqbEx
       # Read-only toward GitHub: no PR comments, no commit-status
-      # write-back (Rob's choice — flate already posts the CI diff).
+      # write-back (Rob's choice — flate already posts the CI diff, as a
+      # sticky comment plus the required "flate successful" check).
       prComments: false
       statusChecks: false
       # Fork PRs run untrusted code through flate; keep off. With forks
       # off, konflate's SSRF egress guard also stays off so it can reach
       # the in-cluster ZOT (a private address) to render.
       renderForkPrs: false
-    # Token supplied by the konflate ExternalSecret (key KONFLATE_TOKEN).
+    # App PEM supplied by the konflate ExternalSecret (key
+    # KONFLATE_APP_PRIVATE_KEY). No KONFLATE_TOKEN — see appClientId above.
     secret:
       existingSecret: konflate-secret
-    # The chart wires existingSecret in via `envFrom`, and environment
-    # variables are fixed for the life of a pod. The GithubAccessToken
-    # generator mints a GitHub App *installation* token, which GitHub
-    # expires after 1 hour — so konflate authenticated for the first hour
-    # after each start and then 401'd forever, while ESO rotated the
-    # Secret underneath it (182 "secret updated" events over 2d17h, all
-    # into a void). Nothing looked wrong: probes are process-level, the
-    # pod never restarted, and ESO reported Ready=True the whole time.
-    # Only konflate's own counters showed it — 148 of 150 diff jobs
-    # erroring, both successes inside the first 20 minutes of uptime.
+    # Retained as a safety net, not as the fix. konflate-secret now holds
+    # only the non-expiring PEM, so this fires approximately never — but if
+    # the key is ever rotated in 1Password, the pod still has to restart to
+    # read it, because the chart delivers the Secret through envFrom.
     #
-    # renovate-operator shares this exact App (2931213) and is unaffected
-    # because it runs a Job per cycle: every run gets a fresh pod that
-    # reads the current Secret at startup. konflate is a long-lived
-    # Deployment, so it never re-reads.
-    #
-    # Reloader rolls the pod when konflate-secret changes, which is the
-    # remedy the chart itself documents on this value. Restart cadence
-    # therefore equals the ExternalSecret's 30m refreshInterval.
+    # It *was* the fix in #13541, rolling the pod every 30m to chase an
+    # expiring installation token. Moving to App auth removed the expiry, and
+    # with it that restart cadence.
     deploymentAnnotations:
       reloader.stakater.com/auto: "true"
     service:

--- a/kubernetes/apps/selfhosted/konflate/app/prometheusrule.yaml
+++ b/kubernetes/apps/selfhosted/konflate/app/prometheusrule.yaml
@@ -32,13 +32,18 @@ spec:
               Check the error first — the log line carries the HTTP status:
                 kubectl -n selfhosted logs deploy/konflate | grep 'list PRs failed'
 
-              "401 Bad credentials" means the installation token is stale.
-              That token is minted by the GithubAccessToken generator and
-              expires 1h after issue, so the pod must be rolled whenever the
-              Secret rotates — verify Reloader is doing that:
+              "401 Bad credentials" means the App credential is not working.
+              konflate authenticates as the GitHub App and mints its own
+              installation tokens from KONFLATE_APP_PRIVATE_KEY, re-minting
+              before each expires — so this is a bad/rotated PEM, a wrong
+              config.appClientId, or the App losing access to the repo, NOT an
+              expired token. Confirm the Secret carries the PEM and that the
+              App still has an installation on this repo:
                 kubectl -n selfhosted get externalsecret konflate
-                kubectl -n selfhosted describe deploy konflate | grep -i reloader
-                kubectl -n kube-system get pods -l app=reloader-reloader
+                kubectl -n selfhosted logs deploy/konflate | grep -i 'App installation\|private key'
+
+              A "find App installation" error means the App was uninstalled or
+              lost repository access — fix that on github.com, not in-cluster.
           # Scaled to per-hour so $value reads as "2.0/h" rather than the
           # raw per-second rate (0.0006), which rounds to 0.0 in the summary.
           expr: |


### PR DESCRIPTION
Follow-up to #13541. That PR stopped konflate's 401s by rolling the pod every 30m to chase an expiring token. Reading konflate's source shows that was the weaker of two available fixes — and that the upstream gap I recorded in its README does not exist.

## What the source says

konflate treats a configured GitHub App as its forge identity for **reads**, not just writes. From `internal/provider/github.go`:

> `newGitHubReadClient` builds the read API client by credential precedence... **a configured GitHub App is konflate's forge identity for reads too** — its installation token lifts the 60/hr anonymous limit and reaches private repos... A read PAT (`KONFLATE_TOKEN`) is the fallback.

Precedence is App → `KONFLATE_TOKEN` → anonymous, on exactly the `ListPRs` path that was failing. And `installTransport.token()` renews itself:

```go
if time.Until(t.exp) > time.Minute { return t.tok, nil }
...
it, _, err := t.apps.Apps.CreateInstallationToken(ctx, t.instID, nil)
t.tok, t.exp = it.GetToken(), it.GetExpiresAt().Time
```

Cached, mutex-guarded, re-minted a minute before expiry.

## What changes

konflate now holds the App **PEM**, which does not expire, and mints its own installation tokens. Nothing has to reach the running process after startup — the property `envFrom` took away. That retires:

- the `GithubAccessToken` generator and the `github-app-pem` ExternalSecret
- the 1-hour token, and the entire class of bug behind #13541
- the 30m restart cadence

The installation is auto-detected from the repo (`GetRepositoryInstallation`), so no installation id is configured either. Net: `externalsecret.yaml` goes from three objects to one.

## Corrections to #13541

- **The upstream follow-up item was wrong** and is removed rather than left to mislead. I had inferred "write-only" from the chart's `values.yaml` phrasing; the code says otherwise. No issue to file.
- **The alert runbook was stale.** It told the operator to check Reloader and ESO rotation on a 401 — a mechanism this PR deletes. Rewritten to point at the real remaining causes: a bad/rotated PEM, a wrong `appClientId`, or the App losing repo access.

## Safety

Supplying the PEM does **not** enable write-back. Upstream AND-gates both write features on the flags we keep false:

```go
func (c *Config) StatusChecksEnabled() bool { return c.StatusChecks && c.WriteEnabled() }
func (c *Config) PRCommentsEnabled() bool   { return c.PRComments   && c.WriteEnabled() }
```

Reloader stays, rescoped as a safety net: `konflate-secret` now holds only the non-expiring PEM, so it fires approximately never — but a manual key rotation still needs a restart to take effect.

## Verification

- `helm template` renders both `KONFLATE_APP_CLIENT_ID` and the `konflate-secret` `envFrom`. This is the check that matters: a dropped values key would silently leave konflate **anonymous** rather than erroring.
- Pre-commit caught that removing an ExternalSecret drifts the root README's `secrets` badge 92 → 91; fixed via `tools/lint-readme-drift.py --fix`.
- The client id is committed as a plain value: it is a public identifier (the PEM is the secret), and the App/installation ids were already in this repo.

## Not yet demonstrated

konflate has not authenticated successfully since 2026-08-08. I'll confirm the 401s stop and `konflate_diff_jobs_total{result="success"}` starts moving after this reconciles — that's the real proof, and it hasn't happened yet. The 2Gi memory question from home-operations/konflate#434 stays open until konflate has a real render workload to measure.