### PR TITLE
fix(collab): bump pump to v0.1.1 — fix black exercise dots

### DIFF
--- a/kubernetes/apps/collab/pump/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump/app/helmrelease.yaml
@@ -49,7 +49,7 @@ spec:
           pump:
             image:
               repository: ghcr.io/rwlove/pump
-              tag: v0.1.0@sha256:150fad31e29088f6b5005f36a50f74cdef3a28487798c2773f6e8c8ca980898d
+              tag: v0.1.1@sha256:d708d443a7f7035c24f9bf1a94a6f8e5a06d8d7025092656e95cd26790362016
 
             env:
               # Activates the /api/cv/* proxy in pump (see internal/web/exercise.go).


### PR DESCRIPTION
Bumps pump to **v0.1.1** (`sha256:d708d443…`). No schema change — patch fixes exercises rendering as a black dot in the Library (treats `#000000` as an unset color and backfills a group-band shade). See PUMP #120.