### PR TITLE
chore(collab): bump pump to v0.2.3 — PWA manifest no-cache fix

### DIFF
--- a/kubernetes/apps/collab/pump/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump/app/helmrelease.yaml
@@ -49,7 +49,7 @@ spec:
           pump:
             image:
               repository: ghcr.io/rwlove/pump
-              tag: v0.2.2@sha256:65f957a290ddb9e73c6871bc23d955655b9d8fe0cfd424eaac9c778147731138
+              tag: v0.2.3@sha256:7710103fc589ce19b0d0f0b2b9d4d38e9a53db6b97259c3fc7e8cf590caa1ab9
 
             env:
               # Activates the /api/cv/* proxy in pump (see internal/web/exercise.go).


### PR DESCRIPTION
Bumps pump to **v0.2.3** (`sha256:7710103…`). Manifest served no-cache from `/manifest.json` + cache-busted icons so installed PWAs stop serving the stale icon. No app/schema change; digest-pinned.