### PR TITLE
fix(windmill-mcp): stop leaking WINDMILL_TOKEN into rendered nginx comments

### DIFF
--- a/kubernetes/apps/mcp-system/windmill-mcp/app/resources/default.conf.template
+++ b/kubernetes/apps/mcp-system/windmill-mcp/app/resources/default.conf.template
@@ -2,8 +2,11 @@
 #
 # The mcp-gateway broker delivers MCP traffic to this proxy at /mcp.
 # We rewrite to Windmill's workspace-scoped MCP endpoint and inject
-# the Authorization: Bearer header from $WINDMILL_TOKEN (set via env
-# from the windmill-mcp-secret ExternalSecret).
+# the Authorization: Bearer header from the WINDMILL_TOKEN env var (set
+# from the windmill-mcp-secret ExternalSecret). NOTE: never write the
+# variable in $-form inside a comment — nginx's envsubst expands ${...}
+# and $NAME anywhere in this file, including comments, which would bake the
+# real token into the rendered conf. Only the proxy_set_header below uses it.
 #
 # Windmill's MCP route is HTTP streamable + SSE. Disable proxy
 # buffering and set generous timeouts so long-running tool calls
@@ -29,9 +32,10 @@ server {
         proxy_set_header Host windmill-app.home.svc.cluster.local;
         proxy_set_header Connection "";
         # Flux postBuild substitution is disabled on this generated CM (see the
-        # kustomization's generatorOptions.annotations), so `${WINDMILL_TOKEN}`
-        # passes through literally for nginx's envsubst to expand from the
-        # WINDMILL_TOKEN env var at startup.
+        # kustomization's generatorOptions.annotations), so the token
+        # placeholder below passes through literally for nginx's envsubst to
+        # expand from the WINDMILL_TOKEN env var at startup. (Do not repeat the
+        # placeholder in $-form in comments — envsubst would expand it here too.)
         proxy_set_header Authorization "Bearer ${WINDMILL_TOKEN}";
 
         # SSE / streamable-HTTP friendliness — Windmill MCP streams.


### PR DESCRIPTION
## Why

`default.conf.template` named the token variable in `$`-form inside two comments. nginx's `envsubst` expands `${VAR}`/`$VAR` **anywhere** in the file — comments included — so the conf rendered into the pod carried the **real token in those comment lines** (beyond the one legitimate `Authorization` directive).

## Change

Reword the two comments to name the variable **without** the `$` (envsubst then ignores them). Only `proxy_set_header Authorization "Bearer ${WINDMILL_TOKEN}"` still expands. Comment-only; no proxying change — reloader restarts nginx to re-render.

## Follow-up (not in this PR)

Recommend **rotating `WINDMILL_TOKEN`** — it was materialized into pod config and surfaced in logs during diagnosis. Separate op (1Password + Windmill workspace token + ExternalSecret refresh); happy to walk through it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)