### PR TITLE
feat(collab): bump pump to v0.1.0 — Exercise Library + schema v14→v17

### DIFF
--- a/kubernetes/apps/collab/pump/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump/app/helmrelease.yaml
@@ -49,7 +49,7 @@ spec:
           pump:
             image:
               repository: ghcr.io/rwlove/pump
-              tag: v0.0.112@sha256:f4bbb1c33c2e7f08810c8f1838963bea3b7ed6c274acc42ba85d46fb6c75091d
+              tag: v0.1.0@sha256:150fad31e29088f6b5005f36a50f74cdef3a28487798c2773f6e8c8ca980898d
 
             env:
               # Activates the /api/cv/* proxy in pump (see internal/web/exercise.go).


### PR DESCRIPTION
Bumps `ghcr.io/rwlove/pump` to **v0.1.0** (`sha256:150fad31…`).

Bundles the Exercise Library work shipped in PUMP #114/#116/#117/#118 (+ favicon #115):
- Exercise create/edit moved off the workout page into a new **Library**
- Managed training **groups** (create/rename/reorder/delete) — migration **v15**
- Multiple **focus muscles** per exercise, primary/secondary — migration **v16**
- **Routines**/templates + start-routine scaffolding — migration **v17**

Migrations v15–v17 are **additive** (new tables + backfills) and were validated **v14→v17 against a restore of the production DB** (3 migrations applied cleanly, groups backfilled). The rolling update is safe — the current v0.0.112 pod keeps serving on schema v14 while the new pod applies the additive migrations on startup.