### PR TITLE
feat(collab): bump pump to v0.2.0 — muscle-level Balance + Grip & Hang

### DIFF
--- a/kubernetes/apps/collab/pump/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump/app/helmrelease.yaml
@@ -49,7 +49,7 @@ spec:
           pump:
             image:
               repository: ghcr.io/rwlove/pump
-              tag: v0.1.1@sha256:d708d443a7f7035c24f9bf1a94a6f8e5a06d8d7025092656e95cd26790362016
+              tag: v0.2.0@sha256:f1407681ef19255d4ecadf7e413644ed805beeeb4fb9fa5f739c9f24cf0636be
 
             env:
               # Activates the /api/cv/* proxy in pump (see internal/web/exercise.go).


### PR DESCRIPTION
Bumps pump to **v0.2.0** (`sha256:f140768…`). Muscle-level Muscle Balance, grip strength L/R + dead-hang metrics (new Stats tab, additive **migration v18** — measurements table), routines one-set-per-item. v18 validated on a prod restore. See PUMP #123/#122/#124.