### PR TITLE
fix(longhorn): back up detached volumes via allowRecurringJobWhileVolumeDetached

### DIFF
--- a/.agents/instructions/storage-class.instructions.md
+++ b/.agents/instructions/storage-class.instructions.md
@@ -98,11 +98,22 @@ New Longhorn volumes need:
   is silently un-backed-up. This bit `paperless-data-xfs` after its
   2026-06-19 restore — see
   [[reference_longhorn_snapshot_not_crash_consistent_use_backup]].
-- A **detached** volume cannot be backed up (no engine to read from).
-  CronJob-only or scaled-to-zero workloads (e.g. `beets`) whose volume
-  is detached during the Saturday 00:00 UTC backup window silently miss
-  weekly backups — their DR floor is whenever the volume last happened
-  to be attached at backup time.
+- A **detached** volume cannot be backed up by itself (no engine to
+  read from), so CronJob-only or scaled-to-zero workloads used to miss
+  their window silently. **Fixed cluster-wide 2026-08-12** by setting
+  `allowRecurringJobWhileVolumeDetached: true` in the Longhorn
+  HelmRelease `defaultSettings`: Longhorn now auto-attaches a detached
+  volume, runs the recurring job, and detaches again. Do **not** design
+  around the old limitation, and do not build per-app backup glue for
+  it. Upstream caveat: while auto-attached the volume is unavailable to
+  workloads, so a workload starting mid-job waits for it to finish —
+  only ever an issue for a volume that was already detached.
+  `beets` was the volume that exposed this. Its CronJob carries
+  `timeZone: America/New_York`, so `0 */12 * * *` is 04:00/16:00 **UTC**
+  (~3h20m per run) and never overlapped the 00:00 UTC recurring window —
+  0 of ~88 daily snapshots, not an intermittent race. **When reasoning
+  about whether a volume is attached at job time, resolve the CronJob's
+  `timeZone` first — the schedule string alone will mislead you.**
 - `unmapMarkSnapChainRemoved=enabled` set per-Volume to prevent
   snapshot-pinned slack.
 - `chmod 755` on `lost+found` if the app runs non-root — fresh ext4

--- a/kubernetes/apps/longhorn-system/longhorn/app/helmrelease.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn/app/helmrelease.yaml
@@ -11,6 +11,21 @@ spec:
   interval: 30m
   values:
     defaultSettings:
+      # Longhorn cannot back up a DETACHED volume on its own — there is
+      # no engine to read from — so CronJob-driven and scaled-to-zero
+      # workloads missed their window silently, and the recurring job
+      # reported nothing wrong because it never had a volume to act on.
+      # `beets` sat 88 days with no recovery point this way: its CronJob
+      # carries timeZone America/New_York, so "0 */12 * * *" is
+      # 04:00/16:00 UTC and never overlapped the 00:00 UTC recurring
+      # window. Not a race — 0 of ~88 daily snapshots.
+      #
+      # With this enabled Longhorn auto-attaches such a volume, runs the
+      # job, then detaches again. Upstream caveat: while auto-attached
+      # the volume is unavailable to workloads, so one starting mid-job
+      # waits for it. That only applies to volumes that were ALREADY
+      # detached, so no running workload is interrupted.
+      allowRecurringJobWhileVolumeDetached: true
       backupTarget: "nfs://beast:/mnt/mass_storage/longhorn-backups"
       createDefaultDiskLabeledNodes: true
       defaultDataLocality: best-effort


### PR DESCRIPTION
Follow-up to #13544, which scoped `LonghornVolumeBackupStale` down to the one volume that represented real risk. This fixes that volume — and the whole class behind it.

## The mechanism (not what it looked like)

Longhorn cannot back up a **detached** volume on its own — no engine to read from — so CronJob-driven and scaled-to-zero workloads missed their window silently. The recurring job reported nothing wrong, because it never had a volume to act on.

`beets` sat **88 days with no recovery point** this way. It looked like a race, since both its CronJob and the recurring jobs nominally fire at `0`. It isn't:

- the CronJob carries **`timeZone: America/New_York`**, so `0 */12 * * *` resolves to **04:00 / 16:00 UTC**
- runs are long — last two measured at **3h05m** and **3h23m**
- every Longhorn recurring job fires at **00:00 UTC**, squarely in the gap

Result: **0 of ~88** daily snapshots and **0 of 12** weekly backups. Deterministic, not intermittent — which is what ruled the race theory out.

> Worth internalizing: the schedule string alone will mislead you here. Resolve the CronJob's `timeZone` before reasoning about whether a volume is attached at job time.

## The fix

Longhorn ships exactly this setting. With `allowRecurringJobWhileVolumeDetached: true`, Longhorn auto-attaches such a volume, runs the job, then detaches again. The chart default is `~` (Longhorn default `false`) and we had never set it.

Chosen over the two alternatives considered:

| option | why not |
|---|---|
| retime the CronJob | fragile — depends on run duration staying long, and needs a bespoke per-volume recurring job |
| rclone to Garage | adds a CronJob, a bucket, and a secret to solve what the storage layer already solves |

Per HOMELAB-SPEC Layer 3 — upstream-first, project features over bespoke glue, fewer moving parts. It also fixes every future CronJob-driven or scaled-to-zero volume, not just this one.

## Blast radius

Bounded. Only **3 volumes are detached** at present (4 at 00:00 UTC once beets is between runs), and `weekly-backups` has `concurrency: 4`. `comfyui-workspace` is 138 GB but already has a 2026-07-18 backup and nothing has written to it since it was parked, so its incremental should be near-zero.

**Upstream caveat**, documented in both changed files: while auto-attached, the volume is unavailable to workloads, so one starting mid-job waits for it. That only applies to volumes that were **already detached** — no running workload is interrupted. For beets the nearest collision is a 00:00 UTC backup against an 04:00 UTC start: a 4-hour margin on a 916 MB incremental.

## Verification

- Setting confirmed present in Longhorn **1.12.0** docs (our chart version), default `false`
- Key confirmed in the mirrored chart at `defaultSettings.allowRecurringJobWhileVolumeDetached` (currently `~`), so it is **not** a silently-ignored Helm value
- All 15 pre-commit hooks pass

## Doc drift

`storage-class.instructions.md` documented the detached-volume limitation as permanent. Left alone it would have led future work to build per-app backup glue around a problem that no longer exists, so it is corrected in the same PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)