### PR TITLE
fix(renovate): gate automerge to prevent dashboard-flush avalanches

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,7 +3,6 @@
   extends: [
     'config:recommended',
     'docker:enableMajor',
-    ':disableRateLimiting',
     ':dependencyDashboard',
     ':semanticCommits',
     ':enablePreCommit',
@@ -30,6 +29,15 @@
   ],
   timezone: 'America/New_York',
   rebaseWhen: 'auto',
+  // Pace merges so a dependency-dashboard flush can't avalanche. Ticking the
+  // dashboard checkboxes force-creates PRs and bypasses minimumReleaseAge;
+  // with automerge on and no rate limit (the removed ':disableRateLimiting'),
+  // a 27-PR flush merged within ~10 minutes on 2026-08-16 → a concurrent
+  // reconcile storm that saturated image pulls and took authelia (the
+  // ext-authz SPOF) down. These caps bound concurrent open PRs (== concurrent
+  // automerges/reconciles) and the creation rate, so a flush trickles instead.
+  prConcurrentLimit: 5,
+  prHourlyLimit: 3,
   commitBodyTable: true,
   // 'disabled' = plain git push. 'enabled' (Contents API) appears to
   // interact badly with Renovate's "Repository has changed during

--- a/.github/renovate/packageRules.json5
+++ b/.github/renovate/packageRules.json5
@@ -8,6 +8,22 @@
       "automerge": false
     },
     {
+      // Never auto-merge cluster-wide blast-radius infra, even minor/patch.
+      // A bad minor here cascades cluster-wide: envoy-gateway 1.9.0 (a MINOR)
+      // disabled Lua by default and set a 500 on every themed route
+      // (2026-08-16). CNI, ingress gateway, storage backends, and the shared
+      // app-template chart (re-renders ~110 releases) get manual review.
+      "description": "Never auto-merge cluster-wide blast-radius infra (CNI, ingress, storage, shared chart)",
+      "matchPackageNames": [
+        "cilium",
+        "docker.io/envoyproxy/gateway-helm",
+        "ghcr.io/home-operations/charts-mirror/longhorn",
+        "ghcr.io/bjw-s-labs/helm/app-template",
+        "/^ghcr\\.io\\/rook\\/rook-ceph/"
+      ],
+      "automerge": false
+    },
+    {
       "matchDatasources": ["docker"],
       "matchPackageNames": ["ghcr.io/kube-vip/kube-vip"],
       "sourceUrl": "https://github.com/kube-vip/kube-vip"


### PR DESCRIPTION
## Why

On 2026-08-16 a dependency-dashboard flush **auto-merged 27 PRs in ~10 minutes**. Force-creating PRs off the dashboard bypasses `minimumReleaseAge`, and with `automerge` on and **no rate limit**, everything merged at once → a concurrent reconcile storm that **saturated image pulls and took authelia (the ext-authz SPOF) down** (403 on every protected route). Separately, `envoy-gateway 1.9.0` — a **minor** — auto-merged and broke ingress (Lua default-off).

## Changes

1. **Pace the flush** (`.github/renovate.json5`): remove `:disableRateLimiting`, add `prConcurrentLimit: 5` + `prHourlyLimit: 3`. Bounding concurrent open PRs bounds concurrent automerges/reconciles, so a flush trickles instead of avalanching. Tune to taste.

2. **Blast-radius firewall** (`.github/renovate/packageRules.json5`): never auto-merge cluster-wide infra even on minor/patch — CNI (`cilium`), ingress gateway (`docker.io/envoyproxy/gateway-helm`), storage backends (`ghcr.io/rook/rook-ceph*`, `charts-mirror/longhorn`), and the shared `app-template` chart (re-renders ~110 releases). Majors were already firewalled; this extends the same discipline to high-blast-radius minors.

## Not included (your call)
- Making `renovate/stability-days` a **required** status check is a branch-protection setting, not in-repo config — can't be done in this PR. Say the word and I'll walk through it in repo settings.
- Renee-facing apps (HA, zwave, frigate, music-assistant) aren't in the firewall — they're user-impacting but not cluster-wide. Easy to add if you want them manual too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)