### PR TITLE
feat(mcp-gateway): global tool-flood guard via discoveryToolThreshold

### DIFF
--- a/kubernetes/apps/mcp-system/mcp-gateway/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/mcp-gateway/app/helmrelease.yaml
@@ -31,6 +31,18 @@ spec:
     broker:
       # How often (in seconds) the broker pings upstream MCP servers
       pollInterval: 60
+      # Global flood guard (chart 0.9.0). The broker federates ~1300 tools
+      # across 18 servers; an unscoped tools/list is ~1.28 MB / ~319k tokens
+      # and silently kills a small-context client on connect (this is why
+      # opencode uses the opencode-readonly MCPVirtualServer subset). Above
+      # this many tools the broker hides raw tools and serves only the
+      # discover_tools / select_tools meta-tools, so a client WITHOUT a
+      # curated subset degrades gracefully instead of drowning. 200 sits well
+      # above any real curated subset (opencode-readonly is ~35) and well
+      # below the full federation, so subset clients are unaffected. 0 = never
+      # hide. Requires clients to speak the discover/select meta-tool flow.
+      discoveryToolsEnabled: true
+      discoveryToolThreshold: 200
 
     # Gateway configuration
     controller:


### PR DESCRIPTION
## What

Sets `broker.discoveryToolThreshold: 200` (and `discoveryToolsEnabled: true` explicitly), a knob new in mcp-gateway chart `0.9.0`.

## Why

The broker federates **~1300 tools across 18 servers**. An unscoped `tools/list` returns ~1.28 MB / ~319k tokens — ~5× a 65k-context model — which silently kills a small-context client on connect (the prompt is admitted, then nothing). That footgun is the documented reason opencode consumes the `opencode-readonly` MCPVirtualServer subset via the `x-mcp-virtualserver` header.

`discoveryToolThreshold` is the **global** version of that guard: above N tools the broker hides raw tools and serves only the `discover_tools` / `select_tools` meta-tools, so a client that connects **without** a curated subset degrades gracefully to the discovery flow instead of drowning.

## Sizing

- curated subsets are small — `opencode-readonly` is ~35 tools
- full federation is ~1300

`200` sits comfortably above any realistic curated subset and far below the full set, so **subset clients (opencode) are unaffected** and only the unscoped full-federation view trips into meta-tool mode.

## Blast radius / caveats

- **Behavior change for unscoped clients:** any client hitting the broker with no MCPVirtualServer subset AND no support for the `discover_tools`/`select_tools` meta-tool flow will now see only the two meta-tools instead of the full list. Known consumers are fine: opencode uses its subset; the meta-tool flow is the established pattern.
- Complements — does not replace — the per-client MCPVirtualServer mechanism.
- Fully reversible: set back to `0` (never hide).

## Note

This is a behavior-changing tweak to a shared substrate, so I've left it for explicit review/merge rather than assuming it should auto-land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)