### PR TITLE
fix(envoy-gateway): enable Lua for EnvoyExtensionPolicy (1.9.0 gate)

### DIFF
--- a/kubernetes/apps/network/envoy-gateway/app/helmrelease.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/helmrelease.yaml
@@ -18,6 +18,11 @@ spec:
       envoyGateway:
         extensionApis:
           enableEnvoyPatchPolicy: true
+          # Lua is disabled by default and is gated behind this flag as of
+          # Envoy Gateway 1.9.0. Required by the *-inject-theme-park
+          # EnvoyExtensionPolicies (Lua CSS injection); without it EG sets a
+          # 500 direct_response on every route carrying one.
+          enableLua: true
         provider:
           kubernetes:
             deploy:


### PR DESCRIPTION
## Incident fix

Envoy Gateway **1.9.0** disables the **Lua** feature by default and gates it behind `extensionApis.enableLua`. Our theme-park CSS-injection `EnvoyExtensionPolicies` are Lua-based. After the `1.8.3 → 1.9.0` chart bump, envoy-gateway began setting a **`500 direct_response`** on every route carrying one of those policies, taking down the affected app UIs (auth was unaffected — the failures are 500, not 403).

Log signature:
```
setting 500 direct response in routes due to errors in EnvoyExtensionPolicy
error: "Lua: Skipping Lua EnvoyExtensionPolicy as feature is disabled in the Gateway"
```

## Fix

Set `extensionApis.enableLua: true` (companion to the existing `enableEnvoyPatchPolicy: true`). Per upstream docs, Lua is disabled by default and requires this flag.

Regression from the `1.9.0` bump. Expedited as an outage fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)