### PR TITLE
chore(collab): bump pump to v0.2.1 — OCI-compliant image

### DIFF
--- a/kubernetes/apps/collab/pump/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump/app/helmrelease.yaml
@@ -49,7 +49,7 @@ spec:
           pump:
             image:
               repository: ghcr.io/rwlove/pump
-              tag: v0.2.0@sha256:f1407681ef19255d4ecadf7e413644ed805beeeb4fb9fa5f739c9f24cf0636be
+              tag: v0.2.1@sha256:1170866328ae3c700d1d192bb979c68ad02a0811538353febeec430f213581b6
 
             env:
               # Activates the /api/cv/* proxy in pump (see internal/web/exercise.go).


### PR DESCRIPTION
Metadata-only bump to **v0.2.1** (`sha256:1170866…`), the OCI-compliant Containerfile build. No app or schema change. All pump-family images remain digest-pinned.