### PR TITLE
fix(longhorn): scope LonghornVolumeBackupStale to actively-used volumes

### DIFF
--- a/kubernetes/apps/longhorn-system/longhorn/app/prometheus-rule.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn/app/prometheus-rule.yaml
@@ -10,39 +10,94 @@ spec:
       rules:
         # Longhorn is the cluster's durable-through-cluster-destruction
         # tier (see .agents/instructions/storage-class.instructions.md),
-        # but nothing watched whether a backup actually happened. On
-        # 2026-08-09 four volumes were found with no recovery point —
-        # three of them 86 days old — and no alert had ever fired:
-        #
-        #   mealie-config-xfs      85.9d   detached
-        #   beets-config-xfs       85.9d   detached
-        #   n8n-data-xfs           85.9d   detached
-        #   comfyui-workspace-xfs  22.9d   detached
-        #
-        # The cause is structural, not a misconfiguration: Longhorn
-        # cannot back up a DETACHED volume — there is no engine to read
-        # from. Any CronJob-driven or scaled-to-zero workload therefore
-        # misses its backup window silently, and the recurring job
-        # reports nothing wrong because it never had a volume to act on.
+        # but nothing watched whether a backup actually happened. Added
+        # 2026-08-09 after four volumes were found with no recovery point.
         #
         # 14d threshold = two missed weekly cycles (weekly-backups runs
-        # Sat 00:00), so a single skipped run does not page.
+        # Sat 00:00 UTC), so a single skipped run does not page.
         #
         # `longhorn_volume_last_backup_at > 0` guards the false positive
         # a naive version would have: a freshly created volume reports 0
         # until its first backup, which would otherwise read as ~56
         # years stale and fire immediately.
+        #
+        # --- 2026-08-12: the two joins below ---
+        #
+        # The original version fired on all four volumes and asserted a
+        # single cause ("detached volumes cannot be backed up"). That was
+        # wrong: they were three unrelated situations, and only one was a
+        # real gap.
+        #
+        #   mealie-config-xfs      orphan  — app retired 2026-05-15
+        #   n8n-data-xfs           orphan  — n8n → Windmill, 2026-05-19
+        #   comfyui-workspace-xfs  parked  — replicas: 0 since #13222
+        #   beets-config-xfs       REAL    — live CronJob, no recovery point
+        #
+        # Staleness alone measures the wrong thing. It is only a risk if
+        # the data is still CHANGING. An orphaned or parked volume is
+        # frozen, so its last backup remains a valid recovery point no
+        # matter how old it gets — but it pages identically to a live
+        # workload that has genuinely lost coverage. Three of four
+        # firings were noise, which is how a real one gets ignored.
+        #
+        # So the alert now requires two things beyond staleness:
+        #
+        #   1. The PVC still exists (`kube_persistentvolumeclaim_info`).
+        #      Drops orphans — Longhorn keeps the Volume CR after the PVC
+        #      and PV are gone, so a retired app leaves a volume behind
+        #      that nothing will ever back up again, correctly.
+        #
+        #   2. Some pod referenced that PVC in the last 7d
+        #      (`kube_pod_spec_volumes_persistentvolumeclaims_info`).
+        #      Drops parked workloads. 7d is wide enough for any
+        #      CronJob-driven volume — beets runs every 12h, so it stays
+        #      visible — while a scaled-to-zero StatefulSet has no pod
+        #      object at all and falls out.
+        #
+        # label_replace maps the Longhorn label names (`pvc`,
+        # `pvc_namespace`) onto the kube-state-metrics ones
+        # (`persistentvolumeclaim`, `namespace`) so the vectors can join.
+        #
+        # Measured when written: 44 volumes total, 41 pass the joins,
+        # exactly the 3 above are suppressed. Deliberately NOT silenced —
+        # if you widen this, re-check that count, because the failure
+        # mode of a too-narrow join is a silent one.
+        #
+        # KNOWN BLIND SPOT: a volume whose workload stays down >7d is
+        # suppressed. That is intended (nothing is writing, so the old
+        # backup still restores it), but it means this alert does not
+        # tell you about backup debt on parked volumes. Cleaning those up
+        # — deleting orphans, deciding whether a parked volume's data is
+        # still wanted — is a separate concern this rule does not cover.
         - alert: LonghornVolumeBackupStale
           annotations:
             summary: Longhorn volume has no recent backup.
             description: >-
               Volume {{ $labels.volume }} (pvc {{ $labels.pvc_namespace }}/{{ $labels.pvc }})
