### PR TITLE
fix(windmill-mcp): disable registration — broker can't consume stateless upstream

### DIFF
--- a/kubernetes/apps/mcp-system/windmill-mcp/mcp/mcpserverregistration.yaml
+++ b/kubernetes/apps/mcp-system/windmill-mcp/mcp/mcpserverregistration.yaml
@@ -7,6 +7,13 @@ metadata:
   labels:
     mcp.kuadrant.io/managed: "true"
 spec:
+  # workaround: https://github.com/Kuadrant/mcp-gateway/issues/1382 — remove when the broker tolerates stateless streamable-HTTP upstreams
+  # Windmill's MCP endpoint is stateless: initialize returns no Mcp-Session-Id
+  # and the GET SSE stream is 405. The v0.9.0 broker requires a stateful session
+  # + a subscriptions/listen channel, so it hard-loops (reconnect many/sec) and
+  # federates zero windmill tools — pure CPU/log churn on the broker and
+  # windmill-app. Disabled until the upstream issue lands; re-enable then.
+  state: Disabled
   targetRef:
     group: gateway.networking.k8s.io
     kind: HTTPRoute


### PR DESCRIPTION
## Why

Windmill's MCP endpoint is **stateless streamable-HTTP**: `initialize` → `200` with **no `Mcp-Session-Id`**, and the `GET` server→client SSE stream → `405`. The mcp-gateway **v0.9.0** broker requires a stateful session + a persistent `subscriptions/listen` channel, so it **hard-loops** (reconnect many times/sec) and federates **zero** windmill tools — pure CPU + log churn on the broker and windmill-app.

Diagnosis (probed the endpoint directly):
- `initialize` → `200 text/event-stream`, no `Mcp-Session-Id`
- bare `tools/list` POST (no session) → `200` (tools reachable statelessly)
- `GET` → `405 Method Not Allowed`

## Change

`state: Disabled` on the `windmill-tools` MCPServerRegistration. **Lossless** — no windmill tools were being federated anyway. Stops the reconnect storm.

Annotated `# workaround:` pointing at upstream **Kuadrant/mcp-gateway#1382**; re-enable when the broker tolerates stateless upstreams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)