### PR TITLE
feat(collab): bump pump to v0.0.112 — exercise QoL + schema v11→v14

### DIFF
--- a/kubernetes/apps/collab/pump/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump/app/helmrelease.yaml
@@ -49,7 +49,7 @@ spec:
           pump:
             image:
               repository: ghcr.io/rwlove/pump
-              tag: v0.0.111@sha256:24e48dc9cc35f406b8cfde364a6802795f44db6209903b74756d6fb543185d2e
+              tag: v0.0.112@sha256:f4bbb1c33c2e7f08810c8f1838963bea3b7ed6c274acc42ba85d46fb6c75091d
 
             env:
               # Activates the /api/cv/* proxy in pump (see internal/web/exercise.go).


### PR DESCRIPTION
Ships [rwlove/PUMP#110](https://github.com/rwlove/PUMP/pull/110): group-first exercise creation, DB-editable muscle catalog + per-exercise focus muscle, bodyweight exercises with added weight, drag-and-drop set reordering, recency-based picker ordering, pre-selected new-exercise colors.

**Schema migrations 12–14** (`exercises.focus/bodyweight`, `sets.position/added_weight`, `muscles` table) run on pod start. Verified clean on a **prod-dump restore (v11→v14)** and a **fresh empty DB**; `position` backfilled dense per date, no data loss. Live DB is at v11 (v0.0.111 added no migrations), so this is exactly the validated v11→v14 hop.

Image `ghcr.io/rwlove/pump:v0.0.112` @ `sha256:f4bbb1c3`.