### PR TITLE
revert(mcp-gateway): drop no-op discoveryToolThreshold (#13622)

### DIFF
--- a/kubernetes/apps/mcp-system/mcp-gateway/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp-system/mcp-gateway/app/helmrelease.yaml
@@ -31,18 +31,6 @@ spec:
     broker:
       # How often (in seconds) the broker pings upstream MCP servers
       pollInterval: 60
-      # Global flood guard (chart 0.9.0). The broker federates ~1300 tools
-      # across 18 servers; an unscoped tools/list is ~1.28 MB / ~319k tokens
-      # and silently kills a small-context client on connect (this is why
-      # opencode uses the opencode-readonly MCPVirtualServer subset). Above
-      # this many tools the broker hides raw tools and serves only the
-      # discover_tools / select_tools meta-tools, so a client WITHOUT a
-      # curated subset degrades gracefully instead of drowning. 200 sits well
-      # above any real curated subset (opencode-readonly is ~35) and well
-      # below the full federation, so subset clients are unaffected. 0 = never
-      # hide. Requires clients to speak the discover/select meta-tool flow.
-      discoveryToolsEnabled: true
-      discoveryToolThreshold: 200
 
     # Gateway configuration
     controller:


### PR DESCRIPTION
Reverts #13622.

## Why

`broker.discoveryToolThreshold` (and `broker.discoveryToolsEnabled`) are **only consumed when the chart creates the MCPGatewayExtension**. This repo runs `mcpGatewayExtension.create: false` and manages that CR out-of-band (for `httpRouteManagement: Disabled` + the external-dns opt-out), so the entire `broker.*` Helm block is ignored — which is also why the working `pollInterval` actually lives on the CR as `backendPingIntervalSeconds`.

Verified: rendering the 0.9.0 chart with our `mcpGatewayExtension.create=false` + `discoveryToolThreshold=200` produces **zero** occurrences of the threshold anywhere. The live broker-router config Secret confirms it's absent, and the br never rolled. The `MCPGatewayExtension` CRD has **no** tool-threshold field, so there's nowhere valid to set it in our topology either.

#13622 was therefore dead, misleading config. Removing it. If tool-flood control is still wanted, it needs a different mechanism (controller operator-wide setting or an upstream feature request) — a separate investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)