### PR TITLE
docs(cnpg): document out-of-Git per-table autovacuum reloptions

### DIFF
--- a/kubernetes/apps/databases/cloudnative-pg/config/lidarr/cluster.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/config/lidarr/cluster.yaml
@@ -22,6 +22,18 @@ spec:
       timezone: "America/New_York"
       max_slot_wal_keep_size: 10GB
       shared_buffers: 256MB
+      # Out-of-Git DB state (documented 2026-08-13). The application database is
+      # "lidarr-main" (the CNPG default "app" DB is empty/unused). Tables
+      # "Tracks", "TrackFiles" and "AlbumReleases" in lidarr-main carry per-table
+      # autovacuum reloptions applied directly via psql — CNPG has no declarative
+      # field for per-table reloptions:
+      #   ALTER TABLE "Tracks"        SET (autovacuum_analyze_scale_factor=0.02, autovacuum_analyze_threshold=500);
+      #   ALTER TABLE "TrackFiles"    SET (autovacuum_analyze_scale_factor=0.02, autovacuum_analyze_threshold=200);
+      #   ALTER TABLE "AlbumReleases" SET (autovacuum_analyze_scale_factor=0.02, autovacuum_analyze_threshold=100);
+      # They keep planner stats fresh enough to avoid intermittent read timeouts
+      # on the ArtistStatistics aggregate (a million-row three-way join). These
+      # reloptions do NOT survive a bootstrap.recovery onto a fresh cluster —
+      # reapply them after any restore.
 
   storage:
     size: 20Gi


### PR DESCRIPTION
## What
Adds a comment to this CNPG `Cluster` manifest documenting per-table autovacuum
reloptions applied directly to the application database (`*-main`) via `psql` on
2026-08-13. CNPG has no declarative field for per-table reloptions, so this
records the out-of-band state in Git.

## Why
Three high-churn tables (`Tracks` / `TrackFiles` / `AlbumReleases`) were hitting
intermittent read-timeouts on a large aggregate query due to coarse/stale planner
statistics. Lowering `autovacuum_analyze_scale_factor` (0.1 -> 0.02) on those three
tables keeps stats fresher.

## Notes
- Comment-only — no change to reconciled cluster state (Flux no-op).
- These reloptions do **not** survive a `bootstrap.recovery` onto a fresh cluster;
  the comment flags they must be reapplied after any restore.
- Follow-up (not in this PR): if the timeout recurs, raise per-column statistics
  targets on the join-key FKs (pending an `EXPLAIN`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
