### PR TITLE
chore(collab): bump pump to v0.2.2 — PWA install icon fix

### DIFF
--- a/kubernetes/apps/collab/pump/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump/app/helmrelease.yaml
@@ -49,7 +49,7 @@ spec:
           pump:
             image:
               repository: ghcr.io/rwlove/pump
-              tag: v0.2.1@sha256:1170866328ae3c700d1d192bb979c68ad02a0811538353febeec430f213581b6
+              tag: v0.2.2@sha256:65f957a290ddb9e73c6871bc23d955655b9d8fe0cfd424eaac9c778147731138
 
             env:
               # Activates the /api/cv/* proxy in pump (see internal/web/exercise.go).


### PR DESCRIPTION
Bumps pump to **v0.2.2** (`sha256:65f957a…`) — the PWA install/home-screen shortcut now shows the PUMP logo (real 192 icon + high-contrast maskable). No app/schema change; digest-pinned.