### PR TITLE
chore(collab): bump pump to v0.2.4 — cache-bust PWA icons

### DIFF
--- a/kubernetes/apps/collab/pump/app/helmrelease.yaml
+++ b/kubernetes/apps/collab/pump/app/helmrelease.yaml
@@ -49,7 +49,7 @@ spec:
           pump:
             image:
               repository: ghcr.io/rwlove/pump
-              tag: v0.2.3@sha256:7710103fc589ce19b0d0f0b2b9d4d38e9a53db6b97259c3fc7e8cf590caa1ab9
+              tag: v0.2.4@sha256:ad4850f3b7800129370ab82a5623f735c004ae7645d3e209c0eca187cd8a7a61
 
             env:
               # Activates the /api/cv/* proxy in pump (see internal/web/exercise.go).


### PR DESCRIPTION
Bumps pump to **v0.2.4** (`sha256:ad4850f…`). Manifest icon URLs now `?v=4` to force the WebAPK minter to re-fetch past the `pump-pwa` public route. No app/schema change; digest-pinned.