-              last completed a backup {{ $value | humanizeDuration }} ago. If the volume is
-              detached it cannot be backed up at all — check whether its workload is a CronJob
-              or scaled to zero, in which case this will not self-resolve.
+              last completed a backup {{ $value | humanizeDuration }} ago. Its PVC exists and a
+              pod used it within the last 7d, so this is an actively-used volume — not a retired
+              or parked one. Most likely the volume is detached when the recurring jobs fire at
+              00:00 UTC (Longhorn cannot back up a detached volume — there is no engine to read
+              from), so a CronJob-driven workload misses the window silently. Check whether the
+              volume is attached at Sat 00:00 UTC; if not, retime the workload or back the data
+              up another way. This will not self-resolve.
           expr: |
-            (time() - longhorn_volume_last_backup_at) > 14 * 86400
-              and longhorn_volume_last_backup_at > 0
+            (
+              (time() - longhorn_volume_last_backup_at) > 14 * 86400
+                and longhorn_volume_last_backup_at > 0
+            )
+            and on (pvc, pvc_namespace)
+            label_replace(label_replace(
+              max by (namespace, persistentvolumeclaim) (kube_persistentvolumeclaim_info),
+              "pvc", "$1", "persistentvolumeclaim", "(.*)"),
+              "pvc_namespace", "$1", "namespace", "(.*)")
+            and on (pvc, pvc_namespace)
+            label_replace(label_replace(
+              max by (namespace, persistentvolumeclaim) (
+                max_over_time(kube_pod_spec_volumes_persistentvolumeclaims_info[7d])
+              ),
+              "pvc", "$1", "persistentvolumeclaim", "(.*)"),
+              "pvc_namespace", "$1", "namespace", "(.*)")
           for: 1h
           labels:
             severity: warning


### PR DESCRIPTION
## What was wrong

`LonghornVolumeBackupStale` (added in #13529) fired on four volumes, and its comment asserted a single cause — *"detached volumes cannot be backed up."* That diagnosis was wrong. They were three unrelated situations, and only one was a real gap:

| volume | situation |
|---|---|
| `mealie-config-xfs` | **orphan** — app retired 2026-05-15 |
| `n8n-data-xfs` | **orphan** — cut over to Windmill 2026-05-19 (#11681) |
| `comfyui-workspace-xfs` | **parked** — `replicas: 0` since #13222 |
| `beets-config-xfs` | **real** — live CronJob, no recovery point in 88 days |

The shared date that made it look like one class was the *decommission* date, not a failure date. Neither orphan has a PVC or PV anywhere in the cluster — Longhorn keeps the Volume CR after the k8s objects are deleted.

## Why staleness alone is the wrong signal

It's only a risk if the data is still **changing**. An orphaned or parked volume is frozen, so its last backup remains a valid recovery point however old it gets — but it paged identically to a live workload that had genuinely lost coverage. Three of four firings were noise, which is exactly how a real one gets ignored.

## The fix

Two joins beyond the staleness condition:

1. **The PVC still exists** (`kube_persistentvolumeclaim_info`) → drops orphans.
2. **Some pod referenced that PVC within 7d** (`kube_pod_spec_volumes_persistentvolumeclaims_info`) → drops parked workloads. 7d keeps CronJob-driven volumes visible (beets runs every 12h) while a scaled-to-zero StatefulSet has no pod object at all.

`label_replace` maps the Longhorn label names (`pvc`, `pvc_namespace`) onto the kube-state-metrics ones (`persistentvolumeclaim`, `namespace`) so the vectors can join.

## Verification

Run against live Prometheus using the expression **parsed back out of the YAML block scalar**, not a hand-typed copy:

- Fires on `beets-config-xfs` only, labels preserved so the annotation still renders
- Suppresses exactly the three volumes above, nothing else
- **41 of 44 volumes remain under watch** — the failure mode of a too-narrow join is a silent one, so this is the count that matters
- `yamllint` clean; all 15 pre-commit hooks pass, including `envsubst-shell-vars` (bare `$1` / `$labels` verified intact on the live object, since this path has `substitution.flux.home.arpa/enabled: "true"`)

## Known blind spot

Documented in the rule itself: a workload down longer than 7d is also suppressed. Intended — nothing is writing, so the old backup still restores it — but it means this alert does not track backup debt on parked or orphaned volumes. Cleaning those up is separate follow-up work.

This does not fix `beets`; it makes the alert page on it alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)