### PR TITLE
fix(recyclarr): cap Sonarr CF upgrade score at Tier 01 to stop re-grab churn

### DIFF
--- a/kubernetes/apps/media/recyclarr/app/resources/recyclarr.yml
+++ b/kubernetes/apps/media/recyclarr/app/resources/recyclarr.yml
@@ -10,10 +10,21 @@ sonarr:
     quality_profiles:
       - name: WEB-1080p
         trash_id: 72dae194fc92bf828f32cde7744e51a1
+        # until_score lowered from the TRaSH template's default 10000 (which is
+        # unreachable — max achievable is ~1775 = WEB Tier 01 + platform) so a
+        # WEB Tier 01 release counts as "at cutoff" and Sonarr stops perpetually
+        # re-grabbing custom-format upgrades it can never satisfy.
+        upgrade:
+          allowed: true
+          until_score: 1700
         reset_unmatched_scores:
           enabled: true
       - name: WEB-2160p (Combined)
         trash_id: c4cadd6b35b95f62c3d47a408e53e2f7
+        # See WEB-1080p above: cap the custom-format upgrade hunt at Tier 01.
+        upgrade:
+          allowed: true
+          until_score: 1700
         reset_unmatched_scores:
           enabled: true
       - name: Bluray+WEB-2160p
@@ -22,6 +33,16 @@ sonarr:
         # for series where you want the upgrade-to-4K workflow but don't
         # want existing Bluray-1080p episodes flagged as out-of-profile.
         trash_id: c4cadd6b35b95f62c3d47a408e53e2f7
+        # Default profile for ~271 series. until_score capped at Tier 01 (1700)
+        # to stop the perpetual re-grab loop; until_quality pinned to the
+        # template's existing cutoff (WEB 2160p) so resolution-upgrade behaviour
+        # is unchanged. Note: this also stops chasing HDR (+500 CF) upgrades on
+        # this profile — acceptable trade to end the churn; split the profile if
+        # 4K-HDR auto-upgrades are wanted for a subset of series.
+        upgrade:
+          allowed: true
+          until_quality: WEB 2160p
+          until_score: 1700
         reset_unmatched_scores:
           enabled: true
         qualities:


### PR DESCRIPTION
## Problem

The three recyclarr-managed Sonarr quality profiles inherit the TRaSH template's `until_score` (*Upgrade Until Custom Format Score*) of **10000**. That score is **unreachable** — the maximum achievable is ~1775 (`WEB Tier 01` +1700 plus a platform tag +75) — so `upgradeAllowed` profiles never reach cutoff and Sonarr **perpetually hunts custom-format upgrades**.

When such an "upgrade" can't be imported — e.g. a completed season pack of single-episode files that can't replace an existing multi-episode file on disk (`importBlocked`) — Sonarr re-grabs it every search cycle, jamming the queue with dozens of duplicate blocked rows pointing at one download.

## Change

Cap `until_score` at **1700** on the three recyclarr-managed profiles so any `WEB Tier 01` release counts as "at cutoff" and the upgrade hunt stops.

| Profile | Series using it | Change |
|---|---|---|
| `Bluray+WEB-2160p` | **271** (de-facto default) | `until_score: 1700`, `until_quality: WEB 2160p` (pinned to current cutoff → resolution-upgrade behaviour unchanged) |
| `WEB-1080p` | 0 | `until_score: 1700` |
| `WEB-2160p (Combined)` | 0 | `until_score: 1700` |

`until_quality` on `Bluray+WEB-2160p` is set to its **existing** cutoff (`WEB 2160p`, id 1003) so only the score changes.

## Trade-off (blast radius: 271 series)

Because HDR is a +500 custom format, a 1700 cutoff means a non-HDR `WEB Tier 01` file (1775) satisfies cutoff and this profile **no longer chases HDR upgrades**. This is the tension of one profile spanning both HD-source shows (max ~1775 — *need* a low cutoff to stop churning) and true 4K-HDR shows (want a high cutoff to pursue HDR). Accepted here to end the churn; the clean long-term fix is a **split profile** for the 4K-HDR subset.

## Out of scope

`WEB-2160p` (id 9) is **unused (0 series) and not recyclarr-managed** — left untouched.

## Rollout / verification

- Not applied until recyclarr's next `@daily` sync (or a manual CronJob trigger) after merge.
- CI validates schema/kustomize/flux only — it does **not** run recyclarr, so green ≠ applied. Verify post-sync that the three profiles show `Upgrade Until Custom Format Score = 1700` in Sonarr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